### PR TITLE
fix: player page blank screen — missing utils.js

### DIFF
--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -160,8 +160,12 @@
 
         switch (msg.phase) {
             case 'LOBBY':
-                pu.showView('lobby-view');
-                lobby.renderLobby(msg);
+                if (!state.playerName) {
+                    pu.showView('join-view');
+                } else {
+                    pu.showView('lobby-view');
+                    lobby.renderLobby(msg);
+                }
                 break;
 
             case 'QUESTION_ACTIVE':

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -599,6 +599,7 @@
 
     <script src="/quizify/static/js/vendor/qrcode.min.js?v=1.0.22"></script>
     <script src="/quizify/static/js/i18n.js?v=1.0.22"></script>
+    <script src="/quizify/static/js/utils.js?v=1.0.22"></script>
     <script src="/quizify/static/js/player-utils.js?v=1.0.22"></script>
     <script src="/quizify/static/js/player-lobby.js?v=1.0.22"></script>
     <script src="/quizify/static/js/player-game.js?v=1.0.22"></script>


### PR DESCRIPTION
## Summary
- **Added missing `utils.js` script include** in `player.html` — `QuizifyUtils` (`escapeHtml`, `formatPoints`, `formatTime`) was undefined, causing every WebSocket message to crash silently and leaving a blank screen
- **Fixed `handleGameState` LOBBY view** in `player-core.js` — unjoined players now see the name input form (`join-view`) instead of the empty lobby

## Test plan
- [ ] Open `/quizify/player` in a browser — should show join form instead of blank screen
- [ ] Enter a name and click "Join Game" — should transition to lobby view
- [ ] Start a game and verify questions, scoring, and reveal flow work on the player page
- [ ] Verify admin "Starten & Beitreten" flow works (redirects to player page with `?name=&admin=true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)