### PR TITLE
fix: re-add utils.js include dropped during version bump

### DIFF
--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -599,6 +599,7 @@
 
     <script src="/quizify/static/js/vendor/qrcode.min.js?v=1.0.24"></script>
     <script src="/quizify/static/js/i18n.js?v=1.0.24"></script>
+    <script src="/quizify/static/js/utils.js?v=1.0.24"></script>
     <script src="/quizify/static/js/player-utils.js?v=1.0.24"></script>
     <script src="/quizify/static/js/player-lobby.js?v=1.0.24"></script>
     <script src="/quizify/static/js/player-game.js?v=1.0.24"></script>


### PR DESCRIPTION
## Summary
- The v1.0.24 version bump in 505d917 replaced the script block in `player.html` and accidentally dropped the `utils.js` include that was added in PR #81
- Without this, the player page is completely broken (blank screen)

## Test plan
- [ ] Open `/quizify/player` — should show join form, not blank screen
- [ ] Join a game and verify gameplay works

🤖 Generated with [Claude Code](https://claude.com/claude-code)