### PR TITLE
fix: player page blank screen, margins, and rankings layout

### DIFF
--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -220,6 +220,12 @@ body {
     padding: var(--space-md);
 }
 
+.player-container {
+    padding: 0 var(--space-md);
+    max-width: 600px;
+    margin: 0 auto;
+}
+
 .view {
     display: none;
     flex-direction: column;
@@ -1438,6 +1444,56 @@ button, .btn {
 .leaderboard-streak {
     font-size: 0.75rem;
     color: var(--color-warning);
+}
+
+/* ==========================================
+   Final Leaderboard (End-of-Game Rankings)
+   ========================================== */
+
+.final-leaderboard {
+    margin-top: var(--space-lg);
+}
+
+.final-leaderboard-header {
+    font-weight: var(--font-weight-bold);
+    font-size: 1.1rem;
+    color: var(--color-text-white);
+    margin-bottom: var(--space-sm);
+}
+
+.final-entry {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+    padding: var(--space-sm) 0;
+    border-bottom: 1px solid var(--color-border-neon);
+}
+
+.final-rank {
+    width: 28px;
+    text-align: center;
+    font-weight: var(--font-weight-bold);
+    font-size: 0.85rem;
+    color: var(--color-text-neon-muted);
+    flex-shrink: 0;
+}
+
+.final-name {
+    flex: 1;
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-white);
+}
+
+.final-score {
+    font-weight: var(--font-weight-bold);
+    font-variant-numeric: tabular-nums;
+    color: var(--color-accent-secondary);
+}
+
+.final-entry.is-current {
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: var(--radius-md);
+    padding: var(--space-sm) var(--space-md);
 }
 
 /* ==========================================

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -22,7 +22,7 @@
 
     <main class="player-container">
         <!-- Loading state -->
-        <div id="loading-view" class="view">
+        <div id="loading-view" class="view active">
             <div class="loading-spinner"></div>
             <p data-i18n="common.connecting">Connecting to game...</p>
         </div>


### PR DESCRIPTION
## Summary
- **Blank screen on load**: `loading-view` now has `class="view active"` so it's visible before JS initializes
- **Missing margins**: Added `.player-container` CSS with `padding: 0 var(--space-md)`, `max-width: 600px`, `margin: 0 auto` — matches admin panel pattern
- **Rankings text run-together**: Added CSS for `.final-entry`, `.final-rank`, `.final-name`, `.final-score` using flexbox layout with gap spacing

## Test plan
- [ ] Open `/quizify/player` — loading spinner visible immediately (not blank)
- [ ] Join a game — lobby, game, reveal views have consistent ~16px left/right padding
- [ ] Play to end — Full Rankings shows properly spaced "#1 Admin 2 0" layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)