### PR TITLE
chore: bump cache-bust version strings to 1.0.26

### DIFF
--- a/custom_components/quizify/manifest.json
+++ b/custom_components/quizify/manifest.json
@@ -12,5 +12,5 @@
   "description": "Multiplayer useless knowledge quiz game for Home Assistant",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/quizify/issues",
-  "version": "1.0.24"
+  "version": "1.0.26"
 }

--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -16,7 +16,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/quizify/static/css/styles.css?v=1.0.24">
+    <link rel="stylesheet" href="/quizify/static/css/styles.css?v=1.0.26">
 </head>
 <body class="theme-dark">
     <header class="admin-header">
@@ -295,13 +295,13 @@
     <div id="error-toast" class="toast hidden" role="alert" aria-live="assertive"></div>
 
     <!-- Version badge -->
-    <div class="version-badge" id="version-badge">v1.0.24</div>
+    <div class="version-badge" id="version-badge">v1.0.26</div>
 
-    <script src="/quizify/static/js/vendor/qrcode.min.js?v=1.0.24"></script>
-    <script src="/quizify/static/js/i18n.js?v=1.0.24"></script>
-    <script src="/quizify/static/js/utils.js?v=1.0.24"></script>
+    <script src="/quizify/static/js/vendor/qrcode.min.js?v=1.0.26"></script>
+    <script src="/quizify/static/js/i18n.js?v=1.0.26"></script>
+    <script src="/quizify/static/js/utils.js?v=1.0.26"></script>
 
-    <script src="/quizify/static/js/admin.js?v=1.0.24"></script>
+    <script src="/quizify/static/js/admin.js?v=1.0.26"></script>
     <script>
         if ("serviceWorker" in navigator) {
             navigator.serviceWorker.register("/quizify/static/sw.js");

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/quizify/static/css/styles.css?v=1.0.24">
+    <link rel="stylesheet" href="/quizify/static/css/styles.css?v=1.0.26">
     <link rel="icon" href="/quizify/static/img/icon-256.png" type="image/png">
     <link rel="manifest" href="/quizify/static/site.webmanifest">
     <!-- Confetti library for celebrations -->
@@ -595,17 +595,17 @@
     </div>
 
     <!-- Version badge -->
-    <div class="version-badge" id="version-badge">v1.0.24</div>
+    <div class="version-badge" id="version-badge">v1.0.26</div>
 
-    <script src="/quizify/static/js/vendor/qrcode.min.js?v=1.0.24"></script>
-    <script src="/quizify/static/js/i18n.js?v=1.0.24"></script>
-    <script src="/quizify/static/js/utils.js?v=1.0.24"></script>
-    <script src="/quizify/static/js/player-utils.js?v=1.0.24"></script>
-    <script src="/quizify/static/js/player-lobby.js?v=1.0.24"></script>
-    <script src="/quizify/static/js/player-game.js?v=1.0.24"></script>
-    <script src="/quizify/static/js/player-reveal.js?v=1.0.24"></script>
-    <script src="/quizify/static/js/player-end.js?v=1.0.24"></script>
-    <script src="/quizify/static/js/player-core.js?v=1.0.24"></script>
+    <script src="/quizify/static/js/vendor/qrcode.min.js?v=1.0.26"></script>
+    <script src="/quizify/static/js/i18n.js?v=1.0.26"></script>
+    <script src="/quizify/static/js/utils.js?v=1.0.26"></script>
+    <script src="/quizify/static/js/player-utils.js?v=1.0.26"></script>
+    <script src="/quizify/static/js/player-lobby.js?v=1.0.26"></script>
+    <script src="/quizify/static/js/player-game.js?v=1.0.26"></script>
+    <script src="/quizify/static/js/player-reveal.js?v=1.0.26"></script>
+    <script src="/quizify/static/js/player-end.js?v=1.0.26"></script>
+    <script src="/quizify/static/js/player-core.js?v=1.0.26"></script>
     <script>
         if ("serviceWorker" in navigator) {
             navigator.serviceWorker.register("/quizify/static/sw.js");


### PR DESCRIPTION
Bumps all ?v= cache-bust strings and version badges from 1.0.24 to 1.0.26 so browsers fetch the updated CSS with .player-container and .final-entry styles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)