### PR TITLE
feat: per-player color coding (#55)

### DIFF
--- a/custom_components/quizify/game/player.py
+++ b/custom_components/quizify/game/player.py
@@ -11,6 +11,31 @@ if TYPE_CHECKING:
     from aiohttp import web
 
 
+# Palette of distinct, accessible colours for player identification
+PLAYER_COLORS = [
+    "#FF6B6B",  # coral red
+    "#4ECDC4",  # teal
+    "#45B7D1",  # sky blue
+    "#96CEB4",  # sage green
+    "#FFEAA7",  # soft yellow
+    "#DDA0DD",  # plum
+    "#98D8C8",  # mint
+    "#F7DC6F",  # gold
+    "#BB8FCE",  # lavender
+    "#F0A500",  # amber
+    "#6BCB77",  # green
+    "#FF9F43",  # orange
+    "#A29BFE",  # periwinkle
+    "#FD79A8",  # pink
+    "#74B9FF",  # light blue
+    "#55EFC4",  # aquamarine
+    "#FDCB6E",  # mango
+    "#E17055",  # terracotta
+    "#00CEC9",  # cyan
+    "#6C5CE7",  # purple
+]
+
+
 @dataclass
 class PlayerSession:
     """Represents a connected player."""
@@ -22,6 +47,7 @@ class PlayerSession:
     streak: int = 0
     connected: bool = True
     is_admin: bool = False
+    color: str = ""  # assigned on join from PLAYER_COLORS palette
     joined_late: bool = False
     joined_at: float = field(default_factory=time.time)
     submitted: bool = False

--- a/custom_components/quizify/game/player_registry.py
+++ b/custom_components/quizify/game/player_registry.py
@@ -18,7 +18,7 @@ from ..const import (
 if TYPE_CHECKING:
     from aiohttp import web
 
-from .player import PlayerSession
+from .player import PlayerSession, PLAYER_COLORS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -77,9 +77,14 @@ class PlayerRegistry:
         joined_late = phase_value != "LOBBY"
         initial_score = average_score_fn() if joined_late else 0
 
+        # Assign a unique color from the palette (cycle if more than palette size)
+        used_colors = {p.color for p in self.players.values()}
+        available = [c for c in PLAYER_COLORS if c not in used_colors]
+        color = available[0] if available else PLAYER_COLORS[len(self.players) % len(PLAYER_COLORS)]
+
         # Add new player
         player = PlayerSession(
-            name=name, ws=ws, score=initial_score, streak=0, joined_late=joined_late
+            name=name, ws=ws, score=initial_score, streak=0, joined_late=joined_late, color=color
         )
         self.players[name] = player
         self._sessions[player.session_id] = name
@@ -133,6 +138,7 @@ class PlayerRegistry:
                 "streak": p.streak,
                 "is_admin": p.is_admin,
                 "submitted": p.submitted,
+                "color": p.color,
             }
             for p in self.players.values()
         ]

--- a/custom_components/quizify/manifest.json
+++ b/custom_components/quizify/manifest.json
@@ -12,5 +12,5 @@
   "description": "Multiplayer useless knowledge quiz game for Home Assistant",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/quizify/issues",
-  "version": "1.0.35"
+  "version": "1.0.36"
 }

--- a/custom_components/quizify/server/serializers.py
+++ b/custom_components/quizify/server/serializers.py
@@ -106,6 +106,7 @@ def serialize_leaderboard(players: list[PlayerSession]) -> list[dict[str, Any]]:
             "streak_bonus": breakdown.get("streak_bonus", 0),
             "difficulty_multiplier": breakdown.get("difficulty_multiplier", 1.0),
             "double_points": breakdown.get("double_points", False),
+            "color": p.color,
         })
     return result
 
@@ -118,6 +119,7 @@ def serialize_player_list(players: list[PlayerSession]) -> list[dict[str, Any]]:
             "score": p.score,
             "streak": p.streak,
             "connected": p.connected,
+            "color": p.color,
         }
         for p in players
     ]

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -227,13 +227,15 @@ class QuizifyWebSocketHandler:
             # Generate session token for reconnect
             session_token = self._conn.create_session_token(name)
 
-            # Send join confirmation with session token
+            # Send join confirmation with session token and assigned color
             powerup = game_state.get_player_powerup(name)
+            player_obj = game_state.get_player(name)
             await self._conn._safe_send(ws, {
                 "type": "joined",
                 "player_id": name,
                 "powerup": powerup.value if powerup else None,
                 "session_token": session_token,
+                "color": player_obj.color if player_obj else "",
             })
 
             # Send current state to the joining player

--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -16,7 +16,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/quizify/static/css/styles.css?v=1.0.35">
+    <link rel="stylesheet" href="/quizify/static/css/styles.css?v=1.0.36">
 </head>
 <body class="theme-dark">
     <header class="admin-header">
@@ -310,13 +310,13 @@
     <div id="error-toast" class="toast hidden" role="alert" aria-live="assertive"></div>
 
     <!-- Version badge -->
-    <div class="version-badge" id="version-badge">v1.0.35</div>
+    <div class="version-badge" id="version-badge">v1.0.36</div>
 
-    <script src="/quizify/static/js/vendor/qrcode.min.js?v=1.0.35"></script>
-    <script src="/quizify/static/js/i18n.js?v=1.0.35"></script>
-    <script src="/quizify/static/js/utils.js?v=1.0.35"></script>
+    <script src="/quizify/static/js/vendor/qrcode.min.js?v=1.0.36"></script>
+    <script src="/quizify/static/js/i18n.js?v=1.0.36"></script>
+    <script src="/quizify/static/js/utils.js?v=1.0.36"></script>
 
-    <script src="/quizify/static/js/admin.js?v=1.0.35"></script>
+    <script src="/quizify/static/js/admin.js?v=1.0.36"></script>
     <script>
         if ("serviceWorker" in navigator) {
             navigator.serviceWorker.register("/quizify/static/sw.js");

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -1136,6 +1136,16 @@ button, .btn {
     to { opacity: 1; transform: scale(1); }
 }
 
+/* Player color dot — used in lobby cards and leaderboard */
+.player-color-dot {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    box-shadow: 0 0 6px currentColor;
+}
+
 /* Player cards grid (Beatify pattern) */
 .player-cards-grid {
     display: grid;

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -97,6 +97,11 @@
                     pu.saveSession(msg.session_token, state.playerName);
                 }
                 if (msg.is_admin) state.isAdmin = true;
+                if (msg.color) {
+                    state.playerColor = msg.color;
+                    // Apply as CSS custom property on root for global use
+                    document.documentElement.style.setProperty('--my-player-color', msg.color);
+                }
                 // Request full state so we switch to the correct view immediately
                 send('get_state', {});
                 break;

--- a/custom_components/quizify/www/js/player-game.js
+++ b/custom_components/quizify/www/js/player-game.js
@@ -413,8 +413,13 @@
             deltaBadge = '<span class="rank-delta rank-delta--down">▼' + Math.abs(entry.rank_delta) + '</span>';
         }
 
-        return '<div class="leaderboard-entry' + currentClass + disconnectedClass + '" data-name="' + pu.escapeHtml(entry.name) + '">' +
+        var colorDot = entry.color
+            ? '<span class="player-color-dot" style="background:' + entry.color + '"></span>'
+            : '';
+        var colorBorder = entry.color ? ' style="border-left:3px solid ' + entry.color + '"' : '';
+        return '<div class="leaderboard-entry' + currentClass + disconnectedClass + '"' + colorBorder + ' data-name="' + pu.escapeHtml(entry.name) + '">' +
             '<span class="entry-rank' + rankClass + '">' + rank + '</span>' +
+            colorDot +
             '<span class="entry-name">' + pu.escapeHtml(entry.name) + youBadge + '</span>' +
             deltaBadge +
             '<span class="entry-score">' + entry.score + '</span>' +

--- a/custom_components/quizify/www/js/player-utils.js
+++ b/custom_components/quizify/www/js/player-utils.js
@@ -22,7 +22,8 @@
         currentPhase: 'LOBBY',
         reconnectAttempts: 0,
         isReconnecting: false,
-        intentionalLeave: false
+        intentionalLeave: false,
+        playerColor: '',  // assigned by server on join
     };
 
     // ============================================
@@ -226,12 +227,15 @@
                 var name = typeof p === 'string' ? p : (p.name || p);
                 var isYou = name === state.playerName;
                 var isDisconnected = p.connected === false;
+                var color = (p.color) || '';
                 var classes = 'player-card' +
                     (isYou ? ' player-card--you' : '') +
                     (isDisconnected ? ' player-card--disconnected' : '');
+                var colorStyle = color ? ' style="--player-color:' + color + ';border-left:4px solid ' + color + ';"' : '';
                 var awayBadge = isDisconnected ? '<span class="away-badge">(away)</span>' : '';
                 var youBadge = isYou ? '<span class="you-badge">(you)</span>' : '';
-                return '<div class="' + classes + '" data-player="' + escapeHtml(name) + '">' +
+                return '<div class="' + classes + '"' + colorStyle + ' data-player="' + escapeHtml(name) + '">' +
+                    '<span class="player-color-dot" style="background:' + (color || '#888') + '"></span>' +
                     '<span class="player-name">' + escapeHtml(name) + youBadge + awayBadge + '</span>' +
                     '</div>';
             })

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/quizify/static/css/styles.css?v=1.0.35">
+    <link rel="stylesheet" href="/quizify/static/css/styles.css?v=1.0.36">
     <link rel="icon" href="/quizify/static/img/icon-256.png" type="image/png">
     <link rel="manifest" href="/quizify/static/site.webmanifest">
     <!-- Confetti library for celebrations -->
@@ -595,16 +595,16 @@
     </div>
 
     <!-- Version badge -->
-    <div class="version-badge" id="version-badge">v1.0.35</div>
+    <div class="version-badge" id="version-badge">v1.0.36</div>
 
-    <script src="/quizify/static/js/vendor/qrcode.min.js?v=1.0.35"></script>
-    <script src="/quizify/static/js/i18n.js?v=1.0.35"></script>
-    <script src="/quizify/static/js/player-utils.js?v=1.0.35"></script>
-    <script src="/quizify/static/js/player-lobby.js?v=1.0.35"></script>
-    <script src="/quizify/static/js/player-game.js?v=1.0.35"></script>
-    <script src="/quizify/static/js/player-reveal.js?v=1.0.35"></script>
-    <script src="/quizify/static/js/player-end.js?v=1.0.35"></script>
-    <script src="/quizify/static/js/player-core.js?v=1.0.35"></script>
+    <script src="/quizify/static/js/vendor/qrcode.min.js?v=1.0.36"></script>
+    <script src="/quizify/static/js/i18n.js?v=1.0.36"></script>
+    <script src="/quizify/static/js/player-utils.js?v=1.0.36"></script>
+    <script src="/quizify/static/js/player-lobby.js?v=1.0.36"></script>
+    <script src="/quizify/static/js/player-game.js?v=1.0.36"></script>
+    <script src="/quizify/static/js/player-reveal.js?v=1.0.36"></script>
+    <script src="/quizify/static/js/player-end.js?v=1.0.36"></script>
+    <script src="/quizify/static/js/player-core.js?v=1.0.36"></script>
     <script>
         if ("serviceWorker" in navigator) {
             navigator.serviceWorker.register("/quizify/static/sw.js");

--- a/custom_components/quizify/www/sw.js
+++ b/custom_components/quizify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'quizify-v1.0.35';
+var CACHE_VERSION = 'quizify-v1.0.36';
 var MAX_CACHE_ITEMS = 60;
 
 // Critical assets to precache on install


### PR DESCRIPTION
Fixes #55\n\nEach player is assigned a unique color from a 20-color palette on join. The color appears as:\n- Colored left border + dot on lobby player cards\n- Colored dot + left border on leaderboard entries\n- `--my-player-color` CSS variable for the current player's own highlight\n\nColor is included in all server payloads: `joined`, `player_joined`, `game_state`, `leaderboard`, `round_summary`.