### PR TITLE
feat: question history tracking (#9)

### DIFF
--- a/custom_components/quizify/game/questions.py
+++ b/custom_components/quizify/game/questions.py
@@ -89,6 +89,11 @@ class QuestionBank:
         self._queue: list[Question] = []
         self._queue_index: int = 0
         self._loaded: bool = False
+        # Question history: maps question_id -> unix timestamp last shown (or 0 if never)
+        self._history: dict[str, float] = {}
+        self._history_path: Path | None = None
+        # Questions shown in the current game (to record at end)
+        self._shown_this_game: list[str] = []
 
     def load_category(self, category: str) -> list[Question]:
         """Load questions for a single category from its JSON file."""
@@ -201,6 +206,47 @@ class QuestionBank:
         # Should never happen with validated questions, but be safe.
         return question.answers[0]
 
+    # ------------------------------------------------------------------
+    # Question history
+    # ------------------------------------------------------------------
+
+    def load_history(self, history_path: Path) -> None:
+        """Load question history from a JSON file."""
+        self._history_path = history_path
+        if history_path.exists():
+            try:
+                raw = json.loads(history_path.read_text(encoding="utf-8"))
+                self._history = {k: float(v) for k, v in raw.items()}
+                _LOGGER.debug("Loaded question history: %d entries", len(self._history))
+            except (json.JSONDecodeError, ValueError) as exc:
+                _LOGGER.warning("Failed to load question history: %s", exc)
+                self._history = {}
+        else:
+            self._history = {}
+
+    def save_history(self) -> None:
+        """Persist question history to disk."""
+        if self._history_path is None:
+            return
+        try:
+            self._history_path.parent.mkdir(parents=True, exist_ok=True)
+            self._history_path.write_text(
+                json.dumps(self._history, indent=2), encoding="utf-8"
+            )
+        except OSError as exc:
+            _LOGGER.warning("Failed to save question history: %s", exc)
+
+    def record_shown(self, question_id: str) -> None:
+        """Mark a question as shown now."""
+        import time as _time
+        self._history[question_id] = _time.time()
+        self._shown_this_game.append(question_id)
+
+    def flush_shown_history(self) -> None:
+        """Save history at end of game and reset the shown-this-game list."""
+        self._shown_this_game = []
+        self.save_history()
+
     def _build_queue(
         self,
         category: str | None = None,
@@ -219,5 +265,15 @@ class QuestionBank:
         if language is not None:
             pool = [q for q in pool if q.language == language]
 
-        self._queue = self.shuffle_questions(pool)
+        # Sort by history: never-shown questions first, then oldest-shown first.
+        # Within each group, randomise to avoid predictable ordering.
+        if self._history:
+            import random as _random
+            never_shown = [q for q in pool if q.id not in self._history]
+            previously_shown = [q for q in pool if q.id in self._history]
+            _random.shuffle(never_shown)
+            previously_shown.sort(key=lambda q: self._history.get(q.id, 0))
+            self._queue = never_shown + previously_shown
+        else:
+            self._queue = self.shuffle_questions(pool)
         self._queue_index = 0

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -98,6 +98,12 @@ class QuizifyGameState:
         self._question_bank = QuestionBank()
         self._powerup_manager = PowerUpManager()
 
+        # Load question history if HA context available
+        if hass is not None:
+            from pathlib import Path as _Path
+            history_path = _Path(hass.config.path("quizify", "question_history.json"))
+            self._question_bank.load_history(history_path)
+
         # Current round state
         self._current_question: Question | None = None
         self._timers: dict[str, QuestionTimer] = {}  # player_id → timer
@@ -242,6 +248,9 @@ class QuizifyGameState:
 
         self.round += 1
         self._current_question = question
+
+        # Record this question as shown for history tracking
+        self._question_bank.record_shown(question.id)
 
         # Determine time limit from difficulty
         try:
@@ -471,6 +480,9 @@ class QuizifyGameState:
 
         # Record to analytics
         self._record_analytics()
+
+        # Save question history so next game prioritises least-recently-shown
+        self._question_bank.flush_shown_history()
 
         _LOGGER.info("Game ended after %d rounds", self.round)
         self._fire_broadcast("game_ended")

--- a/custom_components/quizify/manifest.json
+++ b/custom_components/quizify/manifest.json
@@ -12,5 +12,5 @@
   "description": "Multiplayer useless knowledge quiz game for Home Assistant",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/quizify/issues",
-  "version": "1.0.36"
+  "version": "1.0.37"
 }

--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -16,7 +16,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/quizify/static/css/styles.css?v=1.0.36">
+    <link rel="stylesheet" href="/quizify/static/css/styles.css?v=1.0.37">
 </head>
 <body class="theme-dark">
     <header class="admin-header">
@@ -310,13 +310,13 @@
     <div id="error-toast" class="toast hidden" role="alert" aria-live="assertive"></div>
 
     <!-- Version badge -->
-    <div class="version-badge" id="version-badge">v1.0.36</div>
+    <div class="version-badge" id="version-badge">v1.0.37</div>
 
-    <script src="/quizify/static/js/vendor/qrcode.min.js?v=1.0.36"></script>
-    <script src="/quizify/static/js/i18n.js?v=1.0.36"></script>
-    <script src="/quizify/static/js/utils.js?v=1.0.36"></script>
+    <script src="/quizify/static/js/vendor/qrcode.min.js?v=1.0.37"></script>
+    <script src="/quizify/static/js/i18n.js?v=1.0.37"></script>
+    <script src="/quizify/static/js/utils.js?v=1.0.37"></script>
 
-    <script src="/quizify/static/js/admin.js?v=1.0.36"></script>
+    <script src="/quizify/static/js/admin.js?v=1.0.37"></script>
     <script>
         if ("serviceWorker" in navigator) {
             navigator.serviceWorker.register("/quizify/static/sw.js");

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/quizify/static/css/styles.css?v=1.0.36">
+    <link rel="stylesheet" href="/quizify/static/css/styles.css?v=1.0.37">
     <link rel="icon" href="/quizify/static/img/icon-256.png" type="image/png">
     <link rel="manifest" href="/quizify/static/site.webmanifest">
     <!-- Confetti library for celebrations -->
@@ -595,16 +595,16 @@
     </div>
 
     <!-- Version badge -->
-    <div class="version-badge" id="version-badge">v1.0.36</div>
+    <div class="version-badge" id="version-badge">v1.0.37</div>
 
-    <script src="/quizify/static/js/vendor/qrcode.min.js?v=1.0.36"></script>
-    <script src="/quizify/static/js/i18n.js?v=1.0.36"></script>
-    <script src="/quizify/static/js/player-utils.js?v=1.0.36"></script>
-    <script src="/quizify/static/js/player-lobby.js?v=1.0.36"></script>
-    <script src="/quizify/static/js/player-game.js?v=1.0.36"></script>
-    <script src="/quizify/static/js/player-reveal.js?v=1.0.36"></script>
-    <script src="/quizify/static/js/player-end.js?v=1.0.36"></script>
-    <script src="/quizify/static/js/player-core.js?v=1.0.36"></script>
+    <script src="/quizify/static/js/vendor/qrcode.min.js?v=1.0.37"></script>
+    <script src="/quizify/static/js/i18n.js?v=1.0.37"></script>
+    <script src="/quizify/static/js/player-utils.js?v=1.0.37"></script>
+    <script src="/quizify/static/js/player-lobby.js?v=1.0.37"></script>
+    <script src="/quizify/static/js/player-game.js?v=1.0.37"></script>
+    <script src="/quizify/static/js/player-reveal.js?v=1.0.37"></script>
+    <script src="/quizify/static/js/player-end.js?v=1.0.37"></script>
+    <script src="/quizify/static/js/player-core.js?v=1.0.37"></script>
     <script>
         if ("serviceWorker" in navigator) {
             navigator.serviceWorker.register("/quizify/static/sw.js");

--- a/custom_components/quizify/www/sw.js
+++ b/custom_components/quizify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'quizify-v1.0.36';
+var CACHE_VERSION = 'quizify-v1.0.37';
 var MAX_CACHE_ITEMS = 60;
 
 // Critical assets to precache on install


### PR DESCRIPTION
Fixes #9\n\nPrioritises least-recently-shown questions across games:\n- Saves `config/quizify/question_history.json` with last-shown timestamp per question ID\n- Never-shown questions appear first (randomised within group)\n- Previously-shown questions sorted oldest-first\n- History recorded per question when the round starts, flushed to disk at end of game