### PR TITLE
feat: answer distribution bars on reveal (#32)

### DIFF
--- a/custom_components/quizify/manifest.json
+++ b/custom_components/quizify/manifest.json
@@ -12,5 +12,5 @@
   "description": "Multiplayer useless knowledge quiz game for Home Assistant",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/quizify/issues",
-  "version": "1.0.37"
+  "version": "1.0.38"
 }

--- a/custom_components/quizify/server/serializers.py
+++ b/custom_components/quizify/server/serializers.py
@@ -157,8 +157,12 @@ def serialize_round_summary(
     total_rounds: int,
     all_answers: list[dict[str, Any]] | None = None,
     question_text: str = "",
+    num_answer_options: int = 3,
 ) -> dict[str, Any]:
     """Build round summary broadcast payload."""
+    # Compute answer distribution from all_answers
+    answer_distribution = _compute_answer_distribution(all_answers or [], num_answer_options)
+
     return {
         "type": "round_summary",
         "correct_answer_index": correct_answer_index,
@@ -168,5 +172,44 @@ def serialize_round_summary(
         "round": round_num,
         "total_rounds": total_rounds,
         "all_answers": all_answers or [],
+        "answer_distribution": answer_distribution,
         "question_text": question_text,
     }
+
+
+def _compute_answer_distribution(
+    all_answers: list[dict[str, Any]], num_options: int
+) -> list[dict[str, Any]]:
+    """Compute per-option vote counts and percentages.
+
+    Returns a list of dicts: [{"index": 0, "count": 3, "percent": 60}, ...]
+    Includes a separate entry for no_answer (timeout) players.
+    """
+    counts = [0] * num_options
+    no_answer_count = 0
+    total = len(all_answers)
+
+    for entry in all_answers:
+        idx = entry.get("answer_index")
+        if entry.get("no_answer") or idx is None:
+            no_answer_count += 1
+        elif isinstance(idx, int) and 0 <= idx < num_options:
+            counts[idx] += 1
+
+    distribution = []
+    for i, count in enumerate(counts):
+        distribution.append({
+            "index": i,
+            "count": count,
+            "percent": round(count / total * 100) if total > 0 else 0,
+        })
+
+    if no_answer_count > 0:
+        distribution.append({
+            "index": None,
+            "count": no_answer_count,
+            "percent": round(no_answer_count / total * 100) if total > 0 else 0,
+            "no_answer": True,
+        })
+
+    return distribution

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -661,6 +661,7 @@ class QuizifyWebSocketHandler:
             total_rounds=game_state.total_rounds,
             all_answers=all_answers,
             question_text=summary.question.question,
+            num_answer_options=len(game_state.shuffled_answers),
         )
         await self._conn.broadcast(summary_msg)
 

--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -16,7 +16,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/quizify/static/css/styles.css?v=1.0.37">
+    <link rel="stylesheet" href="/quizify/static/css/styles.css?v=1.0.38">
 </head>
 <body class="theme-dark">
     <header class="admin-header">
@@ -310,13 +310,13 @@
     <div id="error-toast" class="toast hidden" role="alert" aria-live="assertive"></div>
 
     <!-- Version badge -->
-    <div class="version-badge" id="version-badge">v1.0.37</div>
+    <div class="version-badge" id="version-badge">v1.0.38</div>
 
-    <script src="/quizify/static/js/vendor/qrcode.min.js?v=1.0.37"></script>
-    <script src="/quizify/static/js/i18n.js?v=1.0.37"></script>
-    <script src="/quizify/static/js/utils.js?v=1.0.37"></script>
+    <script src="/quizify/static/js/vendor/qrcode.min.js?v=1.0.38"></script>
+    <script src="/quizify/static/js/i18n.js?v=1.0.38"></script>
+    <script src="/quizify/static/js/utils.js?v=1.0.38"></script>
 
-    <script src="/quizify/static/js/admin.js?v=1.0.37"></script>
+    <script src="/quizify/static/js/admin.js?v=1.0.38"></script>
     <script>
         if ("serviceWorker" in navigator) {
             navigator.serviceWorker.register("/quizify/static/sw.js");

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -2613,6 +2613,75 @@ footer {
 }
 
 /* Fun fact section */
+/* Answer distribution bars */
+.answer-distribution-section {
+    background: var(--color-surface-dark);
+    border: 1px solid var(--color-border-neon);
+    border-radius: var(--radius-lg);
+    padding: var(--space-md);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+}
+
+.answer-bar {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.answer-bar__header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    font-size: 0.85rem;
+}
+
+.answer-bar__label {
+    font-weight: 700;
+    color: var(--color-text-muted);
+    min-width: 18px;
+}
+
+.answer-bar__text {
+    flex: 1;
+    color: var(--color-text-white);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.answer-bar__pct {
+    font-weight: 700;
+    color: var(--color-text-muted);
+    min-width: 36px;
+    text-align: right;
+}
+
+.answer-bar--correct .answer-bar__label,
+.answer-bar--correct .answer-bar__pct {
+    color: var(--color-success-neon);
+}
+
+.answer-bar__track {
+    height: 8px;
+    background: rgba(255,255,255,0.08);
+    border-radius: var(--radius-full);
+    overflow: hidden;
+}
+
+.answer-bar__fill {
+    height: 100%;
+    background: var(--color-text-muted);
+    border-radius: var(--radius-full);
+    transition: width 0.6s ease;
+}
+
+.answer-bar--correct .answer-bar__fill {
+    background: var(--color-success-neon);
+    box-shadow: 0 0 8px var(--color-success-neon);
+}
+
 .fun-fact-section {
     background: var(--color-surface-dark);
     border: 1px solid var(--color-border-neon);

--- a/custom_components/quizify/www/js/player-reveal.js
+++ b/custom_components/quizify/www/js/player-reveal.js
@@ -71,6 +71,9 @@
         // Personal result — prefer all_answers entry (has breakdown), fall back to leaderboard player
         renderPersonalResult(myAnswerEntry || currentPlayer);
 
+        // Answer distribution bars
+        renderAnswerDistribution(data.answer_distribution, data.correct_answer_index, allAnswers);
+
         // All answers grid — use all_answers if available, fall back to players
         renderAllAnswers(allAnswers.length > 0 ? allAnswers : players);
 
@@ -110,6 +113,48 @@
      * Render fun fact slide-in card
      * @param {string|null} text - Fun fact text
      */
+    function renderAnswerDistribution(distribution, correctIndex, allAnswers) {
+        var container = document.getElementById('answer-distribution');
+        if (!container) return;
+        if (!distribution || distribution.length === 0) {
+            container.classList.add('hidden');
+            return;
+        }
+
+        // Build answer text map from allAnswers
+        var answerTexts = {};
+        if (allAnswers && allAnswers.length > 0) {
+            allAnswers.forEach(function(a) {
+                if (a.answer_index !== null && a.answer_index !== undefined && a.answer_text) {
+                    answerTexts[a.answer_index] = a.answer_text;
+                }
+            });
+        }
+
+        var optionLabels = ['A', 'B', 'C', 'D'];
+
+        container.innerHTML = distribution
+            .filter(function(d) { return !d.no_answer; })
+            .map(function(d) {
+                var isCorrect = d.index === correctIndex;
+                var label = optionLabels[d.index] || String(d.index + 1);
+                var text = answerTexts[d.index] || '';
+                var barClass = isCorrect ? 'answer-bar answer-bar--correct' : 'answer-bar';
+                var pct = d.percent || 0;
+                return '<div class="' + barClass + '">' +
+                    '<div class="answer-bar__header">' +
+                        '<span class="answer-bar__label">' + label + '</span>' +
+                        (text ? '<span class="answer-bar__text">' + pu.escapeHtml(text) + '</span>' : '') +
+                        '<span class="answer-bar__pct">' + pct + '%</span>' +
+                    '</div>' +
+                    '<div class="answer-bar__track">' +
+                        '<div class="answer-bar__fill" style="width:' + pct + '%"></div>' +
+                    '</div>' +
+                '</div>';
+            }).join('');
+        container.classList.remove('hidden');
+    }
+
     function renderFunFact(text) {
         var container = document.getElementById('fun-fact-container');
         var funFactEl = document.getElementById('fun-fact');

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -7,7 +7,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@700;900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/quizify/static/css/styles.css?v=1.0.37">
+    <link rel="stylesheet" href="/quizify/static/css/styles.css?v=1.0.38">
     <link rel="icon" href="/quizify/static/img/icon-256.png" type="image/png">
     <link rel="manifest" href="/quizify/static/site.webmanifest">
     <!-- Confetti library for celebrations -->
@@ -300,6 +300,9 @@
                 <canvas id="confetti-canvas" class="confetti-canvas"></canvas>
 
                 <!-- Fun Fact Card Section -->
+                <!-- Answer Distribution -->
+                <section id="answer-distribution" class="card-section answer-distribution-section hidden"></section>
+
                 <section id="fun-fact-container" class="card-section fun-fact-section hidden">
                     <h2 class="section-header">
                         <span class="section-icon" aria-hidden="true">💡</span>
@@ -595,16 +598,16 @@
     </div>
 
     <!-- Version badge -->
-    <div class="version-badge" id="version-badge">v1.0.37</div>
+    <div class="version-badge" id="version-badge">v1.0.38</div>
 
-    <script src="/quizify/static/js/vendor/qrcode.min.js?v=1.0.37"></script>
-    <script src="/quizify/static/js/i18n.js?v=1.0.37"></script>
-    <script src="/quizify/static/js/player-utils.js?v=1.0.37"></script>
-    <script src="/quizify/static/js/player-lobby.js?v=1.0.37"></script>
-    <script src="/quizify/static/js/player-game.js?v=1.0.37"></script>
-    <script src="/quizify/static/js/player-reveal.js?v=1.0.37"></script>
-    <script src="/quizify/static/js/player-end.js?v=1.0.37"></script>
-    <script src="/quizify/static/js/player-core.js?v=1.0.37"></script>
+    <script src="/quizify/static/js/vendor/qrcode.min.js?v=1.0.38"></script>
+    <script src="/quizify/static/js/i18n.js?v=1.0.38"></script>
+    <script src="/quizify/static/js/player-utils.js?v=1.0.38"></script>
+    <script src="/quizify/static/js/player-lobby.js?v=1.0.38"></script>
+    <script src="/quizify/static/js/player-game.js?v=1.0.38"></script>
+    <script src="/quizify/static/js/player-reveal.js?v=1.0.38"></script>
+    <script src="/quizify/static/js/player-end.js?v=1.0.38"></script>
+    <script src="/quizify/static/js/player-core.js?v=1.0.38"></script>
     <script>
         if ("serviceWorker" in navigator) {
             navigator.serviceWorker.register("/quizify/static/sw.js");

--- a/custom_components/quizify/www/sw.js
+++ b/custom_components/quizify/www/sw.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-var CACHE_VERSION = 'quizify-v1.0.37';
+var CACHE_VERSION = 'quizify-v1.0.38';
 var MAX_CACHE_ITEMS = 60;
 
 // Critical assets to precache on install


### PR DESCRIPTION
Fixes #32\n\nAfter each round, the reveal screen shows a bar chart with the % of players who chose each answer option. The correct answer bar is highlighted in green. Distribution computed server-side from all_answers data.