### PR TITLE
fix: admin can start game after joining as player

### DIFF
--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -162,6 +162,10 @@ class QuizifyGameState:
         """Get player by WebSocket."""
         return self._player_registry.get_player_by_ws(ws)
 
+    def set_admin(self, name: str) -> bool:
+        """Mark a player as admin."""
+        return self._player_registry.set_admin(name)
+
     def get_players(self) -> list[PlayerSession]:
         """Return list of all player sessions."""
         return list(self._player_registry.players.values())

--- a/custom_components/quizify/server/serializers.py
+++ b/custom_components/quizify/server/serializers.py
@@ -120,6 +120,7 @@ def serialize_player_list(players: list[PlayerSession]) -> list[dict[str, Any]]:
             "streak": p.streak,
             "connected": p.connected,
             "color": p.color,
+            "is_admin": p.is_admin,
         }
         for p in players
     ]

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -126,7 +126,7 @@ class QuizifyWebSocketHandler:
             await self._handle_admin_connect(ws, game_state)
 
         elif msg_type == "join":
-            await self._handle_join(ws, data, game_state)
+            await self._handle_join(ws, data, game_state, is_admin)
 
         elif msg_type == "submit_answer":
             await self._handle_submit_answer(ws, data, game_state)
@@ -135,7 +135,7 @@ class QuizifyWebSocketHandler:
             await self._handle_use_powerup(ws, data, game_state)
 
         elif msg_type == "start_game":
-            if not is_admin:
+            if not self._is_authorized_admin(ws, is_admin, game_state):
                 await self._conn.send_error(ws, ERR_INVALID_ACTION, "Admin only")
                 return
             await self._handle_start_game(ws, data, game_state)
@@ -202,7 +202,11 @@ class QuizifyWebSocketHandler:
     # ------------------------------------------------------------------
 
     async def _handle_join(
-        self, ws: web.WebSocketResponse, data: dict, game_state: QuizifyGameState
+        self,
+        ws: web.WebSocketResponse,
+        data: dict,
+        game_state: QuizifyGameState,
+        is_admin: bool = False,
     ) -> None:
         """Handle player join."""
         name = data.get("name", "").strip()
@@ -221,6 +225,11 @@ class QuizifyWebSocketHandler:
         success, error_code = game_state.add_player(name, ws)
 
         if success:
+            # If this connection is authenticated as admin (role=admin), mark
+            # the joining player as admin so admin controls render in their UI
+            # and admin-gated commands are accepted.
+            if is_admin and data.get("is_admin"):
+                game_state.set_admin(name)
             # Cancel pending removal on reconnect
             self._conn.cancel_pending_removal(name)
 
@@ -236,6 +245,7 @@ class QuizifyWebSocketHandler:
                 "powerup": powerup.value if powerup else None,
                 "session_token": session_token,
                 "color": player_obj.color if player_obj else "",
+                "is_admin": player_obj.is_admin if player_obj else False,
             })
 
             # Send current state to the joining player

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -100,6 +100,8 @@
         var url = new URL('/quizify/player', location.href);
         url.searchParams.set('name', name);
         url.searchParams.set('admin', 'true');
+        var adminToken = sessionStorage.getItem('quizify_admin_session_token');
+        if (adminToken) url.searchParams.set('admin_token', adminToken);
         window.location.href = url.toString();
     }
 
@@ -568,12 +570,16 @@
                 ? selectedCategories
                 : selectedCategory;
 
-        send('start_game', {
+        // Persist game config so the player lobby can send it with start_game.
+        // We defer the actual start until the admin is connected as a player —
+        // sending start_game here races with page navigation and the frame is
+        // often dropped, leaving the game stuck in LOBBY.
+        sessionStorage.setItem('quizify_game_config', JSON.stringify({
             category: categoryPayload,
             difficulty: selectedDifficulty === 'mixed' ? null : selectedDifficulty,
             num_rounds: selectedRounds,
             language: selectedLanguage,
-        });
+        }));
 
         closeAdminJoinModal();
         redirectToPlayer(name);

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -46,6 +46,12 @@
     var _wsOpenTimeout = null;
 
     function connect() {
+        var wsQuery = {};
+        var adminToken = sessionStorage.getItem('quizify_admin_session_token');
+        if (state.isAdmin && adminToken) {
+            wsQuery.role = 'admin';
+            wsQuery.token = adminToken;
+        }
         state.ws = pu.createWebSocket('/api/quizify/ws', {
             onOpen: function () {
                 // Clear the connection timeout
@@ -75,7 +81,7 @@
             onClose: function () {
                 state.ws = null;
             }
-        });
+        }, wsQuery);
     }
 
     // ============================================
@@ -560,6 +566,13 @@
         // Check if admin via URL param
         if (urlParams.get('admin') === 'true') {
             state.isAdmin = true;
+        }
+
+        // Persist admin token from URL so the WS connection can authenticate as admin.
+        // This is set by admin.js#redirectToPlayer when the admin joins as a player.
+        var urlAdminToken = urlParams.get('admin_token');
+        if (urlAdminToken) {
+            sessionStorage.setItem('quizify_admin_session_token', urlAdminToken);
         }
 
         // i18n init

--- a/custom_components/quizify/www/js/player-lobby.js
+++ b/custom_components/quizify/www/js/player-lobby.js
@@ -328,7 +328,15 @@
                 startBtn.disabled = true;
                 startBtn.innerHTML = '<span class="btn-icon" aria-hidden="true">🎉</span><span>Starting...</span>';
 
-                sendFn('start_game', {});
+                // Load game config saved by admin.js when the admin joined as a player
+                var payload = {};
+                try {
+                    var saved = sessionStorage.getItem('quizify_game_config');
+                    if (saved) payload = JSON.parse(saved) || {};
+                } catch (e) { /* ignore */ }
+
+                sendFn('start_game', payload);
+                sessionStorage.removeItem('quizify_game_config');
             });
         }
     }

--- a/custom_components/quizify/www/js/player-utils.js
+++ b/custom_components/quizify/www/js/player-utils.js
@@ -94,9 +94,18 @@
     // WebSocket Factory
     // ============================================
 
-    function createWebSocket(path, handlers) {
+    function createWebSocket(path, handlers, query) {
         var proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
         var url = proto + '//' + location.host + path;
+        if (query && typeof query === 'object') {
+            var parts = [];
+            for (var k in query) {
+                if (Object.prototype.hasOwnProperty.call(query, k) && query[k] != null) {
+                    parts.push(encodeURIComponent(k) + '=' + encodeURIComponent(query[k]));
+                }
+            }
+            if (parts.length) url += '?' + parts.join('&');
+        }
 
         var ws = new WebSocket(url);
 


### PR DESCRIPTION
The "Join as Player" / "Start Gameplay" admin flow sent start_game on the
admin WebSocket and immediately navigated to player.html. The frame was
frequently dropped during page unload, so the game stayed in LOBBY. Once on
player.html, the admin had no way to start: the player WebSocket connected
without role=admin, the server ignored the is_admin flag in the join
message, and the player list didn't expose is_admin, so the admin start
button stayed hidden and start_game would have been rejected anyway.

- admin.js: persist game config to sessionStorage and pass the admin
  session token through the redirect URL instead of sending start_game
  before navigation.
- player-core.js / player-utils.js: forward role=admin and the admin
  token on the player WebSocket so the connection is authenticated.
- player-lobby.js: send start_game with the persisted config when the
  admin clicks Start in the player lobby.
- server/websocket.py: when an authenticated admin connection joins as a
  player, mark the player as admin; allow start_game for connections that
  pass _is_authorized_admin; expose is_admin in the joined response.
- serializers.py: include is_admin in the broadcast player list so the
  admin start button renders for the right player.