### PR TITLE
fix(admin): default UI language to browser locale, not German (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to Quizify are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [1.0.1] — 2026-06-08
+
+### Fixed
+
+- **Admin UI no longer forces German for English speakers.** The setup screen
+  defaulted its interface language to German on first visit, so the brief flash
+  of English at load switched to German and stayed there with no obvious way
+  back ([#152](https://github.com/mholzi/quizify/issues/152)). First-visit UI
+  language now follows the browser locale (German browsers still get German),
+  with the English-chip toggle and stored preference unchanged.
+
 ## [1.0.0] — 2026-06-07
 
 The first official release of Quizify — a multiplayer trivia party game that

--- a/custom_components/quizify/manifest.json
+++ b/custom_components/quizify/manifest.json
@@ -12,5 +12,5 @@
   "description": "Multiplayer trivia quiz game for Home Assistant. Players join via QR code; the TV is the host screen.",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/quizify/issues",
-  "version": "1.0.0"
+  "version": "1.0.1"
 }

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -23,7 +23,12 @@
     let selectedCategories = [];
     let selectedDifficulty = 'medium';
     let selectedRounds = 10;
-    let selectedLanguage = 'de';
+    // First-visit default follows the browser locale so English-speaking
+    // users don't get a German UI they can't read (#152). German browsers
+    // still resolve to 'de'. A stored preference (below) always wins.
+    let selectedLanguage = (window.QuizifyI18n && QuizifyI18n.detectBrowserLanguage)
+        ? QuizifyI18n.detectBrowserLanguage()
+        : 'en';
     // Restore the last-used language across full-page reloads. The player
     // tab's "Neues Spiel starten" button navigates to /quizify/admin, which
     // reloads this script — without persistence an English game silently


### PR DESCRIPTION
## Summary

Fixes [#152](https://github.com/mholzi/quizify/issues/152) — *"I cannot switch the interface from German to English"* (reproduced by two reporters).

The admin setup screen hardcoded `selectedLanguage = 'de'` and passed it straight to `QuizifyI18n.init()`, which bypassed the existing `detectBrowserLanguage()` helper. Result: English-speaking users saw a flash of English on load, then the UI switched to German and stayed there with no obvious way back.

## What changed

- `admin.js` — first-visit UI language now defaults to `QuizifyI18n.detectBrowserLanguage()` instead of a hardcoded `'de'`. A stored `localStorage` preference still wins, and the 🇩🇪/🇬🇧 chip toggle is unchanged.
- `manifest.json` — `1.0.0` → `1.0.1`. The version drives the `?v=` asset cache-buster, so bumping it is what makes the JS fix actually reach already-cached clients.
- `CHANGELOG.md` — 1.0.1 entry.

## Behavior

- English-browser user, first visit → admin loads in English (no flash-then-switch).
- German-browser user → still resolves to `'de'`, unchanged.
- Returning user with a saved preference → preference wins, unchanged.

## Testing

- `python3 -m pytest tests/ -q` → 138 passed.
- `node --check admin.js` → OK.
- Change is JS-only; no Python paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)