### PR TITLE
fix(admin): drive UI language from Home Assistant, drop localStorage (#152)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ All notable changes to Quizify are documented here. This project follows
 
 ### Fixed
 
-- **Admin UI no longer forces German for English speakers.** The setup screen
-  defaulted its interface language to German on first visit, so the brief flash
-  of English at load switched to German and stayed there with no obvious way
-  back ([#152](https://github.com/mholzi/quizify/issues/152)). First-visit UI
-  language now follows the browser locale (German browsers still get German),
-  with the English-chip toggle and stored preference unchanged.
+- **Admin UI now follows your Home Assistant language.** The setup screen
+  defaulted to German on first visit, so English speakers saw a flash of
+  English that switched to German and stayed there with no obvious way back
+  ([#152](https://github.com/mholzi/quizify/issues/152)). The admin interface
+  now uses Home Assistant's configured language (Settings → General). Any
+  non-German language (French, Spanish, …) falls back to English, since the UI
+  ships in German and English only. The 🇩🇪/🇬🇧 toggle still switches the UI for
+  the current session.
 
 ## [1.0.0] — 2026-06-07
 

--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -86,6 +86,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         analytics=analytics,
         ws_handler=ws_handler,
         question_stats=question_stats,
+        # HA's configured language drives the admin UI's initial language
+        # (Settings → General). hass.config.language is always set on HA.
+        ha_language=hass.config.language,
     )
 
     # Stash on hass.data so existing tooling (services.yaml, lookups in

--- a/custom_components/quizify/server/context.py
+++ b/custom_components/quizify/server/context.py
@@ -68,3 +68,8 @@ class AppContext:
     # endpoint. Default-factory keeps existing AppContext(...) call sites
     # working without passing version explicitly.
     version: str = field(default_factory=read_manifest_version)
+    # Home Assistant's configured language (``hass.config.language``), set
+    # only on the HA path. ``None`` on the standalone dev server, which has
+    # no hass. The admin page uses this as the first source for its initial
+    # UI language (substituted into the ``{{HA_LANG}}`` token).
+    ha_language: str | None = None

--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -46,6 +46,12 @@ _MANIFEST_PATH = Path(__file__).parent.parent / "manifest.json"
 # everywhere — no more drift between admin.html / player.html / sw.js.
 _VERSION_TOKEN = "{{VERSION}}"
 
+# Substituted in served HTML with Home Assistant's configured language
+# (``ctx.ha_language``). Empty string on the standalone dev server, where
+# there's no hass — admin.js then falls back to browser locale. Replacing
+# it unconditionally means the raw token never leaks into the page.
+_HA_LANG_TOKEN = "{{HA_LANG}}"
+
 # mtime-keyed cache for the live manifest version. Without this the
 # integration would re-parse manifest.json on every request; with it we
 # only re-read when the file actually changed (which means a deploy
@@ -102,6 +108,7 @@ async def _serve_html(request: web.Request, filename: str) -> web.Response:
     ctx = _get_ctx(request)
     html_content = await ctx.runtime.run_in_executor(html_path.read_text, "utf-8")
     html_content = _apply_version(html_content, _get_live_version(ctx.version))
+    html_content = html_content.replace(_HA_LANG_TOKEN, ctx.ha_language or "")
     return web.Response(
         text=html_content, content_type="text/html", headers=_NO_CACHE_HEADERS
     )

--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="quizify-version" content="{{VERSION}}">
+    <!-- Home Assistant's configured language (Settings → General). Server
+         substitutes the 2-letter code; empty on the standalone dev server.
+         admin.js reads this to pick the initial UI language. -->
+    <meta name="quizify-ha-lang" content="{{HA_LANG}}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title data-i18n="page.titleAdmin">Quizify — Admin</title>
     <link rel="manifest" href="/quizify/static/site.webmanifest">

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -23,20 +23,28 @@
     let selectedCategories = [];
     let selectedDifficulty = 'medium';
     let selectedRounds = 10;
-    // First-visit default follows the browser locale so English-speaking
-    // users don't get a German UI they can't read (#152). German browsers
-    // still resolve to 'de'. A stored preference (below) always wins.
-    let selectedLanguage = (window.QuizifyI18n && QuizifyI18n.detectBrowserLanguage)
-        ? QuizifyI18n.detectBrowserLanguage()
-        : 'en';
-    // Restore the last-used language across full-page reloads. The player
-    // tab's "Neues Spiel starten" button navigates to /quizify/admin, which
-    // reloads this script — without persistence an English game silently
-    // dropped back to German on the next setup screen (Markus 2026-05-31).
-    try {
-        var _storedLang = localStorage.getItem('quizify_admin_language');
-        if (_storedLang === 'de' || _storedLang === 'en') selectedLanguage = _storedLang;
-    } catch (e) { /* localStorage unavailable (private mode / webview) */ }
+    // Initial UI language, in priority order (#152):
+    //   1. Home Assistant's configured language (Settings → General),
+    //      injected server-side into the quizify-ha-lang meta tag.
+    //   2. Browser locale — the standalone dev server has no hass, so the
+    //      meta tag is empty there.
+    //   3. 'en' as a final fallback.
+    // HA is authoritative; there is no localStorage persistence. A full-page
+    // reload (e.g. player-end "Neues Spiel starten" → /quizify/admin) always
+    // resolves back to the HA language rather than a stale per-device choice.
+    let selectedLanguage = (function () {
+        function normalize(code) {
+            return String(code || '').toLowerCase().indexOf('de') === 0 ? 'de' : 'en';
+        }
+        var meta = document.querySelector('meta[name="quizify-ha-lang"]');
+        var haLang = meta ? meta.getAttribute('content') : '';
+        // Guard against an unsubstituted {{HA_LANG}} token leaking through.
+        if (haLang && haLang.indexOf('{') === -1) return normalize(haLang);
+        if (window.QuizifyI18n && QuizifyI18n.detectBrowserLanguage) {
+            return QuizifyI18n.detectBrowserLanguage();
+        }
+        return 'en';
+    })();
     let selectedTimer = 30;  // seconds per question (20 / 30 / 45)
 
     // Game state
@@ -543,10 +551,9 @@
         updateSettingsSummary();
     });
     setupChips(els.languageChips, function (v) {
+        // Session-only switch — not persisted. On the next full-page reload
+        // the UI resolves back to the Home Assistant language (#152).
         selectedLanguage = v;
-        // Persist so a full-page reload (player-end "Neues Spiel starten"
-        // → /quizify/admin) keeps the choice instead of resetting to German.
-        try { localStorage.setItem('quizify_admin_language', v); } catch (e) { /* ignore */ }
         // Show/hide category chips based on selected language
         if (els.categoryChips) {
             var chips = els.categoryChips.querySelectorAll('.chip[data-lang]');

--- a/tests/test_version_cachebuster.py
+++ b/tests/test_version_cachebuster.py
@@ -59,7 +59,7 @@ def _read_manifest_version_from_disk() -> str:
     return json.loads(manifest.read_text())["version"]
 
 
-def _fake_ctx(version: str) -> AppContext:
+def _fake_ctx(version: str, ha_language: str | None = None) -> AppContext:
     """Build a minimal AppContext for view-level tests."""
     runtime = MagicMock()
 
@@ -74,6 +74,7 @@ def _fake_ctx(version: str) -> AppContext:
         ws_handler=MagicMock(),
         question_stats=None,
         version=version,
+        ha_language=ha_language,
     )
 
 
@@ -116,10 +117,10 @@ class TestTemplateSubstitution:
 # ---------- Integration: real view fns + real HTML / sw.js on disk ----------
 
 
-def _fake_request(version: str) -> web.Request:
+def _fake_request(version: str, ha_language: str | None = None) -> web.Request:
     """Minimal request stub: views only read `request.app[APP_CTX_KEY]`."""
     req = MagicMock(spec=web.Request)
-    req.app = {APP_CTX_KEY: _fake_ctx(version)}
+    req.app = {APP_CTX_KEY: _fake_ctx(version, ha_language)}
     return req
 
 
@@ -138,10 +139,24 @@ class TestHtmlSubstitution:
         assert 'name="quizify-version" content="9.9.9-test"' in body
 
     async def test_admin_html_has_no_unresolved_tokens(self) -> None:
-        resp = await admin_view(_fake_request("9.9.9-test"))
+        resp = await admin_view(_fake_request("9.9.9-test", ha_language="en"))
         assert resp.status == 200
         assert "{{VERSION}}" not in resp.text
+        assert "{{HA_LANG}}" not in resp.text
         assert "?v=9.9.9-test" in resp.text
+
+    async def test_admin_html_injects_ha_language(self) -> None:
+        """HA's configured language lands in the meta tag admin.js reads to
+        pick the initial UI language (#152)."""
+        resp = await admin_view(_fake_request("9.9.9-test", ha_language="de"))
+        assert 'name="quizify-ha-lang" content="de"' in resp.text
+
+    async def test_admin_html_empty_ha_language_without_hass(self) -> None:
+        """Standalone dev server has no hass (ha_language is None): the token
+        resolves to an empty string, never leaks the literal {{HA_LANG}}."""
+        resp = await admin_view(_fake_request("9.9.9-test", ha_language=None))
+        assert "{{HA_LANG}}" not in resp.text
+        assert 'name="quizify-ha-lang" content=""' in resp.text
 
     async def test_html_served_with_no_cache_headers(self) -> None:
         """HTML must always revalidate — otherwise a months-old admin.html


### PR DESCRIPTION
## Summary

Folds into the **1.0.1** release (no version bump). Makes Home Assistant's configured language the source of truth for the admin UI, replacing the browser-locale-only default from the first pass at [#152](https://github.com/mholzi/quizify/issues/152), and removes `localStorage` persistence.

## Resolution order

1. **Home Assistant language** (`hass.config.language`, Settings → General) — injected server-side into a `quizify-ha-lang` meta tag.
2. **Browser locale** — standalone dev server has no `hass`, so the meta tag is empty there.
3. **`en`** — final fallback.

Non-German HA languages (French, Spanish, …) resolve to English, since the UI and packs ship in `de`/`en` only.

## No persistence

`localStorage` restore + write are removed. HA is authoritative, so a full-page reload (player-end "Neues Spiel starten" → `/quizify/admin`) resolves back to the HA language instead of a stale per-device choice. The 🇩🇪/🇬🇧 chip is now a session-only switch.

## Changes

- `__init__.py` — pass `hass.config.language` into `AppContext`.
- `context.py` — new `ha_language` field.
- `views.py` — substitute `{{HA_LANG}}` in served HTML (empty on dev server).
- `admin.html` — `<meta name="quizify-ha-lang">`.
- `admin.js` — HA-first resolution; removed restore block and `setItem`.
- `test_version_cachebuster.py` — +2 tests for `{{HA_LANG}}` substitution.
- `CHANGELOG.md` — rewrote the 1.0.1 entry to the final behavior.

## Testing

- `python3 -m pytest tests/ -q` → **140 passed** (+2 new).
- `node --check admin.js` → OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)