### PR TITLE
feat(admin): feature the World Cup pack on the first setup screen

### DIFF
--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -81,6 +81,25 @@
                 </h1>
                 <p class="setup-hero-summary" id="setup-summary"></p>
                 <p class="setup-hero-topics hidden" id="setup-topics"></p>
+                <!-- Featured pack spotlight — surfaces a pack on the first
+                     screen so the host can launch it in one tap, without
+                     opening "Adjust settings". The whole card is the tap
+                     target; the coral pill is a visual affordance. Pack +
+                     copy follow the active language (World Cup / WM). -->
+                <button type="button" id="hero-feature-card" class="hero-feature" data-feature="worldcup">
+                    <span class="hero-feature-icon" aria-hidden="true">🏆</span>
+                    <span class="hero-feature-body">
+                        <span class="hero-feature-top">
+                            <span class="hero-feature-tag" data-i18n="featured.tag">New</span>
+                            <span class="hero-feature-title" data-i18n="featured.worldCupTitle">World Cup</span>
+                        </span>
+                        <span class="hero-feature-desc" data-i18n="featured.worldCupDesc">100 surprising football facts</span>
+                        <span class="hero-feature-play">
+                            <span aria-hidden="true">▶︎</span>
+                            <span data-i18n="featured.worldCupPlay">Play World Cup</span>
+                        </span>
+                    </span>
+                </button>
                 <button type="button" id="start-game-btn" class="btn btn-primary btn-lg btn-block">
                     <span aria-hidden="true">▶︎</span>
                     <span data-i18n="admin.startGame">Start Game</span>

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -3792,6 +3792,68 @@ footer {
 }
 .setup-tweak-link:hover { color: var(--color-text-primary); }
 
+/* Featured pack spotlight on the hero — one-tap launch of a highlighted
+   pack. Soft Parlor card: lifted paper, hairline border, soft shadow, sun
+   "New" pill, coral play affordance. The whole card is the button. */
+.hero-feature {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+    width: 100%;
+    max-width: 360px;
+    text-align: left;
+    background: var(--color-bg-card);
+    border: 1px solid var(--color-border-light);
+    border-radius: var(--radius-xl);
+    padding: 14px 15px;
+    box-shadow: var(--shadow-lg);
+    cursor: pointer;
+    transition: transform 0.12s ease, box-shadow 0.12s ease;
+}
+.hero-feature:hover { transform: translateY(-2px); box-shadow: var(--shadow-xl); }
+.hero-feature:active { transform: translateY(0); }
+.hero-feature-icon { font-size: 2rem; line-height: 1; flex: none; }
+.hero-feature-body { display: flex; flex-direction: column; min-width: 0; }
+.hero-feature-top { display: flex; align-items: center; gap: 8px; }
+.hero-feature-tag {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    background: var(--color-warning);
+    color: #5C4A16;
+    padding: 3px 8px;
+    border-radius: var(--radius-full);
+}
+.hero-feature-title {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 1.1rem;
+    color: var(--color-text-heading);
+}
+.hero-feature-desc {
+    font-family: var(--font-body);
+    font-size: 0.82rem;
+    color: var(--color-text-muted);
+    margin-top: 2px;
+    line-height: 1.35;
+}
+.hero-feature-play {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    align-self: flex-start;
+    margin-top: 10px;
+    background: var(--color-accent-primary);
+    color: #fff;
+    font-family: var(--font-body);
+    font-weight: 700;
+    font-size: 0.82rem;
+    padding: 8px 12px;
+    border-radius: var(--radius-md);
+}
+
 /* Detail (preset stacks) */
 .setup-detail {
     padding: var(--space-md);

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -323,6 +323,12 @@
       "q5": "In welcher Sprache?"
     }
   },
+  "featured": {
+    "tag": "Neu",
+    "worldCupTitle": "Weltmeisterschaft",
+    "worldCupDesc": "Kuriose Fakten zur Fußball-WM",
+    "worldCupPlay": "WM-Quiz starten"
+  },
   "wager": {
     "title": "Letzte Runde — Wagerunde",
     "hint": "Setze einen Teil deiner Punkte. Richtig = gewinnen, falsch = verlieren.",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -323,6 +323,12 @@
       "q5": "Which language?"
     }
   },
+  "featured": {
+    "tag": "New",
+    "worldCupTitle": "World Cup",
+    "worldCupDesc": "100 surprising football facts",
+    "worldCupPlay": "Play World Cup"
+  },
   "wager": {
     "title": "Final Round — Wager",
     "hint": "Bet a chunk of your points. Right = double, wrong = lose.",

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -95,6 +95,7 @@
         lobbyPlayerChips: document.getElementById('lobby-player-chips'),
         lobbyPlayersEmpty: document.getElementById('lobby-players-empty'),
         startGameBtn: document.getElementById('start-game-btn'),
+        heroFeatureCard: document.getElementById('hero-feature-card'),
         startGameplayBtn: document.getElementById('start-gameplay-btn'),
         participateBtn: document.getElementById('participate-btn'),
         // In-game
@@ -1194,6 +1195,25 @@
 
     // Setup screen → Lobby screen (shows QR, waits for players)
     on(els.startGameBtn, 'click', function () {
+        showView('lobby');
+        initJoinUrl();
+    });
+
+    // Featured pack spotlight (hero) → one-tap launch of the World Cup pack
+    // in the admin's current language. Sets it as the active category, then
+    // follows the same path as Start Game (→ lobby / QR screen). The actual
+    // start_game payload is built later from selectedCategory/selectedLanguage.
+    on(els.heroFeatureCard, 'click', function () {
+        var pack = (selectedLanguage === 'de') ? 'weltmeisterschaft' : 'world-cup';
+        selectedCategory = pack;
+        selectedCategories = [pack];
+        // Sync chip active-state so a later "Adjust settings" visit reflects it.
+        if (els.categoryChips) {
+            els.categoryChips.querySelectorAll('.chip').forEach(function (c) {
+                c.classList.toggle('active', c.dataset.value === pack);
+            });
+        }
+        updateCategorySummary();
         showView('lobby');
         initJoinUrl();
     });


### PR DESCRIPTION
## Summary

Surfaces the new World Cup pack on the **first** admin screen so a host can launch it in one tap, without opening "Adjust settings". Direction chosen from a `/design-shotgun` pass (variant **A · Featured ribbon**, picked over quick-pick tiles and a hero takeover), implemented in the real Soft Parlor system.

## Behavior

- One tap on the card → launches a **World Cup** game in the host's current UI language (EN → `world-cup`, DE → `weltmeisterschaft`), straight to the QR/lobby screen.
- Card copy **and** the launched pack follow the active language (World Cup ↔ Weltmeisterschaft) via i18n.
- Existing hero, presets, and "Adjust settings" flow untouched — purely additive.

## Changes

- `admin.html` — featured card markup; the whole card is the tap target (no nested button).
- `styles.css` — `.hero-feature` card: lifted paper, hairline border, soft shadow, sun "New" pill, coral play affordance. All Soft Parlor tokens.
- `admin.js` — `Play World Cup` handler sets the WC pack by language, syncs the category chip, then follows the Start Game path.
- `en.json` / `de.json` — `featured.*` keys.

## Notes

Frontend only (no Python change). Cache-busted by the integration version, so it reaches already-cached clients with the next version bump. 140 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)