### PR TITLE
release: v1.2.0 (pre-release) — World Cup packs + hero feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to Quizify are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [1.2.0] — 2026-06-08
+
+> Pre-release for beta testing.
+
+### Added
+
+- **World Cup quiz packs (English + German).** A new Men's FIFA World Cup
+  category in the surprising-trivia style — `World Cup` (100 questions) and
+  `Weltmeisterschaft` (99). Generated and reviewed for factual accuracy;
+  selectable from the category list like any other pack.
+- **World Cup featured on the first admin screen.** A spotlight card on the
+  setup hero lets the host launch a World Cup game in one tap, without opening
+  “Adjust settings”. The card and the pack it starts follow the active
+  language (World Cup ↔ Weltmeisterschaft).
+
+### Fixed
+
+- **Category cards show the right question counts again.** After the +50-per-pack
+  update the setup-screen cards still read ~100; they now reflect the real
+  counts (150, or 148–149 where review removed an ambiguous question).
+
 ## [1.1.0] — 2026-06-08
 
 ### Added

--- a/custom_components/quizify/manifest.json
+++ b/custom_components/quizify/manifest.json
@@ -12,5 +12,5 @@
   "description": "Multiplayer trivia quiz game for Home Assistant. Players join via QR code; the TV is the host screen.",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/quizify/issues",
-  "version": "1.1.0"
+  "version": "1.2.0"
 }


### PR DESCRIPTION
Pre-release bump to **1.2.0** for beta testing. Bundles already-merged work since v1.1.0:

- World Cup packs (EN + DE, ~200 questions) — PR #156
- Category-card count fix (stale ~100 → real 150/148/149) — PR #156
- World Cup featured card on the first admin screen — PR #157

`manifest.json` 1.1.0 → 1.2.0; CHANGELOG entry added (marked pre-release). 140 tests pass.

After merge this is tagged `v1.2.0` and published as a **GitHub pre-release** (beta-opted HACS users only). Promote to GA later with `gh release edit v1.2.0 --prerelease=false --latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)