### PR TITLE
docs(changelog): drop pre-release note from 1.2.0 (now GA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to Quizify are documented here. This project follows
 
 ## [1.2.0] — 2026-06-08
 
-> Pre-release for beta testing.
-
 ### Added
 
 - **World Cup quiz packs (English + German).** A new Men's FIFA World Cup


### PR DESCRIPTION
v1.2.0 has been promoted from pre-release to GA (latest). Removes the now-inaccurate "Pre-release for beta testing" note from the CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)