### PR TITLE
release: v1.2.1 — fix stale-asset cache-buster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to Quizify are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [1.2.1] — 2026-06-08
+
+### Fixed
+
+- **Stale assets after updating.** While in beta, 1.2.0 was built twice under
+  the same version number, so the `?v=` cache-buster never changed and browsers
+  kept serving the old CSS/JS — the World Cup card showed English text on a
+  German setup and the new pack chips didn't render. 1.2.1 bumps the version so
+  clients fetch the current assets. No functional change beyond 1.2.0.
+
 ## [1.2.0] — 2026-06-08
 
 ### Added

--- a/custom_components/quizify/manifest.json
+++ b/custom_components/quizify/manifest.json
@@ -12,5 +12,5 @@
   "description": "Multiplayer trivia quiz game for Home Assistant. Players join via QR code; the TV is the host screen.",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/quizify/issues",
-  "version": "1.2.0"
+  "version": "1.2.1"
 }


### PR DESCRIPTION
1.2.0 was built twice under the same version while in beta (World Cup card, then the pack picker), so the `?v={{VERSION}}` cache-buster never changed and browsers kept serving old CSS/JS — the World Cup card rendered English on a German setup and the new pack chips didn't appear. Bumping to 1.2.1 forces a fresh fetch. No functional change beyond 1.2.0. 140 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)