### PR TITLE
fix(cache): derive cache-buster from asset fingerprint (#147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to Quizify are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [1.2.2] — 2026-06-08
+
+### Fixed
+
+- **Asset cache-buster no longer depends on bumping the version.** Static
+  assets are served immutable, so the `?v=` query string is the only way to
+  force a refetch — and it was keyed only to the manifest version. A reused or
+  forgotten version bump left `?v=` unchanged, so browsers kept serving old
+  CSS/JS/i18n (the World Cup card showed English on a German setup). The `?v=`
+  params and the service-worker cache key now derive from a fingerprint of the
+  asset files, so any CSS/JS/i18n change invalidates caches automatically. The
+  displayed version stays clean. Resolves the recurrence of #147.
+
 ## [1.2.1] — 2026-06-08
 
 ### Fixed

--- a/custom_components/quizify/manifest.json
+++ b/custom_components/quizify/manifest.json
@@ -12,5 +12,5 @@
   "description": "Multiplayer trivia quiz game for Home Assistant. Players join via QR code; the TV is the host screen.",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/quizify/issues",
-  "version": "1.2.1"
+  "version": "1.2.2"
 }

--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -11,8 +11,10 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import hashlib
 import json
 import os
+import time
 import aiohttp
 from aiohttp import web
 
@@ -51,6 +53,25 @@ _VERSION_TOKEN = "{{VERSION}}"
 # there's no hass — admin.js then falls back to browser locale. Replacing
 # it unconditionally means the raw token never leaks into the page.
 _HA_LANG_TOKEN = "{{HA_LANG}}"
+
+# Cache-buster token for the ``?v=`` asset query strings and the service
+# worker's ``CACHE_VERSION``. Distinct from {{VERSION}} (which stays the clean
+# semantic version for the meta tag) — this one is ``<version>-<fingerprint>``
+# where the fingerprint is a short hash of the served asset files. Because it
+# changes whenever ANY css/js/i18n file changes, cache-busting no longer
+# depends on remembering to bump manifest.json. That manual dependency was the
+# recurring failure (#147, and 1.2.0 being built twice under one version): a
+# reused version left ?v= unchanged, so HA's immutable static cache_headers
+# kept serving stale assets.
+_ASSET_VER_TOKEN = "{{ASSET_VER}}"
+
+# Subdirs under www/ that hold the ?v=-busted assets.
+_ASSET_SUBDIRS = ("css", "js", "i18n")
+
+# Recompute the fingerprint at most this often — a small dir walk, bounded so
+# a burst of player.html loads at game start doesn't re-walk per request.
+_ASSET_FP_TTL_NS = 5 * 1_000_000_000  # 5s
+_ASSET_FP_CACHE: tuple[int, str] | None = None  # (monotonic_ns, fingerprint)
 
 # mtime-keyed cache for the live manifest version. Without this the
 # integration would re-parse manifest.json on every request; with it we
@@ -93,6 +114,50 @@ def _get_live_version(fallback: str) -> str:
         return fallback
 
 
+def _compute_asset_fingerprint(www_dir: Path = _WWW_DIR) -> str:
+    """Short hash over the served assets' (relative path, mtime, size).
+
+    Changes whenever any css/js/i18n file is added, removed, or edited — so the
+    cache-buster moves on any real asset change, with no manifest bump needed.
+    Cheap: a handful of ``stat`` calls. Falls back to an empty-tree hash if the
+    dirs are missing (defensive — runs on the HTML serve path).
+    """
+    h = hashlib.md5(usedforsecurity=False)
+    for sub in _ASSET_SUBDIRS:
+        d = www_dir / sub
+        if not d.is_dir():
+            continue
+        for p in sorted(d.rglob("*")):
+            if not p.is_file():
+                continue
+            try:
+                st = p.stat()
+            except OSError:
+                continue
+            h.update(str(p.relative_to(www_dir)).encode())
+            h.update(str(st.st_mtime_ns).encode())
+            h.update(str(st.st_size).encode())
+    return h.hexdigest()[:8]
+
+
+def _get_asset_version(version: str) -> str:
+    """Cache-buster value ``<version>-<asset_fingerprint>``.
+
+    The version prefix keeps it readable (which release) and back-compatible
+    with assertions that look for ``?v=<version>``; the fingerprint suffix is
+    what makes it move on asset changes. Fingerprint recompute is throttled to
+    ``_ASSET_FP_TTL_NS``.
+    """
+    global _ASSET_FP_CACHE
+    now = time.monotonic_ns()
+    if _ASSET_FP_CACHE is not None and now - _ASSET_FP_CACHE[0] < _ASSET_FP_TTL_NS:
+        fingerprint = _ASSET_FP_CACHE[1]
+    else:
+        fingerprint = _compute_asset_fingerprint()
+        _ASSET_FP_CACHE = (now, fingerprint)
+    return f"{version}-{fingerprint}"
+
+
 def _apply_version(text: str, version: str) -> str:
     """Replace every {{VERSION}} token with the live integration version."""
     return text.replace(_VERSION_TOKEN, version)
@@ -106,8 +171,10 @@ async def _serve_html(request: web.Request, filename: str) -> web.Response:
         return web.Response(text=f"{filename} not found", status=500)
 
     ctx = _get_ctx(request)
+    version = _get_live_version(ctx.version)
     html_content = await ctx.runtime.run_in_executor(html_path.read_text, "utf-8")
-    html_content = _apply_version(html_content, _get_live_version(ctx.version))
+    html_content = _apply_version(html_content, version)
+    html_content = html_content.replace(_ASSET_VER_TOKEN, _get_asset_version(version))
     html_content = html_content.replace(_HA_LANG_TOKEN, ctx.ha_language or "")
     return web.Response(
         text=html_content, content_type="text/html", headers=_NO_CACHE_HEADERS
@@ -127,8 +194,10 @@ async def sw_view(request: web.Request) -> web.Response:
         return web.Response(text="sw.js not found", status=404)
 
     ctx = _get_ctx(request)
+    version = _get_live_version(ctx.version)
     body = await ctx.runtime.run_in_executor(sw_path.read_text, "utf-8")
-    body = _apply_version(body, _get_live_version(ctx.version))
+    body = _apply_version(body, version)
+    body = body.replace(_ASSET_VER_TOKEN, _get_asset_version(version))
     return web.Response(
         text=body, content_type="application/javascript", headers=_NO_CACHE_HEADERS
     )

--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -23,7 +23,7 @@
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
     <link rel="preconnect" href="https://api.fontshare.com" crossorigin>
     <link href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@500,700,800,900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/quizify/static/css/styles.css?v={{VERSION}}">
+    <link rel="stylesheet" href="/quizify/static/css/styles.css?v={{ASSET_VER}}">
 </head>
 <body>
     <header class="admin-header">
@@ -563,11 +563,11 @@
     <!-- Version badge -->
     <div class="version-badge" id="version-badge">v{{VERSION}}</div>
 
-    <script src="/quizify/static/js/vendor/qrcode.min.js?v={{VERSION}}"></script>
-    <script src="/quizify/static/js/i18n.js?v={{VERSION}}"></script>
-    <script src="/quizify/static/js/utils.js?v={{VERSION}}"></script>
+    <script src="/quizify/static/js/vendor/qrcode.min.js?v={{ASSET_VER}}"></script>
+    <script src="/quizify/static/js/i18n.js?v={{ASSET_VER}}"></script>
+    <script src="/quizify/static/js/utils.js?v={{ASSET_VER}}"></script>
 
-    <script src="/quizify/static/js/admin.js?v={{VERSION}}"></script>
-    <script src="/quizify/static/js/sw-update.js?v={{VERSION}}"></script>
+    <script src="/quizify/static/js/admin.js?v={{ASSET_VER}}"></script>
+    <script src="/quizify/static/js/sw-update.js?v={{ASSET_VER}}"></script>
 </body>
 </html>

--- a/custom_components/quizify/www/analytics.html
+++ b/custom_components/quizify/www/analytics.html
@@ -5,7 +5,7 @@
     <meta name="quizify-version" content="{{VERSION}}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Quizify — Analytics</title>
-    <link rel="stylesheet" href="/quizify/static/css/styles.css?v={{VERSION}}">
+    <link rel="stylesheet" href="/quizify/static/css/styles.css?v={{ASSET_VER}}">
     <link rel="icon" href="/quizify/static/img/icon-256.png" type="image/png">
     <style>
         .analytics-container {
@@ -315,7 +315,7 @@
         </div>
     </div>
 
-    <script src="/quizify/static/js/i18n.js?v={{VERSION}}"></script>
+    <script src="/quizify/static/js/i18n.js?v={{ASSET_VER}}"></script>
     <script>
     (function() {
         'use strict';

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -13,7 +13,7 @@
     <link rel="preconnect" href="https://api.fontshare.com" crossorigin>
     <link href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@500,700,800,900&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="/quizify/static/css/styles.css?v={{VERSION}}">
+    <link rel="stylesheet" href="/quizify/static/css/styles.css?v={{ASSET_VER}}">
     <link rel="icon" href="/quizify/static/img/icon-256.png" type="image/png">
     <link rel="manifest" href="/quizify/static/site.webmanifest">
 
@@ -974,8 +974,8 @@
         </div>
     </main>
 
-    <script src="/quizify/static/js/i18n.js?v={{VERSION}}"></script>
-    <script src="/quizify/static/js/utils.js?v={{VERSION}}"></script>
+    <script src="/quizify/static/js/i18n.js?v={{ASSET_VER}}"></script>
+    <script src="/quizify/static/js/utils.js?v={{ASSET_VER}}"></script>
     <script>
     (function() {
         'use strict';
@@ -1325,6 +1325,6 @@
         connect();
     })();
     </script>
-    <script src="/quizify/static/js/sw-update.js?v={{VERSION}}"></script>
+    <script src="/quizify/static/js/sw-update.js?v={{ASSET_VER}}"></script>
 </body>
 </html>

--- a/custom_components/quizify/www/launcher.html
+++ b/custom_components/quizify/www/launcher.html
@@ -150,7 +150,7 @@
     </a>
     <p class="hint" id="hint"></p>
 
-    <script src="/quizify/static/js/i18n.js?v={{VERSION}}"></script>
+    <script src="/quizify/static/js/i18n.js?v={{ASSET_VER}}"></script>
     <script>
         // i18n only — navigation is handled by the <a href>. No popup
         // attempt, no fallback ladder. The launcher is now stateless.

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -10,7 +10,7 @@
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
     <link rel="preconnect" href="https://api.fontshare.com" crossorigin>
     <link href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@500,700,800,900&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/quizify/static/css/styles.css?v={{VERSION}}">
+    <link rel="stylesheet" href="/quizify/static/css/styles.css?v={{ASSET_VER}}">
     <link rel="icon" href="/quizify/static/img/icon-256.png" type="image/png">
     <link rel="manifest" href="/quizify/static/site.webmanifest">
     <!-- Soft Parlor: no confetti library. The warm reveal IS the celebration. See DESIGN.md. -->
@@ -582,16 +582,16 @@
     <!-- Version badge -->
     <div class="version-badge" id="version-badge">v{{VERSION}}</div>
 
-    <script src="/quizify/static/js/vendor/qrcode.min.js?v={{VERSION}}"></script>
-    <script src="/quizify/static/js/i18n.js?v={{VERSION}}"></script>
+    <script src="/quizify/static/js/vendor/qrcode.min.js?v={{ASSET_VER}}"></script>
+    <script src="/quizify/static/js/i18n.js?v={{ASSET_VER}}"></script>
     <!-- DO NOT REMOVE utils.js \u2014 player-utils.js depends on window.QuizifyUtils. -->
     <!-- Dropped twice before (see commits 86025d1, 055e58c). Third time's not charming. -->
-    <script src="/quizify/static/js/utils.js?v={{VERSION}}"></script>
+    <script src="/quizify/static/js/utils.js?v={{ASSET_VER}}"></script>
     <!-- Bundle of player-utils + lobby + game + reveal + end + core
          (concatenated by scripts/build_bundle.py). Cuts the request
          waterfall from 6 sequential JS fetches to 1 \u2014 meaningful on
          4G phones that take ~80ms RTT per request. -->
-    <script src="/quizify/static/js/player.bundle.js?v={{VERSION}}"></script>
-    <script src="/quizify/static/js/sw-update.js?v={{VERSION}}"></script>
+    <script src="/quizify/static/js/player.bundle.js?v={{ASSET_VER}}"></script>
+    <script src="/quizify/static/js/sw-update.js?v={{ASSET_VER}}"></script>
 </body>
 </html>

--- a/custom_components/quizify/www/sw.js
+++ b/custom_components/quizify/www/sw.js
@@ -17,7 +17,7 @@
 // CACHE_VERSION is templated by server/views.py::sw_view at serve time —
 // {{VERSION}} is replaced with the integration version from manifest.json.
 // Bumping manifest.json invalidates every old SW cache on the next install.
-var CACHE_VERSION = 'quizify-v{{VERSION}}';
+var CACHE_VERSION = 'quizify-v{{ASSET_VER}}';
 
 // Listen for SKIP_WAITING from the page (sw-update.js posts it when the
 // user clicks "Reload" in the update banner). Without this the new SW

--- a/tests/test_version_cachebuster.py
+++ b/tests/test_version_cachebuster.py
@@ -28,6 +28,8 @@ from custom_components.quizify.server.context import (  # noqa: E402
 )
 from custom_components.quizify.server.views import (  # noqa: E402
     _apply_version,
+    _compute_asset_fingerprint,
+    _get_asset_version,
     admin_view,
     player_view,
     status_view,
@@ -114,6 +116,49 @@ class TestTemplateSubstitution:
         assert _apply_version(text, "1.2.3") == text
 
 
+class TestAssetFingerprint:
+    """The cache-buster must move on ANY asset change, not just a manifest
+    version bump. These guard the #147 root cause: a reused version (1.2.0 was
+    built twice) left ?v= unchanged, so HA's immutable static cache served
+    stale CSS/JS until the version finally moved."""
+
+    def _write(self, root, sub, name, body):
+        d = root / sub
+        d.mkdir(parents=True, exist_ok=True)
+        (d / name).write_text(body, encoding="utf-8")
+
+    def test_fingerprint_changes_when_asset_content_changes(self, tmp_path) -> None:
+        self._write(tmp_path, "css", "styles.css", "a {}")
+        fp1 = _compute_asset_fingerprint(tmp_path)
+        # Edit the file (size changes) — same as shipping a new CSS build.
+        self._write(tmp_path, "css", "styles.css", "a { color: red }")
+        fp2 = _compute_asset_fingerprint(tmp_path)
+        assert fp1 != fp2, "fingerprint must change when an asset's content changes"
+
+    def test_fingerprint_changes_when_asset_added(self, tmp_path) -> None:
+        self._write(tmp_path, "js", "admin.js", "x")
+        fp1 = _compute_asset_fingerprint(tmp_path)
+        self._write(tmp_path, "i18n", "de.json", "{}")
+        fp2 = _compute_asset_fingerprint(tmp_path)
+        assert fp1 != fp2, "fingerprint must change when an asset is added"
+
+    def test_fingerprint_stable_when_nothing_changes(self, tmp_path) -> None:
+        self._write(tmp_path, "js", "admin.js", "x")
+        assert _compute_asset_fingerprint(tmp_path) == _compute_asset_fingerprint(tmp_path)
+
+    def test_fingerprint_is_short_hex(self, tmp_path) -> None:
+        self._write(tmp_path, "css", "styles.css", "a {}")
+        fp = _compute_asset_fingerprint(tmp_path)
+        assert len(fp) == 8 and all(c in "0123456789abcdef" for c in fp)
+
+    def test_asset_version_is_version_plus_fingerprint(self) -> None:
+        av = _get_asset_version("9.9.9")
+        # Back-compat: starts with the version (so ?v=<version> assertions hold),
+        # and carries a fingerprint suffix that busts on asset changes.
+        assert av.startswith("9.9.9-")
+        assert len(av) > len("9.9.9-")
+
+
 # ---------- Integration: real view fns + real HTML / sw.js on disk ----------
 
 
@@ -142,8 +187,12 @@ class TestHtmlSubstitution:
         resp = await admin_view(_fake_request("9.9.9-test", ha_language="en"))
         assert resp.status == 200
         assert "{{VERSION}}" not in resp.text
+        assert "{{ASSET_VER}}" not in resp.text
         assert "{{HA_LANG}}" not in resp.text
-        assert "?v=9.9.9-test" in resp.text
+        # ?v= now carries <version>-<fingerprint>, not the bare version.
+        assert "?v=9.9.9-test-" in resp.text
+        # The meta tag keeps the clean semantic version.
+        assert 'name="quizify-version" content="9.9.9-test"' in resp.text
 
     async def test_admin_html_injects_ha_language(self) -> None:
         """HA's configured language lands in the meta tag admin.js reads to


### PR DESCRIPTION
## Root cause

Static assets are served immutable (`cache_headers=True`), so the `?v=` query string is the only cache-invalidation lever — and it was keyed only to the manifest version. Building 1.2.0 twice under the same version left `?v=1.2.0` unchanged, so browsers kept serving old CSS/JS/i18n (the World Cup card rendered English on a German setup, unstyled, with no pack chips). The service worker is already network-first (#147), so it wasn't the culprit; the mechanism just depended on perfect version-bump discipline.

## Fix

New `{{ASSET_VER}}` token = `<version>-<fingerprint>`, where the fingerprint is `md5(rel-path + mtime + size)` over `www/css|js|i18n` (8 hex). All 19 `?v=` refs across the 5 HTML pages + the SW `CACHE_VERSION` use it; `{{VERSION}}` stays clean for the meta tag. Any css/js/i18n change moves the buster automatically — **no version bump required**, so this class of bug can't recur.

## Evidence

End-to-end: same version 1.2.0, touch `styles.css` → buster `1.2.0-8d420439` → `1.2.0-d1efc89e` (was identical before).

## Tests

`TestAssetFingerprint` (+5): fingerprint changes on content change / file add, stable otherwise, 8-hex, `?v=` carries the suffix. **145 pass.**

Integration 1.2.1 → 1.2.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)