### PR TITLE
release: v1.2.5 — World Cup Night (consolidated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to Quizify are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [1.2.5] — 2026-06-08
+
+Consolidated release of the 1.2.x line under a fresh version number for clean
+distribution. Bundles everything since 1.1.0: the World Cup packs, the
+first-screen pack picker (with World Cup as a selectable pack), host-screen
+language handling, and the self-healing asset cache-buster. See the 1.2.0–1.2.3
+entries below for the detailed history.
+
 ## [1.2.3] — 2026-06-08
 
 ### Fixed

--- a/custom_components/quizify/manifest.json
+++ b/custom_components/quizify/manifest.json
@@ -12,5 +12,5 @@
   "description": "Multiplayer trivia quiz game for Home Assistant. Players join via QR code; the TV is the host screen.",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/quizify/issues",
-  "version": "1.2.3"
+  "version": "1.2.5"
 }


### PR DESCRIPTION
Fresh version (skips 1.2.4) so HACS pulls it cleanly after the 1.2.x beta tag churn. No code change beyond 1.2.3 — bundles World Cup packs, first-screen pack picker (World Cup selectable), host-screen language handling, and the self-healing asset cache-buster. 145 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)