### PR TITLE
fix(player/admin): i18n name-validation + dedup the rule (#171.1, #171.5)

### DIFF
--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -414,6 +414,7 @@
   "errors": {
     "NAME_TAKEN": "Name bereits vergeben",
     "NAME_INVALID": "Bitte gib einen Namen ein",
+    "NAME_TOO_LONG": "Name zu lang (max. {max} Zeichen)",
     "GAME_FULL": "Spiel ist voll",
     "GAME_NOT_STARTED": "Kein aktives Spiel",
     "GAME_ALREADY_STARTED": "Spiel läuft bereits",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -414,6 +414,7 @@
   "errors": {
     "NAME_TAKEN": "Name already taken",
     "NAME_INVALID": "Please enter a name",
+    "NAME_TOO_LONG": "Name too long (max {max} characters)",
     "GAME_FULL": "Game is full",
     "GAME_NOT_STARTED": "No active game",
     "GAME_ALREADY_STARTED": "Game already running",

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -1236,8 +1236,24 @@
         if (backdrop) backdrop.addEventListener('click', closeAdminJoinModal);
 
         on(els.adminNameInput, 'input', function () {
-            var name = this.value.trim();
-            if (els.adminJoinBtn) els.adminJoinBtn.disabled = !name || name.length > 20;
+            // Use the shared validator (utils.js) so the admin self-join
+            // modal enforces the exact same name rule + limit as the player
+            // join flow — no second hardcoded `length > 20` to drift.
+            var result = window.QuizifyUtils.validateName(this.value);
+            if (els.adminJoinBtn) els.adminJoinBtn.disabled = !result.valid;
+            // Surface the (now localised) error in the dedicated slot —
+            // only when the field is non-empty but invalid (i.e. too long);
+            // an empty field just disables the button without nagging.
+            var errEl = document.getElementById('admin-name-error');
+            if (errEl) {
+                if (!result.valid && this.value.trim()) {
+                    errEl.textContent = result.error;
+                    errEl.classList.remove('hidden');
+                } else {
+                    errEl.textContent = '';
+                    errEl.classList.add('hidden');
+                }
+            }
         });
 
         on(els.adminNameInput, 'keydown', function (e) {

--- a/custom_components/quizify/www/js/player-utils.js
+++ b/custom_components/quizify/www/js/player-utils.js
@@ -32,7 +32,10 @@
 
     var MAX_RECONNECT_ATTEMPTS = 10;
     var MAX_RECONNECT_DELAY_MS = 30000;
-    var MAX_NAME_LENGTH = 20;
+    // Name limit lives in utils.js (QuizifyUtils.MAX_NAME_LENGTH) so the
+    // player flow and the admin modal share one rule. Mirror it locally
+    // for any legacy reference; validateName() delegates to the shared one.
+    var MAX_NAME_LENGTH = (window.QuizifyUtils && window.QuizifyUtils.MAX_NAME_LENGTH) || 20;
     var SESSION_STORAGE_TOKEN = 'quizify_session_token';
     var SESSION_STORAGE_NAME = 'quizify_player_name';
 
@@ -375,6 +378,13 @@
     // ============================================
 
     function validateName(name) {
+        // Delegate to the shared, i18n-aware validator (utils.js). Kept as
+        // a thin wrapper so player-core's pu.validateName() calls are
+        // unchanged. Falls back to a local check only if utils.js somehow
+        // didn't load (it's a hard dependency, loaded before this bundle).
+        if (utils && utils.validateName) {
+            return utils.validateName(name);
+        }
         var trimmed = (name || '').trim();
         if (!trimmed) {
             return { valid: false, error: 'Please enter a name' };

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -37,7 +37,10 @@
 
     var MAX_RECONNECT_ATTEMPTS = 10;
     var MAX_RECONNECT_DELAY_MS = 30000;
-    var MAX_NAME_LENGTH = 20;
+    // Name limit lives in utils.js (QuizifyUtils.MAX_NAME_LENGTH) so the
+    // player flow and the admin modal share one rule. Mirror it locally
+    // for any legacy reference; validateName() delegates to the shared one.
+    var MAX_NAME_LENGTH = (window.QuizifyUtils && window.QuizifyUtils.MAX_NAME_LENGTH) || 20;
     var SESSION_STORAGE_TOKEN = 'quizify_session_token';
     var SESSION_STORAGE_NAME = 'quizify_player_name';
 
@@ -380,6 +383,13 @@
     // ============================================
 
     function validateName(name) {
+        // Delegate to the shared, i18n-aware validator (utils.js). Kept as
+        // a thin wrapper so player-core's pu.validateName() calls are
+        // unchanged. Falls back to a local check only if utils.js somehow
+        // didn't load (it's a hard dependency, loaded before this bundle).
+        if (utils && utils.validateName) {
+            return utils.validateName(name);
+        }
         var trimmed = (name || '').trim();
         if (!trimmed) {
             return { valid: false, error: 'Please enter a name' };

--- a/custom_components/quizify/www/js/utils.js
+++ b/custom_components/quizify/www/js/utils.js
@@ -6,6 +6,12 @@
 (function () {
     'use strict';
 
+    // Single source of truth for the player-name limit. Both the player
+    // join flow (via player-utils.js) and the admin self-join modal
+    // (admin.js) validate against this — keep the two in sync by routing
+    // through validateName() below, never re-implementing the rule.
+    var MAX_NAME_LENGTH = 20;
+
     function escapeHtml(str) {
         if (str == null) return '';
         return String(str)
@@ -16,7 +22,33 @@
             .replace(/'/g, '&#39;');
     }
 
+    // Localised name validation shared across player + admin. Error
+    // messages resolve through QuizifyI18n when ready (so a German player
+    // sees German), with an English fallback if i18n hasn't loaded yet.
+    function validateName(name) {
+        var i18n = window.QuizifyI18n;
+        var ready = i18n && i18n.isReady && i18n.isReady();
+        var trimmed = (name || '').trim();
+        if (!trimmed) {
+            return {
+                valid: false,
+                error: ready ? i18n.t('errors.NAME_INVALID') : 'Please enter a name'
+            };
+        }
+        if (trimmed.length > MAX_NAME_LENGTH) {
+            return {
+                valid: false,
+                error: ready
+                    ? i18n.t('errors.NAME_TOO_LONG', { max: MAX_NAME_LENGTH })
+                    : 'Name too long (max ' + MAX_NAME_LENGTH + ' characters)'
+            };
+        }
+        return { valid: true, name: trimmed };
+    }
+
     window.QuizifyUtils = {
         escapeHtml: escapeHtml,
+        validateName: validateName,
+        MAX_NAME_LENGTH: MAX_NAME_LENGTH,
     };
 })();


### PR DESCRIPTION
Addresses the frontend/UX code-review batch **#171** (points 16–20).

## ✅ Fixed (code)

### #171.1 — Name-validation errors not i18n'd
`validateName` returned hardcoded English (`"Please enter a name"`, `"Name too long (max N characters)"`), so German players always saw English. Messages now resolve through `QuizifyI18n` — new `errors.NAME_TOO_LONG` key in `en.json`/`de.json` (DE/EN parity verified, no orphan keys) — with an English fallback if i18n hasn't loaded yet.

### #171.5 — Duplicated name validation
The admin self-join modal validated with its own inline `name.length > 20` — a second copy of the player rule that could drift. Both flows now route through a single `QuizifyUtils.validateName()` in `utils.js` (the one module loaded by both player + admin); `MAX_NAME_LENGTH` lives there too. The admin modal also surfaces the localised error in the existing-but-unused `#admin-name-error` slot.

`player.bundle.js` regenerated via `scripts/build_bundle.py`. **162 tests pass.**

## ☑️ Verified — no code change needed
- **#171.2 reconnect feedback** — already implemented: `createWebSocket().onclose` shows `#reconnecting-overlay` (spinner + i18n "Reconnecting…"), updates the connection indicator dot, and after `MAX_RECONNECT_ATTEMPTS` shows `#connection-lost-view` with a retry button. The finding pointed at `player-core.js:150` (= `updatePageTitle`); the reconnect UI lives in the connection layer.
- **#171.3 SW client version check** — removed by-design in v1.2.6 (#165): the update banner was dropped because the asset-fingerprint cache-buster (#162) handles freshness on the next load.
- **#171.4 480px vs 390px** — not a bug: the CSS is mobile-first, 390px gets the un-queried base styles; the first `@media(min-width:480px)` only nudges `.pwa-ios-hint` (progressive enhancement).

## ⚠️ Before merge/release
- Mobile-verify (390×844) of the join + admin self-join flows still pending (Chrome remote-debug was off when this was built).

Closes #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)