### PR TITLE
test(server): verify #169 perf/leak invariants + tidy timer tick

### DIFF
--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -87,6 +87,35 @@ class QuizifyWebSocketHandler:
         self._RATE_LIMIT_WINDOW = 1.0  # seconds
         self._RATE_LIMIT_MAX = 15  # max messages per window
 
+    def _check_rate_limit(self, ws: web.WebSocketResponse) -> bool:
+        """Record a message for ``ws`` and report whether it is within the
+        per-connection rate limit.
+
+        Timestamps older than ``_RATE_LIMIT_WINDOW`` are pruned on every call,
+        so each connection's list stays small; the connection's entry itself
+        is dropped by :meth:`_forget_rate_limit` from ``handle()``'s ``finally``
+        on disconnect, so ``_message_timestamps`` is bounded by the number of
+        *live* connections (≤ MAX_PLAYERS + admin/dashboard), never unbounded
+        (#169). A message that exceeds the limit is NOT recorded.
+        """
+        ws_id = id(ws)
+        now = asyncio.get_event_loop().time()
+        timestamps = [
+            t
+            for t in self._message_timestamps.get(ws_id, [])
+            if now - t < self._RATE_LIMIT_WINDOW
+        ]
+        if len(timestamps) >= self._RATE_LIMIT_MAX:
+            self._message_timestamps[ws_id] = timestamps
+            return False
+        timestamps.append(now)
+        self._message_timestamps[ws_id] = timestamps
+        return True
+
+    def _forget_rate_limit(self, ws: web.WebSocketResponse) -> None:
+        """Drop a connection's rate-limit state (called on disconnect)."""
+        self._message_timestamps.pop(id(ws), None)
+
     async def handle(self, request: web.Request) -> web.WebSocketResponse:
         """Handle WebSocket connection."""
         ws = web.WebSocketResponse(heartbeat=self.HEARTBEAT_INTERVAL)
@@ -156,18 +185,12 @@ class QuizifyWebSocketHandler:
                 if msg.type == WSMsgType.TEXT:
                     # Rate limiting: record timestamp BEFORE processing so the
                     # first message is also counted (#21 in logical review).
-                    ws_id = id(ws)
-                    now = asyncio.get_event_loop().time()
-                    timestamps = self._message_timestamps.setdefault(ws_id, [])
-                    # Remove old timestamps outside window
-                    self._message_timestamps[ws_id] = [t for t in timestamps if now - t < self._RATE_LIMIT_WINDOW]
-                    if len(self._message_timestamps[ws_id]) >= self._RATE_LIMIT_MAX:
-                        _LOGGER.warning("Rate limit exceeded for WebSocket %s", ws_id)
+                    if not self._check_rate_limit(ws):
+                        _LOGGER.warning("Rate limit exceeded for WebSocket %s", id(ws))
                         await self._conn.send_error(
                             ws, ERR_INVALID_ACTION, "Rate limit exceeded"
                         )
                         continue
-                    self._message_timestamps[ws_id].append(now)
                     # Parse JSON separately so we can distinguish parse errors
                     # from handler errors (#20 in logical review).
                     try:
@@ -188,7 +211,7 @@ class QuizifyWebSocketHandler:
                     _LOGGER.error("WebSocket error: %s", ws.exception())
         finally:
             self._conn.remove_connection(ws)
-            self._message_timestamps.pop(id(ws), None)
+            self._forget_rate_limit(ws)
             await self._handle_disconnect(ws)
             _LOGGER.debug("WebSocket disconnected, total: %d", len(self._conn.connections))
 
@@ -1107,29 +1130,30 @@ class QuizifyWebSocketHandler:
             try:
                 while game_state.phase == GamePhase.QUESTION_ACTIVE:
                     players = game_state.get_players()
-                    # Send each player their authoritative remaining time.
-                    for p in players:
+                    # Resolve each player's authoritative timer ONCE per tick.
+                    # get_player_timer is an O(1) dict lookup, but it used to be
+                    # called 3-4× per player per tick (once for the send, twice
+                    # more inside the dashboard-minimum comprehension). Compute
+                    # the (player, remaining) pairs once and reuse them for both
+                    # the per-player send and the dashboard minimum (#169). The
+                    # post-sleep expiry check below intentionally re-reads fresh
+                    # timers, since state can change during the 0.5s sleep.
+                    tick_state = [
+                        (p, max(0.0, t.get_remaining()))
+                        for p in players
+                        if (t := game_state.get_player_timer(p.name)) is not None
+                    ]
+                    # Send each connected player their authoritative remaining.
+                    for p, remaining in tick_state:
                         if not p.connected:
                             continue
-                        pt = game_state.get_player_timer(p.name)
-                        if pt is None:
-                            continue
-                        remaining = max(0.0, pt.get_remaining())
                         await self._conn._safe_send(p.ws, {
                             "type": "timer_tick",
                             "remaining": round(remaining, 1),
                         })
-                    # Also broadcast the minimum remaining to dashboards/admins
-                    # so the TV view shows a consistent countdown.
-                    min_remaining = 0.0
-                    if players:
-                        remainings = [
-                            max(0.0, game_state.get_player_timer(p.name).get_remaining())
-                            for p in players
-                            if game_state.get_player_timer(p.name) is not None
-                        ]
-                        if remainings:
-                            min_remaining = min(remainings)
+                    # Broadcast the minimum remaining to dashboards/admins so
+                    # the TV view shows a consistent countdown.
+                    min_remaining = min((r for _, r in tick_state), default=0.0)
                     # Broadcast to pure-admin + dashboards
                     for ws in list(self._conn._admin_connections):
                         if not ws.closed and not any(p.ws is ws for p in players):

--- a/tests/test_performance_169.py
+++ b/tests/test_performance_169.py
@@ -1,0 +1,190 @@
+"""Performance / resource-leak regression tests for issue #169.
+
+The #169 code-review batch flagged three items. On inspection all three are
+non-issues under the actual execution model (single-threaded asyncio, bounded
+player count) — these tests lock in the invariants that make them safe, so a
+future refactor can't silently reintroduce a real leak/race:
+
+  1. The per-connection rate-limit map (`_message_timestamps`) is bounded:
+     each connection's entry is pruned of stale timestamps on every check and
+     removed entirely on disconnect, so the dict never grows beyond the set of
+     live connections.
+  2. (tick-loop) — covered by the existing timer/game-state suite; this file
+     only adds the bounded-map + cache invariants. The tick loop was tidied to
+     resolve each player's timer once per tick (behaviour unchanged; 162 tests
+     still pass).
+  3. The module-global asset/manifest caches return consistent values and are
+     keyed correctly (manifest by mtime, asset fingerprint by a TTL). The
+     read-modify-write sections are synchronous (no `await`), so in
+     single-threaded asyncio they cannot interleave — no lock needed.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.server import views  # noqa: E402
+from custom_components.quizify.server import websocket as ws_mod  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+class _FakeWS:
+    """Stand-in for a WebSocketResponse — only its identity matters here."""
+
+
+@pytest.fixture
+def handler(tmp_path: Path) -> QuizifyWebSocketHandler:
+    return QuizifyWebSocketHandler(
+        runtime=_FakeRuntime(tmp_path),
+        game_state_provider=lambda: None,
+    )
+
+
+def _freeze_clock(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Make the rate limiter read a controllable clock instead of the loop."""
+    clock = {"t": 0.0}
+    monkeypatch.setattr(
+        ws_mod.asyncio,
+        "get_event_loop",
+        lambda: SimpleNamespace(time=lambda: clock["t"]),
+    )
+    return clock
+
+
+# ---------------------------------------------------------------------------
+# 1. Rate-limit map stays bounded
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitBounded:
+    def test_forget_removes_the_entry(
+        self, handler: QuizifyWebSocketHandler, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """After a connection is forgotten (handle()'s finally), it leaves no
+        residue in _message_timestamps — so the dict is bounded by *live*
+        connections, never unbounded (#169.1)."""
+        _freeze_clock(monkeypatch)
+        ws = _FakeWS()
+        assert handler._check_rate_limit(ws) is True
+        assert id(ws) in handler._message_timestamps
+
+        handler._forget_rate_limit(ws)
+        assert id(ws) not in handler._message_timestamps
+        assert handler._message_timestamps == {}
+
+    def test_window_prunes_old_timestamps(
+        self, handler: QuizifyWebSocketHandler, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A long-lived connection's timestamp list does not grow without
+        bound — entries older than the window are dropped each call."""
+        clock = _freeze_clock(monkeypatch)
+        ws = _FakeWS()
+        # Fill the window.
+        for _ in range(handler._RATE_LIMIT_MAX):
+            handler._check_rate_limit(ws)
+        assert len(handler._message_timestamps[id(ws)]) == handler._RATE_LIMIT_MAX
+
+        # Jump past the window — the next check prunes everything stale.
+        clock["t"] += handler._RATE_LIMIT_WINDOW + 1
+        handler._check_rate_limit(ws)
+        assert len(handler._message_timestamps[id(ws)]) == 1
+
+    def test_over_limit_is_rejected_and_not_recorded(
+        self, handler: QuizifyWebSocketHandler, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Hitting the cap returns False and does not append the rejected
+        message (so a flood can't inflate the list past the cap)."""
+        _freeze_clock(monkeypatch)
+        ws = _FakeWS()
+        for _ in range(handler._RATE_LIMIT_MAX):
+            assert handler._check_rate_limit(ws) is True
+        # One past the cap — rejected.
+        assert handler._check_rate_limit(ws) is False
+        assert handler._check_rate_limit(ws) is False
+        assert len(handler._message_timestamps[id(ws)]) == handler._RATE_LIMIT_MAX
+
+    def test_distinct_connections_are_independent(
+        self, handler: QuizifyWebSocketHandler, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Forgetting one connection does not affect another's state."""
+        _freeze_clock(monkeypatch)
+        a, b = _FakeWS(), _FakeWS()
+        handler._check_rate_limit(a)
+        handler._check_rate_limit(b)
+        assert len(handler._message_timestamps) == 2
+
+        handler._forget_rate_limit(a)
+        assert id(a) not in handler._message_timestamps
+        assert id(b) in handler._message_timestamps
+
+
+# ---------------------------------------------------------------------------
+# 3a. Manifest version cache — consistent + mtime-keyed
+# ---------------------------------------------------------------------------
+
+
+class TestManifestCacheConsistent:
+    def test_repeated_reads_are_consistent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text('{"version": "9.9.9"}', encoding="utf-8")
+        monkeypatch.setattr(views, "_MANIFEST_PATH", manifest)
+        monkeypatch.setattr(views, "_MANIFEST_CACHE", None)
+
+        first = views._get_live_version("fallback")
+        second = views._get_live_version("fallback")
+        assert first == second == "9.9.9"
+
+    def test_cache_refreshes_on_mtime_change(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text('{"version": "1.0.0"}', encoding="utf-8")
+        os.utime(manifest, ns=(1_000_000_000, 1_000_000_000))
+        monkeypatch.setattr(views, "_MANIFEST_PATH", manifest)
+        monkeypatch.setattr(views, "_MANIFEST_CACHE", None)
+        assert views._get_live_version("fb") == "1.0.0"
+
+        # New content + a distinct mtime → the cache key changes → re-read.
+        manifest.write_text('{"version": "2.0.0"}', encoding="utf-8")
+        os.utime(manifest, ns=(2_000_000_000, 2_000_000_000))
+        assert views._get_live_version("fb") == "2.0.0"
+
+    def test_missing_file_falls_back(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(views, "_MANIFEST_PATH", tmp_path / "nope.json")
+        monkeypatch.setattr(views, "_MANIFEST_CACHE", None)
+        assert views._get_live_version("the-fallback") == "the-fallback"
+
+
+# ---------------------------------------------------------------------------
+# 3b. Asset-fingerprint cache — consistent within its TTL
+# ---------------------------------------------------------------------------
+
+
+class TestAssetFingerprintCacheConsistent:
+    def test_repeated_calls_consistent_within_ttl(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(views, "_ASSET_FP_CACHE", None)
+        first = views._get_asset_version("1.2.7")
+        second = views._get_asset_version("1.2.7")
+        assert first == second
+        assert first.startswith("1.2.7-")


### PR DESCRIPTION
Addresses the performance / resource-leak code-review batch **#169** (points 10–12).

On inspection all three findings are **non-issues under the actual execution model** (single-threaded asyncio, `MAX_PLAYERS=20`). Rather than add risky changes to working code, this PR pins the invariants that make them safe with regression tests, plus one behaviour-preserving tidy-up.

## Findings

### #169.1 — `_message_timestamps` "unbounded"
`pop(id(ws))` runs in `handle()`'s `finally`, so each connection's entry is removed on disconnect → the map is bounded by **live** connections (≤ `MAX_PLAYERS` + admin/dashboard), never unbounded.
- Extracted the rate-limit logic into `_check_rate_limit()` / `_forget_rate_limit()` — makes the invariant testable and de-clutters the God-object `handle()` (cf #170).
- Tests: forget clears the entry; the window prunes stale timestamps; an over-limit message is rejected and **not** recorded; distinct connections stay independent.

### #169.2 — "O(n) `get_player_by_ws` every 0.5s tick"
**False** — the tick loop never calls `get_player_by_ws`; it iterates `get_players()` and does an **O(1)** `get_player_timer` dict lookup. (The real O(n) `get_player_by_ws` lives in the message handlers, but n ≤ 20.)
- Tidied the loop to resolve each player's timer **once** per tick (it was called 3–4×/player). The post-sleep expiry check still re-reads fresh timers, since state can change during the 0.5s sleep. **Behaviour unchanged.**

### #169.3 — "module caches need a lock"
`_get_live_version` / `_get_asset_version` are **synchronous** (no `await` in the read-modify-write), so in single-threaded asyncio they can't interleave — a lock would be pure overhead. Worst case on a double-miss: a redundant file read, same value.
- Tests: manifest cache is consistent + mtime-keyed + falls back on a missing file; asset-fingerprint cache is consistent within its TTL.

## Result
- **170 tests pass** (8 new in `tests/test_performance_169.py`).
- Backend-only, no UI change → no mobile-verify needed.

Closes #169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)