### PR TITLE
feat: optional question image support (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ All notable changes to Quizify are documented here. This project follows
   announcements that share the same speaker. The mechanism is inert by default
   — no audio file ships with the integration, and nothing plays until both a
   media player and a URL are configured.
+- **Optional question images (#25).** Questions may now carry an optional
+  `image_url` field in their pack JSON. When present, the shared dashboard
+  renders the image above the question text and player screens show a
+  thumbnail — handy for "What film is this from?" or visual geography
+  questions. Only absolute `http(s)` URLs are accepted; relative paths,
+  `data:`/`javascript:` schemes and non-strings are dropped at parse time.
+  Questions without an image render exactly as before.
 
 ## [1.2.7] — 2026-06-09
 

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -65,11 +65,16 @@ custom_components/quizify/questions/<category>.json
       ],
       "difficulty": "medium",
       "fun_fact": "Kanada hat eine Küstenlinie von über 202.000 km — das ist mehr als 5× der Erde.",
+      "image_url": "https://example.com/images/coastline.jpg",
       "source": "Wikipedia"
     }
   ]
 }
 ```
+
+`image_url` is **optional**. When set to an absolute `http(s)` URL the
+dashboard renders the image above the question text and player screens
+show a thumbnail. Relative paths and non-`http(s)` schemes are ignored.
 
 ### Categories (initial set)
 | Kategorie | Datei | Sprachen |

--- a/custom_components/quizify/game/questions.py
+++ b/custom_components/quizify/game/questions.py
@@ -51,6 +51,40 @@ class Question:
     fun_fact: str = ""
     category: str = ""
     language: str = "de"
+    # Optional image rendered above the question text on the dashboard /
+    # as a thumbnail on player screens. Empty string means "no image"
+    # (issue #25). Only http(s) URLs are accepted (see _sanitize_image_url);
+    # anything else is dropped at parse time so a malformed pack can't
+    # inject markup or point at a local path.
+    image_url: str = ""
+
+
+def _sanitize_image_url(raw: object, question_id: str) -> str:
+    """Return a safe http(s) image URL, or "" if absent/invalid.
+
+    Only absolute http/https URLs are allowed. A relative path, a
+    ``javascript:``/``data:`` scheme, or a non-string is dropped (and
+    logged) so a malformed or hostile pack can't break the dashboard
+    render or smuggle markup through the field.
+    """
+    if not raw:
+        return ""
+    if not isinstance(raw, str):
+        _LOGGER.warning(
+            "Question '%s': ignoring non-string image_url (%s)",
+            question_id,
+            type(raw).__name__,
+        )
+        return ""
+    url = raw.strip()
+    if url.lower().startswith(("http://", "https://")):
+        return url
+    _LOGGER.warning(
+        "Question '%s': ignoring image_url with unsupported scheme: %r",
+        question_id,
+        url[:60],
+    )
+    return ""
 
 
 def _parse_question(data: dict, category_name: str) -> Question | None:
@@ -93,6 +127,7 @@ def _parse_question(data: dict, category_name: str) -> Question | None:
         difficulty=data.get("difficulty", "medium"),
         fun_fact=data.get("fun_fact", ""),
         category=data.get("category", category_name),
+        image_url=_sanitize_image_url(data.get("image_url"), data["id"]),
     )
 
 

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -1074,6 +1074,7 @@ class QuizifyGameState:
                 "answers": [a.text for a in q.answers],
                 "difficulty": q.difficulty,
                 "category": q.category,
+                "image_url": q.image_url,
                 "time_limit": self._round_duration,
                 "time_remaining": round(remaining, 1),
             }

--- a/custom_components/quizify/server/protocol.py
+++ b/custom_components/quizify/server/protocol.py
@@ -82,6 +82,9 @@ class QuestionStartedMessage:
     total_rounds: int
     category: str
     difficulty: str
+    # Optional image URL for the question (issue #25). Empty string when
+    # the question carries no image.
+    image_url: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -254,7 +257,7 @@ TYPESCRIPT_DECLARATIONS = """
 //   | { type: 'player_joined' | 'player_left'; players: Player[]; }
 //   | { type: 'question_started'; question_text: string; answers: string[];
 //       timer_duration: number; round_num: number; total_rounds: number;
-//       category: string; difficulty: string; }
+//       category: string; difficulty: string; image_url?: string; }
 //   | { type: 'timer_tick'; remaining: number; }
 //   | { type: 'answer_result'; correct: boolean; points_earned: number;
 //       speed_bonus: number; streak_bonus: number; difficulty_multiplier: number;

--- a/custom_components/quizify/server/serializers.py
+++ b/custom_components/quizify/server/serializers.py
@@ -54,6 +54,7 @@ def serialize_question_for_player(
         "total_rounds": total_rounds,
         "category": question.category,
         "difficulty": question.difficulty,
+        "image_url": question.image_url,
         "is_final_round": is_final_round,
         "player_score": player_score,
     }
@@ -84,6 +85,7 @@ def serialize_question_for_admin(
         "total_rounds": total_rounds,
         "category": question.category,
         "difficulty": question.difficulty,
+        "image_url": question.image_url,
     }
 
 

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -1466,6 +1466,20 @@ button, .btn {
     padding: 0 var(--space-sm);
 }
 
+/* Issue #25: optional question thumbnail on the player screen. Capped
+   height so it never crowds out the answer buttons on a small phone;
+   hidden entirely when the question carries no image. */
+.question-image {
+    display: block;
+    max-width: 100%;
+    max-height: 30vh;
+    width: auto;
+    margin: var(--space-sm) auto;
+    border-radius: var(--radius-md, 12px);
+    object-fit: contain;
+}
+.question-image[hidden] { display: none; }
+
 .question-category {
     display: inline-block;
     font-size: 0.75rem;

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -273,6 +273,20 @@
             max-width: 24ch;
         }
 
+        /* Issue #25: optional question image, rendered above the text.
+           Capped height so a tall image can't push the answers grid
+           off-screen on a 720p TV; object-fit keeps the aspect ratio. */
+        .dashboard-question-image {
+            display: block;
+            max-width: 100%;
+            max-height: clamp(160px, 28vh, 320px);
+            width: auto;
+            border-radius: 16px;
+            margin-bottom: clamp(16px, 2vw, 28px);
+            object-fit: contain;
+        }
+        .dashboard-question-image[hidden] { display: none; }
+
         /* 3-column answer row (questions have exactly 3 answers) */
         .dashboard-answers {
             display: grid;
@@ -933,6 +947,7 @@
             <div class="dashboard-columns">
                 <div class="dashboard-left">
                     <div id="question-category" class="dashboard-category"></div>
+                    <img id="question-image" class="dashboard-question-image" alt="" hidden />
                     <div id="question-text" class="dashboard-question"></div>
                     <div id="answers-grid" class="dashboard-answers"></div>
                     <div id="fun-fact" class="dashboard-funfact">
@@ -997,6 +1012,7 @@
             roundIndicator: document.getElementById('round-indicator'),
             timerFill: document.getElementById('timer-fill'),
             questionCategory: document.getElementById('question-category'),
+            questionImage: document.getElementById('question-image'),
             questionText: document.getElementById('question-text'),
             answersGrid: document.getElementById('answers-grid'),
             leaderboard: document.getElementById('leaderboard'),
@@ -1009,6 +1025,23 @@
         function showView(name) {
             Object.values(views).forEach(function(v) { v.classList.remove('active'); });
             if (views[name]) views[name].classList.add('active');
+        }
+
+        // Issue #25: render the optional question image. Only absolute
+        // http(s) URLs are accepted (the server already sanitises, this
+        // is a defence-in-depth check). Absent/invalid → element hidden,
+        // layout collapses cleanly to the text-only question.
+        function renderQuestionImage(url) {
+            var img = els.questionImage;
+            if (!img) return;
+            var safe = (typeof url === 'string' && /^https?:\/\//i.test(url)) ? url : '';
+            if (safe) {
+                img.src = safe;
+                img.hidden = false;
+            } else {
+                img.removeAttribute('src');
+                img.hidden = true;
+            }
         }
 
         // ---- WebSocket ----
@@ -1087,6 +1120,7 @@
                             round_num: msg.round,
                             total_rounds: msg.total_rounds,
                             category: msg.question.category,
+                            image_url: msg.question.image_url,
                         });
                     } else {
                         showView('question');
@@ -1110,6 +1144,7 @@
                 : 'Question ' + msg.round_num + ' / ' + msg.total_rounds;
             els.questionCategory.textContent = msg.category || '';
             els.questionText.textContent = msg.question_text;
+            renderQuestionImage(msg.image_url);
 
             timerDuration = msg.timer_duration || 30;
             timerRemaining = timerDuration;

--- a/custom_components/quizify/www/js/player-game.js
+++ b/custom_components/quizify/www/js/player-game.js
@@ -116,6 +116,22 @@
         if (questionText) questionText.textContent = data.question_text || '';
         if (questionCategory) questionCategory.textContent = data.category || '';
 
+        // Issue #25: optional question thumbnail on the player screen.
+        // Only absolute http(s) URLs are shown (server already sanitises;
+        // this is defence-in-depth). Absent/invalid → element stays hidden.
+        var questionImage = document.getElementById('question-image');
+        if (questionImage) {
+            var imgUrl = data.image_url;
+            var safeImg = (typeof imgUrl === 'string' && /^https?:\/\//i.test(imgUrl)) ? imgUrl : '';
+            if (safeImg) {
+                questionImage.src = safeImg;
+                questionImage.hidden = false;
+            } else {
+                questionImage.removeAttribute('src');
+                questionImage.hidden = true;
+            }
+        }
+
         // Wager round detection — set BEFORE we touch buttons so we can
         // disable them up-front, then enable once the wager is in.
         _wagerGate.active = !!data.is_final_round;

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -2215,6 +2215,22 @@
         if (questionText) questionText.textContent = data.question_text || '';
         if (questionCategory) questionCategory.textContent = data.category || '';
 
+        // Issue #25: optional question thumbnail on the player screen.
+        // Only absolute http(s) URLs are shown (server already sanitises;
+        // this is defence-in-depth). Absent/invalid → element stays hidden.
+        var questionImage = document.getElementById('question-image');
+        if (questionImage) {
+            var imgUrl = data.image_url;
+            var safeImg = (typeof imgUrl === 'string' && /^https?:\/\//i.test(imgUrl)) ? imgUrl : '';
+            if (safeImg) {
+                questionImage.src = safeImg;
+                questionImage.hidden = false;
+            } else {
+                questionImage.removeAttribute('src');
+                questionImage.hidden = true;
+            }
+        }
+
         // Wager round detection — set BEFORE we touch buttons so we can
         // disable them up-front, then enable once the wager is in.
         _wagerGate.active = !!data.is_final_round;

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -186,6 +186,7 @@
                          data-i18n-aria-label="a11y.currentQuestionRegion"
                          aria-label="Current question">
                         <div id="question-category" class="question-category"></div>
+                        <img id="question-image" class="question-image" alt="" hidden />
                         <div id="question-text" class="question-text"></div>
                     </div>
                     <div id="question-loading" class="album-loading hidden">

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -15,6 +15,7 @@ from custom_components.quizify.game.questions import (  # noqa: E402
     Answer,
     Question,
     QuestionBank,
+    _parse_question,
 )
 
 QUESTIONS_DIR = _REPO_ROOT / "custom_components" / "quizify" / "questions"
@@ -303,3 +304,74 @@ class TestCommunityPacks:
         loaded = qb.load_community_packs()
         assert "community-example-pack" in loaded
         assert qb.get_question_count("community-example-pack") == 3
+
+
+def _valid_question_dict(**overrides) -> dict:
+    """Return a minimal valid question dict (issue #25 image tests)."""
+    base = {
+        "id": "img_001",
+        "question": "What film is this from?",
+        "answers": [
+            {"text": "A", "correct": True},
+            {"text": "B", "correct": False},
+            {"text": "C", "correct": False},
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestQuestionImage:
+    """Optional image_url field on questions (issue #25)."""
+
+    def test_image_url_defaults_to_empty(self) -> None:
+        q = Question(id="x", question="Q?", answers=[])
+        assert q.image_url == ""
+
+    def test_parse_question_without_image(self) -> None:
+        q = _parse_question(_valid_question_dict(), "Test")
+        assert q is not None
+        assert q.image_url == ""
+
+    def test_parse_question_keeps_https_url(self) -> None:
+        url = "https://example.com/poster.jpg"
+        q = _parse_question(_valid_question_dict(image_url=url), "Test")
+        assert q is not None
+        assert q.image_url == url
+
+    def test_parse_question_keeps_http_url(self) -> None:
+        url = "http://example.com/poster.jpg"
+        q = _parse_question(_valid_question_dict(image_url=url), "Test")
+        assert q is not None
+        assert q.image_url == url
+
+    def test_parse_question_strips_whitespace(self) -> None:
+        q = _parse_question(
+            _valid_question_dict(image_url="  https://example.com/p.png  "), "Test"
+        )
+        assert q is not None
+        assert q.image_url == "https://example.com/p.png"
+
+    def test_parse_question_drops_relative_path(self) -> None:
+        q = _parse_question(_valid_question_dict(image_url="/local/p.png"), "Test")
+        assert q is not None
+        assert q.image_url == ""
+
+    def test_parse_question_drops_javascript_scheme(self) -> None:
+        q = _parse_question(
+            _valid_question_dict(image_url="javascript:alert(1)"), "Test"
+        )
+        assert q is not None
+        assert q.image_url == ""
+
+    def test_parse_question_drops_data_uri(self) -> None:
+        q = _parse_question(
+            _valid_question_dict(image_url="data:image/png;base64,AAAA"), "Test"
+        )
+        assert q is not None
+        assert q.image_url == ""
+
+    def test_parse_question_drops_non_string(self) -> None:
+        q = _parse_question(_valid_question_dict(image_url=123), "Test")
+        assert q is not None
+        assert q.image_url == ""


### PR DESCRIPTION
Closes #25

## What

Adds an optional `image_url` field to the question pack JSON schema. When a question carries one, the shared dashboard renders the image above the question text and player screens show a thumbnail — useful for "What film is this from?" or visual geography questions. Questions without an image render exactly as before.

## Schema

```json
{
  "id": "geo_001",
  "question": "...",
  "answers": [ ... ],
  "difficulty": "medium",
  "image_url": "https://example.com/poster.jpg"
}
```

## Implementation

- **Model** (`game/questions.py`): new optional `image_url` field on `Question`, sanitised at parse time via `_sanitize_image_url`. Only absolute `http(s)` URLs are accepted; relative paths, `data:`/`javascript:` schemes and non-strings are dropped and logged.
- **Serializers**: `image_url` added to the player and admin `question_started` payloads.
- **Game state**: `image_url` included in the `QUESTION_ACTIVE` snapshot (mid-round joiners).
- **Protocol**: `QuestionStartedMessage` gains the field (default `""`), TS-doc comment updated.
- **Dashboard** (`dashboard.html`): `<img>` above the question text, rendered only for valid `http(s)` URLs (defence-in-depth check), capped height so it can't push answers off a 720p TV.
- **Player** (`player.html` + `player-game.js`): thumbnail in the question card, same http(s) guard, capped at 30vh; bundle rebuilt.
- Docs: `REQUIREMENTS.md` schema example + `CHANGELOG.md` Unreleased entry.

## Tests

Added `TestQuestionImage` (9 cases: default empty, http/https kept, whitespace stripped, relative/`javascript:`/`data:`/non-string dropped). Full suite: **171 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)