### PR TITLE
feat(questions): community question pack loader (first step of #6)

### DIFF
--- a/custom_components/quizify/game/questions.py
+++ b/custom_components/quizify/game/questions.py
@@ -14,6 +14,23 @@ _LOGGER = logging.getLogger(__name__)
 
 QUESTIONS_DIR = Path(__file__).resolve().parent.parent / "questions"
 
+# Community packs live in a dedicated subfolder so user-contributed JSON is
+# kept apart from the built-in, reviewed packs. The non-recursive ``*.json``
+# glob used for built-in discovery never reaches into this subfolder, so the
+# two namespaces stay cleanly separated.
+COMMUNITY_SUBDIR = "community"
+
+# Slugs of community packs are prefixed so they can never collide with (or
+# silently shadow) a built-in pack slug.
+COMMUNITY_SLUG_PREFIX = "community-"
+
+# Defensive caps applied to user-contributed packs only. Built-in packs are
+# reviewed by hand, but community JSON is untrusted input: a single pack must
+# not be able to exhaust memory or flood the category picker. These ceilings
+# are generous (the largest built-in pack is ~150 questions) but finite.
+MAX_COMMUNITY_PACK_BYTES = 1_048_576  # 1 MiB per pack file
+MAX_COMMUNITY_QUESTIONS = 500  # questions kept per community pack
+
 
 @dataclass
 class Answer:
@@ -156,6 +173,11 @@ class QuestionBank:
                 continue
             self.load_category(category_slug)
 
+        # User-contributed packs are loaded after the built-in packs so the
+        # collision check can see every built-in slug. Failures inside this
+        # call are self-contained (each bad pack is skipped, not raised).
+        self.load_community_packs()
+
         self._loaded = True
         return dict(self._categories)
 
@@ -164,6 +186,142 @@ class QuestionBank:
         self._loaded = False
         self._categories = {}
         return self.load_all_categories()
+
+    def load_community_packs(self) -> dict[str, list[Question]]:
+        """Discover and load user-contributed packs from the community subfolder.
+
+        Community packs are untrusted input, so loading is deliberately
+        defensive: every failure mode (missing folder, unreadable file,
+        oversized file, malformed JSON, wrong top-level shape, missing name,
+        empty/oversized question list, slug collision with a built-in pack) is
+        logged and skipped rather than raised. A single bad pack can never
+        prevent the others — or the built-in packs — from loading.
+
+        Each community pack is registered under a prefixed slug
+        (``community-<filename>``) so it can never shadow a built-in category.
+        Returns the mapping of the community packs that were loaded.
+        """
+        community_dir = self._questions_dir / COMMUNITY_SUBDIR
+        loaded: dict[str, list[Question]] = {}
+
+        if not community_dir.is_dir():
+            _LOGGER.debug("No community pack directory at %s", community_dir)
+            return loaded
+
+        for file_path in sorted(community_dir.glob("*.json")):
+            slug = f"{COMMUNITY_SLUG_PREFIX}{file_path.stem}"
+
+            if slug in self._categories:
+                _LOGGER.warning(
+                    "Skipping community pack '%s': slug '%s' already loaded",
+                    file_path.name,
+                    slug,
+                )
+                continue
+
+            try:
+                size = file_path.stat().st_size
+            except OSError as exc:
+                _LOGGER.warning("Cannot stat community pack '%s': %s", file_path, exc)
+                continue
+
+            if size > MAX_COMMUNITY_PACK_BYTES:
+                _LOGGER.warning(
+                    "Skipping community pack '%s': %d bytes exceeds limit of %d",
+                    file_path.name,
+                    size,
+                    MAX_COMMUNITY_PACK_BYTES,
+                )
+                continue
+
+            try:
+                raw = json.loads(file_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, UnicodeDecodeError, OSError) as exc:
+                _LOGGER.warning("Invalid community pack '%s': %s", file_path.name, exc)
+                continue
+
+            if not isinstance(raw, dict):
+                _LOGGER.warning(
+                    "Skipping community pack '%s': top-level JSON must be an object",
+                    file_path.name,
+                )
+                continue
+
+            questions_data = raw.get("questions")
+            if not isinstance(questions_data, list) or not questions_data:
+                _LOGGER.warning(
+                    "Skipping community pack '%s': 'questions' must be a non-empty list",
+                    file_path.name,
+                )
+                continue
+
+            if len(questions_data) > MAX_COMMUNITY_QUESTIONS:
+                _LOGGER.warning(
+                    "Community pack '%s': truncating %d questions to limit of %d",
+                    file_path.name,
+                    len(questions_data),
+                    MAX_COMMUNITY_QUESTIONS,
+                )
+                questions_data = questions_data[:MAX_COMMUNITY_QUESTIONS]
+
+            category_name = raw.get("name")
+            if not isinstance(category_name, str) or not category_name.strip():
+                _LOGGER.warning(
+                    "Skipping community pack '%s': missing or empty 'name'",
+                    file_path.name,
+                )
+                continue
+
+            pack_language = raw.get("language", "de")
+            if not isinstance(pack_language, str):
+                pack_language = "de"
+            pack_version = raw.get("version", "1.0")
+            if not isinstance(pack_version, (str, int, float)):
+                pack_version = "1.0"
+
+            questions: list[Question] = []
+            seen_ids: set[str] = set()
+            for entry in questions_data:
+                if not isinstance(entry, dict):
+                    continue
+                q = _parse_question(entry, category_name)
+                if q is None:
+                    continue
+                if q.id in seen_ids:
+                    _LOGGER.warning(
+                        "Community pack '%s': dropping duplicate question id '%s'",
+                        file_path.name,
+                        q.id,
+                    )
+                    continue
+                seen_ids.add(q.id)
+                q.language = pack_language
+                questions.append(q)
+
+            if not questions:
+                _LOGGER.warning(
+                    "Skipping community pack '%s': no valid questions after validation",
+                    file_path.name,
+                )
+                continue
+
+            self._categories[slug] = questions
+            self._pack_versions[slug] = {
+                "version": str(pack_version),
+                "name": category_name,
+                "language": pack_language,
+                "question_count": len(questions),
+                "community": True,
+            }
+            loaded[slug] = questions
+            _LOGGER.info(
+                "Loaded community pack '%s' (%d questions) as '%s'",
+                file_path.name,
+                len(questions),
+                slug,
+            )
+
+        return loaded
 
     def get_categories(self) -> list[str]:
         """Return list of loaded category slugs."""

--- a/custom_components/quizify/questions/community/README.md
+++ b/custom_components/quizify/questions/community/README.md
@@ -1,0 +1,80 @@
+# Community Question Packs
+
+This folder holds **user-contributed** question packs. Any `*.json` file you
+drop in here is discovered automatically the next time Quizify loads its
+question bank (a Home Assistant restart, or an in-app pack reload). They appear
+in the category picker alongside the built-in packs.
+
+Community packs are kept separate from the built-in, hand-reviewed packs so
+that user content is clearly namespaced and can be validated independently.
+
+## File format
+
+A community pack is a single JSON object:
+
+```json
+{
+  "name": "My Custom Pack",
+  "language": "en",
+  "version": "1.0",
+  "theme": "general",
+  "questions": [
+    {
+      "id": "mypack_001",
+      "question": "What is the capital of France?",
+      "answers": [
+        {"text": "Paris", "correct": true},
+        {"text": "Lyon", "correct": false},
+        {"text": "Marseille", "correct": false}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Paris has been the capital of France since 508 AD.",
+      "category": "My Custom Pack"
+    }
+  ]
+}
+```
+
+### Top-level fields
+
+| Field       | Required | Notes                                                        |
+|-------------|----------|--------------------------------------------------------------|
+| `name`      | yes      | Display name shown in the picker. Must be a non-empty string.|
+| `questions` | yes      | Non-empty list of question objects (see below).              |
+| `language`  | no       | `"de"` or `"en"`. Defaults to `"de"`.                        |
+| `version`   | no       | Free-form version string. Defaults to `"1.0"`.              |
+| `theme`     | no       | Optional theme key used for the picker icon.                 |
+
+### Question fields
+
+| Field        | Required | Notes                                                  |
+|--------------|----------|--------------------------------------------------------|
+| `id`         | yes      | Unique within the pack. Duplicates are dropped.        |
+| `question`   | yes      | The question text.                                     |
+| `answers`    | yes      | Exactly **3** answers, exactly **one** marked correct. |
+| `difficulty` | no       | `"easy"`, `"medium"`, or `"hard"`. Defaults `"medium"`.|
+| `fun_fact`   | no       | Optional trivia shown on the reveal screen.            |
+| `category`   | no       | Defaults to the pack `name`.                           |
+
+## Validation & limits
+
+Community JSON is treated as untrusted input. Loading is defensive: a malformed
+pack is skipped (and logged) rather than crashing the integration. Concretely,
+a pack is **rejected or trimmed** when:
+
+- the file is larger than **1 MiB**;
+- the JSON is invalid or not a top-level object;
+- `name` is missing/empty, or `questions` is missing/empty;
+- a question does not have exactly 3 answers with exactly 1 correct answer
+  (such questions are skipped individually);
+- more than **500 questions** are present (the list is truncated);
+- the slug collides with an already-loaded pack.
+
+Each pack is registered under a `community-<filename>` slug so it can never
+shadow a built-in pack.
+
+## Contributing upstream
+
+To share a pack with the wider community, open a pull request adding your
+`*.json` file to this folder. Keep it focused (one theme per pack) and run the
+question bank tests before submitting.

--- a/custom_components/quizify/questions/community/example-pack.json
+++ b/custom_components/quizify/questions/community/example-pack.json
@@ -1,0 +1,44 @@
+{
+  "name": "Example Community Pack",
+  "language": "en",
+  "version": "1.0",
+  "theme": "general",
+  "questions": [
+    {
+      "id": "example_001",
+      "question": "Which planet is known as the Red Planet?",
+      "answers": [
+        {"text": "Mars", "correct": true},
+        {"text": "Jupiter", "correct": false},
+        {"text": "Venus", "correct": false}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Mars looks red because its surface is rich in iron oxide — essentially rust.",
+      "category": "Example Community Pack"
+    },
+    {
+      "id": "example_002",
+      "question": "How many continents are there on Earth?",
+      "answers": [
+        {"text": "5", "correct": false},
+        {"text": "7", "correct": true},
+        {"text": "9", "correct": false}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The seven continents are Africa, Antarctica, Asia, Europe, North America, Oceania, and South America.",
+      "category": "Example Community Pack"
+    },
+    {
+      "id": "example_003",
+      "question": "What is the largest mammal on Earth?",
+      "answers": [
+        {"text": "African elephant", "correct": false},
+        {"text": "Blue whale", "correct": true},
+        {"text": "Giraffe", "correct": false}
+      ],
+      "difficulty": "medium",
+      "fun_fact": "A blue whale's heart alone can weigh as much as a small car.",
+      "category": "Example Community Pack"
+    }
+  ]
+}

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -65,7 +66,10 @@ class TestLoadCategory:
     def test_each_category_within_expected_size(self, bank: QuestionBank) -> None:
         # Themed packs run ~150 (148-150 after review deletions); the standalone
         # World Cup packs are a deliberate 100. Floor catches gross truncation.
+        # Community packs are user content with no size invariant — skip them.
         for cat in bank.get_categories():
+            if cat.startswith("community-"):
+                continue
             count = bank.get_question_count(cat)
             assert count >= 95, f"{cat} has only {count} questions (floor: 95)"
             assert count <= 150, f"{cat} has {count} questions (ceiling: 150)"
@@ -154,3 +158,148 @@ class TestQuestionIntegrity:
             questions = bank.load_category(cat)
             for q in questions:
                 assert q.difficulty in valid, f"Question {q.id} has invalid difficulty '{q.difficulty}'"
+
+
+def _make_pack(name="My Pack", language="en", version="1.0", questions=None):
+    """Build a minimal valid pack dict for community-pack tests."""
+    if questions is None:
+        questions = [
+            {
+                "id": "cq_001",
+                "question": "What is 2+2?",
+                "answers": [
+                    {"text": "4", "correct": True},
+                    {"text": "3", "correct": False},
+                    {"text": "5", "correct": False},
+                ],
+                "difficulty": "easy",
+                "fun_fact": "Basic arithmetic.",
+            }
+        ]
+    return {
+        "name": name,
+        "language": language,
+        "version": version,
+        "questions": questions,
+    }
+
+
+def _write_community_pack(community_dir: Path, filename: str, data) -> Path:
+    community_dir.mkdir(parents=True, exist_ok=True)
+    path = community_dir / filename
+    if isinstance(data, str):
+        path.write_text(data, encoding="utf-8")
+    else:
+        path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+class TestCommunityPacks:
+    def test_no_community_dir_is_safe(self, tmp_path: Path) -> None:
+        qb = QuestionBank(questions_dir=tmp_path)
+        loaded = qb.load_community_packs()
+        assert loaded == {}
+
+    def test_loads_valid_pack_with_prefixed_slug(self, tmp_path: Path) -> None:
+        _write_community_pack(tmp_path / "community", "mypack.json", _make_pack())
+        qb = QuestionBank(questions_dir=tmp_path)
+        loaded = qb.load_community_packs()
+        assert "community-mypack" in loaded
+        assert qb.get_question_count("community-mypack") == 1
+        meta = qb.get_pack_versions()["community-mypack"]
+        assert meta["community"] is True
+        assert meta["name"] == "My Pack"
+        assert meta["language"] == "en"
+
+    def test_load_all_categories_picks_up_community(self, tmp_path: Path) -> None:
+        _write_community_pack(tmp_path / "community", "extra.json", _make_pack())
+        qb = QuestionBank(questions_dir=tmp_path)
+        qb.load_all_categories()
+        assert "community-extra" in qb.get_categories()
+
+    def test_invalid_json_is_skipped(self, tmp_path: Path) -> None:
+        _write_community_pack(tmp_path / "community", "broken.json", "{not valid json")
+        qb = QuestionBank(questions_dir=tmp_path)
+        loaded = qb.load_community_packs()
+        assert loaded == {}
+
+    def test_non_object_top_level_is_skipped(self, tmp_path: Path) -> None:
+        _write_community_pack(tmp_path / "community", "list.json", [1, 2, 3])
+        qb = QuestionBank(questions_dir=tmp_path)
+        assert qb.load_community_packs() == {}
+
+    def test_missing_name_is_skipped(self, tmp_path: Path) -> None:
+        pack = _make_pack()
+        del pack["name"]
+        _write_community_pack(tmp_path / "community", "noname.json", pack)
+        qb = QuestionBank(questions_dir=tmp_path)
+        assert qb.load_community_packs() == {}
+
+    def test_empty_questions_is_skipped(self, tmp_path: Path) -> None:
+        _write_community_pack(tmp_path / "community", "empty.json", _make_pack(questions=[]))
+        qb = QuestionBank(questions_dir=tmp_path)
+        assert qb.load_community_packs() == {}
+
+    def test_pack_with_only_invalid_questions_is_skipped(self, tmp_path: Path) -> None:
+        bad = _make_pack(questions=[{"id": "x", "question": "q", "answers": [{"text": "a", "correct": True}]}])
+        _write_community_pack(tmp_path / "community", "badq.json", bad)
+        qb = QuestionBank(questions_dir=tmp_path)
+        assert qb.load_community_packs() == {}
+
+    def test_individual_bad_question_dropped_others_kept(self, tmp_path: Path) -> None:
+        good = _make_pack()["questions"][0]
+        bad = {"id": "bad", "question": "q", "answers": [{"text": "a", "correct": True}]}
+        _write_community_pack(tmp_path / "community", "mixed.json", _make_pack(questions=[good, bad]))
+        qb = QuestionBank(questions_dir=tmp_path)
+        loaded = qb.load_community_packs()
+        assert qb.get_question_count("community-mixed") == 1
+
+    def test_duplicate_ids_deduplicated(self, tmp_path: Path) -> None:
+        q = _make_pack()["questions"][0]
+        _write_community_pack(tmp_path / "community", "dup.json", _make_pack(questions=[q, dict(q)]))
+        qb = QuestionBank(questions_dir=tmp_path)
+        qb.load_community_packs()
+        assert qb.get_question_count("community-dup") == 1
+
+    def test_oversized_file_is_skipped(self, tmp_path: Path) -> None:
+        from custom_components.quizify.game.questions import MAX_COMMUNITY_PACK_BYTES
+
+        community = tmp_path / "community"
+        community.mkdir(parents=True)
+        pack = _make_pack()
+        pack["padding"] = "x" * (MAX_COMMUNITY_PACK_BYTES + 10)
+        (community / "huge.json").write_text(json.dumps(pack), encoding="utf-8")
+        qb = QuestionBank(questions_dir=tmp_path)
+        assert qb.load_community_packs() == {}
+
+    def test_too_many_questions_truncated(self, tmp_path: Path) -> None:
+        from custom_components.quizify.game.questions import MAX_COMMUNITY_QUESTIONS
+
+        base = _make_pack()["questions"][0]
+        many = []
+        for i in range(MAX_COMMUNITY_QUESTIONS + 5):
+            q = dict(base)
+            q["id"] = f"cq_{i:04d}"
+            many.append(q)
+        _write_community_pack(tmp_path / "community", "many.json", _make_pack(questions=many))
+        qb = QuestionBank(questions_dir=tmp_path)
+        qb.load_community_packs()
+        assert qb.get_question_count("community-many") == MAX_COMMUNITY_QUESTIONS
+
+    def test_community_cannot_shadow_builtin(self, tmp_path: Path) -> None:
+        # Pre-load a built-in category, then a community file whose prefixed
+        # slug would collide is the only collision path; verify a same-named
+        # community slug is refused if already present.
+        _write_community_pack(tmp_path / "community", "dupe.json", _make_pack())
+        qb = QuestionBank(questions_dir=tmp_path)
+        qb.load_community_packs()
+        # Second load on the already-populated bank must not duplicate/clobber.
+        loaded_again = qb.load_community_packs()
+        assert loaded_again == {}
+        assert qb.get_question_count("community-dupe") == 1
+
+    def test_shipped_example_pack_loads(self) -> None:
+        qb = QuestionBank(questions_dir=QUESTIONS_DIR)
+        loaded = qb.load_community_packs()
+        assert "community-example-pack" in loaded
+        assert qb.get_question_count("community-example-pack") == 3


### PR DESCRIPTION
## Summary

First, safe, well-scoped step toward **#6 Community Question Packs**. Adds the loader + schema-validation infrastructure for user-contributed packs, kept apart from the built-in reviewed packs.

This does **not** close #6 — it lands the foundational loading/validation layer. The remaining product decisions (distribution / auto-update of community packs, in-app moderation/trust, how the picker should label community vs built-in packs) are intentionally left open.

## What this adds

- **`QuestionBank.load_community_packs()`** — discovers `questions/community/*.json`. Because this is untrusted input, loading is deliberately defensive: every failure mode (missing folder, unreadable/oversized file, malformed JSON, wrong top-level shape, missing `name`, empty/oversized `questions`, per-question validation failures, duplicate ids, slug collision) is logged and skipped — never raised. One bad pack can't break the others or the built-in packs.
- **Namespacing** — community packs register under a `community-<filename>` slug so they can never shadow a built-in category. Metadata carries `"community": true`.
- **Caps** — 1 MiB per file, 500 questions per pack.
- **Auto-discovery** — wired into `load_all_categories()`, so dropping a JSON file in the folder surfaces it in the category picker after a reload/restart.
- **Contribution guide** (`questions/community/README.md`) documenting the JSON schema, fields, and validation rules + an **example pack** as a template.

## Tests

14 new tests in `tests/test_questions.py` covering: valid load + prefixed slug + metadata, auto-discovery via `load_all_categories`, and every rejection path (invalid JSON, non-object top level, missing name, empty questions, all-invalid questions, mixed valid/invalid, duplicate ids, oversized file, truncation at the 500 cap, slug collision), plus the shipped example pack.

Full suite: **176 passed** (162 baseline + 14 new).

Refs #6.