### PR TITLE
feat(finale): dramatic countdown before the final question

### DIFF
--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -4782,6 +4782,77 @@ body.is-admin .reaction-bar {
     font-size: 0.9rem;
 }
 
+/* Finale countdown overlay — a brief dramatic flourish + 3·2·1 shown on the
+   big screen right before the final question is revealed. Pure tension/UX;
+   no scoring impact. Soft-Parlor styling (coral accent on dimmed parlor bg). */
+.finale-countdown-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(31, 27, 20, 0.92);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: var(--z-overlay);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+}
+
+.finale-countdown-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-lg);
+    text-align: center;
+    padding: var(--space-xl);
+}
+
+.finale-countdown-flourish {
+    font-family: var(--font-display);
+    font-weight: var(--font-weight-extrabold);
+    font-size: clamp(2.5rem, 12vw, 5rem);
+    line-height: 1.05;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-accent-primary);
+    text-shadow: 0 0 24px var(--accent-glow);
+    animation: finale-flourish-in 0.6s cubic-bezier(0.2, 0.9, 0.3, 1.3) both;
+}
+
+.finale-countdown-number {
+    font-family: var(--font-mono);
+    font-weight: var(--font-weight-bold);
+    font-size: clamp(4rem, 22vw, 9rem);
+    line-height: 1;
+    color: var(--color-text-neon, #F5EFE6);
+    min-height: 1em;
+}
+
+/* Re-key the number's pop on each digit change via the .tick toggle. */
+.finale-countdown-number.tick {
+    animation: finale-number-pop 0.9s ease-out both;
+}
+
+@keyframes finale-flourish-in {
+    0%   { opacity: 0; transform: scale(0.6) translateY(12px); }
+    100% { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+@keyframes finale-number-pop {
+    0%   { opacity: 0; transform: scale(1.6); }
+    25%  { opacity: 1; transform: scale(1); }
+    100% { opacity: 0.85; transform: scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .finale-countdown-flourish,
+    .finale-countdown-number.tick {
+        animation: none;
+    }
+}
+
 /* Connection lost screen */
 .connection-lost-view {
     display: flex;

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -156,6 +156,7 @@
     "rank": "Platz {rank} — {score} Punkte",
     "roundLabel": "Runde",
     "finalRound": "Letzte Runde!",
+    "finale": "Finale!",
     "submitted": "Abgeschickt",
     "yourAnswer": "Deine Antwort",
     "waitingForHost": "Warte auf den Host…",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -156,6 +156,7 @@
     "rank": "Rank {rank} — {score} Points",
     "roundLabel": "Round",
     "finalRound": "Final Round!",
+    "finale": "Finale!",
     "submitted": "Submitted",
     "yourAnswer": "Your Answer",
     "waitingForHost": "Waiting for the host…",

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -226,7 +226,15 @@
                 break;
 
             case 'question_started':
-                handleQuestionStarted(msg);
+                // On the final round, play a brief dramatic flourish + 3·2·1
+                // countdown on the big screen BEFORE revealing the question.
+                // Pure tension/UX — works regardless of finale type. If timing
+                // data is missing or anything goes wrong, we reveal instantly.
+                if (isFinalRound(msg)) {
+                    playFinaleCountdown(function () { handleQuestionStarted(msg); });
+                } else {
+                    handleQuestionStarted(msg);
+                }
                 break;
 
             case 'timer_tick':
@@ -320,6 +328,9 @@
             _acquireWakeLock();
         } else {
             _releaseWakeLock();
+            // Drop any in-flight finale flourish when leaving an active round
+            // (pause / reveal / reset / reconnect into a non-question phase).
+            _clearFinaleCountdown();
         }
 
         // Sync UI language with the server-side game language so a
@@ -407,6 +418,81 @@
     // Question Started
     // ============================================
 
+    // ============================================
+    // Finale Countdown (dramatic flourish before the final question)
+    // ============================================
+
+    var _finaleCountdownTimers = [];
+
+    // True when this question_started marks the last round. Prefer the
+    // explicit server flag; fall back to round_num >= total_rounds so the
+    // countdown still fires even if is_final_round is ever absent.
+    function isFinalRound(msg) {
+        if (!msg) return false;
+        if (msg.is_final_round === true) return true;
+        var rn = msg.round_num;
+        var tr = msg.total_rounds;
+        return typeof rn === 'number' && typeof tr === 'number' && tr > 0 && rn >= tr;
+    }
+
+    function _clearFinaleCountdown() {
+        for (var i = 0; i < _finaleCountdownTimers.length; i++) {
+            clearTimeout(_finaleCountdownTimers[i]);
+        }
+        _finaleCountdownTimers = [];
+        var overlay = document.getElementById('finale-countdown-overlay');
+        if (overlay) {
+            overlay.classList.add('hidden');
+            overlay.setAttribute('aria-hidden', 'true');
+        }
+    }
+
+    // Show "Finale!" then 3 · 2 · 1 (~2.4s total), then run `done`. The reveal
+    // is always invoked exactly once, even if something throws — the final
+    // question must never be swallowed by this purely cosmetic flourish.
+    function playFinaleCountdown(done) {
+        var fired = false;
+        function finish() {
+            if (fired) return;
+            fired = true;
+            _clearFinaleCountdown();
+            try { done(); } catch (e) { /* reveal already in progress */ }
+        }
+
+        var overlay = document.getElementById('finale-countdown-overlay');
+        var numberEl = document.getElementById('finale-countdown-number');
+        if (!overlay || !numberEl) {
+            // No overlay element (older cached HTML) — skip straight to reveal.
+            finish();
+            return;
+        }
+
+        try {
+            _clearFinaleCountdown();
+            numberEl.textContent = '';
+            overlay.classList.remove('hidden');
+            overlay.setAttribute('aria-hidden', 'false');
+
+            // Flourish shows alone for ~0.7s, then 3 · 2 · 1 at 0.6s each.
+            var digits = [3, 2, 1];
+            digits.forEach(function (d, idx) {
+                _finaleCountdownTimers.push(setTimeout(function () {
+                    numberEl.textContent = String(d);
+                    // Re-trigger the pop animation by toggling the class.
+                    numberEl.classList.remove('tick');
+                    // Force reflow so the animation restarts on each digit.
+                    void numberEl.offsetWidth;
+                    numberEl.classList.add('tick');
+                }, 700 + idx * 600));
+            });
+
+            // After the last digit finishes, reveal the question.
+            _finaleCountdownTimers.push(setTimeout(finish, 700 + digits.length * 600));
+        } catch (e) {
+            finish();
+        }
+    }
+
     function handleQuestionStarted(msg) {
         state.currentPhase = 'QUESTION_ACTIVE';
         currentQuestion = msg;
@@ -459,6 +545,7 @@
     function handleRoundSummary(msg) {
         state.currentPhase = 'ANSWER_REVEAL';
         game.stopCountdown();
+        _clearFinaleCountdown();
         pu.showView('reveal-view');
 
         // Pass question context to reveal
@@ -512,6 +599,7 @@
     function handleFinale(msg) {
         state.currentPhase = 'FINALE';
         game.stopCountdown();
+        _clearFinaleCountdown();
         pu.showView('end-view');
 
         end.updateEndView(msg);

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -3135,7 +3135,15 @@
                 break;
 
             case 'question_started':
-                handleQuestionStarted(msg);
+                // On the final round, play a brief dramatic flourish + 3·2·1
+                // countdown on the big screen BEFORE revealing the question.
+                // Pure tension/UX — works regardless of finale type. If timing
+                // data is missing or anything goes wrong, we reveal instantly.
+                if (isFinalRound(msg)) {
+                    playFinaleCountdown(function () { handleQuestionStarted(msg); });
+                } else {
+                    handleQuestionStarted(msg);
+                }
                 break;
 
             case 'timer_tick':
@@ -3229,6 +3237,9 @@
             _acquireWakeLock();
         } else {
             _releaseWakeLock();
+            // Drop any in-flight finale flourish when leaving an active round
+            // (pause / reveal / reset / reconnect into a non-question phase).
+            _clearFinaleCountdown();
         }
 
         // Sync UI language with the server-side game language so a
@@ -3316,6 +3327,81 @@
     // Question Started
     // ============================================
 
+    // ============================================
+    // Finale Countdown (dramatic flourish before the final question)
+    // ============================================
+
+    var _finaleCountdownTimers = [];
+
+    // True when this question_started marks the last round. Prefer the
+    // explicit server flag; fall back to round_num >= total_rounds so the
+    // countdown still fires even if is_final_round is ever absent.
+    function isFinalRound(msg) {
+        if (!msg) return false;
+        if (msg.is_final_round === true) return true;
+        var rn = msg.round_num;
+        var tr = msg.total_rounds;
+        return typeof rn === 'number' && typeof tr === 'number' && tr > 0 && rn >= tr;
+    }
+
+    function _clearFinaleCountdown() {
+        for (var i = 0; i < _finaleCountdownTimers.length; i++) {
+            clearTimeout(_finaleCountdownTimers[i]);
+        }
+        _finaleCountdownTimers = [];
+        var overlay = document.getElementById('finale-countdown-overlay');
+        if (overlay) {
+            overlay.classList.add('hidden');
+            overlay.setAttribute('aria-hidden', 'true');
+        }
+    }
+
+    // Show "Finale!" then 3 · 2 · 1 (~2.4s total), then run `done`. The reveal
+    // is always invoked exactly once, even if something throws — the final
+    // question must never be swallowed by this purely cosmetic flourish.
+    function playFinaleCountdown(done) {
+        var fired = false;
+        function finish() {
+            if (fired) return;
+            fired = true;
+            _clearFinaleCountdown();
+            try { done(); } catch (e) { /* reveal already in progress */ }
+        }
+
+        var overlay = document.getElementById('finale-countdown-overlay');
+        var numberEl = document.getElementById('finale-countdown-number');
+        if (!overlay || !numberEl) {
+            // No overlay element (older cached HTML) — skip straight to reveal.
+            finish();
+            return;
+        }
+
+        try {
+            _clearFinaleCountdown();
+            numberEl.textContent = '';
+            overlay.classList.remove('hidden');
+            overlay.setAttribute('aria-hidden', 'false');
+
+            // Flourish shows alone for ~0.7s, then 3 · 2 · 1 at 0.6s each.
+            var digits = [3, 2, 1];
+            digits.forEach(function (d, idx) {
+                _finaleCountdownTimers.push(setTimeout(function () {
+                    numberEl.textContent = String(d);
+                    // Re-trigger the pop animation by toggling the class.
+                    numberEl.classList.remove('tick');
+                    // Force reflow so the animation restarts on each digit.
+                    void numberEl.offsetWidth;
+                    numberEl.classList.add('tick');
+                }, 700 + idx * 600));
+            });
+
+            // After the last digit finishes, reveal the question.
+            _finaleCountdownTimers.push(setTimeout(finish, 700 + digits.length * 600));
+        } catch (e) {
+            finish();
+        }
+    }
+
     function handleQuestionStarted(msg) {
         state.currentPhase = 'QUESTION_ACTIVE';
         currentQuestion = msg;
@@ -3368,6 +3454,7 @@
     function handleRoundSummary(msg) {
         state.currentPhase = 'ANSWER_REVEAL';
         game.stopCountdown();
+        _clearFinaleCountdown();
         pu.showView('reveal-view');
 
         // Pass question context to reveal
@@ -3421,6 +3508,7 @@
     function handleFinale(msg) {
         state.currentPhase = 'FINALE';
         game.stopCountdown();
+        _clearFinaleCountdown();
         pu.showView('end-view');
 
         end.updateEndView(msg);

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -489,6 +489,14 @@
         <div id="reaction-container" class="reaction-container"></div>
     </main>
 
+    <!-- Finale Countdown Overlay (dramatic flourish before the final question) -->
+    <div id="finale-countdown-overlay" class="finale-countdown-overlay hidden" aria-hidden="true">
+        <div class="finale-countdown-content">
+            <div id="finale-countdown-flourish" class="finale-countdown-flourish" data-i18n="game.finale">Finale!</div>
+            <div id="finale-countdown-number" class="finale-countdown-number"></div>
+        </div>
+    </div>
+
     <!-- Reconnecting Overlay -->
     <div id="reconnecting-overlay" class="reconnecting-overlay hidden">
         <div class="reconnecting-content">


### PR DESCRIPTION
## What

Adds a brief **dramatic countdown on the host/TV (player) screen right before the final question appears**: a short `Finale!` flourish followed by a `3 · 2 · 1` countdown, then the question is revealed. Pure tension/UX — **no scoring change and the betting/wager finale logic is untouched**. Works regardless of finale type (wager finale or none).

## How

- **Detection** — the last round is detected client-side from the existing `question_started.is_final_round` flag, with a `round_num >= total_rounds` fallback so the countdown still fires even if that flag is ever absent.
- **Insertion point** — the live `question_started` WebSocket handler in `player-core.js`. On the final round it plays the overlay first, then runs the normal `handleQuestionStarted(msg)` reveal. Every other round is unchanged.
- **Fail-safe / skippable** — if the overlay element is missing (e.g. stale cached HTML) or anything throws, the question reveals **instantly**; the cosmetic flourish can never swallow the final question. Total duration ~2.4s.
- **No double-play** — only fires on the live event, **never** on a reconnect into a mid-round `QUESTION_ACTIVE`. The overlay is cleared on reveal / pause / reset / finale transitions.
- **i18n** — `Finale!` label added under `game.finale` in `en.json` + `de.json`.
- **Styling** — Soft-Parlor look (coral accent, parlor-dim backdrop), respects `prefers-reduced-motion`.

## Files

- `www/player.html` — overlay markup
- `www/css/styles.css` — overlay + flourish/number animations
- `www/js/player-core.js` — final-round detection + countdown orchestration
- `www/js/player.bundle.js` — rebuilt
- `www/i18n/{en,de}.json` — `game.finale`

## Tests

- `python3 -m pytest tests/ -q` → **162 passed**
- Bundle rebuilt via `scripts/build_bundle.py`; i18n JSON validated.

## Verification

Host/TV-screen UI change — **Mobile/host-screen verify pending** (Chrome remote-debug likely off); not blocking this PR.

---

Carried over from the (already-closed) issue. **Follow-up to #22.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)