### PR TITLE
refactor(game-server): extract ScoringEngine + BroadcastDispatcher (first step, part of #184)

### DIFF
--- a/custom_components/quizify/game/scoring_engine.py
+++ b/custom_components/quizify/game/scoring_engine.py
@@ -1,0 +1,160 @@
+"""ScoringEngine — pure round-score computation for Quizify.
+
+Extracted from ``QuizifyGameState.submit_answer`` (issue #184, splitting the
+game-server God-objects). This module owns the *pure* arithmetic that turns a
+single submitted answer into points + a client-facing breakdown:
+
+  * base / speed / difficulty / streak scoring (delegates to ``scoring``)
+  * the streak-milestone spike (3/5/10/... → discrete bonus)
+  * the final-round wager override (Jeopardy-style bet)
+
+It is deliberately side-effect free: it never mutates a ``PlayerSession`` and
+never touches game state. ``submit_answer`` keeps ownership of all mutation
+(streak counters, score accumulation, milestone tallies) and simply applies the
+``ScoreComputation`` this engine returns. Behaviour is byte-for-byte identical
+to the previous inline block — the same numbers in the same order — so the
+message protocol and scoring are unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from .scoring import (
+    BASE_POINTS,
+    MAX_SPEED_BONUS,
+    calculate_round_score,
+    get_streak_milestone_bonus,
+    get_streak_multiplier,
+)
+from .types import DIFFICULTY_MULTIPLIERS, Difficulty
+
+
+@dataclass
+class ScoreComputation:
+    """The result of scoring a single submitted answer.
+
+    Carries everything ``submit_answer`` needs to apply to the player and to
+    build the outgoing ``AnswerResult``. No mutation happens in here — the
+    caller owns applying ``points`` to the running score and bumping the
+    milestone tallies via ``milestone_bonus``.
+    """
+
+    points: int
+    speed_bonus: int = 0
+    streak_bonus: int = 0
+    difficulty_multiplier: float = 1.0
+    double_points: bool = False
+    # Set to the absolute wager points when a final-round wager replaced the
+    # normal scoring; None otherwise. Surfaced in the breakdown.
+    wager_used: int | None = None
+    # Discrete milestone spike already folded into ``points`` — surfaced
+    # separately so the caller can tally it and the client can celebrate.
+    milestone_bonus: int = 0
+
+    @property
+    def breakdown(self) -> dict[str, Any]:
+        """The ``round_score_breakdown`` dict the client renders."""
+        return {
+            "speed_bonus": self.speed_bonus,
+            "streak_bonus": self.streak_bonus,
+            "difficulty_multiplier": self.difficulty_multiplier,
+            "double_points": self.double_points,
+            "wager": self.wager_used,
+            "milestone_bonus": self.milestone_bonus,
+        }
+
+
+class ScoringEngine:
+    """Computes the points + breakdown for one submitted answer.
+
+    Stateless: a single shared instance is safe. The method mirrors the exact
+    sequence the inline ``submit_answer`` block used so the result is identical.
+    """
+
+    def score_submission(
+        self,
+        *,
+        correct: bool,
+        elapsed: float,
+        round_duration: float,
+        difficulty: Difficulty,
+        streak: int,
+        double_points_active: bool,
+        is_final_round: bool,
+        wager: int | None,
+        score_before_wager: int,
+    ) -> ScoreComputation:
+        """Compute points and breakdown for one answer.
+
+        Args mirror the inputs the previous inline block read:
+
+          * ``streak`` is the player's streak *after* this round's update
+            (i.e. already incremented for a correct answer / zeroed for wrong).
+          * ``score_before_wager`` is the player's running score *before* this
+            round's points are added — the wager bets against that figure.
+
+        Returns a :class:`ScoreComputation`; the caller applies it.
+        """
+        points = calculate_round_score(
+            correct=correct,
+            elapsed=elapsed,
+            time_limit=round_duration,
+            difficulty=difficulty,
+            streak=streak,
+            double_points_active=double_points_active,
+        )
+
+        # Calculate breakdown for client display.
+        speed_bonus = 0
+        streak_bonus = 0
+        diff_mult = DIFFICULTY_MULTIPLIERS.get(difficulty, 1.0)
+        if correct:
+            time_fraction = (
+                max(0.0, 1.0 - elapsed / round_duration)
+                if round_duration > 0
+                else 0.0
+            )
+            speed_bonus = int(MAX_SPEED_BONUS * time_fraction)
+            streak_mult = get_streak_multiplier(streak)
+            streak_bonus = int((BASE_POINTS + speed_bonus) * diff_mult * (streak_mult - 1.0))
+
+        # Wager override (Jeopardy-style final round). On the final round, if
+        # the player submitted a wager (0-100% of their pre-round score), it
+        # REPLACES the normal scoring: right answer adds the wager value, wrong
+        # subtracts. Speed/streak/difficulty multipliers are ignored — the
+        # wager IS the bet. We bet against the score BEFORE points were added.
+        wager_used: int | None = None
+        if is_final_round and wager is not None:
+            bank = max(0, score_before_wager)
+            wager_pts = int(bank * wager / 100)
+            wager_used = wager_pts
+            if correct:
+                points = wager_pts
+            else:
+                # Lose the wager — but never go below zero so a player can't be
+                # priced out of an existing rematch flow.
+                points = -min(wager_pts, bank)
+            # Clear bonuses since the wager overrides them.
+            speed_bonus = 0
+            streak_bonus = 0
+
+        # Streak milestone bonus — discrete spike awarded the round the streak
+        # EXACTLY equals a milestone value (3, 5, 10, 15, 20, 25). Wager rounds
+        # skip this so the bet stays the only thing in play.
+        milestone_bonus = 0
+        if correct and wager_used is None:
+            milestone_bonus = get_streak_milestone_bonus(streak)
+            if milestone_bonus:
+                points += milestone_bonus
+
+        return ScoreComputation(
+            points=points,
+            speed_bonus=speed_bonus,
+            streak_bonus=streak_bonus,
+            difficulty_multiplier=diff_mult,
+            double_points=double_points_active,
+            wager_used=wager_used,
+            milestone_bonus=milestone_bonus,
+        )

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -30,15 +30,11 @@ from .powerups import FREEZE_DURATION, TIME_BOOST_DURATION, PowerUpEffect, Power
 from .questions import Answer, Question, QuestionBank
 from .highlights import compute_superlatives
 from .scoring import (
-    BASE_POINTS,
-    MAX_SPEED_BONUS,
     calculate_podium,
-    calculate_round_score,
-    get_streak_milestone_bonus,
-    get_streak_multiplier,
 )
+from .scoring_engine import ScoringEngine
 from .timer import QuestionTimer
-from .types import DIFFICULTY_MULTIPLIERS, TIME_LIMITS, Difficulty
+from .types import TIME_LIMITS, Difficulty
 
 if TYPE_CHECKING:
     from aiohttp import web
@@ -119,6 +115,9 @@ class QuizifyGameState:
         self._player_registry = PlayerRegistry()
         self._question_bank = QuestionBank()
         self._powerup_manager = PowerUpManager()
+        # Stateless scoring engine — owns the pure points/breakdown/wager/
+        # milestone arithmetic that submit_answer applies (issue #184).
+        self._scoring_engine = ScoringEngine()
 
         # Load question history if a runtime is available (HA or standalone).
         if runtime is not None:
@@ -504,71 +503,38 @@ class QuizifyGameState:
         if player.streak > player.max_streak:
             player.max_streak = player.streak
 
-        points = calculate_round_score(
+        # Delegate the pure arithmetic (base/speed/difficulty/streak scoring,
+        # the final-round wager override, and the streak-milestone spike) to
+        # the stateless ScoringEngine (#184). It mutates nothing; this method
+        # keeps ownership of applying the result to the player. `player.streak`
+        # was already updated above, and `player.score` is still the pre-round
+        # total here — exactly the inputs the wager bets against.
+        computation = self._scoring_engine.score_submission(
             correct=correct,
             elapsed=elapsed,
-            time_limit=self._round_duration,
+            round_duration=self._round_duration,
             difficulty=diff_enum,
             streak=player.streak,
             double_points_active=double_active,
+            is_final_round=self.round == self.total_rounds,
+            wager=player.wager,
+            score_before_wager=player.score,
         )
 
-        # Calculate breakdown for client display
-        speed_bonus = 0
-        streak_bonus = 0
-        diff_mult = DIFFICULTY_MULTIPLIERS.get(diff_enum, 1.0)
-        if correct:
-            time_fraction = max(0.0, 1.0 - elapsed / self._round_duration) if self._round_duration > 0 else 0.0
-            speed_bonus = int(MAX_SPEED_BONUS * time_fraction)
-            streak_mult = get_streak_multiplier(player.streak)
-            streak_bonus = int((BASE_POINTS + speed_bonus) * diff_mult * (streak_mult - 1.0))
+        points = computation.points
+        speed_bonus = computation.speed_bonus
+        streak_bonus = computation.streak_bonus
+        diff_mult = computation.difficulty_multiplier
+        wager_used = computation.wager_used
+        milestone_bonus = computation.milestone_bonus
 
-        # Wager override (gameplay idea #3, Jeopardy-style final round).
-        # On the final round, if the player submitted a wager (0-100%
-        # of their pre-round score), it REPLACES the normal scoring:
-        # right answer adds the wager value, wrong subtracts. Speed/
-        # streak/difficulty multipliers are ignored — the wager IS the
-        # bet. We snapshot the player's score BEFORE adding points so
-        # the wager is computed against what they bet on, not the
-        # post-bet total.
-        wager_used: int | None = None
-        if (
-            self.round == self.total_rounds
-            and player.wager is not None
-        ):
-            bank = max(0, player.score)
-            wager_pts = int(bank * player.wager / 100)
-            wager_used = wager_pts
-            if correct:
-                points = wager_pts
-            else:
-                # Lose the wager — but never go below zero so a player
-                # can't be priced out of an existing rematch flow.
-                points = -min(wager_pts, bank)
-            # Clear bonuses since the wager overrides them.
-            speed_bonus = 0
-            streak_bonus = 0
-
-        # Streak milestone bonus — discrete spike awarded the round the
-        # streak EXACTLY equals a milestone value (3, 5, 10, 15, 20, 25).
-        # Wager rounds skip this so the bet stays the only thing in play.
-        milestone_bonus = 0
-        if correct and wager_used is None:
-            milestone_bonus = get_streak_milestone_bonus(player.streak)
-            if milestone_bonus:
-                points += milestone_bonus
-                player.streak_milestone_bonus_total += milestone_bonus
-                player.streak_milestones_hit += 1
+        # Tally the milestone hit (engine already folded the bonus into points).
+        if milestone_bonus:
+            player.streak_milestone_bonus_total += milestone_bonus
+            player.streak_milestones_hit += 1
 
         player.round_score = points
-        player.round_score_breakdown = {
-            "speed_bonus": speed_bonus,
-            "streak_bonus": streak_bonus,
-            "difficulty_multiplier": diff_mult,
-            "double_points": double_active,
-            "wager": wager_used,
-            "milestone_bonus": milestone_bonus,
-        }
+        player.round_score_breakdown = computation.breakdown
         player.score += points
         if player.score < 0:
             player.score = 0

--- a/custom_components/quizify/server/broadcast_dispatcher.py
+++ b/custom_components/quizify/server/broadcast_dispatcher.py
@@ -1,0 +1,58 @@
+"""BroadcastDispatcher — routes game-state events to broadcast handlers.
+
+Extracted from ``QuizifyWebSocketHandler.broadcast_state`` (issue #184,
+splitting the game-server God-objects). The game-state layer fires named
+events (``round_evaluated``, ``game_ended``) through the broadcast callback;
+this dispatcher maps each event name to the coroutine that builds and sends the
+matching client message, and falls back to a full-state broadcast for anything
+else (or a payload with no event).
+
+The dispatcher owns only the *routing*; the message-building coroutines stay on
+the handler (they are tightly coupled to the connection manager and the
+serializers). Behaviour is identical to the previous inline ``if event == ...``
+chain — same events, same handlers, same fallback.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+
+class BroadcastDispatcher:
+    """Maps state-event names to their broadcast coroutines.
+
+    Stateless aside from the handler table it is constructed with. A missing
+    event name (or a payload without an ``event`` key) routes to the default
+    full-state broadcast.
+    """
+
+    def __init__(
+        self,
+        *,
+        handlers: dict[str, Callable[[], Awaitable[None]]],
+        default: Callable[[], Awaitable[None]],
+    ) -> None:
+        """Initialise with the per-event handlers and a default handler.
+
+        ``handlers`` maps an event name (e.g. ``"round_evaluated"``) to a
+        zero-arg coroutine factory; ``default`` is used when the payload has no
+        event or an unrecognised one.
+        """
+        self._handlers = handlers
+        self._default = default
+
+    async def dispatch(self, payload: dict[str, Any] | None) -> None:
+        """Route ``payload`` to the matching handler.
+
+        Mirrors the previous inline logic exactly: if the payload carries a
+        recognised ``event``, invoke its handler and return; otherwise fall
+        through to the default full-state broadcast.
+        """
+        if payload is not None:
+            event = payload.get("event")
+            handler = self._handlers.get(event) if event is not None else None
+            if handler is not None:
+                await handler()
+                return
+        await self._default()

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -25,6 +25,7 @@ from custom_components.quizify.const import (
 from custom_components.quizify.game.highlights import compute_superlatives
 from custom_components.quizify.game.powerups import PowerUpEffect, PowerUpType
 from custom_components.quizify.game.state import AnswerResult, GamePhase, QuizifyGameState
+from custom_components.quizify.server.broadcast_dispatcher import BroadcastDispatcher
 from custom_components.quizify.server.connection import ConnectionManager
 from custom_components.quizify.server.serializers import (
     serialize_finale,
@@ -86,6 +87,15 @@ class QuizifyWebSocketHandler:
         self._message_timestamps: dict[int, list[float]] = {}  # ws id -> recent message timestamps
         self._RATE_LIMIT_WINDOW = 1.0  # seconds
         self._RATE_LIMIT_MAX = 15  # max messages per window
+        # Routes named state events (round_evaluated / game_ended) to the
+        # matching broadcast, falling back to a full-state push (#184).
+        self._broadcast_dispatcher = BroadcastDispatcher(
+            handlers={
+                "round_evaluated": self._dispatch_round_evaluated,
+                "game_ended": self._dispatch_game_ended,
+            },
+            default=self._dispatch_full_state,
+        )
 
     def _check_rate_limit(self, ws: web.WebSocketResponse) -> bool:
         """Record a message for ``ws`` and report whether it is within the
@@ -1478,21 +1488,28 @@ class QuizifyWebSocketHandler:
     # ------------------------------------------------------------------
 
     async def broadcast_state(self, payload: dict[str, Any] | None = None) -> None:
-        """Broadcast callback — called by game state on auto-events."""
-        if payload is not None:
-            event = payload.get("event")
-            if event == "round_evaluated":
-                game_state = self._get_game_state()
-                if game_state:
-                    await self._broadcast_round_summary(game_state)
-                return
-            if event == "game_ended":
-                game_state = self._get_game_state()
-                if game_state:
-                    await self._broadcast_finale(game_state)
-                return
+        """Broadcast callback — called by game state on auto-events.
 
-        # Default: broadcast full state
+        Routing lives in the BroadcastDispatcher (#184); the per-event message
+        building stays here. Behaviour is unchanged: each handler re-fetches the
+        current game state and no-ops if there isn't one.
+        """
+        await self._broadcast_dispatcher.dispatch(payload)
+
+    async def _dispatch_round_evaluated(self) -> None:
+        """Handler for the ``round_evaluated`` state event."""
+        game_state = self._get_game_state()
+        if game_state:
+            await self._broadcast_round_summary(game_state)
+
+    async def _dispatch_game_ended(self) -> None:
+        """Handler for the ``game_ended`` state event."""
+        game_state = self._get_game_state()
+        if game_state:
+            await self._broadcast_finale(game_state)
+
+    async def _dispatch_full_state(self) -> None:
+        """Default handler: broadcast a full game-state snapshot."""
         game_state = self._get_game_state()
         if game_state:
             state = game_state.get_state_snapshot()

--- a/tests/test_broadcast_dispatcher_184.py
+++ b/tests/test_broadcast_dispatcher_184.py
@@ -1,0 +1,58 @@
+"""Unit tests for the extracted BroadcastDispatcher (#184)."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.server.broadcast_dispatcher import (  # noqa: E402
+    BroadcastDispatcher,
+)
+
+
+def _make(calls: list[str]):
+    async def handler(name: str) -> None:
+        calls.append(name)
+
+    return BroadcastDispatcher(
+        handlers={
+            "round_evaluated": lambda: handler("round_evaluated"),
+            "game_ended": lambda: handler("game_ended"),
+        },
+        default=lambda: handler("default"),
+    )
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestBroadcastDispatcher:
+    def test_routes_round_evaluated(self):
+        calls: list[str] = []
+        _run(_make(calls).dispatch({"event": "round_evaluated"}))
+        assert calls == ["round_evaluated"]
+
+    def test_routes_game_ended(self):
+        calls: list[str] = []
+        _run(_make(calls).dispatch({"event": "game_ended"}))
+        assert calls == ["game_ended"]
+
+    def test_unknown_event_falls_back_to_default(self):
+        calls: list[str] = []
+        _run(_make(calls).dispatch({"event": "something_else"}))
+        assert calls == ["default"]
+
+    def test_none_payload_falls_back_to_default(self):
+        calls: list[str] = []
+        _run(_make(calls).dispatch(None))
+        assert calls == ["default"]
+
+    def test_payload_without_event_falls_back_to_default(self):
+        calls: list[str] = []
+        _run(_make(calls).dispatch({"type": "game_state"}))
+        assert calls == ["default"]

--- a/tests/test_broadcast_dispatcher_184.py
+++ b/tests/test_broadcast_dispatcher_184.py
@@ -28,7 +28,7 @@ def _make(calls: list[str]):
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 class TestBroadcastDispatcher:

--- a/tests/test_scoring_engine_184.py
+++ b/tests/test_scoring_engine_184.py
@@ -1,0 +1,151 @@
+"""Unit tests for the extracted ScoringEngine (#184).
+
+These pin the *pure* scoring arithmetic that was lifted out of
+QuizifyGameState.submit_answer so the refactor is provably behaviour-preserving.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.scoring import (  # noqa: E402
+    MAX_SPEED_BONUS,
+    calculate_round_score,
+)
+from custom_components.quizify.game.scoring_engine import (  # noqa: E402
+    ScoreComputation,
+    ScoringEngine,
+)
+from custom_components.quizify.game.types import Difficulty  # noqa: E402
+
+ENGINE = ScoringEngine()
+
+
+def _score(**kw):
+    base = dict(
+        correct=True,
+        elapsed=0.0,
+        round_duration=30.0,
+        difficulty=Difficulty.EASY,
+        streak=1,
+        double_points_active=False,
+        is_final_round=False,
+        wager=None,
+        score_before_wager=100,
+    )
+    base.update(kw)
+    return ENGINE.score_submission(**base)
+
+
+class TestScoringEngineMatchesLegacy:
+    def test_wrong_answer_scores_zero(self):
+        c = _score(correct=False, streak=0)
+        assert c.points == 0
+        assert c.speed_bonus == 0
+        assert c.streak_bonus == 0
+        assert c.milestone_bonus == 0
+
+    def test_correct_matches_calculate_round_score(self):
+        # The non-wager, non-milestone path must equal the underlying helper.
+        for elapsed in (0.0, 5.0, 15.0, 29.0):
+            for diff in (Difficulty.EASY, Difficulty.MEDIUM, Difficulty.HARD):
+                for streak in (1, 2, 4):
+                    c = _score(
+                        elapsed=elapsed, difficulty=diff, streak=streak
+                    )
+                    expected = calculate_round_score(
+                        correct=True,
+                        elapsed=elapsed,
+                        time_limit=30.0,
+                        difficulty=diff,
+                        streak=streak,
+                        double_points_active=False,
+                    )
+                    assert c.points == expected
+
+    def test_speed_bonus_full_at_zero_elapsed(self):
+        c = _score(elapsed=0.0)
+        assert c.speed_bonus == MAX_SPEED_BONUS
+
+    def test_double_points_matches_helper(self):
+        double = _score(double_points_active=True)
+        expected = calculate_round_score(
+            correct=True,
+            elapsed=0.0,
+            time_limit=30.0,
+            difficulty=Difficulty.EASY,
+            streak=1,
+            double_points_active=True,
+        )
+        assert double.points == expected
+        assert double.double_points is True
+
+    def test_milestone_spike_folded_into_points(self):
+        # streak 3 → +20 milestone on top of the regular score.
+        regular = calculate_round_score(
+            correct=True,
+            elapsed=0.0,
+            time_limit=30.0,
+            difficulty=Difficulty.EASY,
+            streak=3,
+            double_points_active=False,
+        )
+        c = _score(streak=3)
+        assert c.milestone_bonus == 20
+        assert c.points == regular + 20
+
+    def test_breakdown_dict_shape(self):
+        c = _score(streak=3)
+        bd = c.breakdown
+        assert set(bd) == {
+            "speed_bonus",
+            "streak_bonus",
+            "difficulty_multiplier",
+            "double_points",
+            "wager",
+            "milestone_bonus",
+        }
+        assert bd["milestone_bonus"] == 20
+
+
+class TestWagerOverride:
+    def test_wager_correct_replaces_score(self):
+        c = _score(
+            is_final_round=True, wager=50, score_before_wager=200, streak=2
+        )
+        # 50% of 200 = 100, replaces normal scoring.
+        assert c.points == 100
+        assert c.wager_used == 100
+        assert c.speed_bonus == 0
+        assert c.streak_bonus == 0
+
+    def test_wager_wrong_subtracts_but_not_below_bank(self):
+        c = _score(
+            correct=False,
+            is_final_round=True,
+            wager=50,
+            score_before_wager=200,
+            streak=0,
+        )
+        assert c.points == -100
+        assert c.wager_used == 100
+
+    def test_wager_skips_milestone(self):
+        c = _score(
+            is_final_round=True, wager=10, score_before_wager=100, streak=3
+        )
+        assert c.milestone_bonus == 0
+
+    def test_no_wager_on_non_final_round(self):
+        c = _score(is_final_round=False, wager=50, score_before_wager=200)
+        assert c.wager_used is None
+
+
+class TestScoreComputation:
+    def test_is_dataclass_result(self):
+        c = _score()
+        assert isinstance(c, ScoreComputation)


### PR DESCRIPTION
## Part of #184 — splitting the game-server God-objects

`game/state.py` (~1140 lines) and `server/websocket.py` (~1500 lines) bundle the phase state machine, scoring, power-ups, timers, and broadcast/dispatch. This PR is the **first, lowest-risk step**: two clean, behaviour-preserving seams are extracted, with the original classes delegating to the new units. **Zero functional change** — public behaviour, message protocol, scoring, and timing are identical.

### What was extracted

**1. `ScoringEngine` (`game/scoring_engine.py`)**
The dense inline scoring block inside `QuizifyGameState.submit_answer` — base/speed/difficulty/streak scoring, the final-round wager override, and the streak-milestone spike — is now a **pure, side-effect-free** computation that returns a `ScoreComputation`. `submit_answer` keeps ownership of all mutation (streak counters, score accumulation, milestone tallies) and simply applies the result. Same numbers, computed in the same order.

**2. `BroadcastDispatcher` (`server/broadcast_dispatcher.py`)**
The event-routing table inside `QuizifyWebSocketHandler.broadcast_state` (`round_evaluated` / `game_ended` / default full-state) is now a small dispatcher. The message-building coroutines stay on the handler (they are tightly coupled to the connection manager and serializers); the dispatcher just routes events back to them. Same events, same handlers, same fallback.

### Tests
- Added 16 focused unit tests (`test_scoring_engine_184.py`, `test_broadcast_dispatcher_184.py`), including parity checks against the underlying `calculate_round_score` helper for the non-wager path.
- Full suite: **214 passed** (was 198). Green before and after.

### Follow-up seams (intentionally left for later)
- **PhaseController**: the phase state machine + timer orchestration (pause/resume, per-player `QuestionTimer` lifecycle, the tick loop's expiry logic).
- **Round broadcast fan-out**: the per-round shuffle + per-player question fan-out in `_start_next_question` and the answer-table building in `_broadcast_round_summary`.

These are larger, more state-coupled seams; keeping them as a follow-up keeps this PR small, safe, and easy to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)