### PR TITLE
feat: group-level adaptive difficulty (Auto mode) (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to Quizify are documented here. This project follows
 
 ### Added
 
+- **Group adaptive difficulty (#40).** A new **Auto** difficulty option that
+  tunes the whole table together within a single game. The game still serves
+  one shared question to everyone per round; after each round Quizify looks at
+  the group's overall correct-rate and nudges the difficulty of *upcoming*
+  questions up (group acing it) or down (group struggling). It is deliberately
+  conservative: it starts at medium, only steps one rung at a time, averages
+  over the last few rounds to avoid swinging on a single lucky/brutal question,
+  and stays put until enough rounds of signal exist. Fixed Easy/Medium/Hard
+  picks are untouched — calibration only runs in Auto mode. Per-player adaptive
+  difficulty (personalised question streams) is tracked separately in #186.
 - **Waiting-room music (#56).** Optional ambient background audio in the
   lobby, played through a real Home Assistant speaker. A new "Lobby music URL"
   option lets you point Quizify at an audio file you supply yourself

--- a/custom_components/quizify/const.py
+++ b/custom_components/quizify/const.py
@@ -20,6 +20,14 @@ LOBBY_DISCONNECT_GRACE_PERIOD = 5  # seconds before removing disconnected player
 # Default difficulty (use Difficulty enum from game.types for type-safe comparisons)
 DIFFICULTY_DEFAULT = "medium"
 
+# Group-level adaptive difficulty (#40). When the host picks this instead of a
+# fixed easy/medium/hard, the game starts at medium and nudges the difficulty of
+# upcoming questions up/down based on the whole table's recent correct-rate.
+# Per-player adaptive difficulty is a separate, deferred feature (#186).
+DIFFICULTY_AUTO = "auto"
+# Where "auto" starts before any group signal has accumulated.
+DIFFICULTY_AUTO_START = "medium"
+
 # Error codes
 ERR_NAME_TAKEN = "NAME_TAKEN"
 ERR_NAME_INVALID = "NAME_INVALID"

--- a/custom_components/quizify/game/calibration.py
+++ b/custom_components/quizify/game/calibration.py
@@ -1,0 +1,148 @@
+"""Group-level adaptive difficulty calibration (#40).
+
+The game serves one shared question to every connected player per round, at a
+single difficulty for that round. When the host picks the ``"auto"`` difficulty
+mode, this module nudges the difficulty of *upcoming* questions up or down based
+on the whole group's recent correct-rate:
+
+* If the table is acing it (high correct-rate sustained over a few rounds),
+  lean harder.
+* If the table is struggling, lean easier.
+
+Design goals (all deliberately conservative):
+
+* **Group-level only.** One signal per round (the group's correct-rate), one
+  shared difficulty for the next round. No per-player identity, no per-player
+  difficulty streams — that personalised variant is deferred to #186.
+* **Bounded.** Difficulty only ever steps by one level at a time
+  (easy <-> medium <-> hard); never jumps easy -> hard in a single move.
+* **Smooth.** A step requires the *averaged* correct-rate over the recent
+  window to clear a threshold, not a single lucky/unlucky round. This avoids
+  wild swings from one easy or one brutal question.
+* **No-op without signal.** Until at least ``min_rounds`` rounds with at least
+  one participating player have been observed, the target difficulty never
+  moves. Rounds where nobody answered contribute no signal.
+
+The calibrator is pure with respect to the question bank: it only decides a
+target ``Difficulty``; the bank is responsible for actually serving a question
+at (or near) that difficulty.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+
+from .types import Difficulty
+
+# Ordered difficulty ladder. Index position == relative hardness.
+_LADDER: list[Difficulty] = [Difficulty.EASY, Difficulty.MEDIUM, Difficulty.HARD]
+
+# Default tuning. Chosen to be forgiving: you need a clearly dominant
+# performance over several rounds before the difficulty moves, and the move
+# is a single rung.
+DEFAULT_WINDOW = 3          # rounds of history averaged for the signal
+DEFAULT_MIN_ROUNDS = 2      # min observed rounds before any nudge
+DEFAULT_STEP_UP = 0.80      # avg correct-rate above this -> harder
+DEFAULT_STEP_DOWN = 0.40    # avg correct-rate below this -> easier
+
+
+def _clamp_index(idx: int) -> int:
+    """Clamp a ladder index into the valid range."""
+    return max(0, min(len(_LADDER) - 1, idx))
+
+
+@dataclass
+class GroupCalibrator:
+    """Tracks the group's recent correct-rate and proposes a target difficulty.
+
+    Usage::
+
+        cal = GroupCalibrator(start=Difficulty.MEDIUM)
+        target = cal.current_target            # before any rounds: the start
+        ...
+        cal.record_round(correct=3, total=4)   # after each evaluated round
+        target = cal.next_target()             # difficulty for the next round
+    """
+
+    start: Difficulty = Difficulty.MEDIUM
+    window: int = DEFAULT_WINDOW
+    min_rounds: int = DEFAULT_MIN_ROUNDS
+    step_up_threshold: float = DEFAULT_STEP_UP
+    step_down_threshold: float = DEFAULT_STEP_DOWN
+
+    # Internal state.
+    _target: Difficulty = field(init=False)
+    _rates: deque[float] = field(init=False)
+    _observed: int = field(init=False, default=0)
+
+    def __post_init__(self) -> None:
+        if self.start not in _LADDER:
+            self.start = Difficulty.MEDIUM
+        # window must be >= 1 so the deque always holds at least the last round.
+        if self.window < 1:
+            self.window = 1
+        self._target = self.start
+        self._rates = deque(maxlen=self.window)
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    @property
+    def current_target(self) -> Difficulty:
+        """The difficulty the *next* round should use, given history so far."""
+        return self._target
+
+    @property
+    def observed_rounds(self) -> int:
+        """Number of rounds with signal observed so far."""
+        return self._observed
+
+    def average_rate(self) -> float | None:
+        """Mean correct-rate over the recent window, or None if no signal."""
+        if not self._rates:
+            return None
+        return sum(self._rates) / len(self._rates)
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+
+    def record_round(self, correct: int, total: int) -> None:
+        """Feed one evaluated round's group result.
+
+        ``correct`` = number of participating players who answered correctly.
+        ``total``   = number of participating players (those who answered or
+        timed out). Rounds with ``total <= 0`` carry no signal and are ignored
+        (e.g. a round nobody was present for).
+        """
+        if total <= 0:
+            return
+        rate = max(0.0, min(1.0, correct / total))
+        self._rates.append(rate)
+        self._observed += 1
+
+    def next_target(self) -> Difficulty:
+        """Recompute and return the target difficulty for the upcoming round.
+
+        Bounded (single rung), smooth (uses the windowed average), and a no-op
+        until ``min_rounds`` rounds of signal have accumulated.
+        """
+        # Not enough signal yet -> never move.
+        if self._observed < self.min_rounds:
+            return self._target
+
+        avg = self.average_rate()
+        if avg is None:
+            return self._target
+
+        idx = _LADDER.index(self._target)
+        if avg >= self.step_up_threshold:
+            idx = _clamp_index(idx + 1)
+        elif avg <= self.step_down_threshold:
+            idx = _clamp_index(idx - 1)
+        # else: comfortable band -> hold.
+
+        self._target = _LADDER[idx]
+        return self._target

--- a/custom_components/quizify/game/questions.py
+++ b/custom_components/quizify/game/questions.py
@@ -380,6 +380,56 @@ class QuestionBank:
         self._queue_index += 1
         return question
 
+    def get_next_question_at_difficulty(
+        self, target_difficulty: str
+    ) -> Question | None:
+        """Serve the next unconsumed queued question, preferring ``target_difficulty``.
+
+        Used by the group-level adaptive ("auto") difficulty mode (#40): the
+        queue is built across *all* difficulties (no per-difficulty filter), and
+        each round we pull the next question matching the calibrated target.
+
+        Selection (all over not-yet-consumed queue entries, preserving the
+        history-aware ordering established by ``_build_queue``):
+
+        1. Prefer the first question whose ``difficulty`` equals the target.
+        2. If none remain at the exact target, fall back to the nearest
+           available difficulty on the easy<->medium<->hard ladder.
+        3. If the queue is exhausted, return None.
+
+        The chosen question is removed from the remaining-queue window (so it is
+        not served twice) and the queue index advances past it.
+        """
+        remaining = self._queue[self._queue_index:]
+        if not remaining:
+            return None
+
+        ladder = ["easy", "medium", "hard"]
+        try:
+            target_idx = ladder.index(target_difficulty)
+        except ValueError:
+            target_idx = 1  # treat unknown target as medium
+
+        # Build a search order over difficulties: exact target first, then
+        # the closest rungs outward (so a missing "hard" prefers "medium"
+        # over "easy", etc.). Stable, deterministic.
+        order = sorted(
+            range(len(ladder)),
+            key=lambda i: (abs(i - target_idx), i),
+        )
+
+        for diff_idx in order:
+            diff = ladder[diff_idx]
+            for offset, q in enumerate(remaining):
+                if q.difficulty == diff:
+                    # Consume this question: pull it out of the queue so the
+                    # window shrinks and the next call sees one fewer item.
+                    abs_index = self._queue_index + offset
+                    self._queue.pop(abs_index)
+                    return q
+
+        return None
+
     def shuffle_questions(self, questions: list[Question]) -> list[Question]:
         """Return a shuffled copy of the given question list."""
         shuffled = list(questions)

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -14,6 +14,8 @@ from typing import TYPE_CHECKING, Any
 
 from ..const import (
     DEFAULT_ROUND_DURATION,
+    DIFFICULTY_AUTO,
+    DIFFICULTY_AUTO_START,
     DIFFICULTY_DEFAULT,
     ERR_ALREADY_SUBMITTED,
     ERR_GAME_ALREADY_STARTED,
@@ -28,6 +30,7 @@ from .player import PlayerSession
 from .player_registry import PlayerRegistry
 from .powerups import FREEZE_DURATION, TIME_BOOST_DURATION, PowerUpEffect, PowerUpManager, PowerUpType
 from .questions import Answer, Question, QuestionBank
+from .calibration import GroupCalibrator
 from .highlights import compute_superlatives
 from .scoring import (
     BASE_POINTS,
@@ -124,6 +127,10 @@ class QuizifyGameState:
         if runtime is not None:
             history_path = runtime.data_dir / "question_history.json"
             self._question_bank.load_history(history_path)
+
+        # Group-level adaptive difficulty (#40). Only active when the host
+        # picks the "auto" difficulty mode; None for fixed easy/medium/hard.
+        self._calibrator: GroupCalibrator | None = None
 
         # Current round state
         self._current_question: Question | None = None
@@ -316,6 +323,20 @@ class QuizifyGameState:
         self.round = 0
         self._timer_override = timer_duration
 
+        # Group-level adaptive difficulty (#40). Only the explicit "auto" mode
+        # opts in; any fixed difficulty the host pinned (easy/medium/hard) is
+        # honoured verbatim and never calibrated. When auto, the queue is built
+        # across ALL difficulties (no per-difficulty filter) so we can serve the
+        # calibrated target each round.
+        if self.difficulty == DIFFICULTY_AUTO:
+            self._calibrator = GroupCalibrator(
+                start=Difficulty(DIFFICULTY_AUTO_START)
+            )
+            queue_difficulty: str | None = None
+        else:
+            self._calibrator = None
+            queue_difficulty = difficulty
+
         # Persist for "Play again — same settings" (one-tap rematch).
         # Snapshot here so a later reset_to_lobby keeps these and
         # play_again can reuse them without re-prompting the admin.
@@ -333,7 +354,7 @@ class QuizifyGameState:
         self._question_bank.reset(
             category=category,
             categories=categories,
-            difficulty=difficulty,
+            difficulty=queue_difficulty,
             language=self.language,
         )
 
@@ -395,9 +416,20 @@ class QuizifyGameState:
             self.end_game()
             return None
 
-        question = self._question_bank.get_next_question(
-            category=self.category, difficulty=self.difficulty
-        )
+        if self._calibrator is not None:
+            # Group-level adaptive ("auto") mode: serve the calibrated target
+            # difficulty for this round. The calibrator was fed each completed
+            # round's group correct-rate in _do_evaluate_round; its target only
+            # ever steps one rung at a time and stays put until enough rounds of
+            # signal have accumulated, so this is bounded and smooth.
+            target = self._calibrator.current_target
+            question = self._question_bank.get_next_question_at_difficulty(
+                target.value
+            )
+        else:
+            question = self._question_bank.get_next_question(
+                category=self.category, difficulty=self.difficulty
+            )
         if question is None:
             _LOGGER.warning("No more questions available")
             self.end_game()
@@ -670,6 +702,31 @@ class QuizifyGameState:
 
         self.phase = GamePhase.ANSWER_REVEAL
 
+        # Feed the group-level difficulty calibrator (#40). Signal = the share
+        # of *participating* players (connected, i.e. present for this round)
+        # who answered correctly. Then advance the target for the next round.
+        # No-op when not in "auto" mode. Rounds with zero participants carry no
+        # signal (the calibrator ignores total<=0).
+        if self._calibrator is not None:
+            participants = [
+                p for p in self._player_registry.players.values() if p.connected
+            ]
+            total = len(participants)
+            correct = sum(
+                1 for p in participants if player_correct.get(p.name, False)
+            )
+            self._calibrator.record_round(correct=correct, total=total)
+            new_target = self._calibrator.next_target()
+            _LOGGER.debug(
+                "Auto-difficulty: round %d group %d/%d correct, "
+                "avg=%.2f, next target=%s",
+                self.round,
+                correct,
+                total,
+                self._calibrator.average_rate() or 0.0,
+                new_target.value,
+            )
+
         # Record this round into the per-question stats. Only count
         # players who actually submitted — timeouts shouldn't blame the
         # question for the player being away. ``last_elapsed`` was
@@ -838,6 +895,7 @@ class QuizifyGameState:
         self.shuffle_map = []
         self.shuffled_answers = []
         self._timer_override = None
+        self._calibrator = None
 
         for player in self._player_registry.players.values():
             player.reset_for_new_game()

--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -327,6 +327,7 @@
                             <button type="button" class="chip" data-value="easy" data-i18n="difficulties.easy">Easy</button>
                             <button type="button" class="chip active" data-value="medium" data-i18n="difficulties.medium">Medium</button>
                             <button type="button" class="chip" data-value="hard" data-i18n="difficulties.hard">Hard</button>
+                            <button type="button" class="chip" data-value="auto" data-i18n="difficulties.auto">Auto</button>
                         </div>
                     </div>
 

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -136,7 +136,8 @@
     "easy": "Einfach",
     "medium": "Mittel",
     "hard": "Schwer",
-    "mixed": "Gemischt"
+    "mixed": "Gemischt",
+    "auto": "Automatisch"
   },
   "game": {
     "question": "Frage",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -136,7 +136,8 @@
     "easy": "Easy",
     "medium": "Medium",
     "hard": "Hard",
-    "mixed": "Mixed"
+    "mixed": "Mixed",
+    "auto": "Auto"
   },
   "game": {
     "question": "Question",

--- a/tests/test_calibration_40.py
+++ b/tests/test_calibration_40.py
@@ -1,0 +1,335 @@
+"""Tests for group-level adaptive difficulty calibration (#40).
+
+Covers:
+* GroupCalibrator: no-op without signal, bounded single-rung steps, smoothing
+  over the window, hold in the comfortable band, clamping at easy/hard,
+  ignoring zero-participant rounds.
+* QuestionBank.get_next_question_at_difficulty: exact-target serving, nearest
+  fallback, no-double-serve, exhaustion.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.calibration import GroupCalibrator  # noqa: E402
+from custom_components.quizify.game.questions import (  # noqa: E402
+    Answer,
+    Question,
+    QuestionBank,
+)
+from custom_components.quizify.game.types import Difficulty  # noqa: E402
+
+
+def _q(qid: str, difficulty: str) -> Question:
+    return Question(
+        id=qid,
+        question=f"q-{qid}",
+        answers=[
+            Answer(text="a", correct=True),
+            Answer(text="b", correct=False),
+            Answer(text="c", correct=False),
+        ],
+        difficulty=difficulty,
+    )
+
+
+# ----------------------------------------------------------------------
+# GroupCalibrator
+# ----------------------------------------------------------------------
+
+
+class TestCalibratorNoSignal:
+    def test_starts_at_configured_start(self) -> None:
+        cal = GroupCalibrator(start=Difficulty.MEDIUM)
+        assert cal.current_target == Difficulty.MEDIUM
+
+    def test_invalid_start_falls_back_to_medium(self) -> None:
+        # Passing something not on the ladder is coerced to medium.
+        cal = GroupCalibrator(start="bogus")  # type: ignore[arg-type]
+        assert cal.current_target == Difficulty.MEDIUM
+
+    def test_no_target_move_before_min_rounds(self) -> None:
+        cal = GroupCalibrator(start=Difficulty.MEDIUM, min_rounds=2)
+        # One perfect round is not enough signal -> still medium.
+        cal.record_round(correct=4, total=4)
+        assert cal.next_target() == Difficulty.MEDIUM
+
+    def test_zero_participant_rounds_carry_no_signal(self) -> None:
+        cal = GroupCalibrator(start=Difficulty.MEDIUM, min_rounds=1)
+        cal.record_round(correct=0, total=0)
+        assert cal.observed_rounds == 0
+        assert cal.average_rate() is None
+        assert cal.next_target() == Difficulty.MEDIUM
+
+
+class TestCalibratorStepUp:
+    def test_sustained_high_rate_steps_harder(self) -> None:
+        cal = GroupCalibrator(
+            start=Difficulty.MEDIUM, window=3, min_rounds=2, step_up_threshold=0.8
+        )
+        cal.record_round(correct=4, total=4)  # 1.0
+        cal.record_round(correct=4, total=4)  # 1.0
+        assert cal.next_target() == Difficulty.HARD
+
+    def test_step_is_bounded_to_one_rung(self) -> None:
+        # Even with crushing performance, easy -> medium (not easy -> hard).
+        cal = GroupCalibrator(
+            start=Difficulty.EASY, window=3, min_rounds=2, step_up_threshold=0.8
+        )
+        cal.record_round(correct=5, total=5)
+        cal.record_round(correct=5, total=5)
+        assert cal.next_target() == Difficulty.MEDIUM
+
+    def test_clamps_at_hard(self) -> None:
+        cal = GroupCalibrator(
+            start=Difficulty.HARD, window=2, min_rounds=2, step_up_threshold=0.8
+        )
+        cal.record_round(correct=4, total=4)
+        cal.record_round(correct=4, total=4)
+        assert cal.next_target() == Difficulty.HARD
+
+
+class TestCalibratorStepDown:
+    def test_sustained_low_rate_steps_easier(self) -> None:
+        cal = GroupCalibrator(
+            start=Difficulty.MEDIUM, window=3, min_rounds=2, step_down_threshold=0.4
+        )
+        cal.record_round(correct=0, total=4)
+        cal.record_round(correct=1, total=4)  # avg = 0.125
+        assert cal.next_target() == Difficulty.EASY
+
+    def test_clamps_at_easy(self) -> None:
+        cal = GroupCalibrator(
+            start=Difficulty.EASY, window=2, min_rounds=2, step_down_threshold=0.4
+        )
+        cal.record_round(correct=0, total=4)
+        cal.record_round(correct=0, total=4)
+        assert cal.next_target() == Difficulty.EASY
+
+
+class TestCalibratorSmoothing:
+    def test_comfortable_band_holds(self) -> None:
+        cal = GroupCalibrator(
+            start=Difficulty.MEDIUM,
+            window=3,
+            min_rounds=2,
+            step_up_threshold=0.8,
+            step_down_threshold=0.4,
+        )
+        cal.record_round(correct=2, total=4)  # 0.5
+        cal.record_round(correct=3, total=4)  # 0.75 ; avg 0.625
+        assert cal.next_target() == Difficulty.MEDIUM
+
+    def test_single_lucky_round_does_not_swing_within_window(self) -> None:
+        # A struggling group (lots of misses) with one perfect round mixed in
+        # should NOT be bumped up: the windowed average stays low.
+        cal = GroupCalibrator(
+            start=Difficulty.MEDIUM,
+            window=3,
+            min_rounds=2,
+            step_up_threshold=0.8,
+        )
+        cal.record_round(correct=0, total=4)  # 0.0
+        cal.record_round(correct=0, total=4)  # 0.0
+        cal.record_round(correct=4, total=4)  # 1.0 ; avg over window = 0.33
+        # avg 0.33 < step_up 0.8 -> not harder. (It IS below step_down 0.4,
+        # so it steps easier, which is the correct read of a struggling group.)
+        assert cal.next_target() == Difficulty.EASY
+
+    def test_window_drops_oldest_rounds(self) -> None:
+        cal = GroupCalibrator(
+            start=Difficulty.MEDIUM,
+            window=2,
+            min_rounds=2,
+            step_up_threshold=0.8,
+        )
+        cal.record_round(correct=0, total=4)  # 0.0  (will be dropped)
+        cal.record_round(correct=4, total=4)  # 1.0
+        cal.record_round(correct=4, total=4)  # 1.0 ; window now [1.0, 1.0]
+        assert cal.average_rate() == pytest.approx(1.0)
+        assert cal.next_target() == Difficulty.HARD
+
+
+# ----------------------------------------------------------------------
+# QuestionBank.get_next_question_at_difficulty
+# ----------------------------------------------------------------------
+
+
+def _bank_with(questions: list[Question]) -> QuestionBank:
+    qb = QuestionBank()
+    qb._categories = {"test": questions}
+    # Build the mixed (all-difficulty) queue, as auto mode does.
+    qb.reset(category="test", difficulty=None)
+    return qb
+
+
+class TestBankDifficultyTargeting:
+    def test_serves_exact_target_difficulty(self) -> None:
+        qb = _bank_with(
+            [_q("e1", "easy"), _q("m1", "medium"), _q("h1", "hard")]
+        )
+        q = qb.get_next_question_at_difficulty("hard")
+        assert q is not None
+        assert q.difficulty == "hard"
+
+    def test_does_not_serve_same_question_twice(self) -> None:
+        qb = _bank_with(
+            [_q("m1", "medium"), _q("m2", "medium")]
+        )
+        first = qb.get_next_question_at_difficulty("medium")
+        second = qb.get_next_question_at_difficulty("medium")
+        assert first is not None and second is not None
+        assert first.id != second.id
+
+    def test_falls_back_to_nearest_when_target_missing(self) -> None:
+        # No "hard" questions: targeting hard should fall back to medium
+        # (the nearest rung), not easy.
+        qb = _bank_with(
+            [_q("e1", "easy"), _q("m1", "medium")]
+        )
+        q = qb.get_next_question_at_difficulty("hard")
+        assert q is not None
+        assert q.difficulty == "medium"
+
+    def test_falls_back_outward_to_easy_when_only_easy_left(self) -> None:
+        qb = _bank_with([_q("e1", "easy")])
+        q = qb.get_next_question_at_difficulty("hard")
+        assert q is not None
+        assert q.difficulty == "easy"
+
+    def test_returns_none_when_exhausted(self) -> None:
+        qb = _bank_with([_q("m1", "medium")])
+        assert qb.get_next_question_at_difficulty("medium") is not None
+        assert qb.get_next_question_at_difficulty("medium") is None
+
+
+# ----------------------------------------------------------------------
+# GameState integration: auto mode end-to-end vs. fixed difficulty
+# ----------------------------------------------------------------------
+
+from unittest.mock import MagicMock  # noqa: E402
+
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _fake_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+def _inject_bank(state: QuizifyGameState) -> None:
+    """Replace the loaded packs with a controlled, difficulty-rich set.
+
+    Enough questions at each rung that auto mode can serve several rounds.
+    """
+    questions = []
+    for i in range(6):
+        questions.append(_q(f"e{i}", "easy"))
+        questions.append(_q(f"m{i}", "medium"))
+        questions.append(_q(f"h{i}", "hard"))
+    bank = state._question_bank
+    bank._categories = {"test": questions}
+    bank._loaded = True  # make load_all_categories a cache hit
+
+
+def _correct_idx(state: QuizifyGameState) -> int:
+    return next(
+        i for i, a in enumerate(state._current_question.answers) if a.correct
+    )
+
+
+def _wrong_idx(state: QuizifyGameState) -> int:
+    return next(
+        i for i, a in enumerate(state._current_question.answers) if not a.correct
+    )
+
+
+class TestAutoModeIntegration:
+    def test_fixed_difficulty_creates_no_calibrator(self, tmp_path: Path) -> None:
+        state = QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="t")
+        _inject_bank(state)
+        state.add_player("Alice", _fake_ws())
+        state.start_game(language="de", num_rounds=5, difficulty="medium")
+        assert state._calibrator is None
+        # Fixed mode keeps serving the pinned difficulty.
+        state.start_next_question()
+        assert state._current_question.difficulty == "medium"
+
+    def test_auto_mode_creates_calibrator_starting_medium(
+        self, tmp_path: Path
+    ) -> None:
+        state = QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="t")
+        _inject_bank(state)
+        state.add_player("Alice", _fake_ws())
+        state.start_game(language="de", num_rounds=8, difficulty="auto")
+        assert state._calibrator is not None
+        assert state._calibrator.current_target == Difficulty.MEDIUM
+        # First served question (no signal yet) is the medium start.
+        state.start_next_question()
+        assert state._current_question.difficulty == "medium"
+
+    def test_auto_mode_ramps_harder_on_strong_group(
+        self, tmp_path: Path
+    ) -> None:
+        state = QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="t")
+        _inject_bank(state)
+        state.add_player("Alice", _fake_ws())
+        state.start_game(language="de", num_rounds=8, difficulty="auto")
+
+        served = []
+        for _ in range(5):
+            q = state.start_next_question()
+            if q is None:
+                break
+            served.append(q.difficulty)
+            state.submit_answer("Alice", _correct_idx(state))
+            state.evaluate_round()
+
+        # Started medium; an all-correct group should be served hard by the end.
+        assert served[0] == "medium"
+        assert "hard" in served
+        assert state._calibrator.current_target == Difficulty.HARD
+
+    def test_auto_mode_eases_on_struggling_group(self, tmp_path: Path) -> None:
+        state = QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="t")
+        _inject_bank(state)
+        state.add_player("Alice", _fake_ws())
+        state.start_game(language="de", num_rounds=8, difficulty="auto")
+
+        served = []
+        for _ in range(5):
+            q = state.start_next_question()
+            if q is None:
+                break
+            served.append(q.difficulty)
+            state.submit_answer("Alice", _wrong_idx(state))
+            state.evaluate_round()
+
+        assert served[0] == "medium"
+        assert "easy" in served
+        assert state._calibrator.current_target == Difficulty.EASY
+
+    def test_reset_to_lobby_clears_calibrator(self, tmp_path: Path) -> None:
+        state = QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="t")
+        _inject_bank(state)
+        state.add_player("Alice", _fake_ws())
+        state.start_game(language="de", num_rounds=5, difficulty="auto")
+        assert state._calibrator is not None
+        state.reset_to_lobby()
+        assert state._calibrator is None


### PR DESCRIPTION
Closes #40.

## What

Adds an **Auto** difficulty option that adapts the whole table together within a single game.

The game model is unchanged: one shared question per round, one difficulty per round, served to every connected player at once. With Auto selected, after each round Quizify looks at the **group's overall correct-rate** and nudges the difficulty of *upcoming* questions:

- group is acing it → lean harder
- group is struggling → lean easier

## Scope (group-level only)

This PR implements the **group/table-level** approach explicitly:

- In-game only — **no persistence**, no per-player identity, no per-player difficulty state, no per-player question streams.
- One signal per round (the group's correct-rate), one shared difficulty for the next round.

The original issue text described a per-player variant ("track per-player correct rate per difficulty, bump *their* personal difficulty"). That personalised version requires per-player difficulty state and a per-player question stream and is **deferred to #186**.

## Design — bounded, smooth, no-op without signal

`GroupCalibrator` (`game/calibration.py`):

- **Starts at medium.**
- **Bounded:** only steps one rung at a time on the `easy ↔ medium ↔ hard` ladder; never jumps `easy → hard` in a single move. Clamps at the ends.
- **Smooth:** a step requires the *averaged* correct-rate over a small recent window (default last 3 rounds) to clear a threshold (≥0.80 → harder, ≤0.40 → easier). A single lucky or brutal round can't swing the difficulty.
- **No-op without signal:** the target never moves until at least `min_rounds` (default 2) rounds with participants have been observed. Rounds with zero participants carry no signal.

## Wiring

- `QuestionBank.get_next_question_at_difficulty(target)` serves the next not-yet-consumed question matching the target difficulty, falling back to the nearest available rung, from a queue built across **all** difficulties (Auto mode builds the queue unfiltered).
- `GameState` creates a calibrator **only** when `difficulty == "auto"`. Fixed Easy/Medium/Hard picks are honoured verbatim and never calibrated. After each evaluated round it feeds the group correct-rate and advances the target; `start_next_question` serves the calibrated target.
- Scoring and per-round timers still derive from the **actually-served** question's difficulty, so they are unaffected by the game-level "auto" setting.
- Admin UI gets an **Auto** difficulty chip (+ DE/EN i18n). `admin.js` is loaded directly (not bundled), so no player-bundle rebuild was needed.

## Tests

22 focused new tests in `tests/test_calibration_40.py`:

- calibrator: no-op before min signal, single-rung bounding, smoothing over the window, comfortable-band hold, clamping at easy/hard, ignoring zero-participant rounds;
- bank: exact-target serving, nearest fallback, no-double-serve, exhaustion;
- end-to-end game state: fixed difficulty creates no calibrator; Auto starts medium, ramps to hard on a strong group, eases to easy on a struggling group; `reset_to_lobby` clears the calibrator.

Full suite: **220 passed** (was 198 + 22 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)