### PR TITLE
feat: in-app community pack submission (#180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ All notable changes to Quizify are documented here. This project follows
 
 ### Added
 
+- **Submit a community pack in-app (#180).** Hosts can now compose or paste a
+  community question pack as JSON directly in the admin setup screen, get it
+  validated field-by-field (a per-row ✓/✗ check of the pack name, language,
+  question list and every question's shape — mirroring the on-disk pack schema
+  from #179), and submit it for review. A submitted pack is handed to a small
+  worker that turns it into a GitHub issue in `mholzi/quizify`; the GitHub
+  token lives only in that worker, never in the browser or the integration.
+  Each submission's status is reconciled server-side against the GitHub issue
+  state (throttled to ~hourly): a closed-as-completed issue shows as
+  *Accepted*, a closed-as-not-planned issue as *Declined*. Error messages are
+  localized (`INVALID_FORMAT` / `RATE_LIMITED` / `GITHUB_ERROR`) with a
+  fallback to the raw worker message. The whole feature is **inert by
+  default**: a new optional "Community pack submission URL" option must be set
+  before the section appears — empty means the UI stays hidden and the
+  endpoints accept nothing. (The worker route itself is separate
+  infrastructure and is not part of this integration.)
 - **Group adaptive difficulty (#40).** A new **Auto** difficulty option that
   tunes the whole table together within a single game. The game still serves
   one shared question to everyone per round; after each round Quizify looks at

--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -38,6 +38,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     from .analytics import QuizifyAnalytics  # noqa: PLC0415
     from .const import (  # noqa: PLC0415
+        CONF_COMMUNITY_SUBMIT_URL,
         CONF_LOBBY_MUSIC_URL,
         CONF_MEDIA_PLAYER_ENTITY,
         CONF_PARTY_LIGHT_ENTITIES,
@@ -91,6 +92,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # HA's configured language drives the admin UI's initial language
         # (Settings → General). hass.config.language is always set on HA.
         ha_language=hass.config.language,
+        # Community-pack submission stays inert until this worker URL is set
+        # (#180). Empty/unset → the in-app submit UI hides itself.
+        community_submit_url=(
+            (entry.options or {}).get(CONF_COMMUNITY_SUBMIT_URL) or ""
+        ).strip()
+        or None,
     )
 
     # Stash on hass.data so existing tooling (services.yaml, lookups in
@@ -194,6 +201,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def _update_listener(_hass: HomeAssistant, updated_entry: ConfigEntry) -> None:
         opts = updated_entry.options or {}
         game_state.lobby_music_url = (opts.get(CONF_LOBBY_MUSIC_URL) or "").strip() or None
+        # Toggle the community-pack submit feature live (#180) — no HA restart.
+        ctx.community_submit_url = (
+            opts.get(CONF_COMMUNITY_SUBMIT_URL) or ""
+        ).strip() or None
         domain_data = _hass.data.get(DOMAIN, {})
         pl: QuizifyPartyLights | None = domain_data.get("party_lights")
         tts: QuizifyTTSAnnouncer | None = domain_data.get("tts_announcer")

--- a/custom_components/quizify/config_flow.py
+++ b/custom_components/quizify/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.core import callback
 from homeassistant.helpers import selector
 
 from .const import (
+    CONF_COMMUNITY_SUBMIT_URL,
     CONF_LOBBY_MUSIC_URL,
     CONF_MEDIA_PLAYER_ENTITY,
     CONF_PARTY_LIGHT_ENTITIES,
@@ -99,6 +100,16 @@ class QuizifyOptionsFlow(OptionsFlow):
             vol.Optional(
                 CONF_LOBBY_MUSIC_URL,
                 default=current.get(CONF_LOBBY_MUSIC_URL, ""),
+            ): selector.TextSelector(
+                selector.TextSelectorConfig(type=selector.TextSelectorType.URL),
+            ),
+            # Endpoint a composed community pack is POSTed to so it can land as
+            # a GitHub issue for review (#180). Empty = the whole in-app pack
+            # submission feature stays hidden and inert. The GitHub token lives
+            # in that worker, never in the browser or this integration.
+            vol.Optional(
+                CONF_COMMUNITY_SUBMIT_URL,
+                default=current.get(CONF_COMMUNITY_SUBMIT_URL, ""),
             ): selector.TextSelector(
                 selector.TextSelectorConfig(type=selector.TextSelectorType.URL),
             ),

--- a/custom_components/quizify/const.py
+++ b/custom_components/quizify/const.py
@@ -60,3 +60,40 @@ CONF_MEDIA_PLAYER_ENTITY = "media_player_entity"  # str, single, domain=media_pl
 # Home Assistant's www/ folder). No audio asset ships with the integration, so
 # there is nothing to play unless the user supplies one.
 CONF_LOBBY_MUSIC_URL = "lobby_music_url"  # str, single, free-text URL
+
+# Endpoint a composed community question pack is POSTed to so it lands as a
+# GitHub issue for review (#180). Empty by default — the whole in-app pack
+# submission feature stays completely inert (UI hidden, endpoints accept
+# nothing) until the user points this at a worker URL that holds the GitHub
+# token and creates the issue. The token never lives in the browser or the
+# integration; the worker is separate infrastructure (see issue #180, step 5).
+CONF_COMMUNITY_SUBMIT_URL = "community_submit_url"  # str, single, free-text URL
+
+# ---------------------------------------------------------------------------
+# Community pack submission (#180)
+# ---------------------------------------------------------------------------
+# Validation caps for a pasted/composed community pack. Kept in sync with the
+# community-pack loader limits (game/questions.py) so a pack that validates in
+# the browser also loads once it lands on disk.
+SUBMIT_MAX_QUESTIONS = 500
+SUBMIT_MIN_QUESTIONS = 1
+SUBMIT_ANSWERS_PER_QUESTION = ANSWERS_PER_QUESTION
+SUBMIT_MAX_PACK_BYTES = 1_048_576  # 1 MiB, mirrors MAX_COMMUNITY_PACK_BYTES
+# How many submission records we keep on disk per HA instance, and how often
+# the server reconciles their status against the GitHub issue state.
+SUBMIT_MAX_RECORDS = 100
+SUBMIT_POLL_INTERVAL_SECONDS = 3600  # ~hourly, like Beatify's PlaylistRequestsView
+SUBMIT_POLL_TIMEOUT_SECONDS = 12
+SUBMIT_RECORDS_FILE = "pack_submissions.json"
+
+# Submission status values (issue-state derived; see pack_submission.py).
+SUBMIT_STATUS_PENDING = "pending"
+SUBMIT_STATUS_ACCEPTED = "accepted"  # issue closed as completed
+SUBMIT_STATUS_DECLINED = "declined"  # issue closed as not_planned
+
+# Localized error codes surfaced by the submit flow (#180). The frontend maps
+# these to i18n keys (errors.<CODE>) with a fallback to the raw worker message.
+ERR_SUBMIT_INVALID_FORMAT = "INVALID_FORMAT"
+ERR_SUBMIT_RATE_LIMITED = "RATE_LIMITED"
+ERR_SUBMIT_GITHUB_ERROR = "GITHUB_ERROR"
+ERR_SUBMIT_DISABLED = "SUBMIT_DISABLED"

--- a/custom_components/quizify/server/context.py
+++ b/custom_components/quizify/server/context.py
@@ -73,3 +73,8 @@ class AppContext:
     # no hass. The admin page uses this as the first source for its initial
     # UI language (substituted into the ``{{HA_LANG}}`` token).
     ha_language: str | None = None
+    # Worker endpoint a composed community pack is POSTed to so it lands as a
+    # GitHub issue for review (#180). ``None``/empty keeps the whole in-app
+    # submission feature hidden and inert. Mutable so an options-flow change
+    # toggles the feature without an HA restart.
+    community_submit_url: str | None = None

--- a/custom_components/quizify/server/pack_submission.py
+++ b/custom_components/quizify/server/pack_submission.py
@@ -1,0 +1,474 @@
+"""In-app community-pack submission (#180).
+
+A user composes/pastes a community question pack in the admin UI. The browser
+validates it against the same schema the on-disk loader enforces (#179), then
+POSTs the validated pack here. This view proxies the pack to a configurable
+**worker** endpoint (``community_submit_url``) that holds a GitHub token and
+creates a labelled issue in ``mholzi/quizify`` — the token never lives in the
+browser or this integration. A submission record is persisted in the
+integration data dir.
+
+A separate GET reconciles each persisted submission against the GitHub **issue
+state** (closed-as-completed = accepted, closed-as-not_planned = declined),
+throttled to ~hourly so a busy admin tab can't hammer GitHub's
+unauthenticated, per-IP rate limit. This mirrors Beatify's
+``PlaylistRequestsView`` (the #970 lesson: trust the issue *state*, not labels).
+
+The whole feature stays inert until ``community_submit_url`` is set: the config
+endpoint reports ``enabled: false`` (so the UI hides the section) and POSTs are
+refused with ``SUBMIT_DISABLED``.
+
+No HA coupling: handlers read everything they need from the
+:class:`~..server.context.AppContext` (``ctx.runtime`` for the data dir and
+executor, ``ctx.community_submit_url`` for the endpoint), so the standalone dev
+server runs them unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+import aiohttp
+from aiohttp import web
+
+from ..const import (
+    ERR_SUBMIT_DISABLED,
+    ERR_SUBMIT_GITHUB_ERROR,
+    ERR_SUBMIT_INVALID_FORMAT,
+    ERR_SUBMIT_RATE_LIMITED,
+    SUBMIT_ANSWERS_PER_QUESTION,
+    SUBMIT_MAX_PACK_BYTES,
+    SUBMIT_MAX_QUESTIONS,
+    SUBMIT_MAX_RECORDS,
+    SUBMIT_MIN_QUESTIONS,
+    SUBMIT_POLL_INTERVAL_SECONDS,
+    SUBMIT_POLL_TIMEOUT_SECONDS,
+    SUBMIT_RECORDS_FILE,
+    SUBMIT_STATUS_ACCEPTED,
+    SUBMIT_STATUS_DECLINED,
+    SUBMIT_STATUS_PENDING,
+)
+from .context import APP_CTX_KEY
+
+if TYPE_CHECKING:
+    from .context import AppContext
+
+_LOGGER = logging.getLogger(__name__)
+
+# GitHub issues API for the reconcile poll. Read-only, unauthenticated — the
+# write side (creating the issue) is the worker's job, not ours.
+_GITHUB_ISSUES_API = "https://api.github.com/repos/mholzi/quizify/issues"
+
+# Per-IP submit rate limit. Generous enough for a legitimate compose-and-retry
+# loop, tight enough that an inert anonymous endpoint can't be hammered.
+_RATE_LIMIT_REQUESTS = 5
+_RATE_LIMIT_WINDOW = 60  # seconds
+_rate_buckets: dict[str, list[float]] = {}
+
+
+def _check_rate_limit(client_ip: str) -> bool:
+    """Sliding-window rate limit keyed on client IP. True = allowed."""
+    now = time.monotonic()
+    bucket = _rate_buckets.setdefault(client_ip, [])
+    cutoff = now - _RATE_LIMIT_WINDOW
+    bucket[:] = [t for t in bucket if t > cutoff]
+    if len(bucket) >= _RATE_LIMIT_REQUESTS:
+        return False
+    bucket.append(now)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Validation — server-side mirror of the #179 community-pack schema
+# ---------------------------------------------------------------------------
+#
+# The browser runs the same checks (pack-submit.js) to give per-field ✓/✗
+# feedback before submit; this is the defensive guard so a hand-crafted POST
+# that skips the UI can't push a malformed pack to the worker. Returns
+# (ok, errors): errors is a list of human-readable strings (first 10 surfaced).
+
+
+def validate_pack(pack: object) -> tuple[bool, list[str]]:
+    """Validate a community pack against the #179 schema. Returns (ok, errors)."""
+    errors: list[str] = []
+
+    if not isinstance(pack, dict):
+        return False, ["Top-level JSON must be an object."]
+
+    name = pack.get("name")
+    if not isinstance(name, str) or not name.strip():
+        errors.append("Field 'name' is required and must be a non-empty string.")
+
+    language = pack.get("language", "de")
+    if not isinstance(language, str) or not language.strip():
+        errors.append("Field 'language' must be a non-empty string.")
+
+    questions = pack.get("questions")
+    if not isinstance(questions, list) or not questions:
+        errors.append("Field 'questions' must be a non-empty list.")
+        return False, errors[:10]
+
+    if len(questions) < SUBMIT_MIN_QUESTIONS:
+        errors.append(f"At least {SUBMIT_MIN_QUESTIONS} question is required.")
+    if len(questions) > SUBMIT_MAX_QUESTIONS:
+        errors.append(f"Too many questions (max {SUBMIT_MAX_QUESTIONS}).")
+
+    seen_ids: set[str] = set()
+    for idx, q in enumerate(questions):
+        prefix = f"Question {idx + 1}"
+        if not isinstance(q, dict):
+            errors.append(f"{prefix}: must be an object.")
+            continue
+        qid = q.get("id")
+        if not isinstance(qid, str) or not qid.strip():
+            errors.append(f"{prefix}: 'id' is required and must be a non-empty string.")
+        elif qid in seen_ids:
+            errors.append(f"{prefix}: duplicate id '{qid}'.")
+        else:
+            seen_ids.add(qid)
+        if not isinstance(q.get("question"), str) or not q.get("question", "").strip():
+            errors.append(f"{prefix}: 'question' is required and must be a non-empty string.")
+        answers = q.get("answers")
+        if not isinstance(answers, list) or len(answers) != SUBMIT_ANSWERS_PER_QUESTION:
+            errors.append(
+                f"{prefix}: exactly {SUBMIT_ANSWERS_PER_QUESTION} answers are required."
+            )
+            continue
+        correct_count = 0
+        for a in answers:
+            if not isinstance(a, dict):
+                errors.append(f"{prefix}: each answer must be an object.")
+                continue
+            if not isinstance(a.get("text"), str) or not a.get("text", "").strip():
+                errors.append(f"{prefix}: every answer needs non-empty 'text'.")
+            if a.get("correct") is True:
+                correct_count += 1
+        if correct_count != 1:
+            errors.append(
+                f"{prefix}: exactly 1 answer must be marked correct (got {correct_count})."
+            )
+
+    return (not errors), errors[:10]
+
+
+# ---------------------------------------------------------------------------
+# Persistence + GitHub status reconcile
+# ---------------------------------------------------------------------------
+
+
+def _issue_to_status(state: str, state_reason: str) -> str:
+    """Map a GitHub issue's state + close reason to a submission status.
+
+    The issue STATE is the source of truth (Beatify #970): any closed issue is
+    a decision. ``not_planned`` close reason = declined; anything else closed
+    (e.g. ``completed``) = accepted. Open = still pending.
+    """
+    if state != "closed":
+        return SUBMIT_STATUS_PENDING
+    if state_reason == "not_planned":
+        return SUBMIT_STATUS_DECLINED
+    return SUBMIT_STATUS_ACCEPTED
+
+
+class PackSubmissionStore:
+    """Persisted submission records + throttled GitHub status reconcile.
+
+    Records live in ``<data_dir>/pack_submissions.json``:
+    ``{"submissions": [...], "last_poll": "<iso8601>"}``. Each submission is
+    ``{id, name, language, question_count, issue_number, issue_url, status,
+    created, last_checked}``.
+    """
+
+    _ISSUE_NUMBER_RE = re.compile(r"/issues/(\d+)(?:[#?].*)?$")
+
+    def __init__(self, ctx: "AppContext") -> None:
+        self._ctx = ctx
+        self._path = ctx.runtime.data_dir / SUBMIT_RECORDS_FILE
+
+    # --- blocking helpers (run in executor) ---------------------------------
+
+    def _load(self) -> dict:
+        if self._path.exists():
+            try:
+                data = json.loads(self._path.read_text(encoding="utf-8"))
+                if isinstance(data, dict):
+                    return data
+            except (OSError, ValueError) as err:
+                _LOGGER.warning("Could not read pack submissions: %s", err)
+        return {"submissions": [], "last_poll": None}
+
+    def _save(self, data: dict) -> bool:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._path.write_text(
+                json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8"
+            )
+            return True
+        except OSError as err:
+            _LOGGER.error("Could not write pack submissions: %s", err)
+            return False
+
+    # --- reconcile ----------------------------------------------------------
+
+    def _poll_due(self, data: dict) -> bool:
+        last_poll = data.get("last_poll")
+        if not last_poll:
+            return True
+        try:
+            last = datetime.fromisoformat(str(last_poll).replace("Z", "+00:00"))
+        except ValueError:
+            return True
+        if last.tzinfo is None:
+            last = last.replace(tzinfo=timezone.utc)
+        elapsed = (datetime.now(timezone.utc) - last).total_seconds()
+        return elapsed >= SUBMIT_POLL_INTERVAL_SECONDS
+
+    @staticmethod
+    def issue_number_from_url(url: object) -> int | None:
+        """Extract the issue number from a GitHub issue HTML/API URL."""
+        if not isinstance(url, str):
+            return None
+        match = PackSubmissionStore._ISSUE_NUMBER_RE.search(url)
+        if match:
+            try:
+                return int(match.group(1))
+            except ValueError:
+                return None
+        return None
+
+    async def _fetch_issue(
+        self, session: aiohttp.ClientSession, issue_number: int
+    ) -> tuple[str, str] | None:
+        """Fetch a GitHub issue's (state, state_reason), or None on failure."""
+        try:
+            async with session.get(
+                f"{_GITHUB_ISSUES_API}/{issue_number}",
+                headers={"Accept": "application/vnd.github+json"},
+            ) as resp:
+                if resp.status != 200:
+                    _LOGGER.debug(
+                        "Pack-submission poll: issue %s returned HTTP %s",
+                        issue_number,
+                        resp.status,
+                    )
+                    return None
+                issue = await resp.json()
+            return issue.get("state", ""), issue.get("state_reason") or ""
+        except (aiohttp.ClientError, ValueError) as err:
+            _LOGGER.debug("Pack-submission poll: issue %s failed: %s", issue_number, err)
+            return None
+
+    async def reconcile(self, data: dict) -> dict:
+        """Reconcile pending submissions against GitHub issue state.
+
+        Stamps ``last_poll`` whenever a poll is attempted — even with nothing
+        pending or GitHub unreachable — so a failure backs off for the full
+        interval instead of retrying on every admin-tab open.
+        """
+        now = datetime.now(timezone.utc).isoformat()
+        data["last_poll"] = now
+
+        submissions = data.get("submissions", [])
+        pending = [
+            s
+            for s in submissions
+            if isinstance(s, dict)
+            and s.get("issue_number")
+            and s.get("status") in (None, "", SUBMIT_STATUS_PENDING)
+        ]
+        if not pending:
+            return data
+
+        timeout = aiohttp.ClientTimeout(total=SUBMIT_POLL_TIMEOUT_SECONDS)
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                for sub in pending:
+                    result = await self._fetch_issue(session, sub["issue_number"])
+                    if result is None:
+                        continue
+                    state, state_reason = result
+                    sub["status"] = _issue_to_status(state, state_reason)
+                    sub["last_checked"] = now
+        except (aiohttp.ClientError, ValueError) as err:
+            _LOGGER.debug("Pack-submission reconcile aborted: %s", err)
+        return data
+
+    # --- public async API ---------------------------------------------------
+
+    async def get_with_reconcile(self) -> dict:
+        """Load records, reconcile against GitHub if the poll is due, persist."""
+        data = await self._ctx.runtime.run_in_executor(self._load)
+        if self._poll_due(data):
+            data = await self.reconcile(data)
+            await self._ctx.runtime.run_in_executor(self._save, data)
+        return data
+
+    async def add(self, record: dict) -> None:
+        """Append a submission record (newest first), capped, then persist."""
+        data = await self._ctx.runtime.run_in_executor(self._load)
+        submissions = data.get("submissions")
+        if not isinstance(submissions, list):
+            submissions = []
+        submissions.insert(0, record)
+        data["submissions"] = submissions[:SUBMIT_MAX_RECORDS]
+        await self._ctx.runtime.run_in_executor(self._save, data)
+
+
+# ---------------------------------------------------------------------------
+# HTTP views
+# ---------------------------------------------------------------------------
+
+
+def _get_ctx(request: web.Request) -> "AppContext":
+    return request.app[APP_CTX_KEY]
+
+
+async def submit_config_view(request: web.Request) -> web.Response:
+    """Report whether the submit feature is enabled (drives the UI's visibility).
+
+    Never leaks the worker URL to the browser — the browser POSTs to *our*
+    endpoint, which proxies to the worker server-side. Returns the validation
+    caps so the client validator stays in sync without hardcoding them.
+    """
+    ctx = _get_ctx(request)
+    enabled = bool((ctx.community_submit_url or "").strip())
+    return web.json_response(
+        {
+            "enabled": enabled,
+            "limits": {
+                "max_questions": SUBMIT_MAX_QUESTIONS,
+                "min_questions": SUBMIT_MIN_QUESTIONS,
+                "answers_per_question": SUBMIT_ANSWERS_PER_QUESTION,
+                "max_bytes": SUBMIT_MAX_PACK_BYTES,
+            },
+        }
+    )
+
+
+async def submissions_list_view(request: web.Request) -> web.Response:
+    """Return persisted submissions, reconciling status against GitHub if due."""
+    ctx = _get_ctx(request)
+    store = PackSubmissionStore(ctx)
+    data = await store.get_with_reconcile()
+    return web.json_response({"submissions": data.get("submissions", [])})
+
+
+async def submit_pack_view(request: web.Request) -> web.Response:
+    """Validate a composed pack and proxy it to the configured worker.
+
+    Body: ``{"pack": {...}}``. On success records the submission (so its status
+    can later be reconciled) and returns ``{ok, issue_number, issue_url}``.
+    Error responses carry a localizable ``code`` (INVALID_FORMAT / RATE_LIMITED
+    / GITHUB_ERROR / SUBMIT_DISABLED) plus a raw ``message`` fallback.
+    """
+    ctx = _get_ctx(request)
+    submit_url = (ctx.community_submit_url or "").strip()
+    if not submit_url:
+        return web.json_response(
+            {"code": ERR_SUBMIT_DISABLED, "message": "Pack submission is not configured."},
+            status=403,
+        )
+
+    client_ip = request.remote or "unknown"
+    if not _check_rate_limit(client_ip):
+        return web.json_response(
+            {"code": ERR_SUBMIT_RATE_LIMITED, "message": "Too many submissions, slow down."},
+            status=429,
+        )
+
+    try:
+        body = await request.json()
+    except (ValueError, TypeError):
+        return web.json_response(
+            {"code": ERR_SUBMIT_INVALID_FORMAT, "message": "Body is not valid JSON."},
+            status=400,
+        )
+
+    pack = (body or {}).get("pack") if isinstance(body, dict) else None
+    # Size guard before validation so a giant blob can't be walked field by field.
+    try:
+        encoded = json.dumps(pack).encode("utf-8")
+    except (TypeError, ValueError):
+        return web.json_response(
+            {"code": ERR_SUBMIT_INVALID_FORMAT, "message": "Pack is not serializable JSON."},
+            status=400,
+        )
+    if len(encoded) > SUBMIT_MAX_PACK_BYTES:
+        return web.json_response(
+            {
+                "code": ERR_SUBMIT_INVALID_FORMAT,
+                "message": f"Pack exceeds {SUBMIT_MAX_PACK_BYTES} bytes.",
+            },
+            status=400,
+        )
+
+    ok, errors = validate_pack(pack)
+    if not ok:
+        return web.json_response(
+            {
+                "code": ERR_SUBMIT_INVALID_FORMAT,
+                "message": "; ".join(errors) or "Pack failed validation.",
+                "errors": errors,
+            },
+            status=400,
+        )
+
+    # Proxy to the worker, which holds the GitHub token and creates the issue.
+    timeout = aiohttp.ClientTimeout(total=SUBMIT_POLL_TIMEOUT_SECONDS)
+    worker_payload: dict[str, Any]
+    try:
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(submit_url, json={"pack": pack}) as resp:
+                try:
+                    worker_payload = await resp.json(content_type=None)
+                except (ValueError, aiohttp.ClientError):
+                    worker_payload = {}
+                if resp.status >= 400:
+                    code = worker_payload.get("code") if isinstance(worker_payload, dict) else None
+                    message = (
+                        worker_payload.get("message")
+                        if isinstance(worker_payload, dict)
+                        else None
+                    )
+                    return web.json_response(
+                        {
+                            "code": code or ERR_SUBMIT_GITHUB_ERROR,
+                            "message": message or f"Worker returned HTTP {resp.status}.",
+                        },
+                        status=resp.status if resp.status in (400, 429) else 502,
+                    )
+    except aiohttp.ClientError as err:
+        _LOGGER.warning("Pack submission proxy failed: %s", err)
+        return web.json_response(
+            {"code": ERR_SUBMIT_GITHUB_ERROR, "message": f"Could not reach the worker: {err}"},
+            status=502,
+        )
+
+    if not isinstance(worker_payload, dict):
+        worker_payload = {}
+    issue_url = worker_payload.get("issue_url") or worker_payload.get("html_url")
+    issue_number = worker_payload.get("issue_number")
+    if issue_number is None:
+        issue_number = PackSubmissionStore.issue_number_from_url(issue_url)
+
+    record = {
+        "id": f"{int(time.time() * 1000)}",
+        "name": str(pack.get("name", "")) if isinstance(pack, dict) else "",
+        "language": str(pack.get("language", "")) if isinstance(pack, dict) else "",
+        "question_count": len(pack.get("questions", [])) if isinstance(pack, dict) else 0,
+        "issue_number": issue_number,
+        "issue_url": issue_url,
+        "status": SUBMIT_STATUS_PENDING,
+        "created": datetime.now(timezone.utc).isoformat(),
+        "last_checked": None,
+    }
+    await PackSubmissionStore(ctx).add(record)
+
+    return web.json_response(
+        {"ok": True, "issue_number": issue_number, "issue_url": issue_url}
+    )

--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -19,6 +19,11 @@ import aiohttp
 from aiohttp import web
 
 from .context import APP_CTX_KEY
+from .pack_submission import (
+    submissions_list_view,
+    submit_config_view,
+    submit_pack_view,
+)
 from .serializers import build_game_status_response
 
 if TYPE_CHECKING:
@@ -627,6 +632,11 @@ ROUTES: list[tuple[str, str, object]] = [
     ("GET", "/api/quizify/packs/updates", pack_update_check_view),
     ("POST", "/api/quizify/flag-question", flag_question_view),
     ("GET", "/api/quizify/flags", flag_list_view),
+    # Community pack submission (#180). Inert until community_submit_url is set:
+    # the config endpoint reports enabled:false and POSTs are refused.
+    ("GET", "/api/quizify/pack-submit/config", submit_config_view),
+    ("GET", "/api/quizify/pack-submit/submissions", submissions_list_view),
+    ("POST", "/api/quizify/pack-submit", submit_pack_view),
 ]
 
 

--- a/custom_components/quizify/translations/de.json
+++ b/custom_components/quizify/translations/de.json
@@ -22,13 +22,15 @@
                     "party_light_entities": "Party-Lichter",
                     "tts_entity": "Text-zu-Sprache-Dienst",
                     "media_player_entity": "Mediaplayer für TTS",
-                    "lobby_music_url": "Lobby-Musik-URL"
+                    "lobby_music_url": "Lobby-Musik-URL",
+                    "community_submit_url": "URL für Community-Pack-Einsendung"
                 },
                 "data_description": {
                     "party_light_entities": "Lichter, die mit der Spielphase mitleuchten (Koralle bei Frage, Salbei bei Auflösung, Sonne im Finale).",
                     "tts_entity": "TTS-Entity (z. B. tts.google_translate_say) für Ansagen bei Meilensteinen und Rundenergebnissen.",
                     "media_player_entity": "Lautsprecher, über den die TTS-Ansage abgespielt wird. Pflicht, wenn ein TTS-Dienst gesetzt ist.",
-                    "lobby_music_url": "Optionale URL einer Audiodatei (z. B. /local/quizify-lobby.mp3 aus deinem config/www-Ordner), die in der Lobby über den oben gewählten Mediaplayer in Schleife läuft. Sie stoppt beim Spielstart, damit sie sich nicht mit den TTS-Ansagen über denselben Lautsprecher überlagert. Leer lassen = keine Musik. Es ist keine Audiodatei enthalten — du musst eine eigene angeben."
+                    "lobby_music_url": "Optionale URL einer Audiodatei (z. B. /local/quizify-lobby.mp3 aus deinem config/www-Ordner), die in der Lobby über den oben gewählten Mediaplayer in Schleife läuft. Sie stoppt beim Spielstart, damit sie sich nicht mit den TTS-Ansagen über denselben Lautsprecher überlagert. Leer lassen = keine Musik. Es ist keine Audiodatei enthalten — du musst eine eigene angeben.",
+                    "community_submit_url": "Optionaler Worker-Endpunkt, der eine in der App eingereichte Community-Pack-Einsendung in ein GitHub-Issue zur Begutachtung umwandelt. Leer lassen, um die Einsende-Funktion komplett auszublenden. Das GitHub-Token liegt in diesem Worker, nie im Browser oder in Home Assistant."
                 }
             }
         }

--- a/custom_components/quizify/translations/en.json
+++ b/custom_components/quizify/translations/en.json
@@ -22,13 +22,15 @@
                     "party_light_entities": "Party lights",
                     "tts_entity": "Text-to-speech provider",
                     "media_player_entity": "Media player for TTS",
-                    "lobby_music_url": "Lobby music URL"
+                    "lobby_music_url": "Lobby music URL",
+                    "community_submit_url": "Community pack submission URL"
                 },
                 "data_description": {
                     "party_light_entities": "Lights that should glow with the round phase (coral on question, sage on reveal, sun on finale).",
                     "tts_entity": "TTS entity (e.g. tts.google_translate_say) used to announce milestones and round results.",
                     "media_player_entity": "Speaker the TTS audio plays through. Required if TTS provider is set.",
-                    "lobby_music_url": "Optional URL of an audio file (e.g. /local/quizify-lobby.mp3, served from your config/www folder) looped on the media player above while waiting in the lobby. It stops when the game starts, so it never overlaps the TTS announcements that share the same speaker. Leave blank for no music. No audio file is included — supply your own."
+                    "lobby_music_url": "Optional URL of an audio file (e.g. /local/quizify-lobby.mp3, served from your config/www folder) looped on the media player above while waiting in the lobby. It stops when the game starts, so it never overlaps the TTS announcements that share the same speaker. Leave blank for no music. No audio file is included — supply your own.",
+                    "community_submit_url": "Optional worker endpoint that turns an in-app community-pack submission into a GitHub issue for review. Leave blank to hide the submission feature entirely. The GitHub token lives in that worker, never in your browser or Home Assistant."
                 }
             }
         }

--- a/custom_components/quizify/translations/es.json
+++ b/custom_components/quizify/translations/es.json
@@ -22,13 +22,15 @@
                     "party_light_entities": "Luces de fiesta",
                     "tts_entity": "Proveedor de texto a voz",
                     "media_player_entity": "Reproductor para TTS",
-                    "lobby_music_url": "URL de música de la sala"
+                    "lobby_music_url": "URL de música de la sala",
+                    "community_submit_url": "URL de envío de paquetes de la comunidad"
                 },
                 "data_description": {
                     "party_light_entities": "Luces que cambian de color con la fase de la ronda (coral en pregunta, salvia en revelación, sol en final).",
                     "tts_entity": "Entidad TTS (p. ej. tts.google_translate_say) para anuncios de hitos y resultados.",
                     "media_player_entity": "Altavoz por el que se reproduce el audio TTS. Obligatorio si se configura un proveedor TTS.",
-                    "lobby_music_url": "URL opcional de un archivo de audio (p. ej. /local/quizify-lobby.mp3, desde tu carpeta config/www) que se reproduce en bucle en el reproductor multimedia de arriba mientras se espera en la sala. Se detiene al empezar la partida, para no solaparse con los anuncios TTS que comparten el mismo altavoz. Déjalo vacío para no tener música. No se incluye ningún archivo de audio: usa el tuyo."
+                    "lobby_music_url": "URL opcional de un archivo de audio (p. ej. /local/quizify-lobby.mp3, desde tu carpeta config/www) que se reproduce en bucle en el reproductor multimedia de arriba mientras se espera en la sala. Se detiene al empezar la partida, para no solaparse con los anuncios TTS que comparten el mismo altavoz. Déjalo vacío para no tener música. No se incluye ningún archivo de audio: usa el tuyo.",
+                    "community_submit_url": "Endpoint opcional de un worker que convierte un envío de paquete de la comunidad hecho en la app en una incidencia de GitHub para revisión. Déjalo en blanco para ocultar por completo la función de envío. El token de GitHub reside en ese worker, nunca en tu navegador ni en Home Assistant."
                 }
             }
         }

--- a/custom_components/quizify/translations/fr.json
+++ b/custom_components/quizify/translations/fr.json
@@ -22,13 +22,15 @@
                     "party_light_entities": "Lumières d'ambiance",
                     "tts_entity": "Fournisseur de synthèse vocale",
                     "media_player_entity": "Lecteur multimédia pour TTS",
-                    "lobby_music_url": "URL de la musique du salon"
+                    "lobby_music_url": "URL de la musique du salon",
+                    "community_submit_url": "URL de soumission de pack communautaire"
                 },
                 "data_description": {
                     "party_light_entities": "Lumières qui changent de couleur selon la phase de la manche (corail pendant la question, sauge pendant la révélation, soleil au final).",
                     "tts_entity": "Entité TTS (p. ex. tts.google_translate_say) pour les annonces de jalons et de résultats.",
                     "media_player_entity": "Haut-parleur sur lequel le TTS est diffusé. Obligatoire si un fournisseur TTS est défini.",
-                    "lobby_music_url": "URL facultative d'un fichier audio (p. ex. /local/quizify-lobby.mp3, depuis votre dossier config/www) joué en boucle sur le lecteur multimédia ci-dessus pendant l'attente dans le salon. Elle s'arrête au démarrage de la partie, pour ne pas chevaucher les annonces TTS qui partagent le même haut-parleur. Laissez vide pour aucune musique. Aucun fichier audio n'est fourni — utilisez le vôtre."
+                    "lobby_music_url": "URL facultative d'un fichier audio (p. ex. /local/quizify-lobby.mp3, depuis votre dossier config/www) joué en boucle sur le lecteur multimédia ci-dessus pendant l'attente dans le salon. Elle s'arrête au démarrage de la partie, pour ne pas chevaucher les annonces TTS qui partagent le même haut-parleur. Laissez vide pour aucune musique. Aucun fichier audio n'est fourni — utilisez le vôtre.",
+                    "community_submit_url": "Point de terminaison de worker facultatif qui transforme une soumission de pack communautaire faite dans l'application en une issue GitHub à examiner. Laissez vide pour masquer entièrement la fonction de soumission. Le jeton GitHub réside dans ce worker, jamais dans votre navigateur ni dans Home Assistant."
                 }
             }
         }

--- a/custom_components/quizify/translations/nl.json
+++ b/custom_components/quizify/translations/nl.json
@@ -22,13 +22,15 @@
                     "party_light_entities": "Sfeerverlichting",
                     "tts_entity": "Tekst-naar-spraakprovider",
                     "media_player_entity": "Mediaspeler voor TTS",
-                    "lobby_music_url": "URL lobbymuziek"
+                    "lobby_music_url": "URL lobbymuziek",
+                    "community_submit_url": "URL voor inzending community-pack"
                 },
                 "data_description": {
                     "party_light_entities": "Lampen die meekleuren met de rondefase (koraal bij vraag, salie bij onthulling, zon bij finale).",
                     "tts_entity": "TTS-entiteit (bv. tts.google_translate_say) voor aankondigingen van mijlpalen en uitslagen.",
                     "media_player_entity": "Luidspreker waar de TTS wordt afgespeeld. Verplicht als er een TTS-provider is ingesteld.",
-                    "lobby_music_url": "Optionele URL van een audiobestand (bv. /local/quizify-lobby.mp3 uit je config/www-map) dat tijdens het wachten in de lobby in een lus wordt afgespeeld op de mediaspeler hierboven. Het stopt zodra het spel begint, zodat het de TTS-aankondigingen die dezelfde speaker delen niet overlapt. Laat leeg voor geen muziek. Er wordt geen audiobestand meegeleverd — gebruik je eigen bestand."
+                    "lobby_music_url": "Optionele URL van een audiobestand (bv. /local/quizify-lobby.mp3 uit je config/www-map) dat tijdens het wachten in de lobby in een lus wordt afgespeeld op de mediaspeler hierboven. Het stopt zodra het spel begint, zodat het de TTS-aankondigingen die dezelfde speaker delen niet overlapt. Laat leeg voor geen muziek. Er wordt geen audiobestand meegeleverd — gebruik je eigen bestand.",
+                    "community_submit_url": "Optioneel worker-eindpunt dat een in de app ingediende community-pack-inzending omzet in een GitHub-issue ter beoordeling. Laat leeg om de inzendfunctie volledig te verbergen. Het GitHub-token bevindt zich in die worker, nooit in je browser of in Home Assistant."
                 }
             }
         }

--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -363,27 +363,82 @@
                     <span data-i18n="setup.apply">Apply</span>
                 </button>
 
-                <!-- Community pack submission (#180). Hidden by default; the
-                     pack-submit.js module unhides it only when the integration
-                     reports a configured worker URL. Paste a pack JSON → see a
-                     per-field ✓/✗ table → submit (lands as a GitHub issue via
-                     the worker). -->
+                <!-- Community pack submission (#180), Variant C "Stepper".
+                     Hidden by default; pack-submit.js unhides it only when the
+                     integration reports a configured worker URL. A guided
+                     3-step wizard (Compose → Check → Submit) with a progress
+                     rail and grouped ✓/✗ checks, plus a status timeline for
+                     "My submissions". The pack lands as a GitHub issue via the
+                     worker. -->
                 <section id="pack-submit-section" class="pack-submit-section hidden"
                          aria-labelledby="pack-submit-heading">
-                    <h3 id="pack-submit-heading" class="pack-submit-heading"
-                        data-i18n="packSubmit.heading">Submit a community pack</h3>
-                    <p class="pack-submit-intro" data-i18n="packSubmit.intro">
-                        Paste a community question pack as JSON. It is checked here, then
-                        submitted for review as a GitHub issue.</p>
-                    <textarea id="pack-submit-input" class="pack-submit-input" rows="8"
-                              spellcheck="false"
-                              data-i18n-placeholder="packSubmit.placeholder"
-                              placeholder='{ "name": "My Pack", "language": "en", "questions": [ ... ] }'></textarea>
-                    <div id="pack-submit-result" class="pack-submit-result" aria-live="polite"></div>
-                    <button type="button" id="pack-submit-btn" class="btn btn-primary btn-block"
-                            disabled data-i18n="packSubmit.submit">Submit pack</button>
-                    <div id="pack-submit-status" class="pack-submit-status" role="status" aria-live="polite"></div>
-                    <div id="pack-submit-list" class="pack-submit-list"></div>
+                    <div class="pack-submit-card">
+                        <h3 id="pack-submit-heading" class="pack-submit-heading"
+                            data-i18n="packSubmit.heading">Submit a community pack</h3>
+                        <p class="pack-submit-intro" data-i18n="packSubmit.intro">
+                            Three quick steps. Your pack lands as a review issue on GitHub.</p>
+
+                        <!-- step rail: Compose / Check / Submit -->
+                        <div class="pack-steps" role="list">
+                            <div class="pack-step" data-step="1" role="listitem">
+                                <div class="pack-step-n">1</div>
+                                <div class="pack-step-l" data-i18n="packSubmit.step.compose">Compose</div>
+                            </div>
+                            <div class="pack-step-bar" data-bar="1"></div>
+                            <div class="pack-step" data-step="2" role="listitem">
+                                <div class="pack-step-n">2</div>
+                                <div class="pack-step-l" data-i18n="packSubmit.step.check">Check</div>
+                            </div>
+                            <div class="pack-step-bar" data-bar="2"></div>
+                            <div class="pack-step" data-step="3" role="listitem">
+                                <div class="pack-step-n">3</div>
+                                <div class="pack-step-l" data-i18n="packSubmit.step.submit">Submit</div>
+                            </div>
+                        </div>
+
+                        <!-- step 1: Compose -->
+                        <div class="pack-step-pane" data-pane="1">
+                            <label class="pack-submit-input-label" for="pack-submit-input"
+                                   data-i18n="packSubmit.inputLabel">Your pack JSON</label>
+                            <textarea id="pack-submit-input" class="pack-submit-input" rows="8"
+                                      spellcheck="false"
+                                      data-i18n-placeholder="packSubmit.placeholder"
+                                      placeholder='{ "name": "My Pack", "language": "en", "questions": [ ... ] }'></textarea>
+                            <button type="button" id="pack-submit-check-btn"
+                                    class="btn btn-primary btn-block"
+                                    disabled data-i18n="packSubmit.checkBtn">Check pack →</button>
+                        </div>
+
+                        <!-- step 2: Check (grouped ✓/✗) -->
+                        <div class="pack-step-pane hidden" data-pane="2">
+                            <div id="pack-submit-result" class="pack-submit-result" aria-live="polite"></div>
+                            <button type="button" id="pack-submit-continue-btn"
+                                    class="btn btn-primary btn-block"
+                                    disabled data-i18n="packSubmit.continueBtn">Continue to submit →</button>
+                            <button type="button" id="pack-submit-back-btn"
+                                    class="btn btn-ghost btn-block"
+                                    data-i18n="packSubmit.backBtn">Back to edit</button>
+                        </div>
+
+                        <!-- step 3: Submit -->
+                        <div class="pack-step-pane hidden" data-pane="3">
+                            <p class="pack-submit-confirm" data-i18n="packSubmit.confirm">
+                                Looks good. Submit this pack for review?</p>
+                            <button type="button" id="pack-submit-btn"
+                                    class="btn btn-primary btn-block"
+                                    data-i18n="packSubmit.submit">Submit pack</button>
+                            <button type="button" id="pack-submit-back2-btn"
+                                    class="btn btn-ghost btn-block"
+                                    data-i18n="packSubmit.backBtn">Back to edit</button>
+                            <div id="pack-submit-status" class="pack-submit-status" role="status" aria-live="polite"></div>
+                        </div>
+                    </div>
+
+                    <!-- My submissions timeline -->
+                    <div id="pack-submit-list-card" class="pack-submit-card pack-submit-list-card hidden">
+                        <div class="pack-submit-list-title" data-i18n="packSubmit.recent">My submissions</div>
+                        <div id="pack-submit-list" class="pack-submit-timeline"></div>
+                    </div>
                 </section>
             </div>
         </div>

--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -362,6 +362,29 @@
                 <button type="button" id="setup-apply-btn" class="btn btn-primary btn-lg btn-block">
                     <span data-i18n="setup.apply">Apply</span>
                 </button>
+
+                <!-- Community pack submission (#180). Hidden by default; the
+                     pack-submit.js module unhides it only when the integration
+                     reports a configured worker URL. Paste a pack JSON → see a
+                     per-field ✓/✗ table → submit (lands as a GitHub issue via
+                     the worker). -->
+                <section id="pack-submit-section" class="pack-submit-section hidden"
+                         aria-labelledby="pack-submit-heading">
+                    <h3 id="pack-submit-heading" class="pack-submit-heading"
+                        data-i18n="packSubmit.heading">Submit a community pack</h3>
+                    <p class="pack-submit-intro" data-i18n="packSubmit.intro">
+                        Paste a community question pack as JSON. It is checked here, then
+                        submitted for review as a GitHub issue.</p>
+                    <textarea id="pack-submit-input" class="pack-submit-input" rows="8"
+                              spellcheck="false"
+                              data-i18n-placeholder="packSubmit.placeholder"
+                              placeholder='{ "name": "My Pack", "language": "en", "questions": [ ... ] }'></textarea>
+                    <div id="pack-submit-result" class="pack-submit-result" aria-live="polite"></div>
+                    <button type="button" id="pack-submit-btn" class="btn btn-primary btn-block"
+                            disabled data-i18n="packSubmit.submit">Submit pack</button>
+                    <div id="pack-submit-status" class="pack-submit-status" role="status" aria-live="polite"></div>
+                    <div id="pack-submit-list" class="pack-submit-list"></div>
+                </section>
             </div>
         </div>
 
@@ -566,6 +589,7 @@
     <script src="/quizify/static/js/utils.js?v={{ASSET_VER}}"></script>
 
     <script src="/quizify/static/js/admin.js?v={{ASSET_VER}}"></script>
+    <script src="/quizify/static/js/pack-submit.js?v={{ASSET_VER}}"></script>
     <script src="/quizify/static/js/sw-update.js?v={{ASSET_VER}}"></script>
 </body>
 </html>

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -6389,3 +6389,97 @@ body:not(.is-admin) .pl-result { padding-bottom: 16px; }
 .your-result-score { font-size: 1.04rem; }
 .stat-value { font-size: 1.2rem; }
 .stat-label { font-size: 0.68rem; }
+
+/* ===========================================================================
+   Community pack submission (#180)
+   Hidden by default; pack-submit.js unhides #pack-submit-section only when the
+   integration reports a configured worker URL. Lives at the bottom of the
+   setup-detail flow, near the pack picker.
+   =========================================================================== */
+.pack-submit-section {
+    margin-top: var(--space-xl, 32px);
+    padding-top: var(--space-lg, 24px);
+    border-top: 1px solid var(--color-border-light);
+    text-align: left;
+}
+.pack-submit-heading {
+    font-size: 1.05rem;
+    color: var(--color-text-heading);
+    margin: 0 0 var(--space-xs, 4px);
+}
+.pack-submit-intro {
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+    margin: 0 0 var(--space-md, 16px);
+}
+.pack-submit-input {
+    width: 100%;
+    box-sizing: border-box;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.8rem;
+    line-height: 1.4;
+    padding: var(--space-sm, 8px);
+    border: 1px solid var(--color-border-medium);
+    border-radius: 8px;
+    background: var(--color-bg-surface);
+    color: var(--color-text-primary);
+    resize: vertical;
+}
+.pack-submit-result {
+    margin: var(--space-sm, 8px) 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+.pack-submit-row {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    font-size: 0.82rem;
+    flex-wrap: wrap;
+}
+.pack-submit-mark { font-weight: 700; }
+.pack-submit-row--ok { color: var(--color-success); }
+.pack-submit-row--bad { color: var(--color-error); }
+.pack-submit-label { color: var(--color-text-secondary); }
+.pack-submit-detail {
+    color: var(--color-text-muted);
+    font-size: 0.75rem;
+    flex-basis: 100%;
+    padding-left: 24px;
+}
+.pack-submit-status {
+    margin-top: var(--space-sm, 8px);
+    font-size: 0.85rem;
+    min-height: 1.2em;
+}
+.pack-submit-status--ok { color: var(--color-success); }
+.pack-submit-status--bad { color: var(--color-error); }
+.pack-submit-status--pending { color: var(--color-text-muted); }
+.pack-submit-list { margin-top: var(--space-md, 16px); }
+.pack-submit-list-title {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-xs, 4px);
+}
+.pack-submit-list-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 0;
+    font-size: 0.85rem;
+    border-bottom: 1px solid var(--color-border-light);
+}
+.pack-submit-list-name { overflow: hidden; text-overflow: ellipsis; }
+.pack-submit-badge {
+    font-size: 0.72rem;
+    padding: 2px 8px;
+    border-radius: 999px;
+    white-space: nowrap;
+}
+.pack-submit-badge--pending { background: var(--color-bg-card-alt); color: var(--color-text-muted); }
+.pack-submit-badge--accepted { background: var(--color-success-light); color: var(--color-success-hover); }
+.pack-submit-badge--declined { background: var(--color-error-light); color: var(--color-error-dark); }

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -6391,10 +6391,12 @@ body:not(.is-admin) .pl-result { padding-bottom: 16px; }
 .stat-label { font-size: 0.68rem; }
 
 /* ===========================================================================
-   Community pack submission (#180)
+   Community pack submission (#180) — Variant C "Stepper"
    Hidden by default; pack-submit.js unhides #pack-submit-section only when the
    integration reports a configured worker URL. Lives at the bottom of the
-   setup-detail flow, near the pack picker.
+   setup-detail flow, near the pack picker. A guided 3-step wizard
+   (Compose → Check → Submit) with a progress rail + grouped ✓/✗ checks, plus a
+   status timeline for "My submissions".
    =========================================================================== */
 .pack-submit-section {
     margin-top: var(--space-xl, 32px);
@@ -6402,51 +6404,162 @@ body:not(.is-admin) .pl-result { padding-bottom: 16px; }
     border-top: 1px solid var(--color-border-light);
     text-align: left;
 }
+.pack-submit-card {
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-border-light);
+    border-radius: var(--radius-xl, 14px);
+    box-shadow: var(--shadow-md);
+    padding: var(--space-lg, 24px);
+    margin-bottom: var(--space-md, 16px);
+}
 .pack-submit-heading {
     font-size: 1.05rem;
     color: var(--color-text-heading);
     margin: 0 0 var(--space-xs, 4px);
 }
 .pack-submit-intro {
-    font-size: 0.85rem;
+    font-size: 0.8rem;
     color: var(--color-text-muted);
-    margin: 0 0 var(--space-md, 16px);
+    margin: 0 0 var(--space-lg, 24px);
+}
+
+/* ---- step rail ---- */
+.pack-steps {
+    display: flex;
+    align-items: center;
+    margin-bottom: var(--space-lg, 24px);
+}
+.pack-step {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 5px;
+    flex: none;
+    width: 54px;
+}
+.pack-step-n {
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    font-weight: 700;
+    font-size: 0.82rem;
+    font-family: var(--font-mono);
+}
+.pack-step.done .pack-step-n { background: var(--color-success); color: #fff; }
+.pack-step.active .pack-step-n {
+    background: var(--color-accent-primary);
+    color: #fff;
+    box-shadow: 0 0 0 4px var(--color-error-light);
+}
+.pack-step.todo .pack-step-n { background: var(--color-bg-card-alt); color: var(--color-text-light); }
+.pack-step-l {
+    font-size: 0.66rem;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    text-align: center;
+}
+.pack-step.active .pack-step-l { color: var(--color-text-primary); }
+.pack-step-bar {
+    flex: 1;
+    height: 2px;
+    background: var(--color-border-light);
+    margin: 0 -6px 18px;
+}
+.pack-step-bar.fill { background: var(--color-success); }
+
+/* ---- step 1: compose ---- */
+.pack-submit-input-label {
+    display: block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    margin-bottom: 6px;
 }
 .pack-submit-input {
     width: 100%;
     box-sizing: border-box;
-    font-family: 'JetBrains Mono', monospace;
+    font-family: var(--font-mono);
     font-size: 0.8rem;
-    line-height: 1.4;
-    padding: var(--space-sm, 8px);
+    line-height: 1.5;
+    padding: 11px;
     border: 1px solid var(--color-border-medium);
-    border-radius: 8px;
-    background: var(--color-bg-surface);
+    border-radius: var(--radius-md, 10px);
+    background: var(--color-bg-card-alt);
     color: var(--color-text-primary);
     resize: vertical;
+    margin-bottom: var(--space-md, 16px);
 }
-.pack-submit-result {
-    margin: var(--space-sm, 8px) 0;
+
+/* ---- step 2: grouped checks ---- */
+.pack-submit-result { margin-bottom: var(--space-md, 16px); }
+.pack-vgroup {
+    border: 1px solid var(--color-border-light);
+    border-radius: var(--radius-lg, 12px);
+    overflow: hidden;
+    margin-bottom: 10px;
+}
+.pack-vg-head {
     display: flex;
-    flex-direction: column;
-    gap: 4px;
+    align-items: center;
+    gap: 9px;
+    padding: 11px 14px;
+    font-size: 0.82rem;
+    font-weight: 700;
 }
-.pack-submit-row {
+.pack-vg-ic {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    font-size: 0.75rem;
+    flex: none;
+    color: #fff;
+}
+.pack-vg-head.ok { background: var(--color-success-light); }
+.pack-vg-head.ok .pack-vg-ic { background: var(--color-success); }
+.pack-vg-head.bad { background: var(--color-error-light); }
+.pack-vg-head.bad .pack-vg-ic { background: var(--color-error); }
+.pack-vg-title { color: var(--color-text-primary); }
+.pack-vg-count {
+    margin-left: auto;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--color-text-muted);
+    font-weight: 600;
+}
+.pack-vg-body { padding: 4px 14px 8px; }
+.pack-vrow {
     display: flex;
     align-items: baseline;
-    gap: 8px;
+    gap: 9px;
     font-size: 0.82rem;
+    padding: 6px 0;
     flex-wrap: wrap;
 }
-.pack-submit-mark { font-weight: 700; }
-.pack-submit-row--ok { color: var(--color-success); }
-.pack-submit-row--bad { color: var(--color-error); }
-.pack-submit-label { color: var(--color-text-secondary); }
-.pack-submit-detail {
-    color: var(--color-text-muted);
-    font-size: 0.75rem;
-    flex-basis: 100%;
-    padding-left: 24px;
+.pack-vrow-ic {
+    font-family: var(--font-mono);
+    font-weight: 700;
+    width: 14px;
+    flex: none;
+}
+.pack-vrow.ok .pack-vrow-ic { color: var(--color-success); }
+.pack-vrow.bad .pack-vrow-ic { color: var(--color-error); }
+.pack-vrow-f { flex: 1; color: var(--color-text-secondary); }
+.pack-vrow-d {
+    font-size: 0.7rem;
+    color: var(--color-text-light);
+    font-family: var(--font-mono);
+}
+.pack-vrow.bad .pack-vrow-d { color: var(--color-error); }
+
+/* ---- step 3: submit ---- */
+.pack-submit-confirm {
+    font-size: 0.85rem;
+    color: var(--color-text-secondary);
+    margin: 0 0 var(--space-md, 16px);
 }
 .pack-submit-status {
     margin-top: var(--space-sm, 8px);
@@ -6456,30 +6569,62 @@ body:not(.is-admin) .pl-result { padding-bottom: 16px; }
 .pack-submit-status--ok { color: var(--color-success); }
 .pack-submit-status--bad { color: var(--color-error); }
 .pack-submit-status--pending { color: var(--color-text-muted); }
-.pack-submit-list { margin-top: var(--space-md, 16px); }
+
+/* shared ghost button for "back" / secondary step actions */
+.btn-ghost {
+    background: transparent;
+    border: 1px solid var(--color-border-medium);
+    color: var(--color-text-secondary);
+    font-weight: 600;
+    margin-top: 8px;
+}
+
+/* ---- "My submissions" timeline ---- */
 .pack-submit-list-title {
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--color-text-muted);
-    margin-bottom: var(--space-xs, 4px);
+    font-size: 0.95rem;
+    font-weight: 800;
+    color: var(--color-text-heading);
+    margin-bottom: var(--space-md, 16px);
 }
-.pack-submit-list-row {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 8px;
-    padding: 4px 0;
-    font-size: 0.85rem;
-    border-bottom: 1px solid var(--color-border-light);
+.pack-submit-timeline {
+    position: relative;
+    padding-left: 22px;
 }
-.pack-submit-list-name { overflow: hidden; text-overflow: ellipsis; }
-.pack-submit-badge {
-    font-size: 0.72rem;
-    padding: 2px 8px;
-    border-radius: 999px;
-    white-space: nowrap;
+.pack-submit-timeline::before {
+    content: "";
+    position: absolute;
+    left: 6px;
+    top: 4px;
+    bottom: 4px;
+    width: 2px;
+    background: var(--color-border-light);
 }
-.pack-submit-badge--pending { background: var(--color-bg-card-alt); color: var(--color-text-muted); }
-.pack-submit-badge--accepted { background: var(--color-success-light); color: var(--color-success-hover); }
-.pack-submit-badge--declined { background: var(--color-error-light); color: var(--color-error-dark); }
+.pack-tli {
+    position: relative;
+    padding-bottom: 16px;
+}
+.pack-tli:last-child { padding-bottom: 0; }
+.pack-tli-node {
+    position: absolute;
+    left: -22px;
+    top: 3px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    border: 3px solid var(--color-bg-surface);
+}
+.pack-tli.a .pack-tli-node { background: var(--color-success); }
+.pack-tli.p .pack-tli-node { background: var(--color-warning); }
+.pack-tli.d .pack-tli-node { background: var(--color-error); }
+.pack-tli-t { font-size: 0.85rem; font-weight: 600; color: var(--color-text-primary); }
+.pack-tli-t a { color: inherit; }
+.pack-tli-m {
+    font-size: 0.7rem;
+    color: var(--color-text-light);
+    font-family: var(--font-mono);
+    margin-top: 1px;
+}
+.pack-tli-stat { font-size: 0.7rem; font-weight: 700; margin-top: 3px; }
+.pack-tli.a .pack-tli-stat { color: var(--color-success); }
+.pack-tli.p .pack-tli-stat { color: var(--color-warning); }
+.pack-tli.d .pack-tli-stat { color: var(--color-error); }

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -504,29 +504,44 @@
   },
   "packSubmit": {
     "heading": "Community-Pack einreichen",
-    "intro": "Füge ein Community-Fragenpack als JSON ein. Es wird hier geprüft und dann als GitHub-Issue zur Begutachtung eingereicht.",
+    "intro": "Drei kurze Schritte. Dein Pack landet als Review-Issue auf GitHub.",
     "placeholder": "{ \"name\": \"Mein Pack\", \"language\": \"de\", \"questions\": [ ... ] }",
+    "inputLabel": "Dein Pack als JSON",
+    "checkBtn": "Pack prüfen →",
+    "continueBtn": "Weiter zum Einreichen →",
+    "backBtn": "Zurück zum Bearbeiten",
+    "confirm": "Sieht gut aus. Dieses Pack zur Prüfung einreichen?",
     "submit": "Pack einreichen",
     "submitting": "Wird eingereicht…",
     "success": "Eingereicht — danke! Es wird in Kürze geprüft.",
     "failed": "Einreichung fehlgeschlagen.",
-    "recent": "Deine letzten Einsendungen",
+    "recent": "Meine Einsendungen",
+    "step": {
+      "compose": "Erstellen",
+      "check": "Prüfen",
+      "submit": "Einreichen"
+    },
+    "group": {
+      "structure": "Pack-Struktur",
+      "questions": "Pro-Frage-Prüfungen"
+    },
     "field": {
-      "object": "Pack ist ein JSON-Objekt",
+      "object": "Gültige JSON-Struktur",
       "name": "Pack-Name vorhanden",
-      "language": "Sprache vorhanden",
-      "questions": "Fragenliste vorhanden",
-      "questionCount": "{count} Fragen",
-      "questionShape": "Jede Frage ist korrekt aufgebaut"
+      "language": "Sprachcode gültig",
+      "questions": "Fragenliste nicht leer",
+      "uniqueIds": "Eindeutige Fragen-IDs",
+      "answersShape": "{n} Antworten + genau 1 richtig"
     },
     "err": {
       "json": "Kein gültiges JSON — auf Tippfehler prüfen.",
       "notObject": "Muss ein JSON-Objekt sein.",
-      "questionsEmpty": "Braucht eine nicht-leere 'questions'-Liste."
+      "questionsEmpty": "Braucht eine nicht-leere 'questions'-Liste.",
+      "dupId": "doppelt „{id}“"
     },
     "status": {
       "pending": "In Prüfung",
-      "accepted": "Angenommen",
+      "accepted": "Angenommen — zur Community hinzugefügt",
       "declined": "Abgelehnt"
     }
   }

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -271,14 +271,45 @@
     "ptsUnit": "Pkt.",
     "ptsBonus": "+{count} Pkt.",
     "emotion": {
-      "exact": ["VOLLTREFFER! 🎯", "PERFEKT! 🎯", "STARK! ✨", "BULLSEYE! 🎯"],
-      "wrong": ["Falsch! ❌", "Knapp daneben 😬", "Nicht ganz 😅", "Schade 💨"],
-      "missed": ["Zu langsam! ⏱️", "Zeit um! ⏰", "Verpasst! 😬"],
-      "exactSub": ["Perfekte Antwort!", "Du wusstest es!", "Beeindruckend!"],
-      "fastSub": ["Blitzschnell ⚡", "Tempo-Bonus verdient!"],
-      "streakSub": ["{count}er-Serie! 🔥", "Du läufst heiß! 🔥"],
-      "wrongSub": ["Beim nächsten Mal! 💪", "Weitermachen!", "Die nächste schaffst du!"],
-      "missedSub": ["Keine Antwort abgegeben", "Diese hier verpasst"]
+      "exact": [
+        "VOLLTREFFER! 🎯",
+        "PERFEKT! 🎯",
+        "STARK! ✨",
+        "BULLSEYE! 🎯"
+      ],
+      "wrong": [
+        "Falsch! ❌",
+        "Knapp daneben 😬",
+        "Nicht ganz 😅",
+        "Schade 💨"
+      ],
+      "missed": [
+        "Zu langsam! ⏱️",
+        "Zeit um! ⏰",
+        "Verpasst! 😬"
+      ],
+      "exactSub": [
+        "Perfekte Antwort!",
+        "Du wusstest es!",
+        "Beeindruckend!"
+      ],
+      "fastSub": [
+        "Blitzschnell ⚡",
+        "Tempo-Bonus verdient!"
+      ],
+      "streakSub": [
+        "{count}er-Serie! 🔥",
+        "Du läufst heiß! 🔥"
+      ],
+      "wrongSub": [
+        "Beim nächsten Mal! 💪",
+        "Weitermachen!",
+        "Die nächste schaffst du!"
+      ],
+      "missedSub": [
+        "Keine Antwort abgegeben",
+        "Diese hier verpasst"
+      ]
     },
     "finalResults": "Endergebnis",
     "lateRoundsSummary": "Du bist nach Rundenstart beigetreten — deine Punkte zählen ab der nächsten Frage.",
@@ -441,7 +472,11 @@
     "gameInProgressHint": "Eine Runde läuft gerade. Versuch's gleich noch mal.",
     "gameNotFound": "Spiel nicht gefunden",
     "gameNotFoundHint": "Dieses Spiel existiert nicht oder der Link ist falsch.",
-    "thanksForPlaying": "Danke fürs Mitspielen mit Quizify!"
+    "thanksForPlaying": "Danke fürs Mitspielen mit Quizify!",
+    "INVALID_FORMAT": "Das Pack-Format ist ungültig. Prüfe die markierten Felder.",
+    "RATE_LIMITED": "Zu viele Einsendungen. Bitte kurz warten und erneut versuchen.",
+    "GITHUB_ERROR": "Der Einsende-Dienst ist gerade nicht erreichbar. Später erneut versuchen.",
+    "SUBMIT_DISABLED": "Pack-Einsendung ist nicht konfiguriert."
   },
   "page": {
     "titleAdmin": "Quizify — Admin",
@@ -466,5 +501,33 @@
     "history": "📜 Historie",
     "food": "🍔 Essen",
     "tech": "💡 Tech"
+  },
+  "packSubmit": {
+    "heading": "Community-Pack einreichen",
+    "intro": "Füge ein Community-Fragenpack als JSON ein. Es wird hier geprüft und dann als GitHub-Issue zur Begutachtung eingereicht.",
+    "placeholder": "{ \"name\": \"Mein Pack\", \"language\": \"de\", \"questions\": [ ... ] }",
+    "submit": "Pack einreichen",
+    "submitting": "Wird eingereicht…",
+    "success": "Eingereicht — danke! Es wird in Kürze geprüft.",
+    "failed": "Einreichung fehlgeschlagen.",
+    "recent": "Deine letzten Einsendungen",
+    "field": {
+      "object": "Pack ist ein JSON-Objekt",
+      "name": "Pack-Name vorhanden",
+      "language": "Sprache vorhanden",
+      "questions": "Fragenliste vorhanden",
+      "questionCount": "{count} Fragen",
+      "questionShape": "Jede Frage ist korrekt aufgebaut"
+    },
+    "err": {
+      "json": "Kein gültiges JSON — auf Tippfehler prüfen.",
+      "notObject": "Muss ein JSON-Objekt sein.",
+      "questionsEmpty": "Braucht eine nicht-leere 'questions'-Liste."
+    },
+    "status": {
+      "pending": "In Prüfung",
+      "accepted": "Angenommen",
+      "declined": "Abgelehnt"
+    }
   }
 }

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -504,29 +504,44 @@
   },
   "packSubmit": {
     "heading": "Submit a community pack",
-    "intro": "Paste a community question pack as JSON. It is checked here, then submitted for review as a GitHub issue.",
+    "intro": "Three quick steps. Your pack lands as a review issue on GitHub.",
     "placeholder": "{ \"name\": \"My Pack\", \"language\": \"en\", \"questions\": [ ... ] }",
+    "inputLabel": "Your pack JSON",
+    "checkBtn": "Check pack →",
+    "continueBtn": "Continue to submit →",
+    "backBtn": "Back to edit",
+    "confirm": "Looks good. Submit this pack for review?",
     "submit": "Submit pack",
     "submitting": "Submitting…",
     "success": "Submitted — thanks! It will be reviewed shortly.",
     "failed": "Submission failed.",
-    "recent": "Your recent submissions",
+    "recent": "My submissions",
+    "step": {
+      "compose": "Compose",
+      "check": "Check",
+      "submit": "Submit"
+    },
+    "group": {
+      "structure": "Pack structure",
+      "questions": "Per-question checks"
+    },
     "field": {
-      "object": "Pack is a JSON object",
+      "object": "Valid JSON shape",
       "name": "Pack name present",
-      "language": "Language present",
-      "questions": "Questions list present",
-      "questionCount": "{count} questions",
-      "questionShape": "Every question is well-formed"
+      "language": "Language code valid",
+      "questions": "Questions non-empty",
+      "uniqueIds": "Unique question IDs",
+      "answersShape": "{n} answers + exactly 1 correct"
     },
     "err": {
       "json": "Not valid JSON — check for typos.",
       "notObject": "Must be a JSON object.",
-      "questionsEmpty": "Needs a non-empty 'questions' list."
+      "questionsEmpty": "Needs a non-empty 'questions' list.",
+      "dupId": "dup “{id}”"
     },
     "status": {
-      "pending": "Pending review",
-      "accepted": "Accepted",
+      "pending": "In review",
+      "accepted": "Accepted — added to community",
       "declined": "Declined"
     }
   }

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -271,14 +271,45 @@
     "ptsUnit": "pts",
     "ptsBonus": "+{count} pts",
     "emotion": {
-      "exact": ["CORRECT! 🎯", "NAILED IT! 🎯", "SPOT ON! ✨", "BULLSEYE! 🎯"],
-      "wrong": ["Wrong! ❌", "Nope! 😬", "Not quite! 😅", "Oops! 💨"],
-      "missed": ["Too slow! ⏱️", "Time's up! ⏰", "Missed it! 😬"],
-      "exactSub": ["Perfect answer!", "You knew it!", "Impressive!"],
-      "fastSub": ["Lightning fast ⚡", "Speed bonus earned!"],
-      "streakSub": ["{count}-streak! 🔥", "On a roll! 🔥"],
-      "wrongSub": ["Better luck next time", "Keep going!", "You'll get the next one"],
-      "missedSub": ["No answer submitted", "You missed this one"]
+      "exact": [
+        "CORRECT! 🎯",
+        "NAILED IT! 🎯",
+        "SPOT ON! ✨",
+        "BULLSEYE! 🎯"
+      ],
+      "wrong": [
+        "Wrong! ❌",
+        "Nope! 😬",
+        "Not quite! 😅",
+        "Oops! 💨"
+      ],
+      "missed": [
+        "Too slow! ⏱️",
+        "Time's up! ⏰",
+        "Missed it! 😬"
+      ],
+      "exactSub": [
+        "Perfect answer!",
+        "You knew it!",
+        "Impressive!"
+      ],
+      "fastSub": [
+        "Lightning fast ⚡",
+        "Speed bonus earned!"
+      ],
+      "streakSub": [
+        "{count}-streak! 🔥",
+        "On a roll! 🔥"
+      ],
+      "wrongSub": [
+        "Better luck next time",
+        "Keep going!",
+        "You'll get the next one"
+      ],
+      "missedSub": [
+        "No answer submitted",
+        "You missed this one"
+      ]
     },
     "finalResults": "Final Results",
     "lateRoundsSummary": "You joined after this round started — your points count from the next question.",
@@ -441,7 +472,11 @@
     "gameInProgressHint": "The game is currently in a round. Try again in a moment.",
     "gameNotFound": "Game Not Found",
     "gameNotFoundHint": "This game doesn't exist or the link is incorrect.",
-    "thanksForPlaying": "Thanks for playing Quizify!"
+    "thanksForPlaying": "Thanks for playing Quizify!",
+    "INVALID_FORMAT": "The pack format is invalid. Check the highlighted fields.",
+    "RATE_LIMITED": "Too many submissions. Please wait a moment and try again.",
+    "GITHUB_ERROR": "Submission service is unavailable right now. Try again later.",
+    "SUBMIT_DISABLED": "Pack submission is not configured."
   },
   "page": {
     "titleAdmin": "Quizify — Admin",
@@ -466,5 +501,33 @@
     "history": "📜 History",
     "food": "🍔 Food",
     "tech": "💡 Tech"
+  },
+  "packSubmit": {
+    "heading": "Submit a community pack",
+    "intro": "Paste a community question pack as JSON. It is checked here, then submitted for review as a GitHub issue.",
+    "placeholder": "{ \"name\": \"My Pack\", \"language\": \"en\", \"questions\": [ ... ] }",
+    "submit": "Submit pack",
+    "submitting": "Submitting…",
+    "success": "Submitted — thanks! It will be reviewed shortly.",
+    "failed": "Submission failed.",
+    "recent": "Your recent submissions",
+    "field": {
+      "object": "Pack is a JSON object",
+      "name": "Pack name present",
+      "language": "Language present",
+      "questions": "Questions list present",
+      "questionCount": "{count} questions",
+      "questionShape": "Every question is well-formed"
+    },
+    "err": {
+      "json": "Not valid JSON — check for typos.",
+      "notObject": "Must be a JSON object.",
+      "questionsEmpty": "Needs a non-empty 'questions' list."
+    },
+    "status": {
+      "pending": "Pending review",
+      "accepted": "Accepted",
+      "declined": "Declined"
+    }
   }
 }

--- a/custom_components/quizify/www/js/pack-submit.js
+++ b/custom_components/quizify/www/js/pack-submit.js
@@ -1,11 +1,12 @@
 /**
- * Quizify community-pack submission (#180).
+ * Quizify community-pack submission (#180) — Variant C "Stepper".
  *
- * Lets a host paste/compose a community question pack, validates it in the
- * browser against the #179 schema (per-field ✓/✗ table), and — only when the
- * integration has a worker URL configured — submits it. The submit goes to
- * Quizify's own endpoint, which proxies to the worker that holds the GitHub
- * token; the browser never talks to GitHub directly.
+ * Lets a host paste/compose a community question pack and walk a guided
+ * 3-step wizard: Compose → Check → Submit. A progress rail tracks the active
+ * step; the Check step shows grouped ✓/✗ results (pack structure + per-question
+ * checks). The submit goes to Quizify's own endpoint, which proxies to the
+ * worker that holds the GitHub token; the browser never talks to GitHub
+ * directly. "My submissions" renders as a status timeline.
  *
  * The whole section stays hidden until /api/quizify/pack-submit/config reports
  * enabled:true. Error codes (INVALID_FORMAT / RATE_LIMITED / GITHUB_ERROR /
@@ -28,6 +29,9 @@ window.QuizifyPackSubmit = (function () {
         max_bytes: 1048576
     };
 
+    // The pack that last passed validation — carried from Check to Submit.
+    var validatedPack = null;
+
     function t(key, params) {
         if (window.QuizifyI18n && typeof window.QuizifyI18n.t === 'function') {
             return window.QuizifyI18n.t(key, params);
@@ -37,100 +41,189 @@ window.QuizifyPackSubmit = (function () {
 
     function el(id) { return document.getElementById(id); }
 
+    function escapeHtml(str) {
+        return String(str).replace(/[&<>"']/g, function (c) {
+            return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+        });
+    }
+
     /**
      * Validate a parsed pack object against the #179 schema.
-     * Returns { ok, fields: [{label, ok, detail}] } — fields drives the ✓/✗ table.
+     *
+     * Returns { ok, fields, groups }:
+     *   fields — flat [{label, ok, detail}] (kept for tests / back-compat).
+     *   groups — [{ key, title, ok, pass, total, rows:[{label, ok, detail}] }]
+     *            drives the grouped Stepper "Check" view: one "Pack structure"
+     *            group and one "Per-question checks" group.
      */
     function validatePack(pack) {
         var fields = [];
-        function add(label, ok, detail) { fields.push({ label: label, ok: ok, detail: detail || '' }); }
 
-        if (typeof pack !== 'object' || pack === null || Array.isArray(pack)) {
-            add(t('packSubmit.field.object'), false, t('packSubmit.err.notObject'));
-            return { ok: false, fields: fields };
+        // structure group rows
+        var structRows = [];
+        function struct(label, ok, detail) {
+            var row = { label: label, ok: ok, detail: detail || '' };
+            structRows.push(row);
+            fields.push(row);
+        }
+        // per-question group rows
+        var qRows = [];
+        function qcheck(label, ok, detail) {
+            var row = { label: label, ok: ok, detail: detail || '' };
+            qRows.push(row);
+            fields.push(row);
         }
 
+        function buildGroups() {
+            function grp(key, titleKey, rows) {
+                var pass = rows.filter(function (r) { return r.ok; }).length;
+                return {
+                    key: key,
+                    title: t(titleKey),
+                    ok: rows.length > 0 && pass === rows.length,
+                    pass: pass,
+                    total: rows.length,
+                    rows: rows
+                };
+            }
+            var groups = [grp('structure', 'packSubmit.group.structure', structRows)];
+            if (qRows.length) {
+                groups.push(grp('questions', 'packSubmit.group.questions', qRows));
+            }
+            return groups;
+        }
+
+        function result() {
+            var allOk = fields.length > 0 && fields.every(function (f) { return f.ok; });
+            return { ok: allOk, fields: fields, groups: buildGroups() };
+        }
+
+        if (typeof pack !== 'object' || pack === null || Array.isArray(pack)) {
+            struct(t('packSubmit.field.object'), false, t('packSubmit.err.notObject'));
+            return result();
+        }
+
+        struct(t('packSubmit.field.object'), true);
+
         var nameOk = typeof pack.name === 'string' && pack.name.trim().length > 0;
-        add(t('packSubmit.field.name'), nameOk);
+        struct(t('packSubmit.field.name'), nameOk);
 
         var langOk = typeof pack.language === 'string' && pack.language.trim().length > 0;
-        add(t('packSubmit.field.language'), langOk);
+        struct(t('packSubmit.field.language'), langOk,
+            langOk ? pack.language.trim() : '');
 
         var qs = pack.questions;
         var qsIsList = Array.isArray(qs) && qs.length > 0;
         if (!qsIsList) {
-            add(t('packSubmit.field.questions'), false, t('packSubmit.err.questionsEmpty'));
-            return { ok: false, fields: fields };
+            struct(t('packSubmit.field.questions'), false, t('packSubmit.err.questionsEmpty'));
+            return result();
         }
         var countOk = qs.length >= limits.min_questions && qs.length <= limits.max_questions;
-        add(t('packSubmit.field.questions'), countOk,
-            t('packSubmit.field.questionCount', { count: qs.length }));
+        struct(t('packSubmit.field.questions'), countOk, String(qs.length));
 
-        var allQuestionsOk = true;
+        // ---- per-question checks (two aggregate rows: unique ids; answers shape)
+        var uniqueOk = true;
+        var shapeOk = true;
+        var dupDetail = '';
+        var shapeDetail = '';
         var seen = {};
-        var problems = [];
         for (var i = 0; i < qs.length; i++) {
             var q = qs[i];
             var n = i + 1;
             if (typeof q !== 'object' || q === null) {
-                allQuestionsOk = false; problems.push('Q' + n + ': ' + t('packSubmit.err.notObject')); continue;
+                shapeOk = false; if (!shapeDetail) { shapeDetail = 'Q' + n + ': ' + t('packSubmit.err.notObject'); }
+                continue;
             }
             if (typeof q.id !== 'string' || !q.id.trim()) {
-                allQuestionsOk = false; problems.push('Q' + n + ': id');
+                uniqueOk = false; if (!dupDetail) { dupDetail = 'Q' + n + ': id'; }
             } else if (seen[q.id]) {
-                allQuestionsOk = false; problems.push('Q' + n + ': dup id ' + q.id);
+                uniqueOk = false; if (!dupDetail) { dupDetail = t('packSubmit.err.dupId', { id: q.id }); }
             } else { seen[q.id] = true; }
             if (typeof q.question !== 'string' || !q.question.trim()) {
-                allQuestionsOk = false; problems.push('Q' + n + ': question');
+                shapeOk = false; if (!shapeDetail) { shapeDetail = 'Q' + n + ': question'; }
             }
             var ans = q.answers;
             if (!Array.isArray(ans) || ans.length !== limits.answers_per_question) {
-                allQuestionsOk = false; problems.push('Q' + n + ': answers');
+                shapeOk = false; if (!shapeDetail) { shapeDetail = 'Q' + n + ': answers'; }
                 continue;
             }
             var correct = 0;
             for (var j = 0; j < ans.length; j++) {
                 var a = ans[j];
                 if (typeof a !== 'object' || a === null || typeof a.text !== 'string' || !a.text.trim()) {
-                    allQuestionsOk = false; problems.push('Q' + n + ': answer text');
+                    shapeOk = false; if (!shapeDetail) { shapeDetail = 'Q' + n + ': answer text'; }
                 }
                 if (a && a.correct === true) { correct++; }
             }
             if (correct !== 1) {
-                allQuestionsOk = false; problems.push('Q' + n + ': one correct');
+                shapeOk = false; if (!shapeDetail) { shapeDetail = 'Q' + n + ': one correct'; }
             }
         }
-        add(t('packSubmit.field.questionShape'), allQuestionsOk, problems.slice(0, 3).join('; '));
+        qcheck(t('packSubmit.field.uniqueIds'), uniqueOk, dupDetail);
+        qcheck(t('packSubmit.field.answersShape', { n: limits.answers_per_question }),
+            shapeOk, shapeDetail);
 
-        var allOk = fields.every(function (f) { return f.ok; });
-        return { ok: allOk, fields: fields };
+        return result();
     }
 
+    /** Move the wizard to step 1/2/3 — updates rail state and pane visibility. */
+    function goToStep(step) {
+        var section = el('pack-submit-section');
+        if (!section) { return; }
+        section.querySelectorAll('.pack-step').forEach(function (s) {
+            var n = parseInt(s.getAttribute('data-step'), 10);
+            s.classList.remove('done', 'active', 'todo');
+            if (n < step) { s.classList.add('done'); s.querySelector('.pack-step-n').textContent = '✓'; }
+            else if (n === step) { s.classList.add('active'); s.querySelector('.pack-step-n').textContent = String(n); }
+            else { s.classList.add('todo'); s.querySelector('.pack-step-n').textContent = String(n); }
+        });
+        section.querySelectorAll('.pack-step-bar').forEach(function (b) {
+            var n = parseInt(b.getAttribute('data-bar'), 10);
+            b.classList.toggle('fill', n < step);
+        });
+        section.querySelectorAll('.pack-step-pane').forEach(function (p) {
+            var n = parseInt(p.getAttribute('data-pane'), 10);
+            p.classList.toggle('hidden', n !== step);
+        });
+    }
+
+    /** Render grouped ✓/✗ results into the Check pane. Returns res.ok. */
     function renderResult(parsed) {
         var resultEl = el('pack-submit-result');
-        var submitBtn = el('pack-submit-btn');
+        var continueBtn = el('pack-submit-continue-btn');
         if (!resultEl) { return false; }
 
         if (parsed === null) {
-            resultEl.innerHTML = '<div class="pack-submit-row pack-submit-row--bad">' +
-                '<span class="pack-submit-mark">✗</span>' +
-                '<span>' + t('packSubmit.err.json') + '</span></div>';
-            if (submitBtn) { submitBtn.disabled = true; }
+            resultEl.innerHTML = '<div class="pack-vgroup">' +
+                '<div class="pack-vg-head bad"><span class="pack-vg-ic">✕</span>' +
+                '<span>' + escapeHtml(t('packSubmit.err.json')) + '</span></div></div>';
+            if (continueBtn) { continueBtn.disabled = true; }
             return false;
         }
 
         var res = validatePack(parsed);
         var html = '';
-        res.fields.forEach(function (f) {
-            html += '<div class="pack-submit-row ' +
-                (f.ok ? 'pack-submit-row--ok' : 'pack-submit-row--bad') + '">' +
-                '<span class="pack-submit-mark">' + (f.ok ? '✓' : '✗') + '</span>' +
-                '<span class="pack-submit-label">' + f.label + '</span>' +
-                (f.detail ? '<span class="pack-submit-detail">' + f.detail + '</span>' : '') +
-                '</div>';
+        res.groups.forEach(function (g) {
+            var cls = g.ok ? 'ok' : 'bad';
+            var mark = g.ok ? '✓' : '✕';
+            html += '<div class="pack-vgroup">' +
+                '<div class="pack-vg-head ' + cls + '">' +
+                '<span class="pack-vg-ic">' + mark + '</span>' +
+                '<span class="pack-vg-title">' + escapeHtml(g.title) + '</span>' +
+                '<span class="pack-vg-count">' + g.pass + '/' + g.total + '</span></div>' +
+                '<div class="pack-vg-body">';
+            g.rows.forEach(function (r) {
+                html += '<div class="pack-vrow ' + (r.ok ? 'ok' : 'bad') + '">' +
+                    '<span class="pack-vrow-ic">' + (r.ok ? '✓' : '✕') + '</span>' +
+                    '<span class="pack-vrow-f">' + escapeHtml(r.label) + '</span>' +
+                    (r.detail ? '<span class="pack-vrow-d">' + escapeHtml(r.detail) + '</span>' : '') +
+                    '</div>';
+            });
+            html += '</div></div>';
         });
         resultEl.innerHTML = html;
-        if (submitBtn) { submitBtn.disabled = !res.ok; }
+        if (continueBtn) { continueBtn.disabled = !res.ok; }
+        validatedPack = res.ok ? parsed : null;
         return res.ok;
     }
 
@@ -156,10 +249,16 @@ window.QuizifyPackSubmit = (function () {
         return (payload && payload.message) || fallbackMsg || t('errors.UNKNOWN');
     }
 
-    async function doSubmit() {
+    /** Step 1 → 2: parse + validate, then show the Check pane. */
+    function doCheck() {
         var parsed = parseInput();
-        if (!parsed) { renderResult(parsed === undefined ? null : parsed); return; }
-        if (!renderResult(parsed)) { return; }
+        renderResult(parsed === undefined ? null : parsed);
+        goToStep(2);
+    }
+
+    async function doSubmit() {
+        var parsed = validatedPack;
+        if (!parsed) { goToStep(2); return; }
 
         var submitBtn = el('pack-submit-btn');
         if (submitBtn) { submitBtn.disabled = true; }
@@ -184,6 +283,7 @@ window.QuizifyPackSubmit = (function () {
             setStatus(t('packSubmit.success') + link, 'ok');
             var input = el('pack-submit-input');
             if (input) { input.value = ''; }
+            validatedPack = null;
             loadSubmissions();
         } catch (err) {
             setStatus(errorText({ code: 'GITHUB_ERROR' }, String(err)), 'bad');
@@ -197,25 +297,45 @@ window.QuizifyPackSubmit = (function () {
         return translated === key ? (status || 'pending') : translated;
     }
 
+    // Maps a submission status to the timeline node class + status mark.
+    function statusMeta(status) {
+        if (status === 'accepted') { return { cls: 'a', mark: '✓' }; }
+        if (status === 'declined') { return { cls: 'd', mark: '✕' }; }
+        return { cls: 'p', mark: '●' };
+    }
+
     async function loadSubmissions() {
         var listEl = el('pack-submit-list');
+        var card = el('pack-submit-list-card');
         if (!listEl) { return; }
         try {
             var resp = await fetch(SUBMISSIONS_URL);
             if (!resp.ok) { return; }
             var data = await resp.json();
             var subs = (data && data.submissions) || [];
-            if (!subs.length) { listEl.innerHTML = ''; return; }
-            var html = '<div class="pack-submit-list-title">' + t('packSubmit.recent') + '</div>';
+            if (!subs.length) {
+                listEl.innerHTML = '';
+                if (card) { card.classList.add('hidden'); }
+                return;
+            }
+            var html = '';
             subs.slice(0, 10).forEach(function (s) {
-                var label = (s.issue_url ? '<a href="' + s.issue_url + '" target="_blank" rel="noopener">' +
-                    (s.name || '?') + '</a>' : (s.name || '?'));
-                html += '<div class="pack-submit-list-row">' +
-                    '<span class="pack-submit-list-name">' + label + '</span>' +
-                    '<span class="pack-submit-badge pack-submit-badge--' + (s.status || 'pending') + '">' +
-                    statusLabel(s.status) + '</span></div>';
+                var meta = statusMeta(s.status);
+                var name = escapeHtml(s.name || '?');
+                var title = s.issue_url
+                    ? '<a href="' + escapeHtml(s.issue_url) + '" target="_blank" rel="noopener">' + name + '</a>'
+                    : name;
+                var sub = '';
+                if (s.issue_number) { sub += '#' + escapeHtml(s.issue_number); }
+                html += '<div class="pack-tli ' + meta.cls + '">' +
+                    '<div class="pack-tli-node"></div>' +
+                    '<div class="pack-tli-t">' + title + '</div>' +
+                    (sub ? '<div class="pack-tli-m">' + sub + '</div>' : '') +
+                    '<div class="pack-tli-stat">' + meta.mark + ' ' + escapeHtml(statusLabel(s.status)) + '</div>' +
+                    '</div>';
             });
             listEl.innerHTML = html;
+            if (card) { card.classList.remove('hidden'); }
         } catch (_e) { /* best-effort */ }
     }
 
@@ -237,17 +357,29 @@ window.QuizifyPackSubmit = (function () {
             window.QuizifyI18n.initPageTranslations(section);
         }
 
+        goToStep(1);
+
         var input = el('pack-submit-input');
+        var checkBtn = el('pack-submit-check-btn');
         if (input) {
             input.addEventListener('input', function () {
-                var parsed = parseInput();
-                // undefined (empty) and null (bad JSON) both render the JSON-error
-                // hint; an object renders the per-field ✓/✗ table.
-                renderResult(parsed === undefined ? null : parsed);
+                if (checkBtn) { checkBtn.disabled = !input.value.trim(); }
+                // editing invalidates a prior pass; status clears on re-check
+                validatedPack = null;
             });
         }
+        if (checkBtn) { checkBtn.addEventListener('click', doCheck); }
+
+        var continueBtn = el('pack-submit-continue-btn');
+        if (continueBtn) { continueBtn.addEventListener('click', function () { setStatus(''); goToStep(3); }); }
+
         var submitBtn = el('pack-submit-btn');
         if (submitBtn) { submitBtn.addEventListener('click', doSubmit); }
+
+        var backBtn = el('pack-submit-back-btn');
+        if (backBtn) { backBtn.addEventListener('click', function () { goToStep(1); }); }
+        var back2Btn = el('pack-submit-back2-btn');
+        if (back2Btn) { back2Btn.addEventListener('click', function () { setStatus(''); goToStep(1); }); }
 
         loadSubmissions();
     }

--- a/custom_components/quizify/www/js/pack-submit.js
+++ b/custom_components/quizify/www/js/pack-submit.js
@@ -1,0 +1,265 @@
+/**
+ * Quizify community-pack submission (#180).
+ *
+ * Lets a host paste/compose a community question pack, validates it in the
+ * browser against the #179 schema (per-field ✓/✗ table), and — only when the
+ * integration has a worker URL configured — submits it. The submit goes to
+ * Quizify's own endpoint, which proxies to the worker that holds the GitHub
+ * token; the browser never talks to GitHub directly.
+ *
+ * The whole section stays hidden until /api/quizify/pack-submit/config reports
+ * enabled:true. Error codes (INVALID_FORMAT / RATE_LIMITED / GITHUB_ERROR /
+ * SUBMIT_DISABLED) map to i18n keys with a fallback to the raw message.
+ *
+ * Self-contained IIFE on window.QuizifyPackSubmit — no coupling to admin.js.
+ */
+window.QuizifyPackSubmit = (function () {
+    'use strict';
+
+    var CONFIG_URL = '/api/quizify/pack-submit/config';
+    var SUBMIT_URL = '/api/quizify/pack-submit';
+    var SUBMISSIONS_URL = '/api/quizify/pack-submit/submissions';
+
+    // Defaults; overwritten by the server's reported limits.
+    var limits = {
+        max_questions: 500,
+        min_questions: 1,
+        answers_per_question: 3,
+        max_bytes: 1048576
+    };
+
+    function t(key, params) {
+        if (window.QuizifyI18n && typeof window.QuizifyI18n.t === 'function') {
+            return window.QuizifyI18n.t(key, params);
+        }
+        return key;
+    }
+
+    function el(id) { return document.getElementById(id); }
+
+    /**
+     * Validate a parsed pack object against the #179 schema.
+     * Returns { ok, fields: [{label, ok, detail}] } — fields drives the ✓/✗ table.
+     */
+    function validatePack(pack) {
+        var fields = [];
+        function add(label, ok, detail) { fields.push({ label: label, ok: ok, detail: detail || '' }); }
+
+        if (typeof pack !== 'object' || pack === null || Array.isArray(pack)) {
+            add(t('packSubmit.field.object'), false, t('packSubmit.err.notObject'));
+            return { ok: false, fields: fields };
+        }
+
+        var nameOk = typeof pack.name === 'string' && pack.name.trim().length > 0;
+        add(t('packSubmit.field.name'), nameOk);
+
+        var langOk = typeof pack.language === 'string' && pack.language.trim().length > 0;
+        add(t('packSubmit.field.language'), langOk);
+
+        var qs = pack.questions;
+        var qsIsList = Array.isArray(qs) && qs.length > 0;
+        if (!qsIsList) {
+            add(t('packSubmit.field.questions'), false, t('packSubmit.err.questionsEmpty'));
+            return { ok: false, fields: fields };
+        }
+        var countOk = qs.length >= limits.min_questions && qs.length <= limits.max_questions;
+        add(t('packSubmit.field.questions'), countOk,
+            t('packSubmit.field.questionCount', { count: qs.length }));
+
+        var allQuestionsOk = true;
+        var seen = {};
+        var problems = [];
+        for (var i = 0; i < qs.length; i++) {
+            var q = qs[i];
+            var n = i + 1;
+            if (typeof q !== 'object' || q === null) {
+                allQuestionsOk = false; problems.push('Q' + n + ': ' + t('packSubmit.err.notObject')); continue;
+            }
+            if (typeof q.id !== 'string' || !q.id.trim()) {
+                allQuestionsOk = false; problems.push('Q' + n + ': id');
+            } else if (seen[q.id]) {
+                allQuestionsOk = false; problems.push('Q' + n + ': dup id ' + q.id);
+            } else { seen[q.id] = true; }
+            if (typeof q.question !== 'string' || !q.question.trim()) {
+                allQuestionsOk = false; problems.push('Q' + n + ': question');
+            }
+            var ans = q.answers;
+            if (!Array.isArray(ans) || ans.length !== limits.answers_per_question) {
+                allQuestionsOk = false; problems.push('Q' + n + ': answers');
+                continue;
+            }
+            var correct = 0;
+            for (var j = 0; j < ans.length; j++) {
+                var a = ans[j];
+                if (typeof a !== 'object' || a === null || typeof a.text !== 'string' || !a.text.trim()) {
+                    allQuestionsOk = false; problems.push('Q' + n + ': answer text');
+                }
+                if (a && a.correct === true) { correct++; }
+            }
+            if (correct !== 1) {
+                allQuestionsOk = false; problems.push('Q' + n + ': one correct');
+            }
+        }
+        add(t('packSubmit.field.questionShape'), allQuestionsOk, problems.slice(0, 3).join('; '));
+
+        var allOk = fields.every(function (f) { return f.ok; });
+        return { ok: allOk, fields: fields };
+    }
+
+    function renderResult(parsed) {
+        var resultEl = el('pack-submit-result');
+        var submitBtn = el('pack-submit-btn');
+        if (!resultEl) { return false; }
+
+        if (parsed === null) {
+            resultEl.innerHTML = '<div class="pack-submit-row pack-submit-row--bad">' +
+                '<span class="pack-submit-mark">✗</span>' +
+                '<span>' + t('packSubmit.err.json') + '</span></div>';
+            if (submitBtn) { submitBtn.disabled = true; }
+            return false;
+        }
+
+        var res = validatePack(parsed);
+        var html = '';
+        res.fields.forEach(function (f) {
+            html += '<div class="pack-submit-row ' +
+                (f.ok ? 'pack-submit-row--ok' : 'pack-submit-row--bad') + '">' +
+                '<span class="pack-submit-mark">' + (f.ok ? '✓' : '✗') + '</span>' +
+                '<span class="pack-submit-label">' + f.label + '</span>' +
+                (f.detail ? '<span class="pack-submit-detail">' + f.detail + '</span>' : '') +
+                '</div>';
+        });
+        resultEl.innerHTML = html;
+        if (submitBtn) { submitBtn.disabled = !res.ok; }
+        return res.ok;
+    }
+
+    function parseInput() {
+        var input = el('pack-submit-input');
+        if (!input || !input.value.trim()) { return undefined; }
+        try { return JSON.parse(input.value); } catch (_e) { return null; }
+    }
+
+    function setStatus(msg, kind) {
+        var statusEl = el('pack-submit-status');
+        if (!statusEl) { return; }
+        statusEl.textContent = msg || '';
+        statusEl.className = 'pack-submit-status' + (kind ? ' pack-submit-status--' + kind : '');
+    }
+
+    function errorText(payload, fallbackMsg) {
+        var code = payload && payload.code;
+        if (code) {
+            var translated = t('errors.' + code);
+            if (translated && translated !== 'errors.' + code) { return translated; }
+        }
+        return (payload && payload.message) || fallbackMsg || t('errors.UNKNOWN');
+    }
+
+    async function doSubmit() {
+        var parsed = parseInput();
+        if (!parsed) { renderResult(parsed === undefined ? null : parsed); return; }
+        if (!renderResult(parsed)) { return; }
+
+        var submitBtn = el('pack-submit-btn');
+        if (submitBtn) { submitBtn.disabled = true; }
+        setStatus(t('packSubmit.submitting'), 'pending');
+
+        try {
+            var resp = await fetch(SUBMIT_URL, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ pack: parsed })
+            });
+            var data = {};
+            try { data = await resp.json(); } catch (_e) { /* ignore */ }
+            if (!resp.ok || !data.ok) {
+                setStatus(errorText(data, t('packSubmit.failed')), 'bad');
+                if (submitBtn) { submitBtn.disabled = false; }
+                return;
+            }
+            var link = data.issue_url
+                ? ' (#' + (data.issue_number || '?') + ')'
+                : '';
+            setStatus(t('packSubmit.success') + link, 'ok');
+            var input = el('pack-submit-input');
+            if (input) { input.value = ''; }
+            loadSubmissions();
+        } catch (err) {
+            setStatus(errorText({ code: 'GITHUB_ERROR' }, String(err)), 'bad');
+            if (submitBtn) { submitBtn.disabled = false; }
+        }
+    }
+
+    function statusLabel(status) {
+        var key = 'packSubmit.status.' + (status || 'pending');
+        var translated = t(key);
+        return translated === key ? (status || 'pending') : translated;
+    }
+
+    async function loadSubmissions() {
+        var listEl = el('pack-submit-list');
+        if (!listEl) { return; }
+        try {
+            var resp = await fetch(SUBMISSIONS_URL);
+            if (!resp.ok) { return; }
+            var data = await resp.json();
+            var subs = (data && data.submissions) || [];
+            if (!subs.length) { listEl.innerHTML = ''; return; }
+            var html = '<div class="pack-submit-list-title">' + t('packSubmit.recent') + '</div>';
+            subs.slice(0, 10).forEach(function (s) {
+                var label = (s.issue_url ? '<a href="' + s.issue_url + '" target="_blank" rel="noopener">' +
+                    (s.name || '?') + '</a>' : (s.name || '?'));
+                html += '<div class="pack-submit-list-row">' +
+                    '<span class="pack-submit-list-name">' + label + '</span>' +
+                    '<span class="pack-submit-badge pack-submit-badge--' + (s.status || 'pending') + '">' +
+                    statusLabel(s.status) + '</span></div>';
+            });
+            listEl.innerHTML = html;
+        } catch (_e) { /* best-effort */ }
+    }
+
+    async function init() {
+        var section = el('pack-submit-section');
+        if (!section) { return; }
+        try {
+            var resp = await fetch(CONFIG_URL);
+            if (!resp.ok) { return; }
+            var cfg = await resp.json();
+            if (!cfg || !cfg.enabled) { return; }  // stays hidden — feature off
+            if (cfg.limits) { limits = Object.assign(limits, cfg.limits); }
+        } catch (_e) {
+            return;  // can't reach config → leave hidden
+        }
+
+        section.classList.remove('hidden');
+        if (window.QuizifyI18n && window.QuizifyI18n.initPageTranslations) {
+            window.QuizifyI18n.initPageTranslations(section);
+        }
+
+        var input = el('pack-submit-input');
+        if (input) {
+            input.addEventListener('input', function () {
+                var parsed = parseInput();
+                // undefined (empty) and null (bad JSON) both render the JSON-error
+                // hint; an object renders the per-field ✓/✗ table.
+                renderResult(parsed === undefined ? null : parsed);
+            });
+        }
+        var submitBtn = el('pack-submit-btn');
+        if (submitBtn) { submitBtn.addEventListener('click', doSubmit); }
+
+        loadSubmissions();
+    }
+
+    return {
+        init: init,
+        validatePack: validatePack  // exported for tests
+    };
+})();
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', function () { window.QuizifyPackSubmit.init(); });
+} else {
+    window.QuizifyPackSubmit.init();
+}

--- a/tests/test_pack_submission_180.py
+++ b/tests/test_pack_submission_180.py
@@ -1,0 +1,339 @@
+"""Tests for the community-pack submission feature (#180).
+
+Covers:
+  1. The server-side validator (mirror of the #179 schema) — accept a good
+     pack, reject each malformed shape with a specific error.
+  2. The GitHub issue-state → submission-status mapping.
+  3. The throttled reconcile: it stamps last_poll, only updates pending items,
+     and persists — driven without an implicit event loop (asyncio.run).
+  4. The config endpoint reporting enabled true/false off the AppContext.
+
+CI runs Python 3.13; none of this uses asyncio.get_event_loop(). Async paths
+run via asyncio.run() / pytest-asyncio, and the fake runtime's executor uses
+the running loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.const import (  # noqa: E402
+    SUBMIT_STATUS_ACCEPTED,
+    SUBMIT_STATUS_DECLINED,
+    SUBMIT_STATUS_PENDING,
+)
+from custom_components.quizify.server.pack_submission import (  # noqa: E402
+    PackSubmissionStore,
+    _issue_to_status,
+    validate_pack,
+)
+
+
+def _good_question(qid: str = "q1") -> dict:
+    return {
+        "id": qid,
+        "question": "Which planet is the Red Planet?",
+        "answers": [
+            {"text": "Mars", "correct": True},
+            {"text": "Venus", "correct": False},
+            {"text": "Jupiter", "correct": False},
+        ],
+        "difficulty": "easy",
+    }
+
+
+def _good_pack(n: int = 2) -> dict:
+    return {
+        "name": "Test Pack",
+        "language": "en",
+        "version": "1.0",
+        "questions": [_good_question(f"q{i}") for i in range(n)],
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Validator
+# ---------------------------------------------------------------------------
+
+
+class TestValidatePack:
+    def test_good_pack_passes(self) -> None:
+        ok, errors = validate_pack(_good_pack())
+        assert ok is True
+        assert errors == []
+
+    def test_non_object_rejected(self) -> None:
+        ok, errors = validate_pack(["not", "a", "dict"])
+        assert ok is False
+        assert any("object" in e.lower() for e in errors)
+
+    def test_missing_name_rejected(self) -> None:
+        pack = _good_pack()
+        del pack["name"]
+        ok, errors = validate_pack(pack)
+        assert ok is False
+        assert any("name" in e.lower() for e in errors)
+
+    def test_empty_questions_rejected(self) -> None:
+        pack = _good_pack()
+        pack["questions"] = []
+        ok, errors = validate_pack(pack)
+        assert ok is False
+        assert any("questions" in e.lower() for e in errors)
+
+    def test_wrong_answer_count_rejected(self) -> None:
+        pack = _good_pack()
+        pack["questions"][0]["answers"] = pack["questions"][0]["answers"][:2]
+        ok, errors = validate_pack(pack)
+        assert ok is False
+        assert any("answers" in e.lower() for e in errors)
+
+    def test_no_correct_answer_rejected(self) -> None:
+        pack = _good_pack()
+        for a in pack["questions"][0]["answers"]:
+            a["correct"] = False
+        ok, errors = validate_pack(pack)
+        assert ok is False
+        assert any("correct" in e.lower() for e in errors)
+
+    def test_two_correct_answers_rejected(self) -> None:
+        pack = _good_pack()
+        pack["questions"][0]["answers"][1]["correct"] = True
+        ok, errors = validate_pack(pack)
+        assert ok is False
+        assert any("correct" in e.lower() for e in errors)
+
+    def test_duplicate_ids_rejected(self) -> None:
+        pack = _good_pack()
+        pack["questions"][1]["id"] = pack["questions"][0]["id"]
+        ok, errors = validate_pack(pack)
+        assert ok is False
+        assert any("dup" in e.lower() for e in errors)
+
+    def test_missing_question_text_rejected(self) -> None:
+        pack = _good_pack()
+        pack["questions"][0]["question"] = "  "
+        ok, errors = validate_pack(pack)
+        assert ok is False
+        assert any("question" in e.lower() for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# 2. Issue-state mapping
+# ---------------------------------------------------------------------------
+
+
+class TestIssueToStatus:
+    def test_open_is_pending(self) -> None:
+        assert _issue_to_status("open", "") == SUBMIT_STATUS_PENDING
+
+    def test_closed_completed_is_accepted(self) -> None:
+        assert _issue_to_status("closed", "completed") == SUBMIT_STATUS_ACCEPTED
+
+    def test_closed_no_reason_is_accepted(self) -> None:
+        assert _issue_to_status("closed", "") == SUBMIT_STATUS_ACCEPTED
+
+    def test_closed_not_planned_is_declined(self) -> None:
+        assert _issue_to_status("closed", "not_planned") == SUBMIT_STATUS_DECLINED
+
+
+class TestIssueNumberFromUrl:
+    def test_html_url(self) -> None:
+        assert (
+            PackSubmissionStore.issue_number_from_url(
+                "https://github.com/mholzi/quizify/issues/207"
+            )
+            == 207
+        )
+
+    def test_api_url(self) -> None:
+        assert (
+            PackSubmissionStore.issue_number_from_url(
+                "https://api.github.com/repos/mholzi/quizify/issues/42"
+            )
+            == 42
+        )
+
+    def test_garbage(self) -> None:
+        assert PackSubmissionStore.issue_number_from_url("not a url") is None
+        assert PackSubmissionStore.issue_number_from_url(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Fakes (no implicit event loop — executor uses the running loop)
+# ---------------------------------------------------------------------------
+
+
+class _FakeRuntime:
+    def __init__(self, data_dir: Path) -> None:
+        self.data_dir = data_dir
+
+    async def run_in_executor(self, func, *args) -> Any:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func, *args)
+
+    def create_task(self, coro):  # pragma: no cover — unused here
+        return asyncio.ensure_future(coro)
+
+
+class _FakeCtx:
+    def __init__(self, data_dir: Path, submit_url: str | None = None) -> None:
+        self.runtime = _FakeRuntime(data_dir)
+        self.community_submit_url = submit_url
+
+
+# ---------------------------------------------------------------------------
+# 3. Reconcile
+# ---------------------------------------------------------------------------
+
+
+class TestReconcile:
+    def test_reconcile_stamps_last_poll_and_skips_non_pending(
+        self, tmp_path: Path
+    ) -> None:
+        """Reconcile must always stamp last_poll and never re-fetch a
+        submission that already has a terminal status. We assert that by
+        making _fetch_issue blow up if called — with only an accepted item
+        present, it must not be called."""
+
+        async def _run() -> dict:
+            ctx = _FakeCtx(tmp_path)
+            store = PackSubmissionStore(ctx)
+
+            async def _boom(*_a, **_k):
+                raise AssertionError("should not poll a terminal submission")
+
+            store._fetch_issue = _boom  # type: ignore[assignment]
+
+            data = {
+                "submissions": [
+                    {
+                        "id": "1",
+                        "issue_number": 5,
+                        "status": SUBMIT_STATUS_ACCEPTED,
+                    }
+                ],
+                "last_poll": None,
+            }
+            return await store.reconcile(data)
+
+        result = asyncio.run(_run())
+        assert result["last_poll"] is not None
+        assert result["submissions"][0]["status"] == SUBMIT_STATUS_ACCEPTED
+
+    def test_reconcile_updates_pending_from_github(self, tmp_path: Path) -> None:
+        """A pending submission whose issue is now closed-as-not_planned must
+        flip to declined, with last_checked stamped."""
+
+        async def _run() -> dict:
+            ctx = _FakeCtx(tmp_path)
+            store = PackSubmissionStore(ctx)
+
+            async def _fake_fetch(_session, issue_number):
+                assert issue_number == 9
+                return "closed", "not_planned"
+
+            store._fetch_issue = _fake_fetch  # type: ignore[assignment]
+
+            data = {
+                "submissions": [
+                    {"id": "1", "issue_number": 9, "status": SUBMIT_STATUS_PENDING}
+                ],
+                "last_poll": None,
+            }
+            return await store.reconcile(data)
+
+        result = asyncio.run(_run())
+        sub = result["submissions"][0]
+        assert sub["status"] == SUBMIT_STATUS_DECLINED
+        assert sub["last_checked"] is not None
+
+    def test_add_then_get_persists(self, tmp_path: Path) -> None:
+        """add() writes a record; get_with_reconcile() reads it back. With a
+        fresh last_poll set, the reconcile is skipped so no network is hit."""
+        import datetime as _dt
+
+        async def _run() -> dict:
+            ctx = _FakeCtx(tmp_path)
+            store = PackSubmissionStore(ctx)
+            await store.add(
+                {
+                    "id": "1",
+                    "name": "Test Pack",
+                    "issue_number": 1,
+                    "status": SUBMIT_STATUS_PENDING,
+                }
+            )
+            # Pre-stamp last_poll to now so get_with_reconcile won't poll.
+            raw = json.loads((tmp_path / "pack_submissions.json").read_text())
+            raw["last_poll"] = _dt.datetime.now(_dt.timezone.utc).isoformat()
+            (tmp_path / "pack_submissions.json").write_text(json.dumps(raw))
+            return await store.get_with_reconcile()
+
+        result = asyncio.run(_run())
+        assert len(result["submissions"]) == 1
+        assert result["submissions"][0]["name"] == "Test Pack"
+
+    def test_poll_due_logic(self, tmp_path: Path) -> None:
+        store = PackSubmissionStore(_FakeCtx(tmp_path))
+        assert store._poll_due({"last_poll": None}) is True
+        assert store._poll_due({"last_poll": "garbage"}) is True
+        import datetime as _dt
+
+        recent = _dt.datetime.now(_dt.timezone.utc).isoformat()
+        assert store._poll_due({"last_poll": recent}) is False
+
+
+# ---------------------------------------------------------------------------
+# 4. Config view (enabled flag)
+# ---------------------------------------------------------------------------
+
+
+class TestSubmitConfigView:
+    def test_disabled_when_no_url(self, tmp_path: Path) -> None:
+        from custom_components.quizify.server import pack_submission as ps
+
+        class _Req:
+            app = {ps.APP_CTX_KEY: _FakeCtx(tmp_path, submit_url=None)}
+
+        resp = asyncio.run(ps.submit_config_view(_Req()))
+        body = json.loads(resp.text)
+        assert body["enabled"] is False
+        assert "limits" in body
+
+    def test_enabled_when_url_set(self, tmp_path: Path) -> None:
+        from custom_components.quizify.server import pack_submission as ps
+
+        class _Req:
+            app = {
+                ps.APP_CTX_KEY: _FakeCtx(
+                    tmp_path, submit_url="https://worker.example/quizify"
+                )
+            }
+
+        resp = asyncio.run(ps.submit_config_view(_Req()))
+        body = json.loads(resp.text)
+        assert body["enabled"] is True
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [(" ", False), ("", False), ("https://x", True)],
+)
+def test_enabled_trims_whitespace(tmp_path: Path, url: str, expected: bool) -> None:
+    from custom_components.quizify.server import pack_submission as ps
+
+    class _Req:
+        app = {ps.APP_CTX_KEY: _FakeCtx(tmp_path, submit_url=url)}
+
+    resp = asyncio.run(ps.submit_config_view(_Req()))
+    assert json.loads(resp.text)["enabled"] is expected


### PR DESCRIPTION
Closes #180 (Quizify-side, steps 1–4 of the issue plan).

## What this adds

An in-app flow for hosts to **submit a community question pack**, mirroring Beatify's playlist-request shape (`PlaylistRequestsView` / `playlist-requests.js`, CHANGELOG #835/#937/#970/#1052).

In the admin setup screen a host pastes or composes a pack as JSON, sees a per-field ✓/✗ validation table, and submits it. The pack is POSTed to Quizify's own endpoint, which proxies it to a **configurable worker** that holds the GitHub token and creates a labelled issue in `mholzi/quizify`. The browser never talks to GitHub directly.

### Step-by-step against the plan
1. **Config option** — new optional `community_submit_url` (free-text URL, empty by default = feature OFF). Added to `config_flow` + `const` + the HA config strings in **en/de/es/fr/nl**, plus the `www/i18n` UI strings in **en/de**.
2. **Client-side validator** — `www/js/pack-submit.js` re-implements the #179 community-pack schema in the browser (pack object, `name`, `language`, non-empty `questions`, and every question's id/text/3-answers/exactly-one-correct/no-dup-id) and renders a per-row ✓/✗ table before submit. A server-side mirror (`validate_pack`) guards the POST so a hand-crafted request can't bypass the UI.
3. **Submit UI** — a "Submit a community pack" section at the bottom of the setup-detail flow (near the pack picker). Hidden by default; `pack-submit.js` unhides it only when `/api/quizify/pack-submit/config` reports `enabled: true`.
4. **Status sync** — submission records persist in the integration data dir (`pack_submissions.json`); a throttled (~hourly) GET reconciles each record against the GitHub **issue state** (closed-as-completed = accepted, `not_planned` = declined), like Beatify's `PlaylistRequestsView.get()` (#970 lesson: trust the state, not labels). GitHub is only ever read server-side.
5. **Localized error codes** — `INVALID_FORMAT` / `RATE_LIMITED` / `GITHUB_ERROR` map to i18n keys with a fallback to the raw worker message.

## Inert until configured

The whole feature stays off until `community_submit_url` is set: the config endpoint reports `enabled: false` (UI hides itself) and the POST endpoint refuses with `SUBMIT_DISABLED`.

## Remaining external piece (out of scope here)

Step 5 of the issue — the **worker route** (`quizify/pack-submission` on the existing Beatify Cloudflare worker that creates the labelled issue with its GitHub token) — is separate infrastructure and is **not** part of this PR. This integration is built against a configurable URL and is wired to consume whatever `{ issue_number, issue_url }` the worker returns.

## Tests

- `tests/test_pack_submission_180.py` (25 tests): validator accept/reject cases, issue-state→status mapping, issue-number URL parsing, the throttled reconcile (stamps `last_poll`, only touches pending records, persists), and the config endpoint's enabled flag.
- **No `asyncio.get_event_loop()`** anywhere — async paths use `asyncio.run()` and the fake runtime's executor uses the running loop (CI runs Python 3.13).
- Full suite: 251 passed locally. (10 pre-existing errors on local Python 3.9 + pytest-asyncio 1.2.0 are a test-ordering artifact present on clean `main` too; they pass on CI's Python 3.13 with the pinned deps.)

## Notes

- UI change → **Mobile/host verify pending**.
- `player.bundle.js` rebuilt (unchanged — the new script is an admin-only module, not a player module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)