### PR TITLE
feat(ui): image-question side-by-side presentation (Variant 1)

### DIFF
--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -1486,19 +1486,79 @@ button, .btn {
     padding: 0 var(--space-sm);
 }
 
-/* Issue #25: optional question thumbnail on the player screen. Capped
-   height so it never crowds out the answer buttons on a small phone;
-   hidden entirely when the question carries no image. */
+/* Issue #25 + #183 (Variant 1): question image as a fixed-height banner
+   preview with a tap-to-zoom button. Fixed height (no aspect-driven layout
+   shift between questions); object-fit:contain letterboxes both portrait and
+   landscape images. Hidden entirely when the question carries no image, so
+   the answer pills stay reachable above the fold. */
+.question-media {
+    position: relative;
+    width: 100%;
+    height: 200px;
+    margin: var(--space-sm) 0;
+    border-radius: var(--radius-md, 12px);
+    overflow: hidden;
+    background: var(--color-surface-dark);
+    border: 1px solid var(--color-border-neon);
+}
+.question-media[hidden] { display: none; }
 .question-image {
     display: block;
-    max-width: 100%;
-    max-height: 30vh;
-    width: auto;
-    margin: var(--space-sm) auto;
-    border-radius: var(--radius-md, 12px);
+    width: 100%;
+    height: 100%;
     object-fit: contain;
 }
-.question-image[hidden] { display: none; }
+.question-image-zoom {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    width: 34px;
+    height: 34px;
+    border: none;
+    border-radius: 8px;
+    background: rgba(42, 40, 32, 0.55);
+    color: #fff;
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.question-image-zoom:hover { background: rgba(42, 40, 32, 0.75); }
+
+/* Fullscreen zoom overlay */
+.image-zoom-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    background: rgba(0, 0, 0, 0.92);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-md);
+}
+.image-zoom-overlay.hidden { display: none; }
+.image-zoom-img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+    border-radius: var(--radius-md, 12px);
+}
+.image-zoom-close {
+    position: absolute;
+    top: max(12px, env(safe-area-inset-top));
+    right: 12px;
+    width: 40px;
+    height: 40px;
+    border: none;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.15);
+    color: #fff;
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+}
 
 .question-category {
     display: inline-block;

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -273,19 +273,47 @@
             max-width: 24ch;
         }
 
-        /* Issue #25: optional question image, rendered above the text.
-           Capped height so a tall image can't push the answers grid
-           off-screen on a 720p TV; object-fit keeps the aspect ratio. */
+        /* Issue #183 (Variant 1 — split / side-by-side):
+           When the question has an image, .dashboard-left becomes a 2-pane
+           grid: the image is a co-equal focal point on the left, the
+           question + answer grid on the right. Nothing scrolls; both
+           portrait and landscape images letterbox via object-fit:contain
+           so there is no layout shift between questions. */
+        .dashboard-left.has-image {
+            display: grid;
+            grid-template-columns: 1.15fr 1fr;
+            gap: clamp(24px, 3vw, 44px);
+            align-items: center;
+        }
+        /* Without an image the body keeps the original single-column flow. */
+        .dashboard-question-body {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            min-width: 0;
+        }
+
+        /* Image pane — hidden unless the question carries a valid image. */
+        .dashboard-question-media {
+            display: none;
+            align-items: center;
+            justify-content: center;
+            height: 100%;
+            min-width: 0;
+        }
+        .dashboard-left.has-image .dashboard-question-media {
+            display: flex;
+        }
         .dashboard-question-image {
             display: block;
             max-width: 100%;
-            max-height: clamp(160px, 28vh, 320px);
+            max-height: 62vh;
             width: auto;
+            height: auto;
             border-radius: 16px;
-            margin-bottom: clamp(16px, 2vw, 28px);
+            border: 1px solid var(--dash-border-neon);
             object-fit: contain;
         }
-        .dashboard-question-image[hidden] { display: none; }
 
         /* 3-column answer row (questions have exactly 3 answers) */
         .dashboard-answers {
@@ -915,6 +943,12 @@
             .dashboard-question { font-size: 28px; }
             .dashboard-answers { grid-template-columns: 1fr; }
             .dashboard-answer { font-size: 16px; padding: 14px 16px; min-height: 56px; }
+            /* Narrow screens: stack the split layout (image above Q&A). */
+            .dashboard-left.has-image {
+                grid-template-columns: 1fr;
+                gap: 16px;
+            }
+            .dashboard-left.has-image .dashboard-question-image { max-height: 32vh; }
         }
     </style>
 </head>
@@ -945,14 +979,24 @@
         <!-- QUESTION VIEW -->
         <div id="question-view" class="dashboard-view">
             <div class="dashboard-columns">
-                <div class="dashboard-left">
-                    <div id="question-category" class="dashboard-category"></div>
-                    <img id="question-image" class="dashboard-question-image" alt="" hidden />
-                    <div id="question-text" class="dashboard-question"></div>
-                    <div id="answers-grid" class="dashboard-answers"></div>
-                    <div id="fun-fact" class="dashboard-funfact">
-                        <div class="fun-fact-label" data-i18n="dashboard.didYouKnow">Did you know?</div>
-                        <div id="fun-fact-text" class="fun-fact-text"></div>
+                <div id="dashboard-left" class="dashboard-left">
+                    <!-- Issue #183 (Variant 1 — split layout): when a question
+                         carries an image the .has-image modifier turns this
+                         column into a 2-pane grid (image left, Q&A right). The
+                         image sits in #question-media; the text/answers stay in
+                         #question-body. Without an image .has-image is removed
+                         and the column collapses to the original stacked flow. -->
+                    <figure id="question-media" class="dashboard-question-media" hidden>
+                        <img id="question-image" class="dashboard-question-image" alt="" />
+                    </figure>
+                    <div id="question-body" class="dashboard-question-body">
+                        <div id="question-category" class="dashboard-category"></div>
+                        <div id="question-text" class="dashboard-question"></div>
+                        <div id="answers-grid" class="dashboard-answers"></div>
+                        <div id="fun-fact" class="dashboard-funfact">
+                            <div class="fun-fact-label" data-i18n="dashboard.didYouKnow">Did you know?</div>
+                            <div id="fun-fact-text" class="fun-fact-text"></div>
+                        </div>
                     </div>
                 </div>
                 <div class="dashboard-right">
@@ -1013,6 +1057,8 @@
             timerFill: document.getElementById('timer-fill'),
             questionCategory: document.getElementById('question-category'),
             questionImage: document.getElementById('question-image'),
+            questionMedia: document.getElementById('question-media'),
+            dashboardLeft: document.getElementById('dashboard-left'),
             questionText: document.getElementById('question-text'),
             answersGrid: document.getElementById('answers-grid'),
             leaderboard: document.getElementById('leaderboard'),
@@ -1027,20 +1073,32 @@
             if (views[name]) views[name].classList.add('active');
         }
 
-        // Issue #25: render the optional question image. Only absolute
-        // http(s) URLs are accepted (the server already sanitises, this
-        // is a defence-in-depth check). Absent/invalid → element hidden,
-        // layout collapses cleanly to the text-only question.
+        // Issue #25 + #183 (Variant 1 split layout): render the optional
+        // question image as a side-by-side focal point. Only absolute
+        // http(s) URLs are accepted (the server already sanitises; this is
+        // defence-in-depth). Absent/invalid → the image pane is hidden and
+        // .has-image is removed, so the column collapses cleanly to the
+        // original full-width text-only layout. If the image fails to load
+        // we fall back to the same text-only layout (graceful fallback).
+        function setImageLayout(on) {
+            if (els.dashboardLeft) els.dashboardLeft.classList.toggle('has-image', !!on);
+            if (els.questionMedia) els.questionMedia.hidden = !on;
+        }
         function renderQuestionImage(url) {
             var img = els.questionImage;
             if (!img) return;
             var safe = (typeof url === 'string' && /^https?:\/\//i.test(url)) ? url : '';
+            img.onerror = function() {
+                // Image failed → collapse to text-only, no broken-image icon.
+                img.removeAttribute('src');
+                setImageLayout(false);
+            };
             if (safe) {
                 img.src = safe;
-                img.hidden = false;
+                setImageLayout(true);
             } else {
                 img.removeAttribute('src');
-                img.hidden = true;
+                setImageLayout(false);
             }
         }
 

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -141,6 +141,7 @@
   },
   "game": {
     "question": "Frage",
+    "zoomImage": "Bild vergrößern",
     "soundMute": "Soundeffekte stummschalten",
     "soundUnmute": "Soundeffekte einschalten",
     "of": "von",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -141,6 +141,7 @@
   },
   "game": {
     "question": "Question",
+    "zoomImage": "Zoom image",
     "soundMute": "Mute sound effects",
     "soundUnmute": "Unmute sound effects",
     "of": "of",

--- a/custom_components/quizify/www/js/player-game.js
+++ b/custom_components/quizify/www/js/player-game.js
@@ -115,6 +115,63 @@
     // commit to a bet — which would defeat the Jeopardy-final tension.
     var _wagerGate = { active: false, submitted: false };
 
+    // Issue #183: render the question image banner + wire tap-to-zoom.
+    function renderQuestionImageBanner(imgUrl) {
+        var media = document.getElementById('question-media');
+        var img = document.getElementById('question-image');
+        if (!media || !img) return;
+        var safeImg = (typeof imgUrl === 'string' && /^https?:\/\//i.test(imgUrl)) ? imgUrl : '';
+        img.onerror = function() {
+            // Image failed → hide the banner, fall back to text-only.
+            img.removeAttribute('src');
+            media.hidden = true;
+        };
+        if (safeImg) {
+            img.src = safeImg;
+            media.hidden = false;
+        } else {
+            img.removeAttribute('src');
+            media.hidden = true;
+        }
+    }
+
+    // Wire the fullscreen zoom overlay once. The overlay shows the current
+    // banner image at full size; closing returns to the game view.
+    function _initImageZoom() {
+        var zoomBtn = document.getElementById('question-image-zoom');
+        var overlay = document.getElementById('image-zoom-overlay');
+        var closeBtn = document.getElementById('image-zoom-close');
+        var overlayImg = document.getElementById('image-zoom-img');
+        var bannerImg = document.getElementById('question-image');
+        if (!zoomBtn || !overlay || !overlayImg) return;
+
+        function open() {
+            if (bannerImg && bannerImg.getAttribute('src')) {
+                overlayImg.src = bannerImg.getAttribute('src');
+                overlayImg.alt = bannerImg.getAttribute('alt') || '';
+                overlay.classList.remove('hidden');
+            }
+        }
+        function close() {
+            overlay.classList.add('hidden');
+            overlayImg.removeAttribute('src');
+        }
+        zoomBtn.addEventListener('click', open);
+        if (closeBtn) closeBtn.addEventListener('click', close);
+        overlay.addEventListener('click', function(e) {
+            if (e.target === overlay) close();
+        });
+        document.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape' && !overlay.classList.contains('hidden')) close();
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', _initImageZoom);
+    } else {
+        _initImageZoom();
+    }
+
     function renderQuestion(data) {
         var questionText = document.getElementById('question-text');
         var questionCategory = document.getElementById('question-category');
@@ -123,21 +180,12 @@
         if (questionText) questionText.textContent = data.question_text || '';
         if (questionCategory) questionCategory.textContent = data.category || '';
 
-        // Issue #25: optional question thumbnail on the player screen.
-        // Only absolute http(s) URLs are shown (server already sanitises;
-        // this is defence-in-depth). Absent/invalid → element stays hidden.
-        var questionImage = document.getElementById('question-image');
-        if (questionImage) {
-            var imgUrl = data.image_url;
-            var safeImg = (typeof imgUrl === 'string' && /^https?:\/\//i.test(imgUrl)) ? imgUrl : '';
-            if (safeImg) {
-                questionImage.src = safeImg;
-                questionImage.hidden = false;
-            } else {
-                questionImage.removeAttribute('src');
-                questionImage.hidden = true;
-            }
-        }
+        // Issue #25 + #183 (Variant 1): question image as a fixed-height
+        // banner preview with tap-to-zoom. Only absolute http(s) URLs are
+        // shown (server already sanitises; this is defence-in-depth).
+        // Absent/invalid/load-error → the banner is hidden so the answer
+        // pills stay reachable above the fold (graceful text-only fallback).
+        renderQuestionImageBanner(data.image_url);
 
         // Wager round detection — set BEFORE we touch buttons so we can
         // disable them up-front, then enable once the wager is in.

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -2410,6 +2410,63 @@
     // commit to a bet — which would defeat the Jeopardy-final tension.
     var _wagerGate = { active: false, submitted: false };
 
+    // Issue #183: render the question image banner + wire tap-to-zoom.
+    function renderQuestionImageBanner(imgUrl) {
+        var media = document.getElementById('question-media');
+        var img = document.getElementById('question-image');
+        if (!media || !img) return;
+        var safeImg = (typeof imgUrl === 'string' && /^https?:\/\//i.test(imgUrl)) ? imgUrl : '';
+        img.onerror = function() {
+            // Image failed → hide the banner, fall back to text-only.
+            img.removeAttribute('src');
+            media.hidden = true;
+        };
+        if (safeImg) {
+            img.src = safeImg;
+            media.hidden = false;
+        } else {
+            img.removeAttribute('src');
+            media.hidden = true;
+        }
+    }
+
+    // Wire the fullscreen zoom overlay once. The overlay shows the current
+    // banner image at full size; closing returns to the game view.
+    function _initImageZoom() {
+        var zoomBtn = document.getElementById('question-image-zoom');
+        var overlay = document.getElementById('image-zoom-overlay');
+        var closeBtn = document.getElementById('image-zoom-close');
+        var overlayImg = document.getElementById('image-zoom-img');
+        var bannerImg = document.getElementById('question-image');
+        if (!zoomBtn || !overlay || !overlayImg) return;
+
+        function open() {
+            if (bannerImg && bannerImg.getAttribute('src')) {
+                overlayImg.src = bannerImg.getAttribute('src');
+                overlayImg.alt = bannerImg.getAttribute('alt') || '';
+                overlay.classList.remove('hidden');
+            }
+        }
+        function close() {
+            overlay.classList.add('hidden');
+            overlayImg.removeAttribute('src');
+        }
+        zoomBtn.addEventListener('click', open);
+        if (closeBtn) closeBtn.addEventListener('click', close);
+        overlay.addEventListener('click', function(e) {
+            if (e.target === overlay) close();
+        });
+        document.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape' && !overlay.classList.contains('hidden')) close();
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', _initImageZoom);
+    } else {
+        _initImageZoom();
+    }
+
     function renderQuestion(data) {
         var questionText = document.getElementById('question-text');
         var questionCategory = document.getElementById('question-category');
@@ -2418,21 +2475,12 @@
         if (questionText) questionText.textContent = data.question_text || '';
         if (questionCategory) questionCategory.textContent = data.category || '';
 
-        // Issue #25: optional question thumbnail on the player screen.
-        // Only absolute http(s) URLs are shown (server already sanitises;
-        // this is defence-in-depth). Absent/invalid → element stays hidden.
-        var questionImage = document.getElementById('question-image');
-        if (questionImage) {
-            var imgUrl = data.image_url;
-            var safeImg = (typeof imgUrl === 'string' && /^https?:\/\//i.test(imgUrl)) ? imgUrl : '';
-            if (safeImg) {
-                questionImage.src = safeImg;
-                questionImage.hidden = false;
-            } else {
-                questionImage.removeAttribute('src');
-                questionImage.hidden = true;
-            }
-        }
+        // Issue #25 + #183 (Variant 1): question image as a fixed-height
+        // banner preview with tap-to-zoom. Only absolute http(s) URLs are
+        // shown (server already sanitises; this is defence-in-depth).
+        // Absent/invalid/load-error → the banner is hidden so the answer
+        // pills stay reachable above the fold (graceful text-only fallback).
+        renderQuestionImageBanner(data.image_url);
 
         // Wager round detection — set BEFORE we touch buttons so we can
         // disable them up-front, then enable once the wager is in.

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -189,7 +189,16 @@
                          data-i18n-aria-label="a11y.currentQuestionRegion"
                          aria-label="Current question">
                         <div id="question-category" class="question-category"></div>
-                        <img id="question-image" class="question-image" alt="" hidden />
+                        <!-- Issue #183 (Variant 1): image as a fixed-height
+                             banner preview with a tap-to-zoom button. The
+                             answer pills stay reachable above the fold. When
+                             the question has no image the figure is hidden and
+                             the card collapses to the text-only layout. -->
+                        <figure id="question-media" class="question-media" hidden>
+                            <img id="question-image" class="question-image" alt="" />
+                            <button id="question-image-zoom" type="button" class="question-image-zoom"
+                                    data-i18n-aria-label="game.zoomImage" aria-label="Zoom image">⤢</button>
+                        </figure>
                         <div id="question-text" class="question-text"></div>
                     </div>
                     <div id="question-loading" class="album-loading hidden">
@@ -282,6 +291,15 @@
                     </div>
                 </section>
             </div>
+        </div>
+
+        <!-- Issue #183: fullscreen image zoom overlay (tap-to-zoom from the
+             question banner). Hidden until the zoom button is pressed. -->
+        <div id="image-zoom-overlay" class="image-zoom-overlay hidden" role="dialog"
+             aria-modal="true" data-i18n-aria-label="game.zoomImage" aria-label="Zoom image">
+            <button id="image-zoom-close" type="button" class="image-zoom-close"
+                    data-i18n-aria-label="common.close" aria-label="Close">✕</button>
+            <img id="image-zoom-img" class="image-zoom-img" alt="" />
         </div>
 
         <!-- Reveal View -->


### PR DESCRIPTION
Closes #183. Implements the chosen **Variant 1 — "split / side-by-side"** layout for image questions, replacing the minimal stacked render from #178.

## TV / host screen
- When a question carries an image, the question column becomes a 2-pane grid: **image as a co-equal focal point on the left**, category + question + 3-up answer grid on the right.
- Nothing scrolls; **portrait and landscape images letterbox** via `object-fit: contain`, so there is **no layout shift** between questions.
- Questions **without an image** collapse to the original single-column text-only flow (unchanged behaviour).

## Player phone (390×844)
- Image renders as a **fixed-height banner preview (~200px)** with a **tap-to-zoom** button opening a fullscreen overlay (tap-outside / ✕ / Esc to close).
- Fixed banner height avoids aspect-driven layout shift; **answer pills stay reachable above the fold**.

## Loading / fallback / a11y
- Invalid or absent URLs **and image load errors** hide the image and fall back cleanly to the text-only layout on both surfaces.
- Only absolute `http(s)` URLs are rendered (defence-in-depth on top of the server-side sanitisation from #178).
- `alt` text preserved; new `game.zoomImage` i18n strings added (en/de).

## Notes
- Frontend-only (HTML/CSS/JS/i18n + rebuilt player bundle). No scoring or game-logic change.
- Local tests: 226 passed. The 10 erroring tests are a pre-existing Python 3.9.6 local-environment artifact (pytest-asyncio event-loop fixture); those test files are byte-identical to `main` and unrelated to this frontend-only diff.
- **Mobile/host verify pending** (live 390×844 browser-harness screenshot + cut-off audit before release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)