### PR TITLE
Refine sound-effects mute toggle into header cluster (Variant C) — Closes #194

### DIFF
--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -670,16 +670,25 @@ body {
     margin: 0;
 }
 
+/* Right-side header cluster (Variant C, issue #194). Groups the embedded
+   sound-mute toggle with the round indicator so they read as one piece of
+   furniture. Right-aligns via the header's space-between. margin-right
+   clears the absolutely-positioned connection dot in the top-right corner. */
+.player-header-round-grp {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    margin-right: var(--space-lg);
+}
+
 /* Round indicator — app-bar style (variant C, Markus 2026-05-31). The
    wordmark sits left, this counter right-aligns via space-between and
    appears only on the reveal view (showView in player-utils.js toggles
-   the hidden attr). margin-right clears the absolutely-positioned
-   connection dot in the top-right corner. */
+   the hidden attr). */
 .player-header-round {
     display: inline-flex;
     align-items: center;
     gap: 7px;
-    margin-right: var(--space-lg);
     font-family: var(--font-mono);
     font-weight: 700;
     font-size: 0.7rem;
@@ -701,25 +710,31 @@ body {
 .player-header-round-num { color: var(--color-accent-primary); }
 .player-header-round-sep { color: var(--color-border-dark); }
 
-/* Sound cue mute toggle — sits to the left of the connection dot in the
-   top-right corner of the player header. Tap target stays ≥36px. */
+/* Sound cue mute toggle — Variant C (issue #194). Embedded as a subtle
+   round affordance inside the right-side header cluster, immediately before
+   the round indicator, instead of floating as its own corner icon. Quiet by
+   default (warm card-alt fill, reduced opacity); dims further when muted.
+   Behaviour + persistence unchanged (player-core.js setupSoundToggle). */
 .sound-toggle-btn {
-    position: absolute;
-    top: 8px;
-    right: 30px;
-    min-width: 36px;
-    min-height: 36px;
-    padding: 4px;
+    flex: 0 0 auto;
+    width: 30px;
+    height: 30px;
+    min-width: 30px;
+    min-height: 30px;
+    padding: 0;
     border: none;
-    background: transparent;
-    font-size: 1.1rem;
+    background: var(--color-bg-card-alt);
+    font-size: 1rem;
     line-height: 1;
     cursor: pointer;
-    border-radius: 50%;
-    opacity: 0.85;
+    border-radius: var(--radius-full);
+    opacity: 0.8;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 .sound-toggle-btn:hover { opacity: 1; }
-.sound-toggle-btn.is-muted { opacity: 0.55; }
+.sound-toggle-btn.is-muted { opacity: 0.5; }
 
 /* Connection indicator */
 .connection-indicator {

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -18,20 +18,28 @@
 <body>
     <header class="player-header">
         <h1 class="wordmark"><span class="wordmark-quiz">Quiz</span><span class="wordmark-ify">ify</span></h1>
-        <!-- Round indicator sits inline next to the wordmark on the reveal
-             view. showView() in player-utils.js toggles `hidden` based on
-             whether reveal-view is active. Text is populated by
-             renderFinaleReveal in player-reveal.js. -->
-        <span id="player-header-round" class="player-header-round" hidden aria-live="polite">
-            <span class="player-header-round-dot" aria-hidden="true"></span>
-            <span data-i18n="game.roundLabel">Round</span>
-            <span class="player-header-round-num" id="header-round-num">1</span>
-            <span class="player-header-round-sep" aria-hidden="true">/</span>
-            <span id="header-round-total">10</span>
+        <!-- Right-side header cluster (Variant C, issue #194): the sound mute
+             toggle is embedded as a subtle affordance immediately before the
+             round indicator, reusing the existing right-aligned furniture
+             rather than floating as its own corner icon. The round indicator
+             itself still toggles `hidden` independently (player-utils.js,
+             reveal view only); the speaker stays visible at all times. -->
+        <span class="player-header-round-grp">
+            <!-- Sound cue mute toggle. JS (player-core.js setupSoundToggle)
+                 sets the icon, label and persists the preference. -->
+            <button id="sound-toggle-btn" type="button" class="sound-toggle-btn" aria-pressed="false" aria-label="Mute sound">🔊</button>
+            <!-- Round indicator sits inline next to the wordmark on the reveal
+                 view. showView() in player-utils.js toggles `hidden` based on
+                 whether reveal-view is active. Text is populated by
+                 renderFinaleReveal in player-reveal.js. -->
+            <span id="player-header-round" class="player-header-round" hidden aria-live="polite">
+                <span class="player-header-round-dot" aria-hidden="true"></span>
+                <span data-i18n="game.roundLabel">Round</span>
+                <span class="player-header-round-num" id="header-round-num">1</span>
+                <span class="player-header-round-sep" aria-hidden="true">/</span>
+                <span id="header-round-total">10</span>
+            </span>
         </span>
-        <!-- Sound cue mute toggle. JS (player-core.js setupSoundToggle)
-             sets the icon, label and persists the preference. -->
-        <button id="sound-toggle-btn" type="button" class="sound-toggle-btn" aria-pressed="false" aria-label="Mute sound">🔊</button>
         <!-- Connection status dot — JS updates via conn-status div -->
         <div id="connection-indicator" class="connection-indicator" aria-hidden="true"></div>
     </header>


### PR DESCRIPTION
## Summary

Refines the player-phone **sound-effects mute toggle** (shipped in #177) to the chosen design **Variant C — "subtly embedded into existing control bars"** from the `design-issue-194` exploration.

Previously the toggle was a free-floating speaker icon, absolutely positioned in the top-right corner of the player header. This change folds it into the existing right-aligned header furniture: a new `.player-header-round-grp` cluster groups the toggle with the round indicator, and the toggle is restyled into a small, quiet round chip (warm `--color-bg-card-alt` fill, `--radius-full`, reduced opacity, dimming further when muted) sitting immediately before the round counter. Zero new standalone header furniture.

## Scope

- **Visual / placement refinement only.** No behaviour change.
- The toggle still keys off `#sound-toggle-btn`; `player-core.js` `setupSoundToggle` continues to handle the icon/label swap and the persisted mute preference.
- The round indicator keeps toggling its own `hidden` attribute independently (reveal view only) — the speaker stays visible at all times, including during normal play.
- Out of scope: the lobby-music mute (removed when #181 moved lobby music to the HA `media_player`). This is the player-side sound-effects mute only.

## Changes

- `custom_components/quizify/www/player.html` — wrap speaker + round indicator in a `.player-header-round-grp` cluster; speaker precedes the round indicator.
- `custom_components/quizify/www/css/styles.css` — new `.player-header-round-grp` cluster; restyle `.sound-toggle-btn` from absolute corner icon to embedded inline chip; move the `margin-right` connection-dot clearance onto the cluster.

No backend / Python changes. No `asyncio.get_event_loop()` introduced.

## Verification

- `python3 -m pytest tests/ -q` → **226 passed**. The 10 errors are a pre-existing test-harness event-loop-pollution issue (identical result on clean `origin/main`); unrelated to this HTML/CSS-only change.
- `python3 scripts/build_bundle.py` → rebuilt cleanly.
- All `manifest.json` + question-pack JSON validated.
- Rendered the header against the real stylesheet at 390px width (reveal state + normal-play state): speaker reads as embedded furniture, no overlap with the connection dot, no clipping. Matches the Variant C mockup.

**Mobile verify pending** (live device/HA mobile-width verification still to be done before release).

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)