### PR TITLE
test: isolate asyncio event loop per test (fix cross-module pollution)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+"""Shared pytest fixtures.
+
+Test isolation for asyncio: some tests run a coroutine via ``asyncio.run()``
+(which, on teardown, sets the current event loop to ``None``) or otherwise
+leave the loop closed. On Python 3.9 a subsequent test whose setup calls
+``asyncio.get_event_loop()`` then raises "There is no current event loop in
+thread 'MainThread'". This autouse fixture gives every test a fresh, open loop
+and disposes it afterwards, so test order can never leak a broken loop between
+modules (regression seen after merging parallel feature PRs, 2026-06-09).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _fresh_event_loop():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        yield
+    finally:
+        try:
+            loop.close()
+        finally:
+            asyncio.set_event_loop(asyncio.new_event_loop())


### PR DESCRIPTION
Fixes the 10 setup-time `no current event loop` errors that appeared on main after merging parallel feature PRs (each green alone; combined, an `asyncio.run()` left the loop as None and broke later modules' setup on Python 3.9). Adds an autouse `tests/conftest.py` fixture giving each test a fresh loop. Full suite: 261 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)