### PR TITLE
refactor: extract PhaseController (game flow + timer/pause/resume) from game/state.py

### DIFF
--- a/custom_components/quizify/game/phase_controller.py
+++ b/custom_components/quizify/game/phase_controller.py
@@ -1,0 +1,199 @@
+"""PhaseController — game-flow phase state machine + per-question timing.
+
+Extracted from ``QuizifyGameState`` (issue #188, continuing the God-object
+split started in #184/#187). This module owns the *mechanical* core of the
+game flow:
+
+  * the authoritative :class:`GamePhase` value and its transitions
+  * the per-player :class:`QuestionTimer` map and the round-timing bookkeeping
+    (``round_start_time``, ``round_duration``)
+  * pause / resume — freezing the per-player timers, remembering the phase to
+    resume back into, and the pause reason
+
+It deliberately does **not** know about scoring, the player registry, the
+question bank, calibration or analytics. Those orchestration concerns stay in
+``QuizifyGameState``, which drives this controller through narrow primitives
+and reads/writes its state via delegating properties. Behaviour is identical to
+the previous inline implementation — same phase transitions, same timing, same
+pause/resume snapshot/restore, same message flow.
+
+The controller needs to enumerate the current player names when (re)building
+timers; it receives that through a ``players_fn`` callback rather than holding a
+reference to the registry, keeping the dependency one-directional.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Callable
+from enum import Enum
+
+from ..const import DEFAULT_ROUND_DURATION
+from .timer import QuestionTimer
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class GamePhase(str, Enum):
+    """Game phase states."""
+
+    LOBBY = "LOBBY"
+    QUESTION_ACTIVE = "QUESTION_ACTIVE"
+    ANSWER_REVEAL = "ANSWER_REVEAL"
+    FINALE = "FINALE"
+    # Lightning Round (issue #42) — a self-contained fast bonus mode the
+    # host can trigger after/instead of the normal game. LIGHTNING runs the
+    # rapid 10-question loop (no inter-question reveal); LIGHTNING_RECAP is
+    # the end screen showing totals + the per-question right/wrong grid.
+    # The mode's logic lives in game/lightning.py, not in this class.
+    LIGHTNING = "LIGHTNING"
+    LIGHTNING_RECAP = "LIGHTNING_RECAP"
+    # PAUSED — admin-triggered pause during QUESTION_ACTIVE. Timer is
+    # frozen; resume returns to QUESTION_ACTIVE with the remaining time
+    # the player had before pause. Used both for explicit "Pause" button
+    # and for graceful host-disconnect handling.
+    PAUSED = "PAUSED"
+
+
+class PhaseController:
+    """Owns the game phase + per-question timer mechanics.
+
+    A single instance is held by each :class:`QuizifyGameState`. The host class
+    delegates its ``phase`` and timing attributes here and calls the primitives
+    below at the appropriate points in the game flow.
+    """
+
+    def __init__(self, players_fn: Callable[[], list[str]]) -> None:
+        """Initialize.
+
+        ``players_fn`` returns the current player names (registry keys), used
+        when (re)building per-player timers.
+        """
+        self._players_fn = players_fn
+
+        self.phase: GamePhase = GamePhase.LOBBY
+
+        # Per-question timing.
+        self.timers: dict[str, QuestionTimer] = {}  # player_id → timer
+        self.round_start_time: float | None = None
+        self.round_duration: float = DEFAULT_ROUND_DURATION
+
+        # Pause bookkeeping.
+        self.paused_from: GamePhase | None = None
+        self.paused_remaining: dict[str, float] = {}
+        self.pause_reason: str | None = None
+
+    # ------------------------------------------------------------------
+    # Timer mechanics
+    # ------------------------------------------------------------------
+
+    def add_late_joiner_timer(self, name: str) -> None:
+        """Give a mid-round joiner a timer tracking the round's remaining time.
+
+        Without this the tick loop's "all timers missing or expired → break"
+        condition treats them as already done and the round evaluates ~1s after
+        start when the late-joiner is the ONLY connected player (the
+        admin-self-join + redirect flow). Late joiners can also still answer the
+        in-flight question this way.
+        """
+        if (
+            self.phase == GamePhase.QUESTION_ACTIVE
+            and self.round_start_time is not None
+            and name not in self.timers
+        ):
+            elapsed = time.monotonic() - self.round_start_time
+            remaining = max(0.5, self.round_duration - elapsed)
+            timer = QuestionTimer(remaining)
+            timer.start()
+            self.timers[name] = timer
+
+    def drop_timer(self, name: str) -> None:
+        """Drop a single player's timer (player removed)."""
+        self.timers.pop(name, None)
+
+    def clear_timers(self) -> None:
+        """Drop every timer (full player wipe / reset)."""
+        self.timers.clear()
+
+    def begin_round(self, round_duration: float) -> None:
+        """Open a fresh round: set the duration, stamp the start time and
+        create+start a per-player timer for every current player.
+
+        Transition to QUESTION_ACTIVE is left to ``enter_question_active`` so
+        the caller controls ordering relative to its own per-round resets.
+        """
+        self.round_duration = round_duration
+        self.round_start_time = time.monotonic()
+        self.timers.clear()
+        for name in self._players_fn():
+            timer = QuestionTimer(self.round_duration)
+            timer.start()
+            self.timers[name] = timer
+
+    def enter_question_active(self) -> None:
+        """Flip the phase to QUESTION_ACTIVE."""
+        self.phase = GamePhase.QUESTION_ACTIVE
+
+    def get_timer(self, name: str) -> QuestionTimer | None:
+        """Return the authoritative timer for a player, or None."""
+        return self.timers.get(name)
+
+    def time_remaining_for_snapshot(self) -> float:
+        """Remaining time for a mid-round joiner's state snapshot.
+
+        Mirrors the wall-clock calculation used when serializing
+        QUESTION_ACTIVE: ``round_duration - (now - round_start_time)`` clamped
+        at zero.
+        """
+        elapsed = (
+            time.monotonic() - self.round_start_time
+            if self.round_start_time
+            else 0.0
+        )
+        return max(0.0, self.round_duration - elapsed)
+
+    # ------------------------------------------------------------------
+    # Pause / resume
+    # ------------------------------------------------------------------
+    #
+    # PAUSED freezes the per-player timers and remembers the phase to
+    # resume back into. Only QUESTION_ACTIVE is meaningfully pausable —
+    # pausing in LOBBY / ANSWER_REVEAL / FINALE is a no-op so the admin
+    # button can be wired unconditionally without phase checks in JS.
+
+    def pause(self, reason: str = "admin_paused") -> bool:
+        """Pause the game. Returns True if pause happened, False if no-op."""
+        if self.phase != GamePhase.QUESTION_ACTIVE:
+            return False
+        self.paused_from = GamePhase.QUESTION_ACTIVE
+        self.pause_reason = reason
+        # Snapshot remaining time per player and freeze timers in place.
+        # On resume we'll create fresh timers with the saved remaining.
+        self.paused_remaining = {}
+        for name, timer in self.timers.items():
+            self.paused_remaining[name] = max(0.0, timer.get_remaining())
+        self.timers.clear()
+        self.phase = GamePhase.PAUSED
+        _LOGGER.info("Game paused (reason=%s)", reason)
+        return True
+
+    def resume(self) -> bool:
+        """Resume a paused game. Returns True if resume happened."""
+        if self.phase != GamePhase.PAUSED:
+            return False
+        # Restore timers with the remaining time they had at pause.
+        # Late-joiners during PAUSED won't be in paused_remaining and
+        # get a fresh full-round timer here.
+        full = self.round_duration
+        for name in self._players_fn():
+            remaining = self.paused_remaining.get(name, full)
+            timer = QuestionTimer(remaining)
+            timer.start()
+            self.timers[name] = timer
+        self.paused_remaining = {}
+        self.pause_reason = None
+        self.phase = self.paused_from or GamePhase.QUESTION_ACTIVE
+        self.paused_from = None
+        _LOGGER.info("Game resumed")
+        return True

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -9,7 +9,6 @@ import secrets
 import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
-from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from ..const import (
@@ -28,6 +27,7 @@ from ..const import (
 )
 from .player import PlayerSession
 from .player_registry import PlayerRegistry
+from .phase_controller import GamePhase, PhaseController
 from .powerups import FREEZE_DURATION, TIME_BOOST_DURATION, PowerUpEffect, PowerUpManager, PowerUpType
 from .questions import Answer, Question, QuestionBank
 from .calibration import GroupCalibrator
@@ -46,26 +46,10 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-
-class GamePhase(str, Enum):
-    """Game phase states."""
-
-    LOBBY = "LOBBY"
-    QUESTION_ACTIVE = "QUESTION_ACTIVE"
-    ANSWER_REVEAL = "ANSWER_REVEAL"
-    FINALE = "FINALE"
-    # Lightning Round (issue #42) — a self-contained fast bonus mode the
-    # host can trigger after/instead of the normal game. LIGHTNING runs the
-    # rapid 10-question loop (no inter-question reveal); LIGHTNING_RECAP is
-    # the end screen showing totals + the per-question right/wrong grid.
-    # The mode's logic lives in game/lightning.py, not in this class.
-    LIGHTNING = "LIGHTNING"
-    LIGHTNING_RECAP = "LIGHTNING_RECAP"
-    # PAUSED — admin-triggered pause during QUESTION_ACTIVE. Timer is
-    # frozen; resume returns to QUESTION_ACTIVE with the remaining time
-    # the player had before pause. Used both for explicit "Pause" button
-    # and for graceful host-disconnect handling.
-    PAUSED = "PAUSED"
+# GamePhase moved to phase_controller (issue #188) but is re-exported here so
+# the many `from .state import GamePhase` / `from .game.state import GamePhase`
+# call sites across the integration keep working unchanged.
+__all__ = ["AnswerResult", "GamePhase", "QuizifyGameState", "RoundSummary"]
 
 
 @dataclass
@@ -106,9 +90,17 @@ class QuizifyGameState:
         self._runtime = runtime
         self._entry_id = entry_id
 
+        # Phase + per-question timing state machine (issue #188). Owns the
+        # authoritative phase value, the per-player timers, round-timing
+        # bookkeeping and pause/resume. This class delegates its ``phase``,
+        # ``_timers``, ``_round_*`` and ``_paused_*`` attributes to it via the
+        # properties below so behaviour is unchanged for every caller/test.
+        self._phase_controller = PhaseController(
+            players_fn=lambda: list(self._player_registry.players)
+        )
+
         # Core state
         self.game_id: str | None = None
-        self.phase: GamePhase = GamePhase.LOBBY
         self.round: int = 0
         self.total_rounds: int = 10
         self.category: str | None = None
@@ -138,11 +130,9 @@ class QuizifyGameState:
         # picks the "auto" difficulty mode; None for fixed easy/medium/hard.
         self._calibrator: GroupCalibrator | None = None
 
-        # Current round state
+        # Current round state. Per-player timers and round-timing live in the
+        # PhaseController (exposed via the delegating properties below).
         self._current_question: Question | None = None
-        self._timers: dict[str, QuestionTimer] = {}  # player_id → timer
-        self._round_start_time: float | None = None
-        self._round_duration: float = DEFAULT_ROUND_DURATION
         self._round_summary: RoundSummary | None = None
 
         # Optional admin-chosen timer override (seconds). When set,
@@ -153,11 +143,6 @@ class QuizifyGameState:
         # Last-game settings snapshot for "Play again — same settings".
         # None until a game has been started at least once.
         self._last_settings: dict[str, Any] | None = None
-
-        # Pause bookkeeping.
-        self._paused_from: GamePhase | None = None
-        self._paused_remaining: dict[str, float] = {}
-        self._pause_reason: str | None = None
 
         # Broadcast callback — set by websocket layer
         self._broadcast_callback: Callable[[dict[str, Any]], Awaitable[None]] | None = None
@@ -190,6 +175,72 @@ class QuizifyGameState:
         self.shuffle_map: list[int] = []        # canonical: shuffled_pos -> original_index
         self.shuffled_answers: list[str] = []   # canonical answers in shuffled order
         self.player_shuffles: dict[str, list[int]] = {}  # name -> shuffled_pos -> original_index
+
+    # ------------------------------------------------------------------
+    # Phase / timing delegation (issue #188)
+    # ------------------------------------------------------------------
+    #
+    # These attributes are owned by ``self._phase_controller`` but exposed here
+    # under their original names so every caller, sensor and test that reads or
+    # writes ``state.phase`` / ``state._timers`` / ``state._round_*`` /
+    # ``state._paused_*`` keeps working with byte-for-byte identical behaviour.
+
+    @property
+    def phase(self) -> GamePhase:
+        """Current game phase — owned by the PhaseController."""
+        return self._phase_controller.phase
+
+    @phase.setter
+    def phase(self, value: GamePhase) -> None:
+        self._phase_controller.phase = value
+
+    @property
+    def _timers(self) -> dict[str, QuestionTimer]:
+        return self._phase_controller.timers
+
+    @_timers.setter
+    def _timers(self, value: dict[str, QuestionTimer]) -> None:
+        self._phase_controller.timers = value
+
+    @property
+    def _round_start_time(self) -> float | None:
+        return self._phase_controller.round_start_time
+
+    @_round_start_time.setter
+    def _round_start_time(self, value: float | None) -> None:
+        self._phase_controller.round_start_time = value
+
+    @property
+    def _round_duration(self) -> float:
+        return self._phase_controller.round_duration
+
+    @_round_duration.setter
+    def _round_duration(self, value: float) -> None:
+        self._phase_controller.round_duration = value
+
+    @property
+    def _paused_from(self) -> GamePhase | None:
+        return self._phase_controller.paused_from
+
+    @_paused_from.setter
+    def _paused_from(self, value: GamePhase | None) -> None:
+        self._phase_controller.paused_from = value
+
+    @property
+    def _paused_remaining(self) -> dict[str, float]:
+        return self._phase_controller.paused_remaining
+
+    @_paused_remaining.setter
+    def _paused_remaining(self, value: dict[str, float]) -> None:
+        self._phase_controller.paused_remaining = value
+
+    @property
+    def _pause_reason(self) -> str | None:
+        return self._phase_controller.pause_reason
+
+    @_pause_reason.setter
+    def _pause_reason(self, value: str | None) -> None:
+        self._phase_controller.pause_reason = value
 
     # ------------------------------------------------------------------
     # Player registry delegation
@@ -250,30 +301,17 @@ class QuizifyGameState:
         )
         success, _err = result
         # If the player joined mid-round, give them a timer that tracks the
-        # round's remaining time. Without this the tick loop's "all timers
-        # missing or expired → break" condition treats them as already done
-        # and the round evaluates ~1s after start when the late-joiner is
-        # the ONLY connected player (the admin-self-join + redirect flow).
-        # Late joiners can also still answer the in-flight question this way.
-        if (
-            success
-            and self.phase == GamePhase.QUESTION_ACTIVE
-            and self._round_start_time is not None
-            and name not in self._timers
-        ):
-            elapsed = time.monotonic() - self._round_start_time
-            remaining = max(0.5, self._round_duration - elapsed)
-            timer = QuestionTimer(remaining)
-            timer.start()
-            self._timers[name] = timer
+        # round's remaining time (handled by the PhaseController, which no-ops
+        # outside QUESTION_ACTIVE / when the player already has a timer).
         if success:
+            self._phase_controller.add_late_joiner_timer(name)
             self._notify_state_callbacks()
         return result
 
     def remove_player(self, name: str) -> None:
         """Remove a player from the game."""
         self._player_registry.remove_player(name)
-        self._timers.pop(name, None)
+        self._phase_controller.drop_timer(name)
         self._notify_state_callbacks()
 
     def clear_all_players(self) -> None:
@@ -285,7 +323,7 @@ class QuizifyGameState:
         explicit "wipe everyone" action.
         """
         self._player_registry.reset()
-        self._timers.clear()
+        self._phase_controller.clear_timers()
         self._notify_state_callbacks()
 
     def get_player(self, name: str) -> PlayerSession | None:
@@ -456,25 +494,21 @@ class QuizifyGameState:
         # start_game) wins over the difficulty-derived default — the
         # picker in the admin UI lets the host pick 20/30/45s up front.
         if self._timer_override is not None:
-            self._round_duration = float(self._timer_override)
+            round_duration = float(self._timer_override)
         else:
             try:
                 diff_enum = Difficulty(question.difficulty)
             except ValueError:
                 diff_enum = Difficulty.MEDIUM
-            self._round_duration = float(TIME_LIMITS.get(diff_enum, DEFAULT_ROUND_DURATION))
-        self._round_start_time = time.monotonic()
+            round_duration = float(TIME_LIMITS.get(diff_enum, DEFAULT_ROUND_DURATION))
 
         # Reset per-round state
         for player in self._player_registry.players.values():
             player.reset_round()
         self._powerup_manager.reset_round()
 
-        # Create per-player timers
-        self._timers.clear()
-        for name in self._player_registry.players:
-            self._timers[name] = QuestionTimer(self._round_duration)
-            self._timers[name].start()
+        # Stamp round timing + create+start per-player timers (PhaseController).
+        self._phase_controller.begin_round(round_duration)
 
         # Randomly assign power-ups (one per round, random player)
         connected = [p for p in self._player_registry.players.values() if p.connected]
@@ -483,7 +517,7 @@ class QuizifyGameState:
             powerup = self._powerup_manager.assign_random_powerup(lucky_player.name)
             _LOGGER.debug("Power-up %s assigned to %s", powerup.value, lucky_player.name)
 
-        self.phase = GamePhase.QUESTION_ACTIVE
+        self._phase_controller.enter_question_active()
         self._round_summary = None
 
         _LOGGER.info(
@@ -736,39 +770,15 @@ class QuizifyGameState:
 
     def pause(self, reason: str = "admin_paused") -> bool:
         """Pause the game. Returns True if pause happened, False if no-op."""
-        if self.phase != GamePhase.QUESTION_ACTIVE:
+        if not self._phase_controller.pause(reason):
             return False
-        self._paused_from = GamePhase.QUESTION_ACTIVE
-        self._pause_reason = reason
-        # Snapshot remaining time per player and freeze timers in place.
-        # On resume we'll create fresh timers with the saved remaining.
-        self._paused_remaining = {}
-        for name, timer in self._timers.items():
-            self._paused_remaining[name] = max(0.0, timer.get_remaining())
-        self._timers.clear()
-        self.phase = GamePhase.PAUSED
-        _LOGGER.info("Game paused (reason=%s)", reason)
         self._notify_state_callbacks()
         return True
 
     def resume(self) -> bool:
         """Resume a paused game. Returns True if resume happened."""
-        if self.phase != GamePhase.PAUSED:
+        if not self._phase_controller.resume():
             return False
-        # Restore timers with the remaining time they had at pause.
-        # Late-joiners during PAUSED won't be in _paused_remaining and
-        # get a fresh full-round timer here.
-        full = self._round_duration
-        for name in list(self._player_registry.players):
-            remaining = self._paused_remaining.get(name, full)
-            timer = QuestionTimer(remaining)
-            timer.start()
-            self._timers[name] = timer
-        self._paused_remaining = {}
-        self._pause_reason = None
-        self.phase = self._paused_from or GamePhase.QUESTION_ACTIVE
-        self._paused_from = None
-        _LOGGER.info("Game resumed")
         self._notify_state_callbacks()
         return True
 
@@ -866,7 +876,7 @@ class QuizifyGameState:
         self.round = 0
         self._current_question = None
         self._round_summary = None
-        self._timers.clear()
+        self._phase_controller.clear_timers()
         self._powerup_manager.reset()
         self._finale_podium = None
         self._finale_superlatives = None
@@ -1092,7 +1102,7 @@ class QuizifyGameState:
         Exposed so the WebSocket handler can broadcast per-player remaining
         time (so time-boost and freeze are visible on the player's UI, #4).
         """
-        return self._timers.get(player_name)
+        return self._phase_controller.get_timer(player_name)
 
     def get_player_powerup(self, player_name: str):
         """Get the power-up held by a player."""
@@ -1160,8 +1170,7 @@ class QuizifyGameState:
         if self.phase == GamePhase.QUESTION_ACTIVE and self._current_question:
             q = self._current_question
             # Calculate time remaining for mid-round joiners
-            elapsed = time.monotonic() - self._round_start_time if self._round_start_time else 0.0
-            remaining = max(0.0, self._round_duration - elapsed)
+            remaining = self._phase_controller.time_remaining_for_snapshot()
             snapshot["question"] = {
                 "id": q.id,
                 "text": q.question,

--- a/tests/test_phase_controller_188.py
+++ b/tests/test_phase_controller_188.py
@@ -1,0 +1,169 @@
+"""Focused tests for the extracted PhaseController (issue #188).
+
+The controller owns the game-flow phase value, the per-player question timers
+and the round-timing bookkeeping, plus pause/resume. These tests exercise it in
+isolation (no game state, scoring or registry) to lock in the behaviour the
+extraction must preserve. End-to-end phase/timer behaviour through
+QuizifyGameState is already covered by test_game_state / test_admin_redirect_pause
+/ test_lightning; this file guards the unit itself.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.phase_controller import (  # noqa: E402
+    GamePhase,
+    PhaseController,
+)
+
+
+def _make(players: list[str] | None = None) -> PhaseController:
+    names = list(players or [])
+    return PhaseController(players_fn=lambda: list(names))
+
+
+class TestInitialState:
+    def test_starts_in_lobby_with_no_timers(self) -> None:
+        pc = _make()
+        assert pc.phase == GamePhase.LOBBY
+        assert pc.timers == {}
+        assert pc.round_start_time is None
+        assert pc.paused_from is None
+        assert pc.pause_reason is None
+
+
+class TestBeginRound:
+    def test_creates_started_timer_per_player(self) -> None:
+        pc = _make(["alice", "bob"])
+        pc.begin_round(30.0)
+        assert set(pc.timers) == {"alice", "bob"}
+        assert pc.round_duration == 30.0
+        assert pc.round_start_time is not None
+        # Started timers count down from (near) the full duration.
+        for t in pc.timers.values():
+            assert 0 < t.get_remaining() <= 30.0
+
+    def test_replaces_previous_round_timers(self) -> None:
+        pc = _make(["alice"])
+        pc.begin_round(30.0)
+        first = pc.timers["alice"]
+        pc.begin_round(20.0)
+        assert pc.timers["alice"] is not first
+        assert pc.round_duration == 20.0
+
+    def test_enter_question_active_flips_phase(self) -> None:
+        pc = _make(["alice"])
+        pc.begin_round(30.0)
+        pc.enter_question_active()
+        assert pc.phase == GamePhase.QUESTION_ACTIVE
+
+
+class TestLateJoiner:
+    def test_late_joiner_gets_remaining_time_timer(self) -> None:
+        pc = _make(["alice"])
+        pc.begin_round(30.0)
+        pc.enter_question_active()
+        pc.add_late_joiner_timer("bob")
+        assert "bob" in pc.timers
+        # Tracks remaining round time, never below the 0.5s floor.
+        assert 0.5 <= pc.timers["bob"].get_remaining() <= 30.0
+
+    def test_no_op_outside_question_active(self) -> None:
+        pc = _make(["alice"])
+        # LOBBY — no round running.
+        pc.add_late_joiner_timer("bob")
+        assert "bob" not in pc.timers
+
+    def test_does_not_replace_existing_timer(self) -> None:
+        pc = _make(["alice"])
+        pc.begin_round(30.0)
+        pc.enter_question_active()
+        existing = pc.timers["alice"]
+        pc.add_late_joiner_timer("alice")
+        assert pc.timers["alice"] is existing
+
+
+class TestTimerLifecycle:
+    def test_drop_and_clear(self) -> None:
+        pc = _make(["alice", "bob"])
+        pc.begin_round(30.0)
+        pc.drop_timer("alice")
+        assert "alice" not in pc.timers and "bob" in pc.timers
+        pc.clear_timers()
+        assert pc.timers == {}
+
+    def test_get_timer(self) -> None:
+        pc = _make(["alice"])
+        pc.begin_round(30.0)
+        assert pc.get_timer("alice") is pc.timers["alice"]
+        assert pc.get_timer("ghost") is None
+
+
+class TestPauseResume:
+    def test_pause_only_from_question_active(self) -> None:
+        pc = _make(["alice"])
+        # LOBBY → no-op.
+        assert pc.pause() is False
+        assert pc.phase == GamePhase.LOBBY
+
+    def test_pause_freezes_and_snapshots(self) -> None:
+        pc = _make(["alice", "bob"])
+        pc.begin_round(30.0)
+        pc.enter_question_active()
+        assert pc.pause(reason="admin_paused") is True
+        assert pc.phase == GamePhase.PAUSED
+        assert pc.paused_from == GamePhase.QUESTION_ACTIVE
+        assert pc.pause_reason == "admin_paused"
+        # Timers frozen (cleared) and remaining snapshotted per player.
+        assert pc.timers == {}
+        assert set(pc.paused_remaining) == {"alice", "bob"}
+        assert all(v >= 0 for v in pc.paused_remaining.values())
+
+    def test_resume_restores_to_question_active(self) -> None:
+        pc = _make(["alice"])
+        pc.begin_round(30.0)
+        pc.enter_question_active()
+        pc.pause()
+        assert pc.resume() is True
+        assert pc.phase == GamePhase.QUESTION_ACTIVE
+        assert "alice" in pc.timers
+        assert pc.paused_remaining == {}
+        assert pc.pause_reason is None
+        assert pc.paused_from is None
+
+    def test_resume_only_from_paused(self) -> None:
+        pc = _make(["alice"])
+        assert pc.resume() is False
+
+    def test_late_joiner_during_pause_gets_full_timer(self) -> None:
+        # A player present only at resume (not in the pause snapshot) gets a
+        # fresh full-round timer.
+        names = ["alice"]
+        pc = PhaseController(players_fn=lambda: list(names))
+        pc.begin_round(30.0)
+        pc.enter_question_active()
+        pc.pause()
+        names.append("carol")  # joined while paused
+        pc.resume()
+        assert "carol" in pc.timers
+        # Full duration (allow for the tiny elapsed since start()).
+        assert pc.timers["carol"].get_remaining() > 29.0
+
+
+class TestSnapshotRemaining:
+    def test_time_remaining_for_snapshot(self) -> None:
+        pc = _make(["alice"])
+        pc.begin_round(30.0)
+        pc.enter_question_active()
+        remaining = pc.time_remaining_for_snapshot()
+        assert 0 < remaining <= 30.0
+
+    def test_remaining_is_zero_when_no_round(self) -> None:
+        pc = _make()
+        # No round_start_time → elapsed treated as 0, full duration returned.
+        assert pc.time_remaining_for_snapshot() == pc.round_duration


### PR DESCRIPTION
## Summary

Part of #184 (God-object split), continuing #187 (ScoringEngine). This lifts the **game-flow phase state machine + per-question timing** out of `QuizifyGameState` into a focused `PhaseController` (`game/phase_controller.py`).

The new unit owns:
- the authoritative `GamePhase` value and its transitions;
- the per-player `QuestionTimer` map and round-timing bookkeeping (`round_start_time`, `round_duration`);
- **pause / resume** — freezing the per-player timers, remembering the phase to resume into, and the pause reason.

`QuizifyGameState` delegates `phase` / `_timers` / `_round_start_time` / `_round_duration` / `_paused_from` / `_paused_remaining` / `_pause_reason` to the controller via properties under their **original names**, so every caller, sensor (`lights`/`sensor`/`tts`/`lobby_music`/`binary_sensor`), WS handler and test keeps working unchanged.

`GamePhase` now lives in `phase_controller` and is **re-exported** from `state` — all `from .state import GamePhase` / `from .game.state import GamePhase` call sites are untouched, and it's the **same enum object** (asserted in a smoke test, so dict-keyed lookups like `lights._PHASE_LIGHT_RECIPES` still match).

## Behaviour-preserving
Identical phase transitions, timing, pause/resume snapshot/restore and message flow. Scoring, the player registry, the question bank, group-difficulty calibration and analytics orchestration **stay** in `QuizifyGameState` — only the mechanical phase/timer core moved. **Lightning Round** (`LIGHTNING` / `LIGHTNING_RECAP`, merged #191) phases are part of the moved enum and continue to work.

The async per-second `timer_tick` loop in `server/websocket.py` was deliberately **not** moved — it's a WS-layer concern that reads the model through the existing public accessors (`get_player_timer`, `round_duration`, `evaluate_round`), and moving it would have widened the blast radius without benefit.

## Tests
- New focused `PhaseController` unit tests (`tests/test_phase_controller_188.py`, 16 cases): init state, `begin_round`, late-joiner timer, drop/clear, pause snapshot/freeze, resume restore, late-joiner-during-pause, snapshot remaining.
- Full suite green on Python 3.13 (matching CI): **300 passed**. Byte-compile clean. No `asyncio.get_event_loop()` introduced.

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)