### PR TITLE
refactor: move countdown tick-loop timing into PhaseController

### DIFF
--- a/custom_components/quizify/game/phase_controller.py
+++ b/custom_components/quizify/game/phase_controller.py
@@ -27,12 +27,38 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Callable
+from dataclasses import dataclass, field
 from enum import Enum
 
 from ..const import DEFAULT_ROUND_DURATION
 from .timer import QuestionTimer
 
 _LOGGER = logging.getLogger(__name__)
+
+# Cadence of the per-question countdown broadcast, in seconds. Owned here
+# (rather than in the connection layer) so all timing constants live with the
+# timing logic. Behaviour-preserving: this is the same 0.5s the tick loop has
+# always slept between broadcasts.
+TICK_INTERVAL = 0.5
+
+
+@dataclass
+class TickResolution:
+    """Pure timing result for one broadcast iteration of the countdown loop.
+
+    Produced by :meth:`PhaseController.resolve_tick`; consumed by the
+    connection layer, which turns it into ``timer_tick`` wire messages. Holds no
+    websocket / connection state — only player names and their authoritative
+    remaining seconds, plus the value dashboards/admins show (the minimum across
+    all timed players so the shared TV countdown is consistent).
+    """
+
+    # (player_name, remaining_seconds) for every player that currently has a
+    # timer, in the order the names were supplied. Remaining is clamped at 0.
+    per_player: list[tuple[str, float]] = field(default_factory=list)
+    # Minimum remaining across ``per_player`` (0.0 when nobody has a timer) —
+    # the value broadcast to dashboards and pure-admin connections.
+    dashboard_remaining: float = 0.0
 
 
 class GamePhase(str, Enum):
@@ -138,6 +164,49 @@ class PhaseController:
     def get_timer(self, name: str) -> QuestionTimer | None:
         """Return the authoritative timer for a player, or None."""
         return self.timers.get(name)
+
+    def resolve_tick(self, player_names: list[str]) -> TickResolution:
+        """Resolve the authoritative remaining time for one countdown tick.
+
+        Reads each player's :class:`QuestionTimer` ONCE (an O(1) dict lookup
+        each) and returns the per-player remaining plus the dashboard minimum.
+        Players without a timer (not yet joined this round) are skipped. The
+        result carries no connection state — the caller decides which of these
+        players are connected and turns the numbers into ``timer_tick``
+        messages. Behaviour matches the previous inline ``tick_state``
+        comprehension exactly: same order, same ``max(0.0, …)`` clamp, same
+        ``min(..., default=0.0)`` dashboard value.
+        """
+        per_player = [
+            (name, max(0.0, timer.get_remaining()))
+            for name in player_names
+            if (timer := self.timers.get(name)) is not None
+        ]
+        dashboard_remaining = min(
+            (remaining for _, remaining in per_player), default=0.0
+        )
+        return TickResolution(
+            per_player=per_player,
+            dashboard_remaining=dashboard_remaining,
+        )
+
+    def all_timers_expired(self, player_names: list[str]) -> bool:
+        """Whether every supplied player has an expired timer.
+
+        The countdown loop's stop condition: the round ends once all
+        *connected* players' timers have run out. A player without a timer is
+        ignored (not treated as expired) — that guards the late-joiner /
+        admin-self-join window where a connected player exists before their
+        per-player timer does. Returns False when no supplied player has a timer
+        yet (nothing to expire), matching the previous inline check that
+        required at least one live timer before it could break.
+        """
+        timers = [
+            timer
+            for name in player_names
+            if (timer := self.timers.get(name)) is not None
+        ]
+        return bool(timers) and all(timer.is_expired() for timer in timers)
 
     def time_remaining_for_snapshot(self) -> float:
         """Remaining time for a mid-round joiner's state snapshot.

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -1131,6 +1131,23 @@ class QuizifyGameState:
         """
         return self._phase_controller.get_timer(player_name)
 
+    def resolve_tick(self, player_names: list[str]):
+        """Resolve one countdown-tick's per-player remaining + dashboard min.
+
+        Thin delegate to the PhaseController so all timing logic lives there
+        (#203). The WebSocket handler supplies the current player names and
+        turns the returned :class:`TickResolution` into ``timer_tick`` wire
+        messages; it owns the I/O, the controller owns the timing.
+        """
+        return self._phase_controller.resolve_tick(player_names)
+
+    def all_timers_expired(self, player_names: list[str]) -> bool:
+        """Whether every supplied player's timer has expired (#203).
+
+        The countdown loop's stop condition, delegated to the PhaseController.
+        """
+        return self._phase_controller.all_timers_expired(player_names)
+
     def get_player_powerup(self, player_name: str):
         """Get the power-up held by a player."""
         return self._powerup_manager.get_powerup(player_name)

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -22,6 +22,7 @@ from custom_components.quizify.const import (
     LOBBY_DISCONNECT_GRACE_PERIOD,
 )
 from custom_components.quizify.game.highlights import compute_superlatives
+from custom_components.quizify.game.phase_controller import TICK_INTERVAL
 from custom_components.quizify.game.powerups import PowerUpEffect, PowerUpType
 from custom_components.quizify.game.state import AnswerResult, GamePhase, QuizifyGameState
 from custom_components.quizify.server.broadcast_dispatcher import BroadcastDispatcher
@@ -1362,12 +1363,15 @@ class QuizifyWebSocketHandler:
     # ------------------------------------------------------------------
 
     def _start_timer_tick(self, game_state: QuizifyGameState) -> None:
-        """Start async task that sends timer_tick every second.
+        """Start async task that broadcasts the countdown every tick.
 
-        Reads authoritative remaining time from each player's QuestionTimer
-        instead of a local countdown, so time-boost and freeze power-ups are
-        reflected in the broadcast (#4 in logical review). Targeted ticks are
-        sent per player so each sees their own modified remaining time.
+        The *timing* — which players have a live timer, each one's
+        authoritative remaining time (so time-boost / freeze power-ups are
+        reflected, #4), the dashboard minimum and the all-expired stop
+        condition — lives in the PhaseController (#203). This loop owns only
+        the I/O: turning that timing into ``timer_tick`` wire messages for
+        players, pure-admins and dashboards, the sleep cadence and the
+        auto-evaluate when the round runs out.
         """
         self._cancel_timer_tick()
 
@@ -1375,22 +1379,14 @@ class QuizifyWebSocketHandler:
             try:
                 while game_state.phase == GamePhase.QUESTION_ACTIVE:
                     players = game_state.get_players()
-                    # Resolve each player's authoritative timer ONCE per tick.
-                    # get_player_timer is an O(1) dict lookup, but it used to be
-                    # called 3-4× per player per tick (once for the send, twice
-                    # more inside the dashboard-minimum comprehension). Compute
-                    # the (player, remaining) pairs once and reuse them for both
-                    # the per-player send and the dashboard minimum (#169). The
-                    # post-sleep expiry check below intentionally re-reads fresh
-                    # timers, since state can change during the 0.5s sleep.
-                    tick_state = [
-                        (p, max(0.0, t.get_remaining()))
-                        for p in players
-                        if (t := game_state.get_player_timer(p.name)) is not None
-                    ]
+                    by_name = {p.name: p for p in players}
+                    # Ask the timing unit for this tick's per-player remaining
+                    # plus the shared dashboard minimum (one timer read each).
+                    tick = game_state.resolve_tick([p.name for p in players])
                     # Send each connected player their authoritative remaining.
-                    for p, remaining in tick_state:
-                        if not p.connected:
+                    for name, remaining in tick.per_player:
+                        p = by_name.get(name)
+                        if p is None or not p.connected:
                             continue
                         await self._conn._safe_send(p.ws, {
                             "type": "timer_tick",
@@ -1398,7 +1394,7 @@ class QuizifyWebSocketHandler:
                         })
                     # Broadcast the minimum remaining to dashboards/admins so
                     # the TV view shows a consistent countdown.
-                    min_remaining = min((r for _, r in tick_state), default=0.0)
+                    min_remaining = tick.dashboard_remaining
                     # Broadcast to pure-admin + dashboards
                     for ws in list(self._conn._admin_connections):
                         if not ws.closed and not any(p.ws is ws for p in players):
@@ -1412,24 +1408,18 @@ class QuizifyWebSocketHandler:
                                 "type": "timer_tick",
                                 "remaining": round(min_remaining, 1),
                             })
-                    await asyncio.sleep(0.5)
+                    await asyncio.sleep(TICK_INTERVAL)
 
-                    # Stop if everyone's timer hit zero and phase is still active.
-                    # Only count CONNECTED players with a timer — a missing timer
-                    # used to be treated as "expired", which made the loop break
-                    # the instant a single late-joining player (e.g. admin's own
-                    # /quizify/player tab) connected before their per-player
-                    # timer existed, ending round 1 in ~1s. Now we require an
-                    # actual expired timer to count, and we ignore disconnected
-                    # players so they don't keep the timer alive forever.
-                    connected = [p for p in players if p.connected]
-                    if connected:
-                        timers_with_state = [
-                            game_state.get_player_timer(p.name) for p in connected
-                        ]
-                        timers_with_state = [t for t in timers_with_state if t is not None]
-                        if timers_with_state and all(t.is_expired() for t in timers_with_state):
-                            break
+                    # Stop if everyone's timer hit zero and phase is still
+                    # active. Re-read fresh timers (state can change during the
+                    # sleep) for the CONNECTED players only; the all-expired
+                    # decision itself lives in the PhaseController, which ignores
+                    # players without a timer so a late-joining connected player
+                    # (e.g. the admin's own /quizify/player tab) can't end the
+                    # round before their per-player timer exists.
+                    connected = [p.name for p in players if p.connected]
+                    if connected and game_state.all_timers_expired(connected):
+                        break
 
                 # Timer expired globally
                 if game_state.phase == GamePhase.QUESTION_ACTIVE:

--- a/tests/test_phase_controller_188.py
+++ b/tests/test_phase_controller_188.py
@@ -11,14 +11,17 @@ QuizifyGameState is already covered by test_game_state / test_admin_redirect_pau
 from __future__ import annotations
 
 import sys
+import time
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT))
 
 from custom_components.quizify.game.phase_controller import (  # noqa: E402
+    TICK_INTERVAL,
     GamePhase,
     PhaseController,
+    TickResolution,
 )
 
 
@@ -153,6 +156,86 @@ class TestPauseResume:
         assert "carol" in pc.timers
         # Full duration (allow for the tiny elapsed since start()).
         assert pc.timers["carol"].get_remaining() > 29.0
+
+
+class TestResolveTick:
+    """The per-tick countdown timing (relocated from the WS layer, #203)."""
+
+    def test_tick_interval_is_half_second(self) -> None:
+        # The broadcast cadence is owned here now; behaviour-preserving 0.5s.
+        assert TICK_INTERVAL == 0.5
+
+    def test_per_player_remaining_and_dashboard_min(self) -> None:
+        pc = _make(["alice", "bob"])
+        pc.begin_round(30.0)
+        pc.enter_question_active()
+        # bob has less time → he sets the dashboard minimum.
+        pc.timers["bob"]._duration = 10.0  # type: ignore[attr-defined]
+        result = pc.resolve_tick(["alice", "bob"])
+        assert isinstance(result, TickResolution)
+        names = [n for n, _ in result.per_player]
+        assert names == ["alice", "bob"]  # order preserved
+        remaining = {n: r for n, r in result.per_player}
+        assert remaining["bob"] < remaining["alice"]
+        # Dashboard value is the minimum across timed players.
+        assert result.dashboard_remaining == min(r for _, r in result.per_player)
+
+    def test_skips_players_without_a_timer(self) -> None:
+        pc = _make(["alice"])
+        pc.begin_round(30.0)
+        pc.enter_question_active()
+        # "ghost" has no timer (not joined this round) → omitted entirely.
+        result = pc.resolve_tick(["alice", "ghost"])
+        assert [n for n, _ in result.per_player] == ["alice"]
+
+    def test_remaining_clamped_at_zero(self) -> None:
+        pc = _make(["alice"])
+        pc.begin_round(30.0)
+        pc.enter_question_active()
+        # Force the timer well past expiry.
+        pc.timers["alice"]._start_time = time.monotonic() - 100.0  # type: ignore[attr-defined]
+        result = pc.resolve_tick(["alice"])
+        assert result.per_player[0][1] == 0.0
+
+    def test_empty_when_no_players(self) -> None:
+        pc = _make()
+        result = pc.resolve_tick([])
+        assert result.per_player == []
+        assert result.dashboard_remaining == 0.0
+
+
+class TestAllTimersExpired:
+    """The countdown loop's stop condition (relocated from the WS layer, #203)."""
+
+    def test_false_while_time_remains(self) -> None:
+        pc = _make(["alice", "bob"])
+        pc.begin_round(30.0)
+        pc.enter_question_active()
+        assert pc.all_timers_expired(["alice", "bob"]) is False
+
+    def test_true_when_all_expired(self) -> None:
+        pc = _make(["alice", "bob"])
+        pc.begin_round(30.0)
+        pc.enter_question_active()
+        for t in pc.timers.values():
+            t._start_time = time.monotonic() - 100.0  # type: ignore[attr-defined]
+        assert pc.all_timers_expired(["alice", "bob"]) is True
+
+    def test_false_when_one_still_running(self) -> None:
+        pc = _make(["alice", "bob"])
+        pc.begin_round(30.0)
+        pc.enter_question_active()
+        pc.timers["alice"]._start_time = time.monotonic() - 100.0  # type: ignore[attr-defined]
+        # bob still has time → round must not end.
+        assert pc.all_timers_expired(["alice", "bob"]) is False
+
+    def test_false_when_nobody_has_a_timer_yet(self) -> None:
+        # A connected player who has no timer yet (late-joiner / admin-self-join
+        # window) must NOT end the round — guards the round-1 ~1s bug.
+        pc = _make(["alice"])
+        pc.begin_round(30.0)
+        pc.enter_question_active()
+        assert pc.all_timers_expired(["ghost"]) is False
 
 
 class TestSnapshotRemaining:


### PR DESCRIPTION
Closes #203 (follow-up to #188 / PR #202).

#188 extracted the PhaseController but **deliberately left the per-question
timer-tick broadcast loop in the connection/WebSocket layer** — it worked
through the already-public accessors and moving it carried risk without clear
benefit at the time. This PR does it deliberately, so all timing logic lives
in one place.

## What moved

The tick loop had two intertwined concerns. This splits them along the
existing seam:

- **Timing → PhaseController** (its domain): which players have a live timer,
  each one's authoritative remaining time, the dashboard minimum, the
  all-expired stop condition, and the broadcast cadence.
- **I/O → stays in the WebSocket layer** (its domain): the actual
  `timer_tick` sends to players / pure-admins / dashboards via `_safe_send`,
  the websocket iteration, the `asyncio` task lifecycle and the auto-evaluate.

### New PhaseController API
- `resolve_tick(player_names) -> TickResolution`: per-player `(name, remaining)`
  (one O(1) timer read each, `max(0.0, …)` clamp, order + missing-timer skip
  preserved) plus `dashboard_remaining` (the `min(..., default=0.0)` value).
- `all_timers_expired(player_names) -> bool`: the loop's stop condition —
  ignores players without a timer (guards the late-joiner / admin-self-join
  window that caused the old round-1 ~1s bug) and is False when nobody has a
  timer yet.
- `TICK_INTERVAL = 0.5`: the broadcast cadence constant, now owned with the
  timing.

`QuizifyGameState` exposes both via thin delegates, alongside the existing
`get_player_timer`.

## Behaviour-preserving

Identical `timer_tick` messages, identical 0.5s cadence, identical start/stop
conditions. The Lightning Round runs on its own separate loop and is
untouched. No `asyncio.get_event_loop()` introduced.

## Tests

9 new unit tests in `test_phase_controller_188.py` lock in the relocated logic
(`resolve_tick`: order, dashboard min, missing-timer skip, zero clamp, empty;
`all_timers_expired`: running / all-expired / one-running / no-timer-yet;
`TICK_INTERVAL`). Full suite **310 → 319 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)