### PR TITLE
fix(admin): enforce single-admin invariant on join (#208)

### DIFF
--- a/custom_components/quizify/game/player_registry.py
+++ b/custom_components/quizify/game/player_registry.py
@@ -244,3 +244,26 @@ class PlayerRegistry:
             _LOGGER.info("Admin set: %s", name)
             return True
         return False
+
+    def get_admin(self) -> PlayerSession | None:
+        """Return the current admin player, if any.
+
+        Enforces the single-admin invariant: there is at most one admin
+        per game. Returns the first player flagged ``is_admin`` (insertion
+        order), or ``None`` if no player currently holds the crown.
+        """
+        for player in self.players.values():
+            if player.is_admin:
+                return player
+        return None
+
+    def has_other_admin(self, name: str) -> bool:
+        """Return True if a player *other than* ``name`` already is admin.
+
+        Used to reject a second admin-claim: the first claimant keeps the
+        crown, later claims by a different player are denied. A re-claim by
+        the same player (e.g. the admin's redirect from /admin to /player
+        re-joining under the same name) is idempotent and not blocked.
+        """
+        admin = self.get_admin()
+        return admin is not None and admin.name != name

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -344,6 +344,13 @@ class QuizifyGameState:
         """Return list of all player sessions."""
         return list(self._player_registry.players.values())
 
+    def has_other_admin(self, name: str) -> bool:
+        """Return True if a player other than ``name`` already is admin.
+
+        Enforces the single-admin invariant in the admin-claim path.
+        """
+        return self._player_registry.has_other_admin(name)
+
     # ------------------------------------------------------------------
     # Game flow
     # ------------------------------------------------------------------

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -434,7 +434,24 @@ class QuizifyWebSocketHandler:
             # See DESIGN.md for the full rationale.
             player_obj = game_state.get_player(name)
             if player_obj and data.get("is_admin"):
-                player_obj.is_admin = True
+                # Single-admin invariant (#208): exactly one player may hold
+                # the crown per game. Only grant admin if no *other* player is
+                # already admin. A re-claim by the same name (e.g. the admin's
+                # redirect from /quizify/admin to /quizify/player re-joining
+                # under the same name) is idempotent and still granted; a
+                # claim by a *different* player while an admin exists is
+                # rejected — the original admin keeps the crown. Rejecting
+                # rather than taking over is the safer behaviour: it stops any
+                # LAN client from seizing control mid-game by sending
+                # `is_admin: true`.
+                if game_state.has_other_admin(name):
+                    _LOGGER.warning(
+                        "Admin claim rejected for %s: a different player "
+                        "already holds the single admin slot",
+                        name,
+                    )
+                else:
+                    player_obj.is_admin = True
 
             # If a lightning round is mid-flight, register the late joiner so
             # they can score from the next question on (issue #42).

--- a/tests/test_single_admin_208.py
+++ b/tests/test_single_admin_208.py
@@ -1,0 +1,123 @@
+"""Regression test: issue #208 — two admins must never coexist in one game.
+
+The bug (reproduced live during the v1.2.8 pre-release runthrough):
+  - One player joins/becomes admin (e.g. "HostQA 👑").
+  - From another context a second player joins with `is_admin: true`
+    (e.g. "AdminQA"). The join handler unconditionally set
+    `player_obj.is_admin = True`, so the lobby ended up with *two*
+    crowned admins.
+
+Expected single-admin invariant: at most one player carries the crown.
+A second admin-claim by a *different* player while an admin already
+exists is rejected — the original admin keeps the crown. A re-claim by
+the *same* player (the admin's /admin→/player redirect re-joining under
+the same name) stays idempotent and is still granted.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _ws(closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    ws.send_json = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    runtime = _FakeRuntime(tmp_path)
+    return QuizifyGameState(runtime=runtime, entry_id="test")
+
+
+@pytest.fixture
+def handler(game: QuizifyGameState) -> QuizifyWebSocketHandler:
+    runtime = _FakeRuntime(game._runtime.data_dir)  # type: ignore[attr-defined]
+    h = QuizifyWebSocketHandler(
+        runtime=runtime,
+        game_state_provider=lambda: game,
+    )
+    h._conn = ConnectionManager(runtime, lambda: game)
+    h._conn.broadcast = AsyncMock()
+    return h
+
+
+def _admins(game: QuizifyGameState) -> list[str]:
+    return [p.name for p in game.get_players() if p.is_admin]
+
+
+class TestSingleAdminInvariant:
+    @pytest.mark.asyncio
+    async def test_second_admin_claim_does_not_create_two_admins(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        # First admin claims the crown.
+        host_ws = _ws()
+        await handler._handle_join(
+            host_ws, {"name": "HostQA", "is_admin": True}, game
+        )
+        assert _admins(game) == ["HostQA"]
+
+        # A different player tries to claim admin too.
+        admin_ws = _ws()
+        await handler._handle_join(
+            admin_ws, {"name": "AdminQA", "is_admin": True}, game
+        )
+
+        # Exactly one admin — the original keeps the crown, the claim is rejected.
+        assert _admins(game) == ["HostQA"]
+        assert game.get_player("AdminQA") is not None
+        assert game.get_player("AdminQA").is_admin is False
+
+    @pytest.mark.asyncio
+    async def test_same_player_readmin_is_idempotent(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        # Admin self-joins, then re-joins under the same name (the
+        # /admin → /player redirect path). Must stay admin, still single.
+        ws1 = _ws()
+        await handler._handle_join(ws1, {"name": "Host", "is_admin": True}, game)
+        assert _admins(game) == ["Host"]
+
+        ws2 = _ws()
+        await handler._handle_join(ws2, {"name": "Host", "is_admin": True}, game)
+        assert _admins(game) == ["Host"]
+
+    @pytest.mark.asyncio
+    async def test_non_admin_join_after_admin_stays_non_admin(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        await handler._handle_join(_ws(), {"name": "Host", "is_admin": True}, game)
+        await handler._handle_join(_ws(), {"name": "Bob"}, game)
+        assert _admins(game) == ["Host"]
+        assert game.get_player("Bob").is_admin is False
+
+    def test_registry_has_other_admin_helper(
+        self, game: QuizifyGameState
+    ) -> None:
+        game.add_player("Host", _ws())
+        game.get_player("Host").is_admin = True
+        # No other admin claim for the same name.
+        assert game.has_other_admin("Host") is False
+        # A different name would be blocked.
+        assert game.has_other_admin("Intruder") is True


### PR DESCRIPTION
## Problem

Two players could coexist as admin in the same game — the lobby showed `HostQA 👑` **and** `AdminQA 👑`, both crowned (found during the v1.2.8 pre-release runthrough).

Root cause: `_handle_join` unconditionally set `player_obj.is_admin = True` whenever the join message carried `is_admin: true`. The inline comment claimed "only one admin slot exists per game", but nothing actually enforced it — so a second client claiming admin became a second crowned admin.

## Fix

Enforce the single-admin invariant in the admin-claim path: grant admin only when **no other player** already holds it.

- A **re-claim by the same player** (the admin's `/quizify/admin` → `/quizify/player` redirect re-joining under the same name) stays idempotent and is still granted.
- A **claim by a different player** while an admin already exists is **rejected** and logged — the original admin keeps the crown.

### Chosen behaviour: reject (not take-over)

Rejecting is the safer of the two options the issue offered: take-over would let any client on the LAN seize control mid-game simply by sending `is_admin: true`. With reject, the first claimant owns the single admin slot for the life of the game; later claims by others are denied.

### Implementation

- `PlayerRegistry.get_admin()` / `has_other_admin(name)` — the single-admin invariant now lives in the registry.
- `QuizifyGameState.has_other_admin(name)` passthrough.
- `_handle_join` consults it before granting the crown.

## Tests

New `tests/test_single_admin_208.py` regression test asserts a second admin-claim does **not** yield two admins, plus same-name idempotency and the registry helper. Full suite: **323 passed**.

Pure Python backend change — no `www/`/JS touched, no bundle rebuild needed.

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)