### PR TITLE
feat(setup): "Categories-forward" welcome screen redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to Quizify are documented here. This project follows
 
 ## [Unreleased]
 
+### Changed
+
+- **Welcome screen redesign ("Categories-forward").** The host setup screen now
+  leads with the category picker as a two-column grid of color-tinted tiles, each
+  with an **SVG line icon** (replacing the emoji), the category name, and its
+  question count. Tiles tint by theme across the four Soft Parlor accents and show
+  a coral border + check when selected. The featured pack (World Cup / WM) gets a
+  refreshed "Soft Spotlight" card: an SVG trophy in a sun-tinted badge, an
+  "Empfohlen · Neu" eyebrow, and a round coral selection control. Selection wiring,
+  language filtering, and the start payload are unchanged — the grid is still built
+  from `#category-chips` as the single source of truth.
+
 ## [1.3.0] — 2026-06-09
 
 Feature release on top of the 1.2.7 hardening: a new Lightning Round bonus

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -225,6 +225,12 @@ Warm, soft, welcoming. Easings are longer than Broadcast Living Room, transforms
 - **Primary CTA:** solid coral button, DM Sans 700 in white, soft coral shadow. Sentence-case, not ALL CAPS.
 - **Secondary CTA:** white bg, cream hairline border, warm-ink text.
 
+### Welcome / Setup (host) — "Categories-forward" (approved 2026-06-09)
+
+- **Featured pack ("Soft Spotlight"):** white card with a coral hairline border. SVG line trophy in a sun-tinted rounded badge, mono "Empfohlen · Neu" eyebrow in coral, Cabinet Grotesk 700 title, muted desc, and a round coral selection indicator on the right (outline → filled coral check when the pack is selected). The whole card toggles the pack; Start is separate.
+- **Category picker:** two-column grid of selectable tiles. Each tile: an **SVG line icon** (never emoji) in a theme-tinted rounded disc, Cabinet Grotesk 700 name, mono question count. Icon disc tint + icon stroke cycle the four accents by theme (coral / sage / sky / sun; "Gemischt" stays neutral clay). Default = white + cream hairline; hover = lifts; selected = coral border + coral-wash + corner check.
+- **Icons are keyed by `data-theme`** so both languages share one glyph set (globe, leaf, clapperboard, music note, flag, flask, scroll, fork, bulb, dice, trophy). Tints are flat (no gradients).
+
 ## Accessibility
 
 - All text meets WCAG AA contrast on its paired background:
@@ -253,5 +259,6 @@ Warm, soft, welcoming. Easings are longer than Broadcast Living Room, transforms
 | 2026-04-24 | Cream `#FAF6EC` as primary background | Explicit break from Broadcast Living Room's dark navy. Soft Parlor is light-primary. Warm paper reads as "home", not "studio". |
 | 2026-04-24 | Cabinet Grotesk + DM Sans + JetBrains Mono | Typography stack pivots away from Unbounded (too broadcast). Cabinet Grotesk has the warm-geometric feel Soft Parlor requires. |
 | 2026-04-24 | No confetti on finale (carried forward, 3rd time confirmed) | Restraint has been the consistent preference across three directions. |
+| 2026-06-09 | Welcome/setup hero → "Categories-forward" (SVG-icon tinted category tiles + F1 featured spotlight) | Design-shotgun explored category-pill directions, then full welcome-screen directions; user picked A (categories-forward) with SVG icons (no emoji) and the F1 "Soft Spotlight" featured card. Category icons are now SVG line glyphs keyed by theme, in per-theme accent-tinted discs. |
 | 2026-06-09 | Player-phone podium → "Podium Reborn" (gradient rising blocks) | Design-shotgun explored 4 phone-finale directions; user picked B over the shipped cream-shelf ("Family Trophy Shelf"). Player phone now uses rising blocks with muted single-hue tonal gradient fills + a halo rising from the champion, for a more celebratory finale payoff. Admin/TV keeps the cream shelf. Tonal gradients are a scoped, user-approved exception to the no-gradient rule. |
 | 2026-04-28 | Admin-as-player trust model (Beatify pattern) | Server trusts `is_admin: true` in the join message at face value. No more cryptographic token threading through player joins. The persisted admin token is still validated for the pure admin-dashboard WebSocket connect (`?role=admin&token=...`), but player joins are simpler. **Trade-off:** a malicious LAN client can spoof admin by sending `is_admin: true`. Mitigations: (a) the user's home LAN is generally trusted; (b) Nabu Casa already requires HA auth to reach the integration; (c) "first admin claims it" still applies — only one admin slot per game. Adopting the same pattern as Beatify (which has shipped this without issues for years) closed 8 betas worth of admin-as-player lockout bugs. v1.1.2. |

--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -74,7 +74,6 @@
 
             <!-- HERO (variant A) -->
             <div id="setup-hero" class="setup-hero">
-                <div class="setup-hero-emoji" aria-hidden="true">🧠</div>
                 <h1 class="setup-hero-headline">
                     <span data-i18n="setup.heroLine1">Ready for a</span><br>
                     <span class="accent" data-i18n="setup.heroLine2">round of Quizify?</span>
@@ -87,12 +86,14 @@
                      target; the coral pill is a visual affordance. Pack +
                      copy follow the active language (World Cup / WM). -->
                 <button type="button" id="hero-feature-card" class="hero-feature" data-feature="worldcup" aria-pressed="false">
-                    <span class="hero-feature-icon" aria-hidden="true">🏆</span>
+                    <span class="hero-feature-badge" aria-hidden="true">
+                        <svg viewBox="0 0 24 24"><path d="M7 4h10v4a5 5 0 0 1-10 0V4z"/><path d="M7 6H4v1a3.5 3.5 0 0 0 3.5 3.5M17 6h3v1a3.5 3.5 0 0 1-3.5 3.5"/><path d="M12 13v4M9 20h6M10 20a2 2 0 0 1 2-2 2 2 0 0 1 2 2"/></svg>
+                    </span>
                     <span class="hero-feature-body">
-                        <span class="hero-feature-top">
-                            <span class="hero-feature-tag" data-i18n="featured.tag">New</span>
-                            <span class="hero-feature-title" data-i18n="featured.worldCupTitle">World Cup</span>
+                        <span class="hero-feature-eyebrow">
+                            <span data-i18n="featured.recommended">Recommended</span> · <span data-i18n="featured.tag">New</span>
                         </span>
+                        <span class="hero-feature-title" data-i18n="featured.worldCupTitle">World Cup</span>
                         <span class="hero-feature-desc" data-i18n="featured.worldCupDesc">100 surprising football facts</span>
                     </span>
                     <span class="hero-feature-check" aria-hidden="true">✓</span>
@@ -103,7 +104,7 @@
                      pack; the host then taps Start Game. Category selection
                      thus lives here, not buried in "Adjust settings". -->
                 <div class="hero-packs" id="hero-packs">
-                    <div class="hero-packs-label" data-i18n="featured.orChoose">or choose another</div>
+                    <div class="hero-packs-label" data-i18n="featured.chooseCategory">Choose a category</div>
                     <div class="hero-pack-chips" id="hero-pack-chips" role="group" aria-label="Quiz pack"></div>
                 </div>
                 <button type="button" id="start-game-btn" class="btn btn-primary btn-lg btn-block">

--- a/custom_components/quizify/www/css/src/07-player.css
+++ b/custom_components/quizify/www/css/src/07-player.css
@@ -994,11 +994,6 @@
     text-align: center;
 }
 
-.setup-hero-emoji {
-    font-size: 3.4rem;
-    line-height: 1;
-}
-
 .setup-hero-headline {
     font-family: var(--font-display);
     font-weight: 800;
@@ -1054,68 +1049,63 @@
 /* Featured pack spotlight on the hero — one-tap launch of a highlighted
    pack. Soft Parlor card: lifted paper, hairline border, soft shadow, sun
    "New" pill, coral play affordance. The whole card is the button. */
+/* F1 "Soft Spotlight": SVG trophy in a sun-tinted badge, mono eyebrow,
+   coral-bordered card, round coral selection check. */
 .hero-feature {
     display: flex;
     align-items: center;
-    gap: var(--space-md);
+    gap: 13px;
     width: 100%;
     max-width: 360px;
     text-align: left;
     background: var(--color-bg-card);
-    border: 1px solid var(--color-border-light);
+    border: 1.5px solid var(--color-accent-primary);
     border-radius: var(--radius-xl);
-    padding: 14px 15px;
-    box-shadow: var(--shadow-lg);
+    padding: 14px;
+    box-shadow: 0 6px 16px rgba(232, 138, 127, 0.14);
     cursor: pointer;
     transition: transform 0.12s ease, box-shadow 0.12s ease;
 }
-.hero-feature:hover { transform: translateY(-2px); box-shadow: var(--shadow-xl); }
+.hero-feature:hover { transform: translateY(-2px); box-shadow: 0 10px 22px rgba(232, 138, 127, 0.2); }
 .hero-feature:active { transform: translateY(0); }
 /* Selected state — the card toggles a pack like the chips, not an instant launch. */
 .hero-feature.active {
-    border-color: var(--color-accent-primary);
-    box-shadow: 0 0 0 1.5px rgba(232, 138, 127, 0.35), var(--shadow-lg);
+    box-shadow: 0 0 0 1.5px rgba(232, 138, 127, 0.45), 0 6px 16px rgba(232, 138, 127, 0.18);
 }
-.hero-feature-icon { font-size: 2rem; line-height: 1; flex: none; }
-.hero-feature-body { display: flex; flex-direction: column; min-width: 0; }
-/* Round check on the right; filled coral only when the pack is selected. */
-.hero-feature-check {
+.hero-feature-badge {
     flex: none;
-    margin-left: auto;
-    width: 22px;
-    height: 22px;
-    border-radius: 50%;
-    border: 2px solid var(--color-border-light);
+    width: 46px;
+    height: 46px;
+    border-radius: 13px;
+    background: rgba(232, 196, 127, 0.24);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 0.75rem;
-    font-weight: 700;
-    color: transparent;
-    transition: background 0.12s ease, border-color 0.12s ease;
 }
-.hero-feature.active .hero-feature-check {
-    border-color: var(--color-accent-primary);
-    background: var(--color-accent-primary);
-    color: #fff;
+.hero-feature-badge svg {
+    width: 26px;
+    height: 26px;
+    fill: none;
+    stroke: #C9A24E;
+    stroke-width: 1.9;
+    stroke-linecap: round;
+    stroke-linejoin: round;
 }
-.hero-feature-top { display: flex; align-items: center; gap: 8px; }
-.hero-feature-tag {
+.hero-feature-body { display: flex; flex-direction: column; min-width: 0; }
+.hero-feature-eyebrow {
     font-family: var(--font-mono);
     font-size: 0.6rem;
     font-weight: 700;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.1em;
     text-transform: uppercase;
-    background: var(--color-warning);
-    color: #5C4A16;
-    padding: 3px 8px;
-    border-radius: var(--radius-full);
+    color: var(--color-accent-primary);
 }
 .hero-feature-title {
     font-family: var(--font-display);
     font-weight: 700;
     font-size: 1.1rem;
     color: var(--color-text-heading);
+    margin-top: 1px;
 }
 .hero-feature-desc {
     font-family: var(--font-body);
@@ -1124,19 +1114,25 @@
     margin-top: 2px;
     line-height: 1.35;
 }
-.hero-feature-play {
-    display: inline-flex;
+/* Round coral selection indicator on the right; fills on active. */
+.hero-feature-check {
+    flex: none;
+    margin-left: auto;
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    border: 1.5px solid var(--color-accent-primary);
+    display: flex;
     align-items: center;
-    gap: 6px;
-    align-self: flex-start;
-    margin-top: 10px;
+    justify-content: center;
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--color-accent-primary);
+    transition: background 0.12s ease, color 0.12s ease;
+}
+.hero-feature.active .hero-feature-check {
     background: var(--color-accent-primary);
     color: #fff;
-    font-family: var(--font-body);
-    font-weight: 700;
-    font-size: 0.82rem;
-    padding: 8px 12px;
-    border-radius: var(--radius-md);
 }
 
 /* Pack picker on the hero (variant C): the featured card above, then the
@@ -1152,38 +1148,87 @@
 .hero-packs-label {
     font-family: var(--font-mono);
     font-size: 0.66rem;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--color-text-light);
     text-align: left;
 }
+/* Categories-forward grid (Direction A): two columns of color-tinted tiles. */
 .hero-pack-chips {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 9px;
+}
+.hero-cat-tile {
+    position: relative;
     display: flex;
-    flex-wrap: wrap;
-    gap: 7px;
-}
-.hero-pack-chip {
-    display: inline-flex;
-    align-items: center;
+    flex-direction: column;
+    align-items: flex-start;
     gap: 6px;
+    text-align: left;
     background: var(--color-bg-card);
-    border: 1px solid var(--color-border-light);
-    border-radius: var(--radius-full);
-    padding: 7px 11px;
-    font-family: var(--font-body);
-    font-size: 0.8rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    box-shadow: var(--shadow-sm);
+    border: 1.5px solid var(--color-border-light);
+    border-radius: 13px;
+    padding: 11px;
     cursor: pointer;
-    transition: border-color 0.12s ease, box-shadow 0.12s ease;
+    transition: transform 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
 }
-.hero-pack-chip .hpc-icon { font-size: 0.95rem; line-height: 1; }
-.hero-pack-chip:hover { border-color: var(--color-border-medium); }
-.hero-pack-chip.active {
+.hero-cat-tile:hover {
+    border-color: var(--color-border-medium);
+    transform: translateY(-1px);
+    box-shadow: 0 5px 13px rgba(42, 40, 32, 0.08);
+}
+.hero-cat-tile.active {
     border-color: var(--color-accent-primary);
-    box-shadow: 0 0 0 1.5px rgba(232, 138, 127, 0.35), var(--shadow-sm);
+    background: rgba(232, 138, 127, 0.10);
+    box-shadow: 0 4px 13px rgba(232, 138, 127, 0.16);
 }
+.hero-cat-tile.active::after {
+    content: "\2713";
+    position: absolute;
+    top: 8px;
+    right: 10px;
+    color: var(--color-accent-primary);
+    font-weight: 700;
+    font-size: 0.85rem;
+}
+.hct-icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.hct-icon svg {
+    width: 18px;
+    height: 18px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.9;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+.hct-icon svg .d { fill: currentColor; stroke: none; }
+.hct-name {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 0.82rem;
+    line-height: 1.12;
+    color: var(--color-text-heading);
+}
+.hct-count {
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    color: var(--color-text-muted);
+    letter-spacing: 0.02em;
+}
+/* Per-theme tint: icon disc background + icon stroke color. */
+.hpt-mix   .hct-icon { background: #F1ECDC;                   color: #C99B6E; }
+.hpt-coral .hct-icon { background: rgba(232, 138, 127, 0.16); color: var(--color-accent-primary); }
+.hpt-sage  .hct-icon { background: rgba(127, 168, 151, 0.18); color: var(--color-accent-secondary); }
+.hpt-sky   .hct-icon { background: rgba(127, 168, 196, 0.18); color: var(--color-accent-blue); }
+.hpt-sun   .hct-icon { background: rgba(232, 196, 127, 0.24); color: #C9A24E; }
 
 /* Topics step relocated to the hero — keep it out of the Adjust-settings view. */
 #vF-step-topics[hidden] { display: none; }

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -3910,11 +3910,6 @@ footer {
     text-align: center;
 }
 
-.setup-hero-emoji {
-    font-size: 3.4rem;
-    line-height: 1;
-}
-
 .setup-hero-headline {
     font-family: var(--font-display);
     font-weight: 800;
@@ -3970,68 +3965,63 @@ footer {
 /* Featured pack spotlight on the hero — one-tap launch of a highlighted
    pack. Soft Parlor card: lifted paper, hairline border, soft shadow, sun
    "New" pill, coral play affordance. The whole card is the button. */
+/* F1 "Soft Spotlight": SVG trophy in a sun-tinted badge, mono eyebrow,
+   coral-bordered card, round coral selection check. */
 .hero-feature {
     display: flex;
     align-items: center;
-    gap: var(--space-md);
+    gap: 13px;
     width: 100%;
     max-width: 360px;
     text-align: left;
     background: var(--color-bg-card);
-    border: 1px solid var(--color-border-light);
+    border: 1.5px solid var(--color-accent-primary);
     border-radius: var(--radius-xl);
-    padding: 14px 15px;
-    box-shadow: var(--shadow-lg);
+    padding: 14px;
+    box-shadow: 0 6px 16px rgba(232, 138, 127, 0.14);
     cursor: pointer;
     transition: transform 0.12s ease, box-shadow 0.12s ease;
 }
-.hero-feature:hover { transform: translateY(-2px); box-shadow: var(--shadow-xl); }
+.hero-feature:hover { transform: translateY(-2px); box-shadow: 0 10px 22px rgba(232, 138, 127, 0.2); }
 .hero-feature:active { transform: translateY(0); }
 /* Selected state — the card toggles a pack like the chips, not an instant launch. */
 .hero-feature.active {
-    border-color: var(--color-accent-primary);
-    box-shadow: 0 0 0 1.5px rgba(232, 138, 127, 0.35), var(--shadow-lg);
+    box-shadow: 0 0 0 1.5px rgba(232, 138, 127, 0.45), 0 6px 16px rgba(232, 138, 127, 0.18);
 }
-.hero-feature-icon { font-size: 2rem; line-height: 1; flex: none; }
-.hero-feature-body { display: flex; flex-direction: column; min-width: 0; }
-/* Round check on the right; filled coral only when the pack is selected. */
-.hero-feature-check {
+.hero-feature-badge {
     flex: none;
-    margin-left: auto;
-    width: 22px;
-    height: 22px;
-    border-radius: 50%;
-    border: 2px solid var(--color-border-light);
+    width: 46px;
+    height: 46px;
+    border-radius: 13px;
+    background: rgba(232, 196, 127, 0.24);
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 0.75rem;
-    font-weight: 700;
-    color: transparent;
-    transition: background 0.12s ease, border-color 0.12s ease;
 }
-.hero-feature.active .hero-feature-check {
-    border-color: var(--color-accent-primary);
-    background: var(--color-accent-primary);
-    color: #fff;
+.hero-feature-badge svg {
+    width: 26px;
+    height: 26px;
+    fill: none;
+    stroke: #C9A24E;
+    stroke-width: 1.9;
+    stroke-linecap: round;
+    stroke-linejoin: round;
 }
-.hero-feature-top { display: flex; align-items: center; gap: 8px; }
-.hero-feature-tag {
+.hero-feature-body { display: flex; flex-direction: column; min-width: 0; }
+.hero-feature-eyebrow {
     font-family: var(--font-mono);
     font-size: 0.6rem;
     font-weight: 700;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.1em;
     text-transform: uppercase;
-    background: var(--color-warning);
-    color: #5C4A16;
-    padding: 3px 8px;
-    border-radius: var(--radius-full);
+    color: var(--color-accent-primary);
 }
 .hero-feature-title {
     font-family: var(--font-display);
     font-weight: 700;
     font-size: 1.1rem;
     color: var(--color-text-heading);
+    margin-top: 1px;
 }
 .hero-feature-desc {
     font-family: var(--font-body);
@@ -4040,19 +4030,25 @@ footer {
     margin-top: 2px;
     line-height: 1.35;
 }
-.hero-feature-play {
-    display: inline-flex;
+/* Round coral selection indicator on the right; fills on active. */
+.hero-feature-check {
+    flex: none;
+    margin-left: auto;
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    border: 1.5px solid var(--color-accent-primary);
+    display: flex;
     align-items: center;
-    gap: 6px;
-    align-self: flex-start;
-    margin-top: 10px;
+    justify-content: center;
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--color-accent-primary);
+    transition: background 0.12s ease, color 0.12s ease;
+}
+.hero-feature.active .hero-feature-check {
     background: var(--color-accent-primary);
     color: #fff;
-    font-family: var(--font-body);
-    font-weight: 700;
-    font-size: 0.82rem;
-    padding: 8px 12px;
-    border-radius: var(--radius-md);
 }
 
 /* Pack picker on the hero (variant C): the featured card above, then the
@@ -4068,38 +4064,87 @@ footer {
 .hero-packs-label {
     font-family: var(--font-mono);
     font-size: 0.66rem;
-    letter-spacing: 0.05em;
+    letter-spacing: 0.08em;
     text-transform: uppercase;
     color: var(--color-text-light);
     text-align: left;
 }
+/* Categories-forward grid (Direction A): two columns of color-tinted tiles. */
 .hero-pack-chips {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 9px;
+}
+.hero-cat-tile {
+    position: relative;
     display: flex;
-    flex-wrap: wrap;
-    gap: 7px;
-}
-.hero-pack-chip {
-    display: inline-flex;
-    align-items: center;
+    flex-direction: column;
+    align-items: flex-start;
     gap: 6px;
+    text-align: left;
     background: var(--color-bg-card);
-    border: 1px solid var(--color-border-light);
-    border-radius: var(--radius-full);
-    padding: 7px 11px;
-    font-family: var(--font-body);
-    font-size: 0.8rem;
-    font-weight: 600;
-    color: var(--color-text-primary);
-    box-shadow: var(--shadow-sm);
+    border: 1.5px solid var(--color-border-light);
+    border-radius: 13px;
+    padding: 11px;
     cursor: pointer;
-    transition: border-color 0.12s ease, box-shadow 0.12s ease;
+    transition: transform 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
 }
-.hero-pack-chip .hpc-icon { font-size: 0.95rem; line-height: 1; }
-.hero-pack-chip:hover { border-color: var(--color-border-medium); }
-.hero-pack-chip.active {
+.hero-cat-tile:hover {
+    border-color: var(--color-border-medium);
+    transform: translateY(-1px);
+    box-shadow: 0 5px 13px rgba(42, 40, 32, 0.08);
+}
+.hero-cat-tile.active {
     border-color: var(--color-accent-primary);
-    box-shadow: 0 0 0 1.5px rgba(232, 138, 127, 0.35), var(--shadow-sm);
+    background: rgba(232, 138, 127, 0.10);
+    box-shadow: 0 4px 13px rgba(232, 138, 127, 0.16);
 }
+.hero-cat-tile.active::after {
+    content: "\2713";
+    position: absolute;
+    top: 8px;
+    right: 10px;
+    color: var(--color-accent-primary);
+    font-weight: 700;
+    font-size: 0.85rem;
+}
+.hct-icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.hct-icon svg {
+    width: 18px;
+    height: 18px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.9;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+.hct-icon svg .d { fill: currentColor; stroke: none; }
+.hct-name {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 0.82rem;
+    line-height: 1.12;
+    color: var(--color-text-heading);
+}
+.hct-count {
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    color: var(--color-text-muted);
+    letter-spacing: 0.02em;
+}
+/* Per-theme tint: icon disc background + icon stroke color. */
+.hpt-mix   .hct-icon { background: #F1ECDC;                   color: #C99B6E; }
+.hpt-coral .hct-icon { background: rgba(232, 138, 127, 0.16); color: var(--color-accent-primary); }
+.hpt-sage  .hct-icon { background: rgba(127, 168, 151, 0.18); color: var(--color-accent-secondary); }
+.hpt-sky   .hct-icon { background: rgba(127, 168, 196, 0.18); color: var(--color-accent-blue); }
+.hpt-sun   .hct-icon { background: rgba(232, 196, 127, 0.24); color: #C9A24E; }
 
 /* Topics step relocated to the hero — keep it out of the Adjust-settings view. */
 #vF-step-topics[hidden] { display: none; }

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -364,7 +364,9 @@
     "worldCupTitle": "Weltmeisterschaft",
     "worldCupDesc": "Kuriose Fakten zur Fußball-WM",
     "worldCupPlay": "WM-Quiz starten",
-    "orChoose": "oder wähle ein anderes Pack"
+    "orChoose": "oder wähle ein anderes Pack",
+    "recommended": "Empfohlen",
+    "chooseCategory": "Kategorie wählen"
   },
   "wager": {
     "title": "Letzte Runde — Wagerunde",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -364,7 +364,9 @@
     "worldCupTitle": "World Cup",
     "worldCupDesc": "100 surprising football facts",
     "worldCupPlay": "Play World Cup",
-    "orChoose": "or choose another pack"
+    "orChoose": "or choose another pack",
+    "recommended": "Recommended",
+    "chooseCategory": "Choose a category"
   },
   "wager": {
     "title": "Final Round — Wager",

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -229,6 +229,38 @@
     // (World Cup / Weltmeisterschaft) is excluded — it has the spotlight card.
     var _FEATURED_PACK_VALUES = ['world-cup', 'weltmeisterschaft'];
 
+    // SVG line icons keyed by the category's data-theme. Soft Parlor: stroke
+    // icons (no emoji) drawn in the tile's accent color via currentColor.
+    // Keyed by theme so both languages (Geographie / Geography) share an icon.
+    var _CATEGORY_ICON_SVG = {
+        mixed: '<rect x="4" y="4" width="16" height="16" rx="4"/><circle class="d" cx="9" cy="9" r="1.1"/><circle class="d" cx="15" cy="9" r="1.1"/><circle class="d" cx="12" cy="12" r="1.1"/><circle class="d" cx="9" cy="15" r="1.1"/><circle class="d" cx="15" cy="15" r="1.1"/>',
+        geography: '<circle cx="12" cy="12" r="9"/><path d="M3 12h18"/><path d="M12 3c3.2 2.6 3.2 15.4 0 18M12 3c-3.2 2.6-3.2 15.4 0 18"/>',
+        nature: '<path d="M5 19c0-9 7-14 15-14 0 9-7 14-15 14z"/><path d="M5 19c4.5-4.5 8-7 11-8"/>',
+        popculture: '<rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 9.5h18"/><path d="M7.5 5v4.5M12 5v4.5M16.5 5v4.5"/>',
+        sport: '<path d="M6 21V4"/><path d="M6 4h11l-2.5 3.5L17 11H6"/>',
+        music: '<path d="M9 17V5l10-2v12"/><circle cx="6.5" cy="17" r="2.5"/><circle cx="16.5" cy="15" r="2.5"/>',
+        science: '<path d="M9 3h6M10 3v6l-5 9a2 2 0 0 0 2 3h10a2 2 0 0 0 2-3l-5-9V3"/><path d="M8 15h8"/>',
+        history: '<path d="M7 4h9a2 2 0 0 1 2 2v12a2 2 0 0 0 2 2H8a2 2 0 0 1-2-2V6"/><path d="M6 6a2 2 0 0 0-2 2v1h2"/><path d="M10 9h5M10 13h5"/>',
+        food: '<path d="M7 3v18M5 3v6a2 2 0 0 0 4 0V3"/><path d="M16 3c-1.6 0-2.5 2.2-2.5 5s1 4 2.5 4 2.5-1.2 2.5-4-.9-5-2.5-5zM16 12v9"/>',
+        tech: '<path d="M9.5 18h5M11 21h2"/><path d="M12 3a6 6 0 0 0-3.8 10.6c.8.7 1.3 1.5 1.3 2.4h5c0-.9.5-1.7 1.3-2.4A6 6 0 0 0 12 3z"/>',
+        worldcup: '<path d="M7 4h10v4a5 5 0 0 1-10 0V4z"/><path d="M7 6H4v1a3.5 3.5 0 0 0 3.5 3.5M17 6h3v1a3.5 3.5 0 0 1-3.5 3.5"/><path d="M12 13v4M9 20h6M10 20a2 2 0 0 1 2-2 2 2 0 0 1 2 2"/>'
+    };
+    // Accent tint per theme, cycling the 4 Soft Parlor accents; mixed stays neutral.
+    var _CATEGORY_TINT = {
+        mixed: 'mix', geography: 'coral', nature: 'sage', popculture: 'sky',
+        sport: 'sun', music: 'coral', science: 'sage', history: 'sky',
+        food: 'sun', tech: 'coral'
+    };
+
+    function _categoryIconSvg(theme) {
+        var inner = _CATEGORY_ICON_SVG[theme] || _CATEGORY_ICON_SVG.mixed;
+        return '<svg viewBox="0 0 24 24" aria-hidden="true">' + inner + '</svg>';
+    }
+
+    // Hero category grid: color-tinted SVG tiles (Direction A "Categories-
+    // forward"). Built from #category-chips so it stays the single source of
+    // truth for selection + the start payload. The featured pack (World Cup /
+    // Weltmeisterschaft) is excluded — it has the spotlight card above.
     function buildHeroPackChips() {
         if (!els.heroPackChips || !els.categoryChips) return;
         els.heroPackChips.innerHTML = '';
@@ -241,16 +273,21 @@
 
             var nameEl = cat.querySelector('.pack-card-name');
             var name = nameEl ? nameEl.textContent : value;
-            var icon = cat.dataset.icon || '';
+            var countEl = cat.querySelector('.pack-card-count');
+            var count = countEl ? countEl.textContent : '';
+            var theme = cat.dataset.theme || 'mixed';
 
-            var chip = document.createElement('button');
-            chip.type = 'button';
-            chip.className = 'hero-pack-chip' + (cat.classList.contains('active') ? ' active' : '');
-            chip.dataset.value = value;
-            chip.innerHTML = '<span class="hpc-icon" aria-hidden="true">' + icon + '</span>' +
-                '<span class="hpc-name"></span>';
-            chip.querySelector('.hpc-name').textContent = name;
-            chip.addEventListener('click', function () {
+            var tile = document.createElement('button');
+            tile.type = 'button';
+            tile.className = 'hero-cat-tile hpt-' + (_CATEGORY_TINT[theme] || 'mix') +
+                (cat.classList.contains('active') ? ' active' : '');
+            tile.dataset.value = value;
+            tile.innerHTML = '<span class="hct-icon">' + _categoryIconSvg(theme) + '</span>' +
+                '<span class="hct-name"></span>' +
+                '<span class="hct-count"></span>';
+            tile.querySelector('.hct-name').textContent = name;
+            tile.querySelector('.hct-count').textContent = count;
+            tile.addEventListener('click', function () {
                 // Proxy to the real category chip so all existing selection
                 // logic (mixed/single/multi + summary) runs unchanged.
                 var target = els.categoryChips.querySelector('.chip[data-value="' + value + '"]');
@@ -258,16 +295,16 @@
                 syncHeroPackChips();
                 syncHeroFeatureCardState();
             });
-            els.heroPackChips.appendChild(chip);
+            els.heroPackChips.appendChild(tile);
         });
         syncHeroFeatureCardState();
     }
 
     function syncHeroPackChips() {
         if (!els.heroPackChips || !els.categoryChips) return;
-        els.heroPackChips.querySelectorAll('.hero-pack-chip').forEach(function (chip) {
-            var cat = els.categoryChips.querySelector('.chip[data-value="' + chip.dataset.value + '"]');
-            chip.classList.toggle('active', !!(cat && cat.classList.contains('active')));
+        els.heroPackChips.querySelectorAll('.hero-cat-tile').forEach(function (tile) {
+            var cat = els.categoryChips.querySelector('.chip[data-value="' + tile.dataset.value + '"]');
+            tile.classList.toggle('active', !!(cat && cat.classList.contains('active')));
         });
     }
 


### PR DESCRIPTION
## What

Redesigns the host **welcome / setup hero** screen — Direction A ("Categories-forward") from a `/design-shotgun` exploration, with two rounds of feedback (SVG icons instead of emoji; reworked featured pack).

## Changes

- **Category picker → color-tinted SVG tile grid.** The hero picker is now a two-column grid of selectable tiles, each with an **SVG line icon** (no emoji), category name (Cabinet Grotesk), and question count (mono). Each tile tints by `data-theme` across the four Soft Parlor accents (coral / sage / sky / sun; "Gemischt" neutral). Default = white + hairline; hover lifts; selected = coral border + coral-wash + corner check.
- **Featured pack → "Soft Spotlight" (F1).** SVG trophy in a sun-tinted badge, mono "Empfohlen · Neu" eyebrow, Cabinet Grotesk title, and a round coral selection control (fills on select).
- **SVG icon set** keyed by `data-theme` so both languages (Geographie / Geography) share glyphs: globe, leaf, clapperboard, music note, flag, flask, scroll, fork, bulb, dice, trophy.
- Removed the standalone 🧠 hero emoji; picker label is now "Kategorie wählen" / "Choose a category".

## Scope / safety

- **Selection logic unchanged.** `buildHeroPackChips()` still builds from `#category-chips` (single source of truth) and proxies clicks to it, so mixed/single/multi selection, language filtering, the featured-card sync, and the start payload all work as before.
- `admin.js` is served directly (not bundled), so the JS ships without a bundle step. `player.bundle.js` untouched.
- The hidden "Adjust settings" detail view (its pack cards) is out of scope and unchanged.
- `DESIGN.md` updated (new "Welcome / Setup (host)" subsection + Decisions Log) so this reads as intent, not drift. Tints are flat — no gradients.

## Verification

- `python3 -m pytest -q` → **326 passed**.
- Rendered the real built `styles.css` against the exact markup `buildHeroPackChips()` emits (tinted tiles + F1 card): icons, per-theme tints, selected state, and the featured spotlight all land as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)