### PR TITLE
fix(reset): authorize the legitimate host's reset + recover orphaned admin crown (Closes #207)

### DIFF
--- a/custom_components/quizify/game/player_registry.py
+++ b/custom_components/quizify/game/player_registry.py
@@ -258,12 +258,24 @@ class PlayerRegistry:
         return None
 
     def has_other_admin(self, name: str) -> bool:
-        """Return True if a player *other than* ``name`` already is admin.
+        """Return True if a *connected* player other than ``name`` is admin.
 
         Used to reject a second admin-claim: the first claimant keeps the
         crown, later claims by a different player are denied. A re-claim by
         the same player (e.g. the admin's redirect from /admin to /player
         re-joining under the same name) is idempotent and not blocked.
+
+        Crown-recovery (#207 regression of #209): a *disconnected/stale*
+        admin slot must NOT block the legitimate host's re-claim. When the
+        host's /admin -> /player redirect (or any reload) takes the
+        fresh-join path, the still-open old admin slot momentarily holds
+        the crown under a disambiguated name ("Host 2"); the strict
+        name-only check then denied the host admin, and once the stale
+        slot was pruned NOBODY held the crown — so every admin-only action
+        (reset/pause/skip/resume, which share one auth guard) was silently
+        rejected and the client swallowed the error. We therefore only let
+        a *connected* admin block the claim. A live admin still keeps the
+        crown (the #208 anti-takeover guarantee is preserved).
         """
         admin = self.get_admin()
-        return admin is not None and admin.name != name
+        return admin is not None and admin.name != name and admin.connected

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -351,6 +351,10 @@ class QuizifyGameState:
         """
         return self._player_registry.has_other_admin(name)
 
+    def get_admin(self) -> PlayerSession | None:
+        """Return the current admin player (single-admin invariant), if any."""
+        return self._player_registry.get_admin()
+
     # ------------------------------------------------------------------
     # Game flow
     # ------------------------------------------------------------------

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -305,7 +305,14 @@ class QuizifyWebSocketHandler:
             await self._handle_resume_game(ws, game_state)
 
         elif msg_type == "reset_game":
-            if not self._is_authorized_admin(ws, is_admin, game_state):
+            # Reset is the recovery escape-hatch (#207). Besides the normal
+            # admin check, allow it whenever NO connected admin currently
+            # holds the crown: in that orphaned-crown state (the legitimate
+            # host lost its admin slot to the #209 name-disambiguation race)
+            # the host has no other way back to a clean lobby. Reset is safe
+            # and idempotent — it can only return the game to its initial
+            # state, never escalate privilege — so this cannot be abused.
+            if not self._is_reset_authorized(ws, is_admin, game_state):
                 await self._conn.send_error(ws, ERR_INVALID_ACTION, "Admin only")
                 return
             await self._handle_reset_game(ws, game_state)
@@ -451,6 +458,21 @@ class QuizifyWebSocketHandler:
                         name,
                     )
                 else:
+                    # Crown-recovery (#207 regression of #209): if a *stale*
+                    # (disconnected) admin slot still lingers under a different
+                    # name — the host's old /admin slot during the
+                    # /admin -> /player redirect — demote it before crowning the
+                    # re-joining host. has_other_admin() no longer blocks on a
+                    # disconnected admin, so without this demotion two players
+                    # would briefly carry is_admin and break the #208 invariant.
+                    stale_admin = game_state.get_admin()
+                    if stale_admin is not None and stale_admin.name != name:
+                        stale_admin.is_admin = False
+                        _LOGGER.info(
+                            "Crown transferred from stale admin %s to %s",
+                            stale_admin.name,
+                            name,
+                        )
                     player_obj.is_admin = True
 
             # If a lightning round is mid-flight, register the late joiner so
@@ -1636,6 +1658,24 @@ class QuizifyWebSocketHandler:
         """Return True if the connection is authorized to perform admin actions."""
         player = game_state.get_player_by_ws(ws)
         return is_admin or bool(player and player.is_admin)
+
+    def _is_reset_authorized(
+        self, ws: web.WebSocketResponse, is_admin: bool, game_state: QuizifyGameState
+    ) -> bool:
+        """Authorize a reset_game request.
+
+        Stricter-than-nothing escape hatch (#207): a normal authorized admin
+        may always reset; additionally, ANY connected client may reset when
+        no *connected* admin currently holds the crown. The latter recovers
+        the legitimate host from the orphaned-crown state left by the #209
+        single-admin name race, where otherwise every admin-only action is
+        silently rejected. Reset only ever returns the game to its initial
+        state, so granting it in the admin-less case cannot escalate control.
+        """
+        if self._is_authorized_admin(ws, is_admin, game_state):
+            return True
+        admin = game_state.get_admin()
+        return admin is None or not admin.connected
 
     def _notify_tts_milestone(self, player_name: str, streak: int) -> None:
         """Forward a milestone hit to the TTS announcer if one is wired.

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -195,6 +195,22 @@
                 handleGameState(msg);
                 break;
 
+            case 'game_reset':
+                // Admin wiped the whole session (issue #207). Drop our
+                // identity + session token so the now-stale token can't
+                // resurrect us, and return to the join screen explicitly.
+                // The server also closes our socket right after this, but
+                // handling the broadcast directly makes the return to the
+                // join screen deterministic instead of relying on the
+                // close + reconnect_failed race.
+                pu.clearSession();
+                state.sessionToken = null;
+                state.playerName = null;
+                state.playerId = null;
+                state.isAdmin = false;
+                pu.showView('join-view');
+                break;
+
             case 'joined':
             case 'reconnected':
                 state.playerName = msg.player_id || state.playerName;

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -3640,6 +3640,22 @@
                 handleGameState(msg);
                 break;
 
+            case 'game_reset':
+                // Admin wiped the whole session (issue #207). Drop our
+                // identity + session token so the now-stale token can't
+                // resurrect us, and return to the join screen explicitly.
+                // The server also closes our socket right after this, but
+                // handling the broadcast directly makes the return to the
+                // join screen deterministic instead of relying on the
+                // close + reconnect_failed race.
+                pu.clearSession();
+                state.sessionToken = null;
+                state.playerName = null;
+                state.playerId = null;
+                state.isAdmin = false;
+                pu.showView('join-view');
+                break;
+
             case 'joined':
             case 'reconnected':
                 state.playerName = msg.player_id || state.playerName;

--- a/tests/test_reset_game_207.py
+++ b/tests/test_reset_game_207.py
@@ -176,3 +176,175 @@ async def test_reset_during_active_game_delivers_to_all_players(
         assert delivered.get(id(ws)) == ["game_reset", "game_state"]
     assert game.phase == GamePhase.LOBBY
     assert game.get_players() == []
+
+
+# ---------------------------------------------------------------------------
+# Auth-path regression (#207 reopened): the original tests above call
+# ``_handle_reset_game`` DIRECTLY, so they never exercised the admin-only
+# auth guard in ``_handle_message`` — which is exactly where the reopened
+# bug lived. Pressing reset routed through ``reset_game`` → the guard
+# rejected the legitimate host → the client silently swallowed the
+# "Admin only" error → nothing happened server-side ("no reset processing
+# at all"). Root cause: the #209 single-admin invariant compared admin
+# slots by NAME only, so when the host's /admin → /player redirect
+# re-joined under a disambiguated name ("Host 2") while the stale "Host"
+# admin slot lingered, the host's crown claim was rejected; once the stale
+# slot was pruned NOBODY held the crown and every admin-only action failed.
+# These tests drive the real dispatch + auth path.
+# ---------------------------------------------------------------------------
+
+
+def _auth_handler(game: QuizifyGameState, tmp_path: Path) -> QuizifyWebSocketHandler:
+    """Handler whose broadcast is a no-op recorder — we only assert on
+    server-side STATE changes here, driving the real ``_handle_message``
+    dispatch + auth guard (not the broadcast-ordering of the tests above)."""
+    runtime = _FakeRuntime(tmp_path)
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    h._conn = ConnectionManager(runtime, lambda: game)
+    h._get_game_state = lambda: game  # type: ignore[assignment]
+
+    sent: dict[int, list[dict]] = {}
+
+    async def _noop_broadcast(message: dict) -> None:
+        return None
+
+    async def _safe_send(ws, message: dict) -> None:
+        sent.setdefault(id(ws), []).append(message)
+
+    h._conn.broadcast = _noop_broadcast  # type: ignore[assignment]
+    h._conn._safe_send = _safe_send  # type: ignore[assignment]
+    h._sent = sent  # type: ignore[attr-defined]
+    return h
+
+
+@pytest.mark.asyncio
+async def test_legit_admin_reset_authorized_and_clears(
+    game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """A legitimate admin's reset_game (routed through _handle_message) is
+    authorized, wipes all players incl. the admin, and returns to LOBBY."""
+    h = _auth_handler(game, tmp_path)
+    admin_ws = _ws()
+    h._conn.add_connection(admin_ws, is_admin=True, is_dashboard=False)
+    game.add_player("Host", admin_ws)
+    game.get_player("Host").is_admin = True
+    game.add_player("Bob", _ws())
+    game.start_game(language="de", num_rounds=3, difficulty="easy")
+    game.start_next_question()
+    assert game.phase == GamePhase.QUESTION_ACTIVE
+
+    # WS-level admin tab.
+    await h._handle_message(admin_ws, {"type": "reset_game"}, is_admin=True)
+
+    assert game.phase == GamePhase.LOBBY
+    assert game.get_players() == []
+    # No "Admin only" rejection was sent to the host.
+    sent = h._sent  # type: ignore[attr-defined]
+    errs = [m for m in sent.get(id(admin_ws), []) if m.get("type") == "error"]
+    assert errs == []
+
+
+@pytest.mark.asyncio
+async def test_orphaned_crown_host_reset_authorized(
+    game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """The reopened #207 scenario: the legitimate host is on a player WS
+    (post /admin → /player redirect) with is_admin False, and NO connected
+    admin holds the crown. Reset MUST still be authorized (escape hatch) so
+    the host can recover — previously it was silently rejected."""
+    h = _auth_handler(game, tmp_path)
+    host_ws = _ws()  # player-role WS, NOT a WS-level admin
+    h._conn.add_connection(host_ws, is_admin=False, is_dashboard=False)
+    game.add_player("Host 2", host_ws)  # disambiguated, non-admin slot
+    game.add_player("Bob", _ws())
+    assert game.get_admin() is None  # crown is orphaned
+
+    await h._handle_message(host_ws, {"type": "reset_game"}, is_admin=False)
+
+    sent = h._sent  # type: ignore[attr-defined]
+    errs = [m for m in sent.get(id(host_ws), []) if m.get("type") == "error"]
+    assert errs == [], "orphaned-crown host was wrongly rejected (#207)"
+    assert game.phase == GamePhase.LOBBY
+    assert game.get_players() == []
+
+
+@pytest.mark.asyncio
+async def test_non_admin_reset_rejected_while_live_admin_present(
+    game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """A non-admin player cannot reset while a CONNECTED admin holds the
+    crown — the escape hatch only opens when the crown is orphaned."""
+    h = _auth_handler(game, tmp_path)
+    admin_ws = _ws()
+    h._conn.add_connection(admin_ws, is_admin=True, is_dashboard=False)
+    game.add_player("Host", admin_ws)
+    game.get_player("Host").is_admin = True
+
+    rogue_ws = _ws()
+    h._conn.add_connection(rogue_ws, is_admin=False, is_dashboard=False)
+    game.add_player("Rogue", rogue_ws)
+
+    await h._handle_message(rogue_ws, {"type": "reset_game"}, is_admin=False)
+
+    sent = h._sent  # type: ignore[attr-defined]
+    errs = [m for m in sent.get(id(rogue_ws), []) if m.get("type") == "error"]
+    assert errs and errs[0]["message"] == "Admin only"
+    # Game untouched: both players still present, crown still on the host.
+    assert len(game.get_players()) == 2
+    assert game.get_admin() is not None and game.get_admin().name == "Host"
+
+
+@pytest.mark.asyncio
+async def test_host_reclaims_crown_from_stale_slot_on_rejoin(
+    game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """#209 crown-recovery: when the host re-joins under a disambiguated
+    name while the stale (disconnected) old admin slot lingers, the host
+    must (re)acquire the single admin crown — and the stale slot must be
+    demoted so exactly one admin exists (single-admin invariant #208)."""
+    h = _auth_handler(game, tmp_path)
+
+    # Old admin slot (the /quizify/admin tab joined-as-player), now stale:
+    old_ws = _ws()
+    game.add_player("Host", old_ws)
+    game.get_player("Host").is_admin = True
+    game.get_player("Host").connected = False  # admin WS closing on redirect
+
+    # Host re-joins on a fresh player WS; the lingering "Host" slot forces
+    # the disambiguated "Host 2" name, carrying is_admin: true.
+    new_ws = _ws()
+    h._conn.add_connection(new_ws, is_admin=False, is_dashboard=False)
+    await h._handle_message(
+        new_ws, {"type": "join", "name": "Host 2", "is_admin": True}, is_admin=False
+    )
+
+    new_player = game.get_player("Host 2")
+    assert new_player is not None
+    assert new_player.is_admin, "host failed to reclaim crown (#207/#209)"
+    # Single-admin invariant: stale slot demoted, exactly one admin.
+    admins = [p for p in game.get_players() if p.is_admin]
+    assert len(admins) == 1
+    assert admins[0].name == "Host 2"
+
+
+@pytest.mark.asyncio
+async def test_live_admin_blocks_second_admin_claim(
+    game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """Single-admin invariant (#208) still holds: a DIFFERENT player cannot
+    seize the crown while a CONNECTED admin already holds it."""
+    h = _auth_handler(game, tmp_path)
+    admin_ws = _ws()
+    game.add_player("Host", admin_ws)
+    game.get_player("Host").is_admin = True  # connected admin
+
+    rogue_ws = _ws()
+    h._conn.add_connection(rogue_ws, is_admin=False, is_dashboard=False)
+    await h._handle_message(
+        rogue_ws, {"type": "join", "name": "Rogue", "is_admin": True}, is_admin=False
+    )
+
+    assert game.get_player("Rogue") is not None
+    assert not game.get_player("Rogue").is_admin, "second admin was wrongly granted"
+    admins = [p for p in game.get_players() if p.is_admin]
+    assert len(admins) == 1 and admins[0].name == "Host"


### PR DESCRIPTION
## Problem (reopened #207)

Pressing reset (⟲) → confirm did nothing: players were not cleared, the admin stayed on the lobby, and the HA log showed **no reset processing at all**. The same silent failure affected every admin-only action (pause/resume/skip), because they all share one auth guard.

## Root cause — a regression of the #209 single-admin invariant

`has_other_admin()` compared admin slots by **name only**. When the host's `/quizify/admin → /quizify/player` redirect re-joins under a **disambiguated** name (`Host 2`) while the still-open old `Host` admin slot lingers, the host's admin re-claim was rejected and the crown stayed on the stale slot. Once that stale slot was pruned, **nobody** held the crown, so `_is_authorized_admin` failed for the legitimate host. The client **swallows** the resulting `INVALID_ACTION / "Admin only"` error, so the user saw nothing happen.

## Fix

- **`has_other_admin()`** now only lets a **connected** admin block a re-claim — a stale/disconnected admin slot no longer steals the crown from the returning host. A live admin still keeps it, so the #208 anti-takeover guarantee is preserved.
- **On grant**, any lingering stale admin under a different name is demoted, so exactly one admin exists (single-admin invariant intact).
- **`reset_game` escape hatch**: when no *connected* admin holds the crown, any connected client may reset. Reset only ever returns the game to its initial state, so this can't escalate privilege — it recovers the host from the orphaned-crown state.
- **Client**: players now handle the `game_reset` broadcast explicitly (clear session + return to the join screen) instead of relying on the socket-close + `reconnect_failed` race. The admin already lands on the initial setup screen.

## Reset now reliably

clears all players **and** the host, returns the admin to the initial **setup** screen, and returns players to the **join** screen.

## Tests

The old tests called `_handle_reset_game` **directly**, never hitting the auth guard where the bug lived. New tests drive the real `_handle_message` dispatch + auth path:

- legitimate admin's reset is authorized → clears players + admin → phase back to LOBBY
- orphaned-crown host's reset is authorized (escape hatch)
- a non-admin is still rejected while a **live** admin is present
- the host **reclaims** the crown from a stale slot on re-join (single-admin invariant holds: exactly one admin)
- a second **live**-admin claim is still blocked (#208)

`python3 -m pytest tests/ -q` → **331 passed**. Player JS bundle rebuilt.

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)