### PR TITLE
fix(pwa): safe service-worker auto-reload on idle screens

### DIFF
--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -1410,6 +1410,16 @@
             return el.innerHTML;
         }
 
+        // #215: hook for sw-update.js — is the TV/dashboard idle enough that a
+        // service-worker-triggered reload won't interrupt anything? The
+        // always-on host screen is idle only on the waiting (lobby) and finale
+        // (end) views; the question view covers live questions, the per-round
+        // reveal, and lightning, so we treat it as not-idle and never reload
+        // mid-round.
+        window.quizifyIsIdleForReload = function () {
+            return (views.question == null) || !views.question.classList.contains('active');
+        };
+
         // ---- Init ----
         if (window.QuizifyI18n && typeof window.QuizifyI18n.init === 'function') {
             window.QuizifyI18n.init(window.QuizifyI18n.getPreferredLanguage()).then(function () {

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -51,6 +51,23 @@
     let currentPhase = 'LOBBY';
     let playerCount = 0;
 
+    // #215: hook for sw-update.js — is the admin screen idle enough that a
+    // service-worker-triggered reload won't interrupt anything? Idle = setup /
+    // lobby, the per-round reveal, the lightning recap, and the finale end
+    // screen. NOT idle during a live question or a live lightning round, where
+    // a reload would yank the host out mid-play.
+    window.quizifyIsIdleForReload = function () {
+        switch (currentPhase) {
+            case 'QUESTION_ACTIVE':
+            case 'LIGHTNING':
+                return false;
+            default:
+                // LOBBY, ANSWER_REVEAL, LIGHTNING_RECAP, FINALE, and any
+                // setup state before a game starts.
+                return true;
+        }
+    };
+
     // ---- Simple inline timer ----
     var adminTimerEl = null;
     var adminTimerInterval = null;

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -1116,4 +1116,23 @@
         send: send
     };
 
+    // #215: hook for sw-update.js — is the player screen idle enough that a
+    // service-worker-triggered reload won't interrupt anything? Idle = join,
+    // lobby, the per-round reveal, the lightning recap, and the finale end
+    // screen. NOT idle during a live question, a live lightning round, or a
+    // paused game (resuming reloads straight back into a question).
+    window.quizifyIsIdleForReload = function () {
+        switch (state.currentPhase) {
+            case 'QUESTION_ACTIVE':
+            case 'PLAYING':
+            case 'LIGHTNING':
+            case 'PAUSED':
+                return false;
+            default:
+                // LOBBY, ANSWER_REVEAL/REVEAL, LIGHTNING_RECAP, FINALE/END,
+                // and the pre-join state.
+                return true;
+        }
+    };
+
 })();

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -4561,4 +4561,23 @@
         send: send
     };
 
+    // #215: hook for sw-update.js — is the player screen idle enough that a
+    // service-worker-triggered reload won't interrupt anything? Idle = join,
+    // lobby, the per-round reveal, the lightning recap, and the finale end
+    // screen. NOT idle during a live question, a live lightning round, or a
+    // paused game (resuming reloads straight back into a question).
+    window.quizifyIsIdleForReload = function () {
+        switch (state.currentPhase) {
+            case 'QUESTION_ACTIVE':
+            case 'PLAYING':
+            case 'LIGHTNING':
+            case 'PAUSED':
+                return false;
+            default:
+                // LOBBY, ANSWER_REVEAL/REVEAL, LIGHTNING_RECAP, FINALE/END,
+                // and the pre-join state.
+                return true;
+        }
+    };
+
 })();

--- a/custom_components/quizify/www/js/sw-update.js
+++ b/custom_components/quizify/www/js/sw-update.js
@@ -1,15 +1,24 @@
 /**
- * Quizify Service Worker registration
+ * Quizify Service Worker registration + safe auto-reload
  *
- * Registers the SW for PWA install + offline asset caching, and quietly
- * refreshes it on tab-focus. That's it — no "New version available" banner
- * and no forced reload.
+ * Registers the SW for PWA install + offline asset caching, refreshes it on
+ * tab-focus, and — new in #215 — reloads the page once when a new SW takes
+ * control, but ONLY while the screen is idle.
  *
- * Why no banner: the asset cache-buster is now a content fingerprint
- * (?v=<version>-<hash>), so the next natural page load already pulls fresh
- * CSS/JS/i18n. There's nothing to nag about, and dropping the auto-reload
- * means an always-on host screen can't reload itself mid-game. A new SW
- * activates silently in the background; its assets land on the next load.
+ * Why the auto-reload: the asset cache-buster is a content fingerprint
+ * (?v=<version>-<hash>), so the next *natural* page load pulls fresh CSS/JS.
+ * But on an always-open PWA / tablet that natural load never happens, so the
+ * host keeps running stale admin.js/CSS forever even after a deploy. #215
+ * fixes that by reloading when the SW controller changes — without ever
+ * reloading mid-game.
+ *
+ * Idle gate: the shared script asks the host app via window.quizifyIsIdleForReload()
+ * (a function returning boolean). Each app (admin / player / dashboard) wires
+ * this to its own screen/phase notion and returns true only on idle screens
+ * (setup / lobby / join / end / recap), false during an active question, game
+ * round, or lightning round. If the hook is absent we fall back to "no reload"
+ * — a missed refresh is harmless (next natural load fixes it), a mid-game
+ * reload is not.
  *
  * Self-contained so admin.html / player.html / dashboard.html can all drop a
  * single <script> tag.
@@ -19,11 +28,45 @@
 
     if (!('serviceWorker' in navigator)) return;
 
+    // Module-level guard: a controllerchange-triggered reload must happen at
+    // most once per page life, so we never loop (the reload installs a fresh
+    // controller, which could otherwise fire controllerchange again).
+    var reloadTriggered = false;
+
+    // Decide whether it's safe to reload right now.
+    //   - Prefer the explicit host hook window.quizifyIsIdleForReload().
+    //   - If the hook is missing, default to SAFE = do not reload. A stale
+    //     frontend self-heals on the next natural load; a mid-game reload
+    //     (wrong "idle" guess) would visibly break the session.
+    function isIdleForReload() {
+        try {
+            if (typeof window.quizifyIsIdleForReload === 'function') {
+                return !!window.quizifyIsIdleForReload();
+            }
+        } catch (e) {
+            // A throwing hook counts as "not idle" — stay conservative.
+            return false;
+        }
+        return false;
+    }
+
+    function maybeReload() {
+        if (reloadTriggered) return;
+        if (!isIdleForReload()) return;
+        reloadTriggered = true;
+        // Full reload so the fresh SW serves the new fingerprinted assets.
+        window.location.reload();
+    }
+
+    // A new SW took control of this page → its (changed) assets are now what
+    // the network-first SW will serve. Reload once, but only while idle.
+    navigator.serviceWorker.addEventListener('controllerchange', maybeReload);
+
     navigator.serviceWorker.register('/quizify/static/sw.js')
         .then(function (reg) {
             // Check for a newer SW when the host comes back to the tab. The new
-            // SW installs and activates on its own; fresh assets are served on
-            // the next page load. No banner, no forced reload.
+            // SW installs and activates on its own (skipWaiting + clients.claim),
+            // which fires controllerchange → maybeReload above.
             document.addEventListener('visibilitychange', function () {
                 if (document.visibilityState === 'visible') {
                     reg.update().catch(function () { /* ignore */ });


### PR DESCRIPTION
Closes #215

## Problem
On a long-lived PWA / always-open tablet the old service worker never released while the app stayed open, so the user kept running the **old admin.js/CSS** even after a deploy updated the `?v=<version>-<fingerprint>` cache-buster server-side. `sw-update.js` deliberately did **no auto-reload**, so fresh fingerprinted assets only landed on the next *manual* load — which never happens on a never-closed PWA. This made the host run pre-#214 JS, so reset/pause/skip looked broken (stale client, not a server bug).

Server-side cache-busting is already correct (network-first SW, `skipWaiting` + `clients.claim` + old-cache purge). The gap was purely client-side.

## Fix
Add a `navigator.serviceWorker` **`controllerchange`** listener in `sw-update.js`: when a new SW takes control (assets changed), **reload the page once** — guarded by a module-level flag so it never loops.

The reload is gated on an idle check via a `window.quizifyIsIdleForReload()` hook. If the hook is absent or throws, we default to **NOT reloading** (a stale frontend self-heals on the next natural load; a wrong-guess mid-game reload does not). The existing `visibilitychange → reg.update()` is kept.

Each app wires the hook to its own screen/phase:
- **admin.js** — idle except `QUESTION_ACTIVE` / `LIGHTNING`.
- **player-core.js** — idle except `QUESTION_ACTIVE` / `PLAYING` / `LIGHTNING` / `PAUSED`.
- **dashboard.html (TV)** — idle only on the `waiting` (lobby) and `finale` (end) views; the `question` view covers live question + reveal + lightning, so the always-on host never reloads mid-round.

Idle screens (reload allowed): setup / join / lobby / per-round reveal / lightning recap / finale end. Not allowed: active question, active round, active lightning, paused game.

## Build / tests
- `player-core.js` changed → rebuilt `player.bundle.js` via `scripts/build_bundle.py`.
- `python3 -m pytest tests/ -q` → **331 passed**.
- All touched JS passes `node --check`.

Behaviour-only change, no visual/design change.

## Verification needed
Needs a real PWA/device verify: deploy a new version with the PWA already open, confirm the SW update triggers an idle auto-reload (no manual close needed) and that **no** reload fires mid-game (active question / lightning / paused) on admin, player, and the always-on TV/dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)