### PR TITLE
fix(lightning): include lightning sub-state in game_state snapshot (Closes #221)

### DIFF
--- a/custom_components/quizify/server/round_message_builder.py
+++ b/custom_components/quizify/server/round_message_builder.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from custom_components.quizify.game.phase_controller import GamePhase
 from custom_components.quizify.server.serializers import (
     serialize_leaderboard,
     serialize_player_list,
@@ -96,7 +97,7 @@ class RoundMessageBuilder:
         player list to avoid a redundant ``get_players`` call.
         """
         leaderboard = serialize_leaderboard(players)
-        return {
+        payload: dict[str, Any] = {
             "type": "game_state",
             "phase": game_state.phase.value,
             "round": game_state.round,
@@ -105,6 +106,56 @@ class RoundMessageBuilder:
             "players": leaderboard,
             "leaderboard": leaderboard,
         }
+        # During a lightning round (#42) a leaderboard-refresh ``game_state``
+        # must carry the lightning sub-state, or the client's LIGHTNING case
+        # (player-core.js ~437) falls through to an empty ``lightning-view`` —
+        # i.e. a blank player screen (#221). Mirror the canonical shape built
+        # by ``QuizifyGameState.get_state_snapshot()`` so reconnect snapshots
+        # and live refreshes are wire-identical.
+        lightning = self._build_lightning_substate(game_state)
+        if lightning is not None:
+            payload["lightning"] = lightning
+        return payload
+
+    def _build_lightning_substate(
+        self, game_state: QuizifyGameState
+    ) -> dict[str, Any] | None:
+        """Build the ``lightning`` sub-object for a LIGHTNING ``game_state``.
+
+        Returns ``None`` outside a lightning round. The shape is byte-for-byte
+        identical to the lightning branch of
+        ``QuizifyGameState.get_state_snapshot()`` so the player client reads
+        the same keys regardless of which builder produced the message:
+
+        * ``splash_pending`` — True while the intro splash (#201) is up and no
+          question has been broadcast yet (``question`` is then omitted).
+        * ``index`` / ``num_questions`` / ``seconds_per_question`` — progress.
+        * ``time_remaining`` — seconds left on the current question.
+        * ``question`` — canonical (admin/TV) answer order; players still get
+          their own shuffle via the ``lightning_question`` event.
+        """
+        if game_state.phase != GamePhase.LIGHTNING:
+            return None
+        lr = game_state.lightning
+        if lr is None:
+            return None
+        substate: dict[str, Any] = {
+            "index": lr.index,
+            "num_questions": lr.num_questions,
+            "time_remaining": round(lr.time_remaining(), 1),
+            "seconds_per_question": lr.seconds_per_question,
+            "leaderboard": lr.leaderboard(),
+            "splash_pending": game_state.lightning_splash_pending,
+        }
+        q = lr.current_question
+        if q is not None:
+            substate["question"] = {
+                "text": q.question,
+                "answers": [a.text for a in q.answers],
+                "category": q.category,
+                "image_url": q.image_url,
+            }
+        return substate
 
     def build_round_summary(
         self,

--- a/tests/test_lightning_snapshot_221.py
+++ b/tests/test_lightning_snapshot_221.py
@@ -1,0 +1,142 @@
+"""Regression tests for issue #221 — blank player screen during lightning.
+
+Root cause: the live ``game_state`` leaderboard-refresh builder
+``RoundMessageBuilder.build_game_state_with_leaderboard()`` emitted only the
+base keys (``type/phase/round/total_rounds/player_count/players/leaderboard``)
+with **no** ``lightning`` sub-object. When such a message arrived while the
+phase was LIGHTNING, the player client's LIGHTNING case (player-core.js ~437)
+found no ``msg.lightning`` and fell through to an empty ``lightning-view`` —
+a blank screen. The fix makes the builder carry the same ``lightning``
+sub-state that ``QuizifyGameState.get_state_snapshot()`` already produced, so
+reconnect snapshots and live refreshes are wire-identical.
+
+These tests assert the builder's ``game_state`` payload includes a non-empty
+``lightning`` payload during LIGHTNING, covering both the splash-pending and
+the live-question states.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+from custom_components.quizify.server.round_message_builder import (  # noqa: E402
+    RoundMessageBuilder,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _fake_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+@pytest.fixture
+def state(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+@pytest.fixture
+def builder() -> RoundMessageBuilder:
+    return RoundMessageBuilder()
+
+
+def test_game_state_includes_lightning_when_splash_pending(
+    state: QuizifyGameState, builder: RoundMessageBuilder
+) -> None:
+    """Splash-pending: payload carries lightning meta, splash_pending=True."""
+    state.add_player("A", _fake_ws())
+    assert state.start_lightning_round() is True
+    assert state.phase == GamePhase.LIGHTNING
+    assert state.lightning_splash_pending is True
+
+    payload = builder.build_game_state_with_leaderboard(
+        state, players=state.get_players()
+    )
+
+    assert payload["type"] == "game_state"
+    assert payload["phase"] == "LIGHTNING"
+    # The fix: a non-empty lightning sub-object must be present.
+    assert "lightning" in payload
+    ln = payload["lightning"]
+    assert ln["splash_pending"] is True
+    assert ln["num_questions"] >= 1
+    assert isinstance(ln["seconds_per_question"], (int, float))
+    assert isinstance(ln["time_remaining"], (int, float))
+    assert ln["index"] == 0
+
+
+def test_game_state_includes_lightning_with_live_question(
+    state: QuizifyGameState, builder: RoundMessageBuilder
+) -> None:
+    """Live round: splash_pending=False and a fully-shaped question is sent."""
+    state.add_player("A", _fake_ws())
+    assert state.start_lightning_round() is True
+    # Admin dismisses the intro splash → questions are live.
+    assert state.begin_lightning_questions() is True
+    assert state.lightning_splash_pending is False
+
+    payload = builder.build_game_state_with_leaderboard(
+        state, players=state.get_players()
+    )
+
+    assert "lightning" in payload
+    ln = payload["lightning"]
+    assert ln["splash_pending"] is False
+    assert "question" in ln
+    q = ln["question"]
+    assert isinstance(q["text"], str) and q["text"]
+    assert isinstance(q["answers"], list) and q["answers"]
+    assert "category" in q
+    assert "image_url" in q  # may be None, key must exist
+
+
+def test_lightning_substate_matches_snapshot_shape(
+    state: QuizifyGameState, builder: RoundMessageBuilder
+) -> None:
+    """The builder's lightning sub-object is wire-identical to the snapshot's.
+
+    Guards the contract that drove #221: both message producers must hand the
+    client the same key set, so the LIGHTNING client path behaves the same on
+    a reconnect snapshot and on a live leaderboard refresh.
+    """
+    state.add_player("A", _fake_ws())
+    assert state.start_lightning_round() is True
+    assert state.begin_lightning_questions() is True
+
+    snap = state.get_state_snapshot()
+    payload = builder.build_game_state_with_leaderboard(
+        state, players=state.get_players()
+    )
+
+    assert set(payload["lightning"].keys()) == set(snap["lightning"].keys())
+    assert set(payload["lightning"]["question"].keys()) == set(
+        snap["lightning"]["question"].keys()
+    )
+
+
+def test_non_lightning_game_state_has_no_lightning_key(
+    state: QuizifyGameState, builder: RoundMessageBuilder
+) -> None:
+    """Outside LIGHTNING the builder must not inject a lightning sub-object."""
+    state.add_player("A", _fake_ws())
+    payload = builder.build_game_state_with_leaderboard(
+        state, players=state.get_players()
+    )
+    assert payload["phase"] != "LIGHTNING"
+    assert "lightning" not in payload


### PR DESCRIPTION
## Root cause
Issue #221 — the player screen went blank after a WS reconnect at the start of a Lightning Round.

`RoundMessageBuilder.build_game_state_with_leaderboard()` (the live leaderboard-refresh `game_state` broadcast) returned only the base keys (`type/phase/round/total_rounds/player_count/players/leaderboard`) with **no** `lightning` sub-object. The player client's `LIGHTNING` case in `player-core.js` (~line 437) reads `msg.lightning`: if absent, it falls through to `showView('lightning-view')` with no content — a blank screen.

So any `game_state` sent while `phase == LIGHTNING` (a live leaderboard refresh broadcast to a player who had just reconnected into the lightning view) produced an empty lightning view.

Note: the dedicated reconnect snapshot path (`QuizifyGameState.get_state_snapshot()`) already builds a correct `lightning` sub-object — only this leaderboard-refresh builder was missing it.

## Fix (server-only)
`build_game_state_with_leaderboard()` now attaches a `lightning` sub-object when `phase == LIGHTNING`, byte-for-byte identical to the lightning branch of `get_state_snapshot()`:

```
lightning: {
  splash_pending: bool,          # true while the intro splash (#201) is up
  index: int,
  num_questions: int,
  seconds_per_question: number,
  time_remaining: number,
  leaderboard: [...],
  question: {                    # omitted while splash_pending and no question
    text, answers, category, image_url
  }
}
```

The client already handles this payload, so no JS change / bundle rebuild was needed.

## Test
Adds `tests/test_lightning_snapshot_221.py`:
- `game_state` during splash-pending carries a `lightning` sub-object (`splash_pending=True`, no/empty question).
- `game_state` during a live question carries a fully-shaped `question`.
- shape-parity check: the builder's `lightning` key set matches `get_state_snapshot()`'s.
- guard: non-LIGHTNING `game_state` has no `lightning` key.

Full suite green: 335 passed (331 baseline + 4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)