### PR TITLE
fix(perf): write question history off the event loop (Closes #222)

### DIFF
--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -70,6 +70,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     game_state = QuizifyGameState(runtime=runtime, entry_id=entry.entry_id)
     game_state._stats_service = analytics
     game_state._question_stats = question_stats
+    # Read persisted question history off the event loop (issue #222).
+    await game_state.async_load_history()
 
     ws_handler = QuizifyWebSocketHandler(
         runtime=runtime,

--- a/custom_components/quizify/game/questions.py
+++ b/custom_components/quizify/game/questions.py
@@ -488,31 +488,80 @@ class QuestionBank:
     # Question history
     # ------------------------------------------------------------------
 
-    def load_history(self, history_path: Path) -> None:
-        """Load question history from a JSON file."""
+    def set_history_path(self, history_path: Path) -> None:
+        """Bind the history file path without touching disk (non-blocking)."""
         self._history_path = history_path
+
+    def _read_history(self) -> None:
+        """Blocking read of the history file. MUST run off the event loop."""
+        history_path = self._history_path
+        if history_path is None:
+            return
         if history_path.exists():
             try:
                 raw = json.loads(history_path.read_text(encoding="utf-8"))
                 self._history = {k: float(v) for k, v in raw.items()}
                 _LOGGER.debug("Loaded question history: %d entries", len(self._history))
-            except (json.JSONDecodeError, ValueError) as exc:
+            except (json.JSONDecodeError, ValueError, OSError) as exc:
                 _LOGGER.warning("Failed to load question history: %s", exc)
                 self._history = {}
         else:
             self._history = {}
 
-    def save_history(self) -> None:
-        """Persist question history to disk."""
+    def load_history(self, history_path: Path) -> None:
+        """Load question history from a JSON file (synchronous).
+
+        Retained for the standalone dev server and tests. On the HA event
+        loop use :meth:`load_history_async` so the ``read_text`` is offloaded
+        (issue #222 read-path).
+        """
+        self.set_history_path(history_path)
+        self._read_history()
+
+    async def load_history_async(self, history_path: Path, runtime) -> None:
+        """Bind the path and load history via the runtime's executor thread."""
+        self.set_history_path(history_path)
+        await runtime.run_in_executor(self._read_history)
+
+    def _write_history(self) -> None:
+        """Blocking write of the history file. MUST run off the event loop.
+
+        Snapshot a copy of ``self._history`` *before* dispatching this to an
+        executor thread so the serialized payload can't tear if the loop
+        thread mutates the dict (via ``record_shown``) while the write runs.
+        """
         if self._history_path is None:
             return
+        snapshot = dict(self._history)
         try:
             self._history_path.parent.mkdir(parents=True, exist_ok=True)
             self._history_path.write_text(
-                json.dumps(self._history, indent=2), encoding="utf-8"
+                json.dumps(snapshot, indent=2), encoding="utf-8"
             )
         except OSError as exc:
             _LOGGER.warning("Failed to save question history: %s", exc)
+
+    def save_history(self) -> None:
+        """Persist question history to disk (synchronous).
+
+        Retained for the standalone dev server and tests. In Home Assistant
+        this blocks the event loop — callers on the loop thread MUST use
+        :meth:`save_history_async` / :meth:`flush_shown_history_async`
+        instead (issue #222).
+        """
+        self._write_history()
+
+    async def save_history_async(self, runtime) -> None:
+        """Persist question history via the runtime's executor thread.
+
+        Mirrors the offload pattern used by ``QuestionStats`` and the
+        asset-fingerprint walk (#213): the blocking ``write_text`` never
+        runs on the event loop. ``runtime`` is a
+        :class:`~custom_components.quizify.runtime.Runtime`.
+        """
+        if self._history_path is None:
+            return
+        await runtime.run_in_executor(self._write_history)
 
     def record_shown(self, question_id: str) -> None:
         """Mark a question as shown now."""
@@ -521,9 +570,23 @@ class QuestionBank:
         self._shown_this_game.append(question_id)
 
     def flush_shown_history(self) -> None:
-        """Save history at end of game and reset the shown-this-game list."""
+        """Save history at end of game and reset the shown-this-game list.
+
+        Synchronous variant — only safe off the event loop (standalone
+        server / tests). On the HA event loop use
+        :meth:`flush_shown_history_async`.
+        """
         self._shown_this_game = []
         self.save_history()
+
+    async def flush_shown_history_async(self, runtime) -> None:
+        """Async flush: reset shown-this-game and persist via the executor.
+
+        The shown-this-game list is cleared synchronously (cheap, in-memory)
+        and only the file write is offloaded to a thread (issue #222).
+        """
+        self._shown_this_game = []
+        await self.save_history_async(runtime)
 
     def _build_queue(
         self,

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -121,10 +121,14 @@ class QuizifyGameState:
         # milestone arithmetic that submit_answer applies (issue #184).
         self._scoring_engine = ScoringEngine()
 
-        # Load question history if a runtime is available (HA or standalone).
+        # Bind the question-history path if a runtime is available (HA or
+        # standalone). The actual disk READ is deferred to
+        # ``async_load_history`` so __init__ never blocks the event loop on
+        # the read path (issue #222); callers that don't await it (bare unit
+        # tests, standalone) simply start with an empty in-memory history.
         if runtime is not None:
             history_path = runtime.data_dir / "question_history.json"
-            self._question_bank.load_history(history_path)
+            self._question_bank.set_history_path(history_path)
 
         # Group-level adaptive difficulty (#40). Only active when the host
         # picks the "auto" difficulty mode; None for fixed easy/medium/hard.
@@ -827,8 +831,10 @@ class QuizifyGameState:
         # Record to analytics
         self._record_analytics()
 
-        # Save question history so next game prioritises least-recently-shown
-        self._question_bank.flush_shown_history()
+        # Save question history so next game prioritises least-recently-shown.
+        # The write is offloaded to an executor thread so end_game never
+        # blocks the event loop on disk I/O (issue #222).
+        self._flush_history()
 
         # Persist any per-question stats accumulated this game.
         if self._question_stats is not None:
@@ -847,6 +853,51 @@ class QuizifyGameState:
         self._fire_broadcast("game_ended")
 
         return finale_data
+
+    async def async_load_history(self) -> None:
+        """Load persisted question history off the event loop (#222).
+
+        Called once from ``async_setup_entry`` after construction. The
+        blocking ``read_text`` of ``question_history.json`` runs in an
+        executor thread. A no-op when no runtime is wired.
+        """
+        if self._runtime is None:
+            return
+        history_path = self._runtime.data_dir / "question_history.json"
+        await self._question_bank.load_history_async(history_path, self._runtime)
+
+    def _flush_history(self) -> None:
+        """Persist question history without blocking the event loop (#222).
+
+        When a runtime is available (HA or standalone), the blocking
+        ``write_text`` of ``question_history.json`` is offloaded to an
+        executor thread via a fire-and-forget task — mirroring how the
+        per-question stats are saved in ``end_game``. Without a runtime
+        (bare unit tests) it falls back to the synchronous flush so the
+        behaviour and the on-disk result are unchanged.
+        """
+        bank = self._question_bank
+        runtime = self._runtime
+
+        # No runtime, or no running event loop (bare synchronous unit tests):
+        # fall back to the synchronous write. The on-disk result is identical;
+        # there is no loop to block in that path.
+        if runtime is None:
+            bank.flush_shown_history()
+            return
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            bank.flush_shown_history()
+            return
+
+        async def _do_flush() -> None:
+            try:
+                await bank.flush_shown_history_async(runtime)
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Failed to save question history")
+
+        runtime.create_task(_do_flush())
 
     def _record_analytics(self) -> None:
         """Record game to analytics service if available."""
@@ -981,7 +1032,7 @@ class QuizifyGameState:
         """Transition out of an active lightning round into its recap screen."""
         if self.phase == GamePhase.LIGHTNING:
             self.phase = GamePhase.LIGHTNING_RECAP
-            self._question_bank.flush_shown_history()
+            self._flush_history()
             self._notify_state_callbacks()
 
     # ------------------------------------------------------------------

--- a/scripts/dev_server.py
+++ b/scripts/dev_server.py
@@ -169,6 +169,7 @@ def main(argv: list[str] | None = None) -> int:
         await ctx.analytics.load()
         if ctx.question_stats is not None:
             await ctx.question_stats.load()
+        await ctx.game.async_load_history()
         await ctx.ws_handler._conn.async_load_admin_token()
 
     app.on_startup.append(_load_state)

--- a/tests/test_history_executor_222.py
+++ b/tests/test_history_executor_222.py
@@ -1,0 +1,163 @@
+"""Regression tests for issue #222 — question history I/O off the event loop.
+
+`end_game` used to persist `question_history.json` via a synchronous
+`Path.write_text()` on the event-loop thread (`flush_shown_history ->
+save_history`), stalling the WS server for every client at end-of-game. HA's
+loop-protection flagged the blocking call on v1.3.0-RC2.
+
+The history file write (and the startup read) now run in an executor thread via
+the integration's `Runtime.run_in_executor` offload (same pattern as #213's
+asset-fingerprint walk and the per-question stats save). These tests lock in:
+
+  * `flush_shown_history_async` / `save_history_async` route the blocking write
+    through the runtime executor and never touch disk on the loop thread,
+  * the persisted JSON is unchanged vs. the synchronous path,
+  * `end_game` schedules the flush as an offloaded task and still persists,
+  * `load_history_async` reads back what was written, off the loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.questions import QuestionBank  # noqa: E402
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+
+
+class _ExecutorRuntime:
+    """Runtime double that records which thread the blocking work ran on.
+
+    Mirrors `StandaloneRuntime`: `run_in_executor` offloads to a real worker
+    thread, `create_task` schedules on the running loop. `executor_thread_ids`
+    captures the thread id the offloaded callable actually executed on so a
+    test can assert it was *not* the event-loop thread.
+    """
+
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+        self.executor_calls = 0
+
+    def create_task(self, coro):
+        return asyncio.ensure_future(coro)
+
+    async def run_in_executor(self, func, *args):
+        self.executor_calls += 1
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func, *args)
+
+
+def _fake_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+@pytest.mark.asyncio
+async def test_save_history_async_offloads_write(tmp_path: Path) -> None:
+    """`save_history_async` writes via the executor, not on the loop thread."""
+    runtime = _ExecutorRuntime(tmp_path)
+    bank = QuestionBank()
+    bank.set_history_path(tmp_path / "question_history.json")
+    bank._history = {"q1": 111.0, "q2": 222.0}
+
+    await bank.save_history_async(runtime)
+
+    assert runtime.executor_calls == 1
+    written = json.loads((tmp_path / "question_history.json").read_text())
+    assert written == {"q1": 111.0, "q2": 222.0}
+
+
+@pytest.mark.asyncio
+async def test_async_and_sync_save_produce_same_file(tmp_path: Path) -> None:
+    """The async (executor) path persists byte-identical JSON to the sync path."""
+    runtime = _ExecutorRuntime(tmp_path)
+    history = {"a": 1.0, "b": 2.5, "c": 3.0}
+
+    sync_path = tmp_path / "sync.json"
+    bank_sync = QuestionBank()
+    bank_sync.set_history_path(sync_path)
+    bank_sync._history = dict(history)
+    bank_sync.save_history()
+
+    async_path = tmp_path / "async.json"
+    bank_async = QuestionBank()
+    bank_async.set_history_path(async_path)
+    bank_async._history = dict(history)
+    await bank_async.save_history_async(runtime)
+
+    assert sync_path.read_text() == async_path.read_text()
+
+
+@pytest.mark.asyncio
+async def test_flush_shown_history_async_clears_and_persists(tmp_path: Path) -> None:
+    """Async flush resets the shown list and writes history via the executor."""
+    runtime = _ExecutorRuntime(tmp_path)
+    bank = QuestionBank()
+    bank.set_history_path(tmp_path / "question_history.json")
+    bank.record_shown("q1")
+    bank.record_shown("q2")
+    assert bank._shown_this_game == ["q1", "q2"]
+
+    await bank.flush_shown_history_async(runtime)
+
+    assert bank._shown_this_game == []
+    assert runtime.executor_calls == 1
+    written = json.loads((tmp_path / "question_history.json").read_text())
+    assert set(written) == {"q1", "q2"}
+
+
+@pytest.mark.asyncio
+async def test_load_history_async_roundtrip(tmp_path: Path) -> None:
+    """`load_history_async` reads back persisted history off the loop."""
+    runtime = _ExecutorRuntime(tmp_path)
+    path = tmp_path / "question_history.json"
+    path.write_text(json.dumps({"x": 10.0, "y": 20.0}))
+
+    bank = QuestionBank()
+    await bank.load_history_async(path, runtime)
+
+    assert runtime.executor_calls == 1
+    assert bank._history == {"x": 10.0, "y": 20.0}
+
+
+@pytest.mark.asyncio
+async def test_end_game_schedules_offloaded_history_flush(tmp_path: Path) -> None:
+    """`end_game` persists history through the executor, not on the loop.
+
+    `end_game` is synchronous; it schedules the flush as a fire-and-forget
+    task. We drive a real event loop, end the game, then let the scheduled
+    task drain and assert the file landed via the executor path.
+    """
+    runtime = _ExecutorRuntime(tmp_path)
+    state = QuizifyGameState(runtime=runtime, entry_id="test")
+
+    state.add_player("Alice", _fake_ws())
+    state.start_game(language="de", num_rounds=3)
+    # Mark a question as shown so there is history worth persisting.
+    state._question_bank.record_shown("seed-q")
+
+    state.end_game()
+    assert state.phase == GamePhase.FINALE
+
+    # Let the fire-and-forget flush task run to completion.
+    await asyncio.sleep(0)
+    for _ in range(10):
+        await asyncio.sleep(0)
+        if (tmp_path / "question_history.json").exists():
+            break
+
+    assert runtime.executor_calls >= 1
+    written = json.loads((tmp_path / "question_history.json").read_text())
+    assert "seed-q" in written

--- a/tests/test_history_executor_222.py
+++ b/tests/test_history_executor_222.py
@@ -48,9 +48,14 @@ class _ExecutorRuntime:
     def __init__(self, tmp_path: Path) -> None:
         self.data_dir = tmp_path
         self.executor_calls = 0
+        # Track scheduled fire-and-forget tasks so a test can await them
+        # to completion deterministically (instead of racing on sleep(0)).
+        self.tasks: list[asyncio.Future] = []
 
     def create_task(self, coro):
-        return asyncio.ensure_future(coro)
+        task = asyncio.ensure_future(coro)
+        self.tasks.append(task)
+        return task
 
     async def run_in_executor(self, func, *args):
         self.executor_calls += 1
@@ -151,12 +156,12 @@ async def test_end_game_schedules_offloaded_history_flush(tmp_path: Path) -> Non
     state.end_game()
     assert state.phase == GamePhase.FINALE
 
-    # Let the fire-and-forget flush task run to completion.
-    await asyncio.sleep(0)
-    for _ in range(10):
-        await asyncio.sleep(0)
-        if (tmp_path / "question_history.json").exists():
-            break
+    # Drain the fire-and-forget flush task(s) to completion. Awaiting the
+    # tracked task is deterministic: the file existing isn't enough (the
+    # executor thread may still be mid-write), so a sleep(0) poll on
+    # existence races and can read a half-written/empty file.
+    assert runtime.tasks, "end_game should have scheduled a flush task"
+    await asyncio.gather(*runtime.tasks)
 
     assert runtime.executor_calls >= 1
     written = json.loads((tmp_path / "question_history.json").read_text())

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -36,6 +36,13 @@ class _FakeRuntime:
     def __init__(self, tmp_path: Path) -> None:
         self.data_dir = tmp_path
 
+    def create_task(self, coro):
+        return asyncio.ensure_future(coro)
+
+    async def run_in_executor(self, func, *args):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func, *args)
+
 
 def _fake_ws() -> MagicMock:
     ws = MagicMock()


### PR DESCRIPTION
## Problem

During v1.3.0-RC2 live QA, HA's loop-protection flagged a blocking file write from `quizify` at end-of-game:

```
WARNING homeassistant.util.loop] Detected blocking call to write_text ...
  custom_components/quizify/game/questions.py, line 511: self._history_path.write_text(
  server/websocket.py:952 _handle_end_game -> game/state.py:831 end_game
    -> game/questions.py:526 flush_shown_history -> game/questions.py:511 save_history
```

`end_game` (and `finish_lightning_round`) persisted `question_history.json` via a **synchronous** `Path.write_text()` on the event-loop thread, so the WS server stalled for *every* connected client while the file was written. Same class as #213 (blocking `scandir`).

## Fix

Offload the history file I/O to an executor thread using the integration's existing `Runtime.run_in_executor` pattern (the same offload #213 used for the asset-fingerprint walk, and that the per-question stats save already uses).

- **`QuestionBank`** — split the blocking write into `_write_history` (snapshots `_history` first so the serialized payload can't tear if the loop thread mutates the dict mid-write) and add `save_history_async` / `flush_shown_history_async`, which run the write via `runtime.run_in_executor`. The synchronous `save_history` / `flush_shown_history` are retained for the standalone dev server and tests.
- **`QuizifyGameState._flush_history`** — schedules the async flush as a fire-and-forget task via `runtime.create_task` (mirrors how `_save_qs` already offloads question stats in `end_game`). Used by both `end_game` and `finish_lightning_round`. Falls back to the synchronous write when there is no runtime or no running loop (bare unit tests) — identical on-disk result, nothing to block in that path.

### Read-path (same offender class, also fixed)

`QuizifyGameState.__init__` previously did a synchronous `read_text` of the history file via `load_history`, running on the loop during `async_setup_entry`. That read is now split out into `load_history_async` (executor-offloaded) and called from `async_setup_entry` and the dev-server startup hook; `__init__` only binds the path (`set_history_path`, non-blocking). No read-path blocking is left deferred.

No UI change — backend-only.

## Tests

New `tests/test_history_executor_222.py` (5 cases): asserts the async save/flush/load route through the executor, persist byte-identical JSON to the sync path, and that `end_game` schedules an offloaded flush that lands on disk. Updated `test_lightning`'s runtime double to implement the full `Runtime` protocol.

`python3 -m pytest -q` → **336 passed** (baseline 331 + 5 new).

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)