### PR TITLE
feat(icons): replace remaining emoji UI icons with SVG — P4 (Closes #225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to Quizify are documented here. This project follows
 
 ## [Unreleased]
 
+### Changed
+
+- **Remaining emoji UI icons replaced with SVG line icons — P4 (#225).** The
+  standalone emoji-as-icon surfaces missed by the original #212 P1 inventory now
+  use the shared Rounded Duotone set (`window.QuizifyIcons`): the admin lobby
+  (Cast to TV, Join as Player, Start), the player nav/section icons (controller,
+  target, brain, trophy, party, hourglass, sparkle, bulb) and error/hero states,
+  the game control bar (skip, pause, resume, end, finish) and the paused screen,
+  plus the status/utility glyphs (connection-lost antenna, invite-copy clipboard)
+  and the lightning bolt icons. A new `UI_ICON_SVG` map + `uiIcon(name)` accessor
+  back these; a `paintUiIcons()` pass swaps the `data-ui-icon` spans on init.
+  Language flags and the floating reaction bar emoji are intentionally retained;
+  emoji embedded in translated strings (P3 #220) and the setup presets/awards
+  (P2 #219) are unchanged.
+
 ## [1.3.0-RC4] — 2026-06-10
 
 Fourth release candidate for 1.3.0. Completes the event-loop-blocking cleanup

--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -486,7 +486,7 @@
                 </div>
 
                 <a href="#" id="dashboard-link" class="lobby-e-cast" target="_blank">
-                    <span aria-hidden="true">📺</span>
+                    <span class="qz-icon qz-icon--sky" data-ui-icon="tv" aria-hidden="true">📺</span>
                     <span data-i18n="dashboard.castToTv">Cast to TV</span>
                     <span aria-hidden="true">→</span>
                 </a>
@@ -508,11 +508,11 @@
 
                 <div class="lobby-e-actions">
                     <button type="button" id="start-gameplay-btn" class="btn btn-primary btn-lg btn-block hidden">
-                        <span class="btn-icon" aria-hidden="true">▶️</span>
+                        <span class="btn-icon qz-icon qz-icon--sage" data-ui-icon="play" aria-hidden="true">▶️</span>
                         <span data-i18n="admin.startGameplay">Start Game</span>
                     </button>
                     <button type="button" id="participate-btn" class="btn btn-secondary btn-lg btn-block">
-                        <span class="btn-icon" aria-hidden="true">🎮</span>
+                        <span class="btn-icon qz-icon qz-icon--coral" data-ui-icon="controller" aria-hidden="true">🎮</span>
                         <span data-i18n="admin.joinAsPlayer">Join as Player</span>
                     </button>
                 </div>
@@ -652,7 +652,7 @@
             </div>
             <div class="modal-actions">
                 <button type="button" id="admin-join-btn" class="btn btn-primary" disabled>
-                    <span aria-hidden="true">▶️</span>
+                    <span class="qz-icon qz-icon--sage" data-ui-icon="play" aria-hidden="true">▶️</span>
                     <span id="admin-join-btn-label" data-i18n="admin.joinModalBtnStart">Start &amp; Join</span>
                 </button>
                 <button type="button" id="admin-cancel-btn" class="btn btn-secondary" data-i18n="common.cancel">Cancel</button>

--- a/custom_components/quizify/www/css/src/02-shared.css
+++ b/custom_components/quizify/www/css/src/02-shared.css
@@ -439,6 +439,41 @@ button, .btn {
     vertical-align: middle;
 }
 .theme-tab .theme-tab-label { vertical-align: middle; }
+
+/* ---- #225 P4: standalone UI icons reuse .qz-icon at varied sizes ----
+   The remaining emoji-as-icon surfaces (lobby, player nav/section, game
+   control bar, status/utility) opt into the shared duotone disc via
+   data-ui-icon. Most inline icons (.section-icon / .btn-icon /
+   .pl-result-sec-head span / .wager-panel-title span / .pl-rulesTitle
+   span / .powerup-icon / .lr-splash-adminbar button span) keep the
+   default 32px disc. The control bar wants a smaller disc, and the
+   hero/error/splash states want a bigger one. */
+.control-icon.qz-icon {
+    width: 24px;
+    height: 24px;
+    border-radius: 7px;
+}
+/* Hero/full-screen states: larger duotone disc so the glyph still reads
+   as a focal point (these spans previously rendered as a 3rem emoji). */
+.error-icon.qz-icon,
+.paused-icon.qz-icon,
+.connection-lost-icon.qz-icon {
+    width: 64px;
+    height: 64px;
+    border-radius: 20px;
+    margin-bottom: var(--space-sm);
+}
+/* Lightning splash bolt: bold focal disc on the intro splash. */
+.lr-splash-bolt .qz-icon {
+    width: 72px;
+    height: 72px;
+    border-radius: 22px;
+}
+.lr-splash-stage.lr-splash-tv .lr-splash-bolt .qz-icon {
+    width: 96px;
+    height: 96px;
+    border-radius: 28px;
+}
 #category-chips.chip-group--cards .pack-card-name {
     font-family: var(--font-display, var(--font-system, inherit));
     font-weight: 700;

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -1198,6 +1198,41 @@ button, .btn {
     vertical-align: middle;
 }
 .theme-tab .theme-tab-label { vertical-align: middle; }
+
+/* ---- #225 P4: standalone UI icons reuse .qz-icon at varied sizes ----
+   The remaining emoji-as-icon surfaces (lobby, player nav/section, game
+   control bar, status/utility) opt into the shared duotone disc via
+   data-ui-icon. Most inline icons (.section-icon / .btn-icon /
+   .pl-result-sec-head span / .wager-panel-title span / .pl-rulesTitle
+   span / .powerup-icon / .lr-splash-adminbar button span) keep the
+   default 32px disc. The control bar wants a smaller disc, and the
+   hero/error/splash states want a bigger one. */
+.control-icon.qz-icon {
+    width: 24px;
+    height: 24px;
+    border-radius: 7px;
+}
+/* Hero/full-screen states: larger duotone disc so the glyph still reads
+   as a focal point (these spans previously rendered as a 3rem emoji). */
+.error-icon.qz-icon,
+.paused-icon.qz-icon,
+.connection-lost-icon.qz-icon {
+    width: 64px;
+    height: 64px;
+    border-radius: 20px;
+    margin-bottom: var(--space-sm);
+}
+/* Lightning splash bolt: bold focal disc on the intro splash. */
+.lr-splash-bolt .qz-icon {
+    width: 72px;
+    height: 72px;
+    border-radius: 22px;
+}
+.lr-splash-stage.lr-splash-tv .lr-splash-bolt .qz-icon {
+    width: 96px;
+    height: 96px;
+    border-radius: 28px;
+}
 #category-chips.chip-group--cards .pack-card-name {
     font-family: var(--font-display, var(--font-system, inherit));
     font-weight: 700;

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -453,6 +453,20 @@
         }
     }
 
+    // P4 of #225: paint the static UI emoji-icon spans (admin lobby
+    // cast/join/start) with the shared Rounded Duotone set. Any element
+    // carrying both `.qz-icon` and `data-ui-icon="<name>"` gets its emoji
+    // swapped for the matching window.QuizifyIcons.uiIcon() <svg>. Existing
+    // layout classes (.btn-icon etc.) + the qz-icon--<tint> class stay put.
+    function paintUiIcons() {
+        var Icons = window.QuizifyIcons;
+        if (!Icons || !Icons.uiIcon) return;
+        document.querySelectorAll('.qz-icon[data-ui-icon]').forEach(function (slot) {
+            var svg = Icons.uiIcon(slot.getAttribute('data-ui-icon'));
+            if (svg) slot.innerHTML = svg;
+        });
+    }
+
     function setupFeaturedSpotlight() {
         if (!els.featuredSpotlight || !els.categoryChips) return;
         els.featuredSpotlight.addEventListener('click', function () {
@@ -680,6 +694,7 @@
     setupCategoryChips(els.categoryChips);
     setupThemeTabs();
     paintP1Icons();
+    paintUiIcons();
     setupFeaturedSpotlight();
     // Initial scaling pass — paints spotlight/tabs once we know the
     // visible-pack-count for the default language.

--- a/custom_components/quizify/www/js/icons.js
+++ b/custom_components/quizify/www/js/icons.js
@@ -31,6 +31,34 @@
         worldcup: '<path d="M7 4h10v4a5 5 0 0 1-10 0V4z"/><path d="M7 6H4v1a3.5 3.5 0 0 0 3.5 3.5M17 6h3v1a3.5 3.5 0 0 1-3.5 3.5"/><path d="M12 13v4M9 20h6M10 20a2 2 0 0 1 2-2 2 2 0 0 1 2 2"/>'
     };
 
+    // UI line icons keyed by a semantic name (NOT a theme). Used for the
+    // standalone emoji-as-icon surfaces missed by the original #212 P1
+    // inventory: admin lobby (cast/join/start), player nav + section
+    // icons, the game control bar, and status/utility glyphs (#225 P4).
+    // Same Rounded Duotone style as CATEGORY_ICON_SVG — `.d` marks a
+    // filled detail dot (fill:currentColor in CSS). Paths approved by
+    // Markus (2026-06-10) — do not redraw.
+    var UI_ICON_SVG = {
+        tv: '<rect x="3" y="5" width="18" height="11" rx="2"/><path d="M8.5 20h7M12 16v4"/>',
+        controller: '<path d="M9 9h6M16.5 9a5 5 0 0 1 4.4 7.3l-.6 1.1a2.2 2.2 0 0 1-3.8.2L15 15H9l-1.5 2.6a2.2 2.2 0 0 1-3.8-.2l-.6-1.1A5 5 0 0 1 7.5 9z"/><path d="M6 12.5h2.4M7.2 11.3v2.4"/><circle class="d" cx="16.3" cy="11.8" r="1"/><circle class="d" cx="18" cy="13.3" r="1"/>',
+        play: '<path d="M8 5.5v13l10.5-6.5z"/>',
+        target: '<circle cx="12" cy="12" r="8.5"/><circle cx="12" cy="12" r="3.8"/><circle class="d" cx="12" cy="12" r="1.1"/>',
+        brain: '<path d="M12 5.5V19"/><path d="M12 6a3 3 0 0 0-5.3-1.9A2.7 2.7 0 0 0 4.4 8 2.8 2.8 0 0 0 5 13.4 2.9 2.9 0 0 0 8.5 18 3 3 0 0 0 12 18.5"/><path d="M12 6a3 3 0 0 1 5.3-1.9A2.7 2.7 0 0 1 19.6 8 2.8 2.8 0 0 1 19 13.4 2.9 2.9 0 0 1 15.5 18 3 3 0 0 1 12 18.5"/>',
+        trophy: '<path d="M8 4h8v4a4 4 0 0 1-8 0z"/><path d="M8 6H5v1a3 3 0 0 0 3 3M16 6h3v1a3 3 0 0 1-3 3"/><path d="M12 12v4M9 20h6M9.5 20a2.5 2.5 0 0 1 5 0"/>',
+        party: '<path d="M4 20l4.5-12 7.5 7.5z"/><path d="M8 12l-1 4M11 9l4 4"/><path d="M15 4.5l.6 1.6M19 6l-1.4 1.2M19.5 10.5l-1.7-.3"/>',
+        hourglass: '<path d="M6.5 3.5h11M6.5 20.5h11"/><path d="M7.5 3.5c0 5 4.5 5.5 4.5 8.5s-4.5 3.5-4.5 8.5M16.5 3.5c0 5-4.5 5.5-4.5 8.5s4.5 3.5 4.5 8.5"/>',
+        sparkle: '<path d="M12 3.5l1.9 6.6L20 12l-6.1 1.9L12 20.5l-1.9-6.6L4 12l6.1-1.9z"/>',
+        bulb: '<path d="M9.5 18.5h5M11 21h2"/><path d="M12 3a6 6 0 0 0-3.8 10.6c.8.7 1.3 1.5 1.3 2.4h5c0-.9.5-1.7 1.3-2.4A6 6 0 0 0 12 3z"/>',
+        signaloff: '<path d="M5 12.6a10 10 0 0 1 5-2.7M14 9.9a10 10 0 0 1 5 2.7"/><path d="M8 15.6a5.5 5.5 0 0 1 3-1.4M13 14.2a5.5 5.5 0 0 1 3 1.4"/><circle class="d" cx="12" cy="19" r="1.1"/><path d="M4 4l16 16"/>',
+        copy: '<rect x="8.5" y="8.5" width="11" height="12.5" rx="2"/><path d="M5.5 15.5V5a2 2 0 0 1 2-2H15"/>',
+        bolt: '<path d="M13 3l-7.5 10H11l-1 8 8-11h-5.5z"/>',
+        finish: '<path d="M5.5 3.5v17"/><path d="M5.5 4.5h12l-2.5 3.5 2.5 3.5h-12"/><path d="M9.5 4.5v7M13.5 4.5v7M5.5 8h12"/>',
+        pause: '<path d="M9 5v14M15 5v14"/>',
+        stop: '<rect x="6" y="6" width="12" height="12" rx="2.5"/>',
+        skipnext: '<path d="M6.5 5.5v13l8-6.5zM16.5 5.5v13"/>',
+        skipprev: '<path d="M17.5 5.5v13l-8-6.5zM7.5 5.5v13"/>'
+    };
+
     // Accent tint per theme, cycling the 4 Soft Parlor accents; mixed stays
     // neutral. Consumed for the duotone backing disc (see .qz-icon CSS).
     var CATEGORY_TINT = {
@@ -55,11 +83,22 @@
         return CATEGORY_TINT[theme] || 'mix';
     }
 
+    // Returns a full <svg> element string for a UI icon name (#225 P4),
+    // or '' when the name is unknown (so a bad data-ui-icon paints
+    // nothing rather than a misleading fallback glyph).
+    function uiIcon(name) {
+        var glyph = UI_ICON_SVG[name];
+        if (!glyph) return '';
+        return '<svg viewBox="0 0 24 24" aria-hidden="true">' + glyph + '</svg>';
+    }
+
     window.QuizifyIcons = {
         CATEGORY_ICON_SVG: CATEGORY_ICON_SVG,
         CATEGORY_TINT: CATEGORY_TINT,
+        UI_ICON_SVG: UI_ICON_SVG,
         inner: inner,
         icon: icon,
-        tint: tint
+        tint: tint,
+        uiIcon: uiIcon
     };
 })();

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -954,6 +954,7 @@
     }
 
     function init() {
+        pu.paintUiIcons();
         setupJoinForm();
         lobby.init(send);
         setupRetryConnection();

--- a/custom_components/quizify/www/js/player-utils.js
+++ b/custom_components/quizify/www/js/player-utils.js
@@ -298,6 +298,25 @@
         }
     }
 
+    // Paint the static UI emoji-icon spans with the shared Rounded Duotone
+    // SVG set (#225 P4). Any element carrying both `.qz-icon` and a
+    // `data-ui-icon="<name>"` gets its emoji glyph swapped for the matching
+    // window.QuizifyIcons.uiIcon() <svg>. The existing layout class
+    // (.section-icon / .control-icon / .btn-icon / .paused-icon / etc.) and
+    // the qz-icon--<tint> class stay put — we only replace innerHTML. Safe to
+    // call more than once; already-painted spans just get re-filled.
+    function paintUiIcons(root) {
+        var Icons = window.QuizifyIcons;
+        if (!Icons || !Icons.uiIcon) return;
+        var scope = root || document;
+        var slots = scope.querySelectorAll('.qz-icon[data-ui-icon]');
+        for (var i = 0; i < slots.length; i++) {
+            var name = slots[i].getAttribute('data-ui-icon');
+            var svg = Icons.uiIcon(name);
+            if (svg) slots[i].innerHTML = svg;
+        }
+    }
+
     // ============================================
     // QR Code Generation
     // ============================================
@@ -461,6 +480,7 @@
         renderLeaderboard: renderLeaderboard,
         renderPlayerCards: renderPlayerCards,
         setupCollapsibles: setupCollapsibles,
+        paintUiIcons: paintUiIcons,
         generateQR: generateQR,
         showToast: showToast,
         saveSession: saveSession,

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -303,6 +303,25 @@
         }
     }
 
+    // Paint the static UI emoji-icon spans with the shared Rounded Duotone
+    // SVG set (#225 P4). Any element carrying both `.qz-icon` and a
+    // `data-ui-icon="<name>"` gets its emoji glyph swapped for the matching
+    // window.QuizifyIcons.uiIcon() <svg>. The existing layout class
+    // (.section-icon / .control-icon / .btn-icon / .paused-icon / etc.) and
+    // the qz-icon--<tint> class stay put — we only replace innerHTML. Safe to
+    // call more than once; already-painted spans just get re-filled.
+    function paintUiIcons(root) {
+        var Icons = window.QuizifyIcons;
+        if (!Icons || !Icons.uiIcon) return;
+        var scope = root || document;
+        var slots = scope.querySelectorAll('.qz-icon[data-ui-icon]');
+        for (var i = 0; i < slots.length; i++) {
+            var name = slots[i].getAttribute('data-ui-icon');
+            var svg = Icons.uiIcon(name);
+            if (svg) slots[i].innerHTML = svg;
+        }
+    }
+
     // ============================================
     // QR Code Generation
     // ============================================
@@ -466,6 +485,7 @@
         renderLeaderboard: renderLeaderboard,
         renderPlayerCards: renderPlayerCards,
         setupCollapsibles: setupCollapsibles,
+        paintUiIcons: paintUiIcons,
         generateQR: generateQR,
         showToast: showToast,
         saveSession: saveSession,
@@ -4399,6 +4419,7 @@
     }
 
     function init() {
+        pu.paintUiIcons();
         setupJoinForm();
         lobby.init(send);
         setupRetryConnection();

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -53,7 +53,7 @@
 
         <!-- Error: Game not found -->
         <div id="not-found-view" class="view hidden">
-            <div class="error-icon">🧠</div>
+            <div class="error-icon qz-icon qz-icon--sky" data-ui-icon="brain">🧠</div>
             <h1 data-i18n="errors.gameNotFound">Game Not Found</h1>
             <p data-i18n="errors.gameNotFoundHint">This game doesn't exist or the link is incorrect.</p>
             <p class="hint" data-i18n="errors.askHostQr">Ask the host for a new QR code.</p>
@@ -62,7 +62,7 @@
 
         <!-- Error: Game ended -->
         <div id="ended-view" class="view hidden">
-            <div class="error-icon">🎉</div>
+            <div class="error-icon qz-icon qz-icon--sun" data-ui-icon="party">🎉</div>
             <h1 data-i18n="errors.gameHasEnded">Game Has Ended</h1>
             <p data-i18n="errors.thanksForPlaying">Thanks for playing Quizify!</p>
             <p class="hint" data-i18n="errors.askHostNewGame">Ask the host to start a new game.</p>
@@ -70,7 +70,7 @@
 
         <!-- Error: Game in progress (can't join mid-round) -->
         <div id="in-progress-view" class="view hidden">
-            <div class="error-icon">⏳</div>
+            <div class="error-icon qz-icon qz-icon--mix" data-ui-icon="hourglass">⏳</div>
             <h1 data-i18n="errors.gameInProgress">Game In Progress</h1>
             <p data-i18n="errors.gameInProgressHint">The game is currently in a round. Try again in a moment.</p>
             <button id="retry-btn" class="btn btn-primary btn-glow" data-i18n="common.retry">Try Again</button>
@@ -123,7 +123,7 @@
             <!-- Variant D: rules. Always visible (was collapsible). -->
             <section class="pl-rules">
                 <h2 class="pl-rulesTitle">
-                    <span aria-hidden="true">🧠</span>
+                    <span class="qz-icon qz-icon--sky" data-ui-icon="brain" aria-hidden="true">🧠</span>
                     <span data-i18n="lobby.howToPlay">How to Play</span>
                 </h2>
                 <ol>
@@ -158,7 +158,7 @@
             <!-- Sticky Admin Actions -->
             <div id="admin-controls" class="lobby-actions lobby-actions--sticky hidden">
                 <button id="start-game-btn" class="btn btn-primary btn-large btn-full-width">
-                    <span class="btn-icon" aria-hidden="true">🎉</span>
+                    <span class="btn-icon qz-icon qz-icon--sun" data-ui-icon="party" aria-hidden="true">🎉</span>
                     <span data-i18n="lobby.startGame">Start Game</span>
                 </button>
             </div>
@@ -170,7 +170,7 @@
                 <!-- Game Header with Round Info -->
                 <div class="game-header-compact">
                     <div class="game-header-left">
-                        <span class="section-icon" aria-hidden="true">🎮</span>
+                        <span class="section-icon qz-icon qz-icon--coral" data-ui-icon="controller" aria-hidden="true">🎮</span>
                         <span id="round-indicator" class="round-indicator-text">
                             <span data-i18n="game.roundLabel">Round</span>
                             <span id="current-round">1</span>
@@ -231,7 +231,7 @@
                      Answer buttons stay disabled until the wager is submitted. -->
                 <section id="wager-panel" class="wager-panel hidden" aria-live="polite">
                     <h2 class="wager-panel-title">
-                        <span aria-hidden="true">🎰</span>
+                        <span class="qz-icon qz-icon--sky" data-ui-icon="sparkle" aria-hidden="true">🎰</span>
                         <span id="wager-panel-title">Wagerunde</span>
                     </h2>
                     <p id="wager-panel-hint" class="wager-panel-hint"></p>
@@ -252,7 +252,7 @@
                 <!-- Answer Buttons A/B/C (replaces year-selector) - card-section pattern -->
                 <section id="answers-container" class="card-section answer-section">
                     <h2 class="section-header">
-                        <span class="section-icon" aria-hidden="true">🎯</span>
+                        <span class="section-icon qz-icon qz-icon--coral" data-ui-icon="target" aria-hidden="true">🎯</span>
                         <span data-i18n="game.yourAnswer">Your Answer</span>
                     </h2>
                     <div id="answer-buttons" class="answer-buttons">
@@ -273,7 +273,7 @@
                     <!-- Power-up Button (replaces bet-toggle) -->
                     <div class="powerup-container">
                         <button id="powerup-btn" class="powerup-btn" type="button">
-                            <span class="powerup-icon">⚡</span>
+                            <span class="powerup-icon qz-icon qz-icon--sun" data-ui-icon="bolt" aria-hidden="true">⚡</span>
                             <span class="powerup-label" data-i18n="game.powerup">Power-Up</span>
                         </button>
                     </div>
@@ -287,7 +287,7 @@
                 <!-- Leaderboard - Collapsible section pattern -->
                 <section id="game-leaderboard" class="section-collapsible leaderboard-section collapsed">
                     <button type="button" class="section-header-collapsible" id="leaderboard-toggle" aria-expanded="false" aria-controls="leaderboard-content">
-                        <span class="section-icon" aria-hidden="true">🏆</span>
+                        <span class="section-icon qz-icon qz-icon--sun" data-ui-icon="trophy" aria-hidden="true">🏆</span>
                         <span data-i18n="leaderboard.title">Leaderboard</span>
                         <span class="section-summary" id="leaderboard-summary">--</span>
                         <span class="section-toggle" aria-hidden="true">▼</span>
@@ -324,7 +324,7 @@
 
                 <section id="fun-fact-container" class="pl-result-section pl-result-funfact-section hidden">
                     <div class="pl-result-sec-head">
-                        <span aria-hidden="true">💡</span>
+                        <span class="qz-icon qz-icon--sun" data-ui-icon="bulb" aria-hidden="true">💡</span>
                         <span data-i18n="reveal.funFact">Did you know?</span>
                         <button id="flag-question-btn"
                                 type="button"
@@ -340,7 +340,7 @@
 
                 <section class="pl-result-section">
                     <div class="pl-result-sec-head">
-                        <span aria-hidden="true">🏆</span>
+                        <span class="qz-icon qz-icon--sun" data-ui-icon="trophy" aria-hidden="true">🏆</span>
                         <span data-i18n="leaderboard.standings">Standings</span>
                     </div>
                     <div id="reveal-standings" class="pl-result-standings"></div>
@@ -379,7 +379,7 @@
         <!-- Paused View -->
         <div id="paused-view" class="view hidden">
             <div class="paused-container">
-                <div class="paused-icon">⏸️</div>
+                <div class="paused-icon qz-icon qz-icon--mix" data-ui-icon="pause">⏸️</div>
                 <h1 id="pause-title" data-i18n="admin.pausedTitle">Game Paused</h1>
                 <p id="pause-message" data-i18n="admin.pausedHint">The host paused the game</p>
                 <div class="paused-spinner">
@@ -490,7 +490,7 @@
         <div id="lightning-splash-view" class="view hidden">
             <div class="lr-splash-stage">
                 <div class="lr-splash-rays" aria-hidden="true"></div>
-                <div class="lr-splash-bolt"><span aria-hidden="true">⚡</span></div>
+                <div class="lr-splash-bolt"><span class="qz-icon qz-icon--sun" data-ui-icon="bolt" aria-hidden="true">⚡</span></div>
                 <div class="lr-splash-kicker" data-i18n="lightning.splashKicker">Lightning Round</div>
                 <div class="lr-splash-title" data-i18n="lightning.splashTitle">Get ready!</div>
                 <div class="lr-splash-chips">
@@ -518,7 +518,7 @@
                 <div class="lr-splash-adminmeta" data-i18n="lightning.splashAdminMeta">Splash visible to all players</div>
                 <button id="lightning-splash-start-btn" class="lr-splash-startbtn" type="button">
                     <span data-i18n="lightning.splashStart">Let's go</span>
-                    <span aria-hidden="true">⚡</span>
+                    <span class="qz-icon qz-icon--sun" data-ui-icon="bolt" aria-hidden="true">⚡</span>
                 </button>
             </div>
         </div>
@@ -528,7 +528,7 @@
             <div class="game-container lightning-container">
                 <div class="game-header-compact">
                     <div class="game-header-left">
-                        <span class="section-icon" aria-hidden="true">⚡</span>
+                        <span class="section-icon qz-icon qz-icon--sun" data-ui-icon="bolt" aria-hidden="true">⚡</span>
                         <span class="round-indicator-text">
                             <span data-i18n="lightning.title">Lightning Round</span>
                         </span>
@@ -581,7 +581,7 @@
 
                 <div id="lightning-admin-bar" class="admin-control-bar hidden" style="position:static;">
                     <button id="lightning-end-btn" class="control-btn control-btn--danger" type="button">
-                        <span class="control-icon">🏁</span>
+                        <span class="control-icon qz-icon qz-icon--coral" data-ui-icon="finish">🏁</span>
                         <span class="control-label" data-i18n="lightning.endNow">End Lightning</span>
                     </button>
                 </div>
@@ -593,7 +593,7 @@
             <div class="end-container lightning-recap-container">
                 <div class="end-header">
                     <p class="end-subtitle">
-                        <span aria-hidden="true">⚡</span>
+                        <span class="qz-icon qz-icon--sun" data-ui-icon="bolt" aria-hidden="true">⚡</span>
                         <span data-i18n="lightning.recapTitle">Lightning Round Results</span>
                     </p>
                 </div>
@@ -627,23 +627,23 @@
         <!-- Admin Control Bar - visible across PLAYING/REVEAL for admin -->
         <div id="admin-control-bar" class="admin-control-bar hidden">
             <button id="skip-question-btn" class="control-btn" type="button">
-                <span class="control-icon">⏭️</span>
+                <span class="control-icon qz-icon qz-icon--mix" data-ui-icon="skipnext">⏭️</span>
                 <span class="control-label" data-i18n="admin.skip">Skip</span>
             </button>
             <button id="pause-game-btn" class="control-btn" type="button">
-                <span class="control-icon">⏸️</span>
+                <span class="control-icon qz-icon qz-icon--mix" data-ui-icon="pause">⏸️</span>
                 <span class="control-label" data-i18n="admin.pause">Pause</span>
             </button>
             <button id="resume-game-btn" class="control-btn hidden" type="button">
-                <span class="control-icon">▶️</span>
+                <span class="control-icon qz-icon qz-icon--mix" data-ui-icon="play">▶️</span>
                 <span class="control-label" data-i18n="admin.resume">Resume</span>
             </button>
             <button id="next-round-admin-btn" class="control-btn" type="button">
-                <span class="control-icon">⏭️</span>
+                <span class="control-icon qz-icon qz-icon--mix" data-ui-icon="skipnext">⏭️</span>
                 <span class="control-label" data-i18n="admin.next">Next</span>
             </button>
             <button id="end-game-btn" class="control-btn control-btn--danger" type="button">
-                <span class="control-icon">🛑</span>
+                <span class="control-icon qz-icon qz-icon--coral" data-ui-icon="stop">🛑</span>
                 <span class="control-label" data-i18n="admin.end">End</span>
             </button>
         </div>
@@ -696,7 +696,7 @@
     <!-- Connection Lost View -->
     <div id="connection-lost-view" class="view hidden">
         <div class="connection-lost-container">
-            <div class="connection-lost-icon">📡</div>
+            <div class="connection-lost-icon qz-icon qz-icon--coral" data-ui-icon="signaloff">📡</div>
             <h1 data-i18n="errors.CONNECTION_LOST">Connection Lost</h1>
             <p data-i18n="errors.connectionLostHint">We couldn't reconnect to the game server.</p>
             <button id="retry-connection-btn" class="btn btn-primary btn-glow" data-i18n="common.retry">Try Again</button>
@@ -751,7 +751,7 @@
                 <button id="invite-copy-btn" class="invite-copy-btn" type="button"
                         data-i18n-aria-label="a11y.copyJoinLinkAria"
                         aria-label="Copy join link">
-                    <span class="invite-copy-icon">📋</span>
+                    <span class="invite-copy-icon qz-icon qz-icon--sage" data-ui-icon="copy">📋</span>
                 </button>
             </div>
             <p id="invite-copy-feedback" class="invite-copy-feedback hidden">Copied!</p>
@@ -781,6 +781,10 @@
     <!-- DO NOT REMOVE utils.js \u2014 player-utils.js depends on window.QuizifyUtils. -->
     <!-- Dropped twice before (see commits 86025d1, 055e58c). Third time's not charming. -->
     <script src="/quizify/static/js/utils.js?v={{ASSET_VER}}"></script>
+    <!-- Shared Rounded Duotone SVG icon set (window.QuizifyIcons). Loaded
+         before the bundle so player-utils.paintUiIcons() can swap the
+         static emoji-as-icon spans on init (#225 P4). -->
+    <script src="/quizify/static/js/icons.js?v={{ASSET_VER}}"></script>
     <!-- Bundle of player-utils + lobby + game + reveal + end + core
          (concatenated by scripts/build_bundle.py). Cuts the request
          waterfall from 6 sequential JS fetches to 1 \u2014 meaningful on


### PR DESCRIPTION
## What

P4 of the SVG line-icon migration ([#212](https://github.com/mholzi/quizify/issues/212)). A full emoji-in-UI audit after RC4 ([#225](https://github.com/mholzi/quizify/issues/225)) found the original P1 inventory was not exhaustive — several surfaces still rendered **emoji as standalone UI icons**. This PR replaces those with the already-approved **Rounded Duotone** glyph set, reusing the shared `.qz-icon` system.

## New shared glyphs

Adds a `UI_ICON_SVG` map + `uiIcon(name)` accessor to `www/js/icons.js` (sibling to `CATEGORY_ICON_SVG` / `icon()`), exported on `window.QuizifyIcons`. 19 approved glyphs (verbatim, not redrawn): `tv`, `controller`, `play`, `target`, `brain`, `trophy`, `party`, `hourglass`, `sparkle`, `bulb`, `signaloff`, `copy`, `bolt`, `finish`, `pause`, `stop`, `skipnext`, `skipprev`.

A `paintUiIcons()` pass (added to `admin.js` and `player-utils.js`, called on init) swaps any element carrying `.qz-icon` + `data-ui-icon="<name>"` for the matching `<svg>`. `icons.js` is now loaded on `player.html` ahead of the bundle so the player page can paint too.

## Surfaces converted

- **Admin lobby** (`admin.html`): Cast to TV → `tv`, Join as Player → `controller`, Start / Start & Join → `play`.
- **Player nav/section + error-hero icons** (`player.html`): `controller` (round header), `target` (your answer), `brain` (rules / not-found), `trophy` (leaderboard + standings), `party` (start / game-ended), `hourglass` (in-progress), `sparkle` (wager panel), `bulb` (fun fact).
- **Game control bar** (`player.html`): skip → `skipnext`, pause → `pause`, resume → `play`, end → `stop`, lightning end → `finish`; paused screen → `pause`.
- **Status / utility** (`player.html`): connection-lost → `signaloff`, invite-copy → `copy`, power-up + lightning bolts → `bolt`.

New CSS scopes the shared disc per surface: control bar 24px, hero/error/connection-lost 64px, lightning splash bolt 72/96px (TV). Built via `scripts/build_css.py` + `scripts/build_bundle.py`.

## Kept / deferred (out of scope)

- **Kept as emoji** (decided): language flags 🇩🇪/🇬🇧, floating reaction bar 🔥😂😱👏🤔.
- **Deferred to P3 ([#220](https://github.com/mholzi/quizify/issues/220))**: emoji embedded in translated strings (e.g. `leaderboard.thanksEmoji` 🎉), and `⚡`/`🏁` used as a **text prefix inside a translated label** (`lightning.start`, `lightning.endNow`, etc. in `admin.html` :588/600/605/612/615/623/632 and `player.html` :471) — only standalone aria-hidden icon spans were converted here.
- **Deferred to P2 ([#219](https://github.com/mholzi/quizify/issues/219))**: setup presets ⚡🧠🏆 (`.preset-icon`), end-game awards.

## Verification

- `python3 -m pytest -q` → **340 passed** (baseline held).
- Standalone harness rendered headless at 390px (Chrome) — all 19 glyphs crisp, no clipping at 24/32/64/72px. Parent will run the full live mobile-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)