### PR TITLE
fix(player): show join screen on failed reconnect instead of a blank view (Closes #227)

### DIFF
--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -230,8 +230,15 @@
                 break;
 
             case 'reconnect_failed':
+                // The stored session token no longer maps to a joinable game
+                // (game ended/reset, or token expired). Drop the stale token
+                // and route back to the join screen — without this the client
+                // is left with every view hidden → blank screen (issue #227,
+                // same family as #207/#221). Mirror the deterministic return
+                // used by game_reset above.
                 pu.clearSession();
                 state.sessionToken = null;
+                pu.showView('join-view');
                 break;
 
             case 'player_joined':
@@ -476,6 +483,14 @@
                 var resumeBtnP = document.getElementById('resume-game-btn');
                 if (pauseBtnP) pauseBtnP.classList.add('hidden');
                 if (resumeBtnP) resumeBtnP.classList.remove('hidden');
+                break;
+
+            default:
+                // Safety net (issue #227, same reasoning as #221): an unknown
+                // or unmapped phase must never leave the player with zero
+                // visible views (blank screen). Fall back to the lobby if we
+                // already have an identity, otherwise the join screen.
+                pu.showView(state.playerName ? 'lobby-view' : 'join-view');
                 break;
         }
     }

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -3675,8 +3675,15 @@
                 break;
 
             case 'reconnect_failed':
+                // The stored session token no longer maps to a joinable game
+                // (game ended/reset, or token expired). Drop the stale token
+                // and route back to the join screen — without this the client
+                // is left with every view hidden → blank screen (issue #227,
+                // same family as #207/#221). Mirror the deterministic return
+                // used by game_reset above.
                 pu.clearSession();
                 state.sessionToken = null;
+                pu.showView('join-view');
                 break;
 
             case 'player_joined':
@@ -3921,6 +3928,14 @@
                 var resumeBtnP = document.getElementById('resume-game-btn');
                 if (pauseBtnP) pauseBtnP.classList.add('hidden');
                 if (resumeBtnP) resumeBtnP.classList.remove('hidden');
+                break;
+
+            default:
+                // Safety net (issue #227, same reasoning as #221): an unknown
+                // or unmapped phase must never leave the player with zero
+                // visible views (blank screen). Fall back to the lobby if we
+                // already have an identity, otherwise the join screen.
+                pu.showView(state.playerName ? 'lobby-view' : 'join-view');
                 break;
         }
     }

--- a/tests/test_reconnect_failed_227.py
+++ b/tests/test_reconnect_failed_227.py
@@ -1,0 +1,104 @@
+"""Regression tests for issue #227 — failed reconnect must be observable.
+
+Issue #227: opening the player with a dead/stale session (e.g.
+``/quizify/player?name=Foo&reconnect=1`` with no joinable game) left the
+client on a blank screen — the ``reconnect_failed`` case in player-core.js
+cleared the session but never routed to a visible view.
+
+The *fix* is client-side JS (``reconnect_failed`` now calls
+``showView('join-view')``, plus a ``default:`` fallback in the game_state
+view router). That routing cannot be exercised from Python.
+
+What *is* server-observable — and what the client fix depends on — is that
+the server actually emits a ``reconnect_failed`` message for an unknown or
+stale session token. These tests lock that contract so a future server
+change can't silently drop the message and re-introduce the blank screen.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    runtime = _FakeRuntime(tmp_path)
+    return QuizifyGameState(runtime=runtime, entry_id="test")
+
+
+@pytest.fixture
+def handler(game: QuizifyGameState) -> QuizifyWebSocketHandler:
+    runtime = _FakeRuntime(game._runtime.data_dir)  # type: ignore[attr-defined]
+    h = QuizifyWebSocketHandler(
+        runtime=runtime,
+        game_state_provider=lambda: game,
+    )
+    h._conn = ConnectionManager(runtime, lambda: game)
+    h._conn.broadcast = AsyncMock()
+    return h
+
+
+def _sent_types(ws: MagicMock) -> list[str]:
+    """Message ``type`` strings the server sent on *ws* (via _safe_send)."""
+    return [
+        call.args[0].get("type")
+        for call in ws.send_json.await_args_list
+        if call.args and isinstance(call.args[0], dict)
+    ]
+
+
+class TestReconnectFailedContract:
+    @pytest.mark.asyncio
+    async def test_unknown_token_emits_reconnect_failed(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        """A reconnect with a token the server has never seen must reply
+        ``reconnect_failed`` — the trigger the client uses to fall back to
+        the join screen (issue #227)."""
+        ws = _ws()
+        await handler._handle_reconnect(
+            ws, {"session_token": "no-such-token", "name": "Foo"}, game
+        )
+        assert "reconnect_failed" in _sent_types(ws)
+
+    @pytest.mark.asyncio
+    async def test_stale_token_after_player_removed_emits_reconnect_failed(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        """Token is valid but the player was fully removed (game ended/reset):
+        the server must still emit ``reconnect_failed`` and drop the token."""
+        token = handler._conn.create_session_token("Foo")
+        # Player exists only in the token map, never added to game_state →
+        # game_state.get_player("Foo") is None, the stale-token branch.
+        ws = _ws()
+        await handler._handle_reconnect(
+            ws, {"session_token": token, "name": "Foo"}, game
+        )
+        assert "reconnect_failed" in _sent_types(ws)
+        # Stale token must be purged so it can't resurrect later.
+        assert handler._conn.get_player_for_token(token) is None


### PR DESCRIPTION
## Root cause

`custom_components/quizify/www/js/player-core.js` — the `reconnect_failed`
case in the message router cleared the session token but never routed the
client to a visible view:

```js
case 'reconnect_failed':
    pu.clearSession();
    state.sessionToken = null;
    break;   // <-- no showView(...) — every .view stays hidden → blank
```

Opening the player with a dead/stale session (e.g.
`/quizify/player?name=Foo&reconnect=1` with no joinable game) makes the
server reply `reconnect_failed`, which left all 14 `.view` containers hidden
— only the header + version badge rendered → **blank screen** (issue #227).
Same family as #207/#221, where an unmapped/edge state left the client with
no view.

## Fix

1. **`reconnect_failed` → join screen.** After clearing the session it now
   calls `pu.showView('join-view')`, mirroring the deterministic return
   already used by the `game_reset` case. A failed reconnect now lands the
   player back on the join form instead of a blank page.

2. **Safety fallback in the game_state view router.** Added a `default:` to
   the phase `switch` in `handleGameState`:
   ```js
   default:
       pu.showView(state.playerName ? 'lobby-view' : 'join-view');
       break;
   ```
   Any unknown/unmapped phase now falls back to lobby (if we already have an
   identity) or the join screen — the player can never end up with zero
   visible views. This mirrors how #221 reasoned about unmapped states.

3. Rebuilt `player.bundle.js` (player.html loads the bundle).

## Tests

The view-routing fix is client-side JS and is not Python-observable, so it is
verified by reasoning + a static check that `reconnect_failed` calls
`showView('join-view')` and the `default:` fallback is present.

Added `tests/test_reconnect_failed_227.py` to lock the **server contract the
client fix depends on**: an unknown or stale (player-removed) session token
must emit a `reconnect_failed` message, and a stale token is purged. This
guards against a future server change silently dropping the message and
re-introducing the blank screen.

`/usr/bin/python3 -m pytest -q` → **342 passed** (340 baseline + 2 new).

## Acceptance
- [x] A failed reconnect shows the join screen (not blank).
- [x] Loading the player with no active game / stale token shows join, never blank.
- [x] A safety fallback ensures the player always has one visible view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)