### PR TITLE
fix(icons): white glyph for icons inside filled primary buttons

### DIFF
--- a/custom_components/quizify/www/css/src/02-shared.css
+++ b/custom_components/quizify/www/css/src/02-shared.css
@@ -430,6 +430,15 @@ button, .btn {
 .qz-icon--sky   { background: rgba(127, 168, 196, 0.18); color: var(--color-accent-blue); }
 .qz-icon--sun   { background: rgba(232, 196, 127, 0.24); color: #C9A24E; }
 
+/* Icons inside a filled primary (coral) button: the tinted disc washes out on
+   the coral fill (e.g. the sage play glyph on "Start Game"). Drop the disc and
+   render the glyph white so it matches the button's white label. Secondary /
+   outline buttons keep their tinted discs. (Markus 2026-06-10 live QA.) */
+.btn-primary .qz-icon {
+    background: transparent;
+    color: #fff;
+}
+
 /* Theme filter tabs: small duotone icon + text label, side by side. */
 .theme-tab .qz-icon {
     width: 22px;

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -1189,6 +1189,15 @@ button, .btn {
 .qz-icon--sky   { background: rgba(127, 168, 196, 0.18); color: var(--color-accent-blue); }
 .qz-icon--sun   { background: rgba(232, 196, 127, 0.24); color: #C9A24E; }
 
+/* Icons inside a filled primary (coral) button: the tinted disc washes out on
+   the coral fill (e.g. the sage play glyph on "Start Game"). Drop the disc and
+   render the glyph white so it matches the button's white label. Secondary /
+   outline buttons keep their tinted discs. (Markus 2026-06-10 live QA.) */
+.btn-primary .qz-icon {
+    background: transparent;
+    color: #fff;
+}
+
 /* Theme filter tabs: small duotone icon + text label, side by side. */
 .theme-tab .qz-icon {
     width: 22px;


### PR DESCRIPTION
Live-QA finding (Markus 2026-06-10): the P4 "Start Game" play icon (a sage-tinted `.qz-icon` disc) washes out against the coral `.btn-primary` fill — poor contrast.

Fix: scope `.btn-primary .qz-icon { background: transparent; color: #fff }` so icons inside a filled primary button drop the tinted disc and render white, matching the button's white label. Secondary / outline buttons keep their tinted discs. Pure CSS (`02-shared.css` + rebuilt `styles.css`); 342 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)