### PR TITLE
fix(player): populate the in-game leaderboard during a live question (Closes #235)

### DIFF
--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -414,6 +414,15 @@
                         category: msg.question.category
                     });
 
+                    // Feed the in-game leaderboard panel from the game_state's
+                    // leaderboard. question_started carries no leaderboard, so
+                    // without this the panel sat at "--" during a live question
+                    // (it was only updated at reveal). The trailing game_state
+                    // broadcast after each round start does carry it.
+                    if (msg.leaderboard && game && game.updateLeaderboard) {
+                        game.updateLeaderboard({ leaderboard: msg.leaderboard }, 'leaderboard-list');
+                    }
+
                     // #14: if we're reconnecting mid-round and server thinks
                     // we've already submitted, lock the UI accordingly so we
                     // don't get ERR_ALREADY_SUBMITTED toasts on re-tap.

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -414,15 +414,6 @@
                         category: msg.question.category
                     });
 
-                    // Feed the in-game leaderboard panel from the game_state's
-                    // leaderboard. question_started carries no leaderboard, so
-                    // without this the panel sat at "--" during a live question
-                    // (it was only updated at reveal). The trailing game_state
-                    // broadcast after each round start does carry it.
-                    if (msg.leaderboard && game && game.updateLeaderboard) {
-                        game.updateLeaderboard({ leaderboard: msg.leaderboard }, 'leaderboard-list');
-                    }
-
                     // #14: if we're reconnecting mid-round and server thinks
                     // we've already submitted, lock the UI accordingly so we
                     // don't get ERR_ALREADY_SUBMITTED toasts on re-tap.
@@ -436,6 +427,16 @@
                     }
                 } else {
                     pu.showView('game-view');
+                }
+
+                // Feed the in-game leaderboard panel from the game_state's
+                // leaderboard — OUTSIDE the msg.question guard, because the
+                // trailing leaderboard-refresh broadcast carries `leaderboard`
+                // but no `question` (so it lands in the else branch above).
+                // Without this the panel sat at "--" during a live question;
+                // it was only ever updated at reveal.
+                if (msg.leaderboard && game && game.updateLeaderboard) {
+                    game.updateLeaderboard({ leaderboard: msg.leaderboard }, 'leaderboard-list');
                 }
                 break;
 

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -363,6 +363,15 @@
     function handleGameState(msg) {
         state.currentPhase = msg.phase;
 
+        // Keep the in-game leaderboard panel current from ANY game_state that
+        // carries a leaderboard (the round-start refresh and the ANSWER_REVEAL
+        // broadcast both do). Without this the panel was never fed during a
+        // live question — only the reveal's own `reveal-leaderboard-list` was —
+        // so #leaderboard-list/#leaderboard-summary sat at "--" mid-round (#235).
+        if (msg.leaderboard && game && game.updateLeaderboard) {
+            game.updateLeaderboard({ leaderboard: msg.leaderboard }, 'leaderboard-list');
+        }
+
         // Wake lock: only hold during active question. Cheap battery,
         // doesn't fight the OS on lobby/reveal/finale screens where
         // a sleeping screen costs nothing.
@@ -427,16 +436,6 @@
                     }
                 } else {
                     pu.showView('game-view');
-                }
-
-                // Feed the in-game leaderboard panel from the game_state's
-                // leaderboard — OUTSIDE the msg.question guard, because the
-                // trailing leaderboard-refresh broadcast carries `leaderboard`
-                // but no `question` (so it lands in the else branch above).
-                // Without this the panel sat at "--" during a live question;
-                // it was only ever updated at reveal.
-                if (msg.leaderboard && game && game.updateLeaderboard) {
-                    game.updateLeaderboard({ leaderboard: msg.leaderboard }, 'leaderboard-list');
                 }
                 break;
 

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -3879,15 +3879,6 @@
                         category: msg.question.category
                     });
 
-                    // Feed the in-game leaderboard panel from the game_state's
-                    // leaderboard. question_started carries no leaderboard, so
-                    // without this the panel sat at "--" during a live question
-                    // (it was only updated at reveal). The trailing game_state
-                    // broadcast after each round start does carry it.
-                    if (msg.leaderboard && game && game.updateLeaderboard) {
-                        game.updateLeaderboard({ leaderboard: msg.leaderboard }, 'leaderboard-list');
-                    }
-
                     // #14: if we're reconnecting mid-round and server thinks
                     // we've already submitted, lock the UI accordingly so we
                     // don't get ERR_ALREADY_SUBMITTED toasts on re-tap.
@@ -3901,6 +3892,16 @@
                     }
                 } else {
                     pu.showView('game-view');
+                }
+
+                // Feed the in-game leaderboard panel from the game_state's
+                // leaderboard — OUTSIDE the msg.question guard, because the
+                // trailing leaderboard-refresh broadcast carries `leaderboard`
+                // but no `question` (so it lands in the else branch above).
+                // Without this the panel sat at "--" during a live question;
+                // it was only ever updated at reveal.
+                if (msg.leaderboard && game && game.updateLeaderboard) {
+                    game.updateLeaderboard({ leaderboard: msg.leaderboard }, 'leaderboard-list');
                 }
                 break;
 

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -3879,6 +3879,15 @@
                         category: msg.question.category
                     });
 
+                    // Feed the in-game leaderboard panel from the game_state's
+                    // leaderboard. question_started carries no leaderboard, so
+                    // without this the panel sat at "--" during a live question
+                    // (it was only updated at reveal). The trailing game_state
+                    // broadcast after each round start does carry it.
+                    if (msg.leaderboard && game && game.updateLeaderboard) {
+                        game.updateLeaderboard({ leaderboard: msg.leaderboard }, 'leaderboard-list');
+                    }
+
                     // #14: if we're reconnecting mid-round and server thinks
                     // we've already submitted, lock the UI accordingly so we
                     // don't get ERR_ALREADY_SUBMITTED toasts on re-tap.

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -3828,6 +3828,15 @@
     function handleGameState(msg) {
         state.currentPhase = msg.phase;
 
+        // Keep the in-game leaderboard panel current from ANY game_state that
+        // carries a leaderboard (the round-start refresh and the ANSWER_REVEAL
+        // broadcast both do). Without this the panel was never fed during a
+        // live question — only the reveal's own `reveal-leaderboard-list` was —
+        // so #leaderboard-list/#leaderboard-summary sat at "--" mid-round (#235).
+        if (msg.leaderboard && game && game.updateLeaderboard) {
+            game.updateLeaderboard({ leaderboard: msg.leaderboard }, 'leaderboard-list');
+        }
+
         // Wake lock: only hold during active question. Cheap battery,
         // doesn't fight the OS on lobby/reveal/finale screens where
         // a sleeping screen costs nothing.
@@ -3892,16 +3901,6 @@
                     }
                 } else {
                     pu.showView('game-view');
-                }
-
-                // Feed the in-game leaderboard panel from the game_state's
-                // leaderboard — OUTSIDE the msg.question guard, because the
-                // trailing leaderboard-refresh broadcast carries `leaderboard`
-                // but no `question` (so it lands in the else branch above).
-                // Without this the panel sat at "--" during a live question;
-                // it was only ever updated at reveal.
-                if (msg.leaderboard && game && game.updateLeaderboard) {
-                    game.updateLeaderboard({ leaderboard: msg.leaderboard }, 'leaderboard-list');
                 }
                 break;
 


### PR DESCRIPTION
Reproduced live in desktop Chrome (390px) on a round-2 question: the in-game leaderboard panel showed `--` with an empty list. Root cause: `handleGameState` PLAYING never routed the game_state's `leaderboard` to the in-game panel (only reveal did). Fix routes it via the same `game.updateLeaderboard(..., 'leaderboard-list')` path used at reveal. Bundle rebuilt; 342 tests pass.

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)