### PR TITLE
fix(player): admin control bar pins to the bottom on iOS Safari (Closes #232)

### DIFF
--- a/custom_components/quizify/www/css/src/07-player.css
+++ b/custom_components/quizify/www/css/src/07-player.css
@@ -1900,11 +1900,14 @@
     align-items: center;
     justify-content: space-around;
     padding: var(--space-sm) var(--space-md);
-    background: rgba(250, 246, 236, 0.96);
+    /* Solid cream (was 96%-opaque + blur). A `position: fixed` element with
+       `backdrop-filter` is a WebKit bug: Safari positions it relative to its
+       container instead of the viewport, so the bar rendered mid-page on iOS
+       (#232) while Chrome pinned it correctly. Dropping the (near-invisible at
+       96% opacity) blur restores a viewport-pinned bottom bar in Safari. */
+    background: #FAF6EC;
     border-top: 1px solid #E5DFCF;
     z-index: var(--z-control-bar);
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
 }
 
 /* Reserve scroll headroom so the sticky admin-control-bar doesn't

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -4953,11 +4953,14 @@ footer {
     align-items: center;
     justify-content: space-around;
     padding: var(--space-sm) var(--space-md);
-    background: rgba(250, 246, 236, 0.96);
+    /* Solid cream (was 96%-opaque + blur). A `position: fixed` element with
+       `backdrop-filter` is a WebKit bug: Safari positions it relative to its
+       container instead of the viewport, so the bar rendered mid-page on iOS
+       (#232) while Chrome pinned it correctly. Dropping the (near-invisible at
+       96% opacity) blur restores a viewport-pinned bottom bar in Safari. */
+    background: #FAF6EC;
     border-top: 1px solid #E5DFCF;
     z-index: var(--z-control-bar);
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
 }
 
 /* Reserve scroll headroom so the sticky admin-control-bar doesn't


### PR DESCRIPTION
Root cause (found while reproducing #232): `.admin-control-bar` is `position: fixed` **and** has `backdrop-filter: blur(10px)`. A fixed element with backdrop-filter is a known WebKit bug — Safari positions it relative to its containing block instead of the viewport, so the Pause/End bar rendered mid-page on iPhone. Chrome handles it correctly (so it didn't reproduce in the desktop-Chrome repro). The bar's background was already 96% opaque, making the blur near-invisible; dropping it and using a solid cream restores a viewport-pinned bottom bar in Safari with no real visual change. CSS-only; 342 tests pass. Needs on-device (iPhone Safari) verification. 🤖 Generated with [Claude Code](https://claude.com/claude-code)