### PR TITLE
fix(player): watchdog falls back to join screen instead of a blank page (Closes #237)

### DIFF
--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -1120,6 +1120,23 @@
                 connect();
             });
         }
+
+        // Safety watchdog against a blank screen. A dead-reconnect URL
+        // (?name=X&admin=true&reconnect=1 with no live session) sends a
+        // `join` that yields no game_state, so neither the reconnect_failed
+        // handler (#227) nor the game_state default (#228) fires — the player
+        // was left on no/loading view. A few seconds after boot, if no real
+        // view has rendered (still on loading or nothing) and no game state
+        // ever arrived, fall back to the join screen so there's always a way
+        // forward instead of a blank page.
+        setTimeout(function () {
+            var visible = [].slice.call(document.querySelectorAll('.view'))
+                .find(function (e) { return e.offsetParent !== null; });
+            var stuck = !visible || visible.id === 'loading-view';
+            if (stuck && state.currentPhase == null) {
+                pu.showView('join-view');
+            }
+        }, 4000);
     }
 
     // ============================================

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -4585,6 +4585,23 @@
                 connect();
             });
         }
+
+        // Safety watchdog against a blank screen. A dead-reconnect URL
+        // (?name=X&admin=true&reconnect=1 with no live session) sends a
+        // `join` that yields no game_state, so neither the reconnect_failed
+        // handler (#227) nor the game_state default (#228) fires — the player
+        // was left on no/loading view. A few seconds after boot, if no real
+        // view has rendered (still on loading or nothing) and no game state
+        // ever arrived, fall back to the join screen so there's always a way
+        // forward instead of a blank page.
+        setTimeout(function () {
+            var visible = [].slice.call(document.querySelectorAll('.view'))
+                .find(function (e) { return e.offsetParent !== null; });
+            var stuck = !visible || visible.id === 'loading-view';
+            if (stuck && state.currentPhase == null) {
+                pu.showView('join-view');
+            }
+        }, 4000);
     }
 
     // ============================================


### PR DESCRIPTION
A dead-reconnect URL (`?name=X&admin=true&reconnect=1` with no live session) left the player blank: with no session token the client sends a `join` that yields no `game_state`, so neither `reconnect_failed` (#227) nor the `game_state` default (#228) fired. **Confirmed NOT caching** — the fresh RC7 bundle (with both fixes) was loaded. Fix: a boot watchdog that, ~4s after init, falls back to the join screen if no real view rendered and no game state arrived. Verified live (lands on join-view). 342 tests pass. 🤖 Generated with [Claude Code](https://claude.com/claude-code)