### PR TITLE
feat(icons): SVG icons for setup presets, end-game awards, highlights tab — P2 (Closes #219)

### DIFF
--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -130,7 +130,7 @@
                      data-i18n-aria-label="setup.pickMode" aria-label="Pick a mode">
                     <button type="button" class="preset-card" data-preset="schnellrunde"
                             data-rounds="5" data-difficulty="easy" data-timer="20">
-                        <span class="preset-icon" aria-hidden="true">⚡</span>
+                        <span class="preset-icon qz-icon qz-icon--sun" data-ui-icon="bolt" aria-hidden="true">⚡</span>
                         <span class="preset-body">
                             <span class="preset-name" data-i18n="setup.preset.fastName">Quick round</span>
                             <span class="preset-meta" data-i18n="setup.preset.fastMeta">5 rounds · Easy · 20 s</span>
@@ -139,7 +139,7 @@
                     </button>
                     <button type="button" class="preset-card is-active" data-preset="klassiker"
                             data-rounds="10" data-difficulty="medium" data-timer="30">
-                        <span class="preset-icon" aria-hidden="true">🧠</span>
+                        <span class="preset-icon qz-icon qz-icon--sky" data-ui-icon="brain" aria-hidden="true">🧠</span>
                         <span class="preset-body">
                             <span class="preset-name" data-i18n="setup.preset.classicName">Classic</span>
                             <span class="preset-meta" data-i18n="setup.preset.classicMeta">10 rounds · Medium · 30 s</span>
@@ -148,7 +148,7 @@
                     </button>
                     <button type="button" class="preset-card" data-preset="marathon"
                             data-rounds="20" data-difficulty="hard" data-timer="45">
-                        <span class="preset-icon" aria-hidden="true">🏆</span>
+                        <span class="preset-icon qz-icon qz-icon--sun" data-ui-icon="trophy" aria-hidden="true">🏆</span>
                         <span class="preset-body">
                             <span class="preset-name" data-i18n="setup.preset.marathonName">Marathon</span>
                             <span class="preset-meta" data-i18n="setup.preset.marathonMeta">20 rounds · Hard · 45 s</span>
@@ -156,7 +156,7 @@
                         <span class="preset-duration">~20 min</span>
                     </button>
                     <button type="button" class="preset-card" data-preset="eigene">
-                        <span class="preset-icon" aria-hidden="true">⚙️</span>
+                        <span class="preset-icon qz-icon qz-icon--sage" data-ui-icon="gear" aria-hidden="true">⚙️</span>
                         <span class="preset-body">
                             <span class="preset-name" data-i18n="setup.preset.customName">Custom settings</span>
                             <span class="preset-meta" data-i18n="setup.preset.customMeta">Pick category, difficulty, rounds yourself</span>

--- a/custom_components/quizify/www/css/src/07-player.css
+++ b/custom_components/quizify/www/css/src/07-player.css
@@ -175,10 +175,21 @@
     font-size: 1.15rem;
     margin-bottom: var(--space-xs);
 }
-.sup-disc--coral { background: rgba(232, 138, 127, 0.18); }
-.sup-disc--sage  { background: rgba(127, 168, 151, 0.18); }
-.sup-disc--sky   { background: rgba(127, 168, 196, 0.18); }
-.sup-disc--sun   { background: rgba(232, 196, 127, 0.22); }
+.sup-disc--coral { background: rgba(232, 138, 127, 0.18); color: var(--color-accent-primary); }
+.sup-disc--sage  { background: rgba(127, 168, 151, 0.18); color: var(--color-accent-secondary); }
+.sup-disc--sky   { background: rgba(127, 168, 196, 0.18); color: var(--color-accent-blue); }
+.sup-disc--sun   { background: rgba(232, 196, 127, 0.22); color: #C9A24E; }
+/* #219 P2: award discs holding an SVG glyph instead of an emoji. */
+.superlative-disc--svg svg {
+    width: 60%;
+    height: 60%;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+.superlative-disc--svg svg .d { fill: currentColor; stroke: none; }
 
 .superlative-title {
     font-family: var(--font-display);

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -3228,10 +3228,21 @@ footer {
     font-size: 1.15rem;
     margin-bottom: var(--space-xs);
 }
-.sup-disc--coral { background: rgba(232, 138, 127, 0.18); }
-.sup-disc--sage  { background: rgba(127, 168, 151, 0.18); }
-.sup-disc--sky   { background: rgba(127, 168, 196, 0.18); }
-.sup-disc--sun   { background: rgba(232, 196, 127, 0.22); }
+.sup-disc--coral { background: rgba(232, 138, 127, 0.18); color: var(--color-accent-primary); }
+.sup-disc--sage  { background: rgba(127, 168, 151, 0.18); color: var(--color-accent-secondary); }
+.sup-disc--sky   { background: rgba(127, 168, 196, 0.18); color: var(--color-accent-blue); }
+.sup-disc--sun   { background: rgba(232, 196, 127, 0.22); color: #C9A24E; }
+/* #219 P2: award discs holding an SVG glyph instead of an emoji. */
+.superlative-disc--svg svg {
+    width: 60%;
+    height: 60%;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+.superlative-disc--svg svg .d { fill: currentColor; stroke: none; }
 
 .superlative-title {
     font-family: var(--font-display);

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -225,7 +225,7 @@
     "copied": "Kopiert!"
   },
   "highlights": {
-    "highlightsTab": "🎬 Highlights",
+    "highlightsTab": "Highlights",
     "topScore": "Höchste Punktzahl",
     "bestStreak": "Beste Serie",
     "mostCorrect": "Meiste Richtige",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -225,7 +225,7 @@
     "copied": "Copied!"
   },
   "highlights": {
-    "highlightsTab": "🎬 Highlights",
+    "highlightsTab": "Highlights",
     "topScore": "Top Score",
     "bestStreak": "Best Streak",
     "mostCorrect": "Most Correct",

--- a/custom_components/quizify/www/js/icons.js
+++ b/custom_components/quizify/www/js/icons.js
@@ -56,7 +56,16 @@
         pause: '<path d="M9 5v14M15 5v14"/>',
         stop: '<rect x="6" y="6" width="12" height="12" rx="2.5"/>',
         skipnext: '<path d="M6.5 5.5v13l8-6.5zM16.5 5.5v13"/>',
-        skipprev: '<path d="M17.5 5.5v13l-8-6.5zM7.5 5.5v13"/>'
+        skipprev: '<path d="M17.5 5.5v13l-8-6.5zM7.5 5.5v13"/>',
+        // Setup-preset + end-game-award glyphs (#219 P2). Approved by
+        // Markus (2026-06-10) — do not redraw.
+        gear: '<circle cx="12" cy="12" r="3"/><path d="M12 4.5V2.5M12 21.5v-2M4.5 12h-2M21.5 12h-2M6.5 6.5 5 5M19 19l-1.5-1.5M17.5 6.5 19 5M5 19l1.5-1.5"/>',
+        medal: '<circle cx="12" cy="14.5" r="5.5"/><path d="M9.2 9.7 6.5 3.2h3.2L12 7.5 14.3 3.2h3.2L14.8 9.7"/><path d="M12 12.2l.95 1.93 2.13.31-1.54 1.5.36 2.12L12 16.6l-1.9 1 .36-2.12-1.54-1.5 2.13-.31z" class="d"/>',
+        rocket: '<path d="M12 3c2.4 1.7 3.7 4.6 3.7 7.8 0 1.6-.4 3-1 4.2H9.3c-.6-1.2-1-2.6-1-4.2C8.3 7.6 9.6 4.7 12 3z"/><circle class="d" cx="12" cy="9.5" r="1.1"/><path d="M9 15.5l-2.2 2.2.3 2.6 2.4-1.2M15 15.5l2.2 2.2-.3 2.6-2.4-1.2"/>',
+        flame: '<path d="M12 21a5.5 5.5 0 0 0 5.5-5.5c0-3.6-3-5.4-3-8.6-2 1-2.6 3-2.6 4.6-1-.5-1.6-2-1.6-3.6-2.6 2-4.3 4.6-4.3 7.6A5.5 5.5 0 0 0 12 21z"/>',
+        freeze: '<path d="M12 2.5v19M3.8 7.25l16.4 9.5M20.2 7.25l-16.4 9.5"/><path d="M12 5.6l-2 1.2M12 5.6l2 1.2M12 18.4l-2-1.2M12 18.4l2-1.2M5.6 9.2v2.3M18.4 9.2v2.3M5.6 12.5v2.3M18.4 12.5v2.3"/>',
+        // Highlights tab — reuse the popculture clapperboard glyph.
+        highlights: '<rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 9.5h18"/><path d="M7.5 5v4.5M12 5v4.5M16.5 5v4.5"/>'
     };
 
     // Accent tint per theme, cycling the 4 Soft Parlor accents; mixed stays

--- a/custom_components/quizify/www/js/player-end.js
+++ b/custom_components/quizify/www/js/player-end.js
@@ -216,11 +216,28 @@
         // Trophy Tiles: 2-col grid of square cards, each with the award glyph
         // in a rotating colored disc (coral/sage/sky/sun across the palette).
         var DISC_TINTS = ['sup-disc--coral', 'sup-disc--sage', 'sup-disc--sky', 'sup-disc--sun'];
+        // award_key → shared SVG glyph (#219 P2). Renders the icon client-side
+        // from the stable key rather than the server emoji; falls back to the
+        // server emoji for any future award_key not in this map.
+        var AWARD_GLYPH = {
+            'highlights.awards.topScore': 'medal',
+            'highlights.awards.fastestFinger': 'bolt',
+            'highlights.awards.comebackKing': 'rocket',
+            'highlights.awards.hotStreak': 'flame',
+            'highlights.awards.mostAccurate': 'target',
+            'highlights.awards.buzzkill': 'freeze',
+            'highlights.awards.knowledgeExpert': 'brain'
+        };
+        var icons = window.QuizifyIcons;
         var cards = '';
         superlatives.forEach(function (award, index) {
             // Server format: {award, icon, winner, detail, award_key, detail_key, detail_params}
             // Legacy format: {title, emoji, player_name, value}
             var emoji = award.icon || award.emoji || '🏆';
+            // Resolve the SVG glyph from the award_key; fall back to the emoji.
+            var glyphName = AWARD_GLYPH[award.award_key];
+            var glyphSvg = (glyphName && icons) ? icons.uiIcon(glyphName) : '';
+            var discInner = glyphSvg || emoji;
             // Prefer i18n keys if the server sent them; fall back to English literals.
             var titleKey = award.award_key;
             var detailKey = award.detail_key;
@@ -235,7 +252,7 @@
 
             var tint = DISC_TINTS[index % DISC_TINTS.length];
             cards += '<div class="superlative-card" style="animation-delay: ' + (index * 0.2) + 's">' +
-                '<div class="superlative-disc ' + tint + '">' + emoji + '</div>' +
+                '<div class="superlative-disc ' + tint + (glyphSvg ? ' superlative-disc--svg' : '') + '">' + discInner + '</div>' +
                 '<div class="superlative-title">' + pu.escapeHtml(title) + '</div>' +
                 '<div class="superlative-player">' + pu.escapeHtml(player) + '</div>' +
                 '<div class="superlative-value">' + pu.escapeHtml(String(detail)) + '</div>' +

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -2136,11 +2136,28 @@
         // Trophy Tiles: 2-col grid of square cards, each with the award glyph
         // in a rotating colored disc (coral/sage/sky/sun across the palette).
         var DISC_TINTS = ['sup-disc--coral', 'sup-disc--sage', 'sup-disc--sky', 'sup-disc--sun'];
+        // award_key → shared SVG glyph (#219 P2). Renders the icon client-side
+        // from the stable key rather than the server emoji; falls back to the
+        // server emoji for any future award_key not in this map.
+        var AWARD_GLYPH = {
+            'highlights.awards.topScore': 'medal',
+            'highlights.awards.fastestFinger': 'bolt',
+            'highlights.awards.comebackKing': 'rocket',
+            'highlights.awards.hotStreak': 'flame',
+            'highlights.awards.mostAccurate': 'target',
+            'highlights.awards.buzzkill': 'freeze',
+            'highlights.awards.knowledgeExpert': 'brain'
+        };
+        var icons = window.QuizifyIcons;
         var cards = '';
         superlatives.forEach(function (award, index) {
             // Server format: {award, icon, winner, detail, award_key, detail_key, detail_params}
             // Legacy format: {title, emoji, player_name, value}
             var emoji = award.icon || award.emoji || '🏆';
+            // Resolve the SVG glyph from the award_key; fall back to the emoji.
+            var glyphName = AWARD_GLYPH[award.award_key];
+            var glyphSvg = (glyphName && icons) ? icons.uiIcon(glyphName) : '';
+            var discInner = glyphSvg || emoji;
             // Prefer i18n keys if the server sent them; fall back to English literals.
             var titleKey = award.award_key;
             var detailKey = award.detail_key;
@@ -2155,7 +2172,7 @@
 
             var tint = DISC_TINTS[index % DISC_TINTS.length];
             cards += '<div class="superlative-card" style="animation-delay: ' + (index * 0.2) + 's">' +
-                '<div class="superlative-disc ' + tint + '">' + emoji + '</div>' +
+                '<div class="superlative-disc ' + tint + (glyphSvg ? ' superlative-disc--svg' : '') + '">' + discInner + '</div>' +
                 '<div class="superlative-title">' + pu.escapeHtml(title) + '</div>' +
                 '<div class="superlative-player">' + pu.escapeHtml(player) + '</div>' +
                 '<div class="superlative-value">' + pu.escapeHtml(String(detail)) + '</div>' +

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -460,7 +460,10 @@
 
                 <!-- Highlights Reel -->
                 <div id="highlights-container" class="highlights-container hidden">
-                    <div class="highlights-header" data-i18n="highlights.highlightsTab">🎬 Highlights</div>
+                    <div class="highlights-header">
+                        <span class="qz-icon qz-icon--sky" data-ui-icon="highlights" aria-hidden="true">🎬</span>
+                        <span data-i18n="highlights.highlightsTab">Highlights</span>
+                    </div>
                     <div id="highlights-list" class="highlights-list">
                         <!-- Populated by JavaScript -->
                     </div>


### PR DESCRIPTION
Part of #212 (follow-up to P1 #218 / P4). Replaces the remaining standalone emoji-as-icon surfaces with the shared **Rounded Duotone** SVG set (`www/js/icons.js`, `window.QuizifyIcons`), reusing the existing `data-ui-icon` span + `paintUiIcons()` swap mechanism. Designs were pre-approved — glyph paths used verbatim.

## Surfaces converted
- **Setup preset cards** (`admin.html`) — ⚡→`bolt` (sun), 🧠→`brain` (sky), 🏆→`trophy` (sun), ⚙️→`gear` (sage). Each `.preset-icon` span now carries `qz-icon qz-icon--<tint> data-ui-icon=...`; emoji kept as fallback text.
- **Highlights tab** (`player.html`) — clapperboard rendered as a separate `data-ui-icon="highlights"` span next to the label; the emoji was pulled out of the `highlights.highlightsTab` i18n string (de + en) so it now holds text only ("Highlights").
- **End-game award discs** (`player-end.js` `renderSuperlatives()`) — the SVG glyph is resolved **client-side from the stable `award_key`** (not piped through as an emoji string), and injected into the existing rotating-tint disc. Falls back to the server emoji for any future `award_key` not in the map (forward-compatible). No change to `game/highlights.py`.

## New glyphs added to `UI_ICON_SVG`
`gear`, `medal`, `rocket`, `flame`, `freeze` — plus a `highlights` alias reusing the `popculture` clapperboard inner SVG so `uiIcon('highlights')` works.

## `award_key` → glyph map
| award_key | glyph |
|---|---|
| `highlights.awards.topScore` | `medal` |
| `highlights.awards.fastestFinger` | `bolt` |
| `highlights.awards.comebackKing` | `rocket` |
| `highlights.awards.hotStreak` | `flame` |
| `highlights.awards.mostAccurate` | `target` |
| `highlights.awards.buzzkill` | `freeze` |
| `highlights.awards.knowledgeExpert` | `brain` |

## Build / tests
- Player bundle rebuilt (`scripts/build_bundle.py`) and CSS rebuilt (`scripts/build_css.py`; added a `.superlative-disc--svg` rule + per-tint `color` on the award discs).
- `pytest -q`: **342 passed** (baseline unchanged).
- Verified at 390px viewport (headless Chrome): all 4 presets, the highlights tab, and all 7 award discs render as crisp line glyphs in their tints — no emoji fallback, no clipping.

## Out of scope (unchanged)
- Reaction bar + language flags stay emoji (not in scope).
- P3 reveal/toast i18n strings (#220).

🤖 Generated with [Claude Code](https://claude.com/claude-code)