### PR TITLE
fix(lightning): render the lightning round on admin-as-player reconnect (Closes #239)

### DIFF
--- a/custom_components/quizify/www/js/player-utils.js
+++ b/custom_components/quizify/www/js/player-utils.js
@@ -54,7 +54,16 @@
     var viewIds = [
         'loading-view', 'not-found-view', 'ended-view', 'in-progress-view',
         'join-view', 'lobby-view', 'game-view', 'reveal-view',
-        'paused-view', 'end-view', 'connection-lost-view'
+        'paused-view', 'end-view', 'connection-lost-view',
+        // Lightning Round (#42) views. These MUST be registered here or
+        // showView() can never reveal them: a view is shown by ADDING the
+        // 'active' class (`.view.active { display:flex }`), and showView only
+        // touches IDs in this list. Without them, showView('lightning-view')
+        // hides every other view but never un-hides the lightning one, so on
+        // a reconnect into a live LIGHTNING round both #lightning-view and
+        // #lightning-splash-view stay `class="view hidden"` → blank screen
+        // (#239, cousin of #221's data-path fix).
+        'lightning-splash-view', 'lightning-view', 'lightning-recap-view'
     ];
 
     function showView(viewId) {

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -59,7 +59,16 @@
     var viewIds = [
         'loading-view', 'not-found-view', 'ended-view', 'in-progress-view',
         'join-view', 'lobby-view', 'game-view', 'reveal-view',
-        'paused-view', 'end-view', 'connection-lost-view'
+        'paused-view', 'end-view', 'connection-lost-view',
+        // Lightning Round (#42) views. These MUST be registered here or
+        // showView() can never reveal them: a view is shown by ADDING the
+        // 'active' class (`.view.active { display:flex }`), and showView only
+        // touches IDs in this list. Without them, showView('lightning-view')
+        // hides every other view but never un-hides the lightning one, so on
+        // a reconnect into a live LIGHTNING round both #lightning-view and
+        // #lightning-splash-view stay `class="view hidden"` → blank screen
+        // (#239, cousin of #221's data-path fix).
+        'lightning-splash-view', 'lightning-view', 'lightning-recap-view'
     ];
 
     function showView(viewId) {

--- a/tests/test_lightning_view_registration_239.py
+++ b/tests/test_lightning_view_registration_239.py
@@ -1,0 +1,121 @@
+"""Regression tests for issue #239 — lightning round renders no view on reconnect.
+
+Root cause (client): a player view is shown by ADDING the ``active`` class to
+its container (``.view.active { display:flex }`` in styles.css), and
+``player-utils.js`` ``showView()`` only ever touches the IDs listed in its
+``viewIds`` array. The three Lightning Round (#42) view containers —
+``lightning-splash-view``, ``lightning-view`` and ``lightning-recap-view`` —
+were **never registered** in that array. So ``showView('lightning-view')``
+hid every *other* view but never un-hid the lightning one, leaving it as the
+initial ``class="view hidden"``. On a reconnect into a live LIGHTNING round
+(``/quizify/player?...&reconnect=1``) the LIGHTNING handler therefore ended
+with BOTH ``#lightning-view`` and ``#lightning-splash-view`` hidden → a blank
+screen (the RC8 watchdog then fell back to the join view).
+
+This is the cousin of #221, which fixed the *data* path (the reconnect/refresh
+``game_state`` now carries the ``lightning`` sub-state). #239 is the *view*
+path: even with the data present, the view could not be revealed.
+
+The fix registers the three lightning view IDs in ``viewIds``. These tests:
+
+1. Statically assert the lightning view IDs are present in ``viewIds`` in both
+   the source module and the built bundle (guards this exact regression).
+2. Re-assert the server reconnect snapshot carries the full ``lightning``
+   sub-state, so the now-revealable client actually has data to render.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+
+_WWW_JS = _REPO_ROOT / "custom_components" / "quizify" / "www" / "js"
+_LIGHTNING_VIEW_IDS = (
+    "lightning-splash-view",
+    "lightning-view",
+    "lightning-recap-view",
+)
+
+
+def _extract_view_ids(js_text: str) -> set[str]:
+    """Pull the string literals out of the first ``var viewIds = [ ... ];``."""
+    match = re.search(r"var\s+viewIds\s*=\s*\[(.*?)\];", js_text, re.DOTALL)
+    assert match, "could not locate the viewIds array literal"
+    # Strip // comments so apostrophes inside explanatory text (e.g.
+    # showView('lightning-view') in a comment) aren't mistaken for entries.
+    body = re.sub(r"//[^\n]*", "", match.group(1))
+    return set(re.findall(r"'([^']+)'", body))
+
+
+@pytest.mark.parametrize("filename", ["player-utils.js", "player.bundle.js"])
+def test_lightning_views_registered_in_viewids(filename: str) -> None:
+    """showView() can only reveal IDs present in viewIds — lightning ones must be."""
+    js_text = (_WWW_JS / filename).read_text(encoding="utf-8")
+    view_ids = _extract_view_ids(js_text)
+    for vid in _LIGHTNING_VIEW_IDS:
+        assert vid in view_ids, (
+            f"{filename}: '{vid}' missing from viewIds — showView() cannot "
+            "reveal it, so the lightning round renders blank (#239)."
+        )
+
+
+def test_lightning_view_containers_exist_in_html() -> None:
+    """Sanity: the registered IDs actually correspond to real view containers."""
+    html = (
+        _REPO_ROOT
+        / "custom_components"
+        / "quizify"
+        / "www"
+        / "player.html"
+    ).read_text(encoding="utf-8")
+    for vid in _LIGHTNING_VIEW_IDS:
+        assert f'id="{vid}"' in html, f"player.html missing #{vid}"
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _fake_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+def test_reconnect_snapshot_carries_lightning_substate(tmp_path: Path) -> None:
+    """The reconnect snapshot must hand the (now revealable) client its data.
+
+    Mirrors the #221 contract from the snapshot side: a player reconnecting
+    into a live LIGHTNING round gets ``get_state_snapshot()``, which must
+    include the ``lightning`` sub-state the client's LIGHTNING case reads to
+    pick splash vs question — otherwise even a fixed showView() has nothing
+    to render.
+    """
+    state = QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+    state.add_player("A", _fake_ws())
+    assert state.start_lightning_round() is True
+    assert state.begin_lightning_questions() is True
+    assert state.phase == GamePhase.LIGHTNING
+
+    snap = state.get_state_snapshot()
+
+    assert snap["phase"] == "LIGHTNING"
+    assert "lightning" in snap
+    ln = snap["lightning"]
+    assert ln["splash_pending"] is False
+    assert "question" in ln
+    assert isinstance(ln["question"]["text"], str) and ln["question"]["text"]
+    assert isinstance(ln["question"]["answers"], list) and ln["question"]["answers"]


### PR DESCRIPTION
## Problem

On reconnect into a live LIGHTNING round via `/quizify/player?name=X&admin=true&reconnect=1`, the client ends with `game_state` phase `LIGHTNING` but **both** `#lightning-view` and `#lightning-splash-view` stay `class="view hidden"` — no view shown (blank). Confirmed live. The RC8 watchdog falls back to the join view so it isn't blank, but the player should actually SEE the lightning round on reconnect.

## Root cause — the VIEW path, not the data path

This is the cousin of [#221](https://github.com/mholzi/quizify/issues/221), which fixed the **data** path (the reconnect/refresh `game_state` now carries the `lightning` sub-state). #239 is the **view** path.

A player view is revealed by **adding the `active` class** to its container:

```css
.view        { display: none; }
.view.active { display: flex; }
```

`player-utils.js` `showView(id)` only ever mutates the IDs listed in its `viewIds` array — it adds `active` to the match and `hidden` to the rest. The three Lightning Round (#42) view containers — `lightning-splash-view`, `lightning-view`, `lightning-recap-view` — **were never registered in `viewIds`**.

So `showView('lightning-view')` (called by `handleLightningSplash` / `handleLightningQuestion`):

1. iterated `viewIds`, hid every OTHER view ✓
2. but never touched `lightning-view` (not in the list) ✗ → it kept its initial `class="view hidden"`

Hence both lightning containers stayed hidden and every `.view` was off-screen → blank. The data was already present in the snapshot (thanks to #221); the view simply could not be turned on.

## Fix

Register the three lightning view IDs in `viewIds` (source `player-utils.js` + rebuilt `player.bundle.js`). No client handler change is needed — `handleLightningSplash` / `handleLightningQuestion` / `handleLightningRecap` already call `showView`, which now works for them.

## Tests

`tests/test_lightning_view_registration_239.py`:

- Static assertion that all three lightning view IDs are present in `viewIds` in **both** the source module and the built bundle (guards this exact regression and keeps source/bundle in sync).
- Sanity check that those IDs correspond to real `#...` containers in `player.html`.
- Server-side re-assertion that the reconnect snapshot (`get_state_snapshot()`) carries the full `lightning` sub-state, so the now-revealable client actually has data to render.

`346 passed` (342 baseline + 4 new cases). Bundle rebuilt via `scripts/build_bundle.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)