### PR TITLE
fix(cache): a new release number resets the client cache (no-cache sw.js)

### DIFF
--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -9,14 +9,14 @@
     <meta name="quizify-ha-lang" content="{{HA_LANG}}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title data-i18n="page.titleAdmin">Quizify — Admin</title>
-    <link rel="manifest" href="/quizify/static/site.webmanifest">
+    <link rel="manifest" href="/quizify/static/site.webmanifest?v={{ASSET_VER}}">
     <meta name="theme-color" content="#FAF6EC">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="Quizify">
-    <link rel="apple-touch-icon" href="/quizify/static/img/icon-256.png">
+    <link rel="apple-touch-icon" href="/quizify/static/img/icon-256.png?v={{ASSET_VER}}">
     <meta name="mobile-web-app-capable" content="yes">
-    <link rel="icon" href="/quizify/static/img/icon-256.png" type="image/png">
+    <link rel="icon" href="/quizify/static/img/icon-256.png?v={{ASSET_VER}}" type="image/png">
     <!-- Preconnect for faster font loading -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/custom_components/quizify/www/analytics.html
+++ b/custom_components/quizify/www/analytics.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Quizify — Analytics</title>
     <link rel="stylesheet" href="/quizify/static/css/styles.css?v={{ASSET_VER}}">
-    <link rel="icon" href="/quizify/static/img/icon-256.png" type="image/png">
+    <link rel="icon" href="/quizify/static/img/icon-256.png?v={{ASSET_VER}}" type="image/png">
     <style>
         .analytics-container {
             max-width: 800px;

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -15,8 +15,8 @@
     <link href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@500,700,800,900&display=swap" rel="stylesheet">
 
     <link rel="stylesheet" href="/quizify/static/css/styles.css?v={{ASSET_VER}}">
-    <link rel="icon" href="/quizify/static/img/icon-256.png" type="image/png">
-    <link rel="manifest" href="/quizify/static/site.webmanifest">
+    <link rel="icon" href="/quizify/static/img/icon-256.png?v={{ASSET_VER}}" type="image/png">
+    <link rel="manifest" href="/quizify/static/site.webmanifest?v={{ASSET_VER}}">
 
     <!-- Soft Parlor: no confetti. A gentle champion reveal with warm light IS the effect. See DESIGN.md. -->
 

--- a/custom_components/quizify/www/js/sw-update.js
+++ b/custom_components/quizify/www/js/sw-update.js
@@ -62,8 +62,21 @@
     // the network-first SW will serve. Reload once, but only while idle.
     navigator.serviceWorker.addEventListener('controllerchange', maybeReload);
 
-    navigator.serviceWorker.register('/quizify/static/sw.js')
+    // updateViaCache: 'none' — the SW script (and any future importScripts)
+    // must NEVER be satisfied from the browser HTTP cache. The server already
+    // sends no-cache headers on sw.js, but older browsers honored the HTTP
+    // cache for up to 24h on the SW script; an HTTP-cached sw.js carries the
+    // OLD CACHE_VERSION, so the old cache never gets invalidated and a new
+    // release can't reset the client. Belt-and-braces for the same invariant.
+    navigator.serviceWorker.register('/quizify/static/sw.js', { updateViaCache: 'none' })
         .then(function (reg) {
+            // Deterministic update check on every page load — don't rely on
+            // the browser's own (possibly throttled, up-to-24h) navigation
+            // check. A release bump is detected at the latest on the next
+            // page load: fresh sw.js → new CACHE_VERSION → install/activate
+            // deletes every old quizify-* cache.
+            reg.update().catch(function () { /* ignore */ });
+
             // Check for a newer SW when the host comes back to the tab. The new
             // SW installs and activates on its own (skipWaiting + clients.claim),
             // which fires controllerchange → maybeReload above.

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -18,8 +18,8 @@
     <link rel="preconnect" href="https://api.fontshare.com" crossorigin>
     <link href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@500,700,800,900&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/quizify/static/css/styles.css?v={{ASSET_VER}}">
-    <link rel="icon" href="/quizify/static/img/icon-256.png" type="image/png">
-    <link rel="manifest" href="/quizify/static/site.webmanifest">
+    <link rel="icon" href="/quizify/static/img/icon-256.png?v={{ASSET_VER}}" type="image/png">
+    <link rel="manifest" href="/quizify/static/site.webmanifest?v={{ASSET_VER}}">
     <!-- Soft Parlor: no confetti library. The warm reveal IS the celebration. See DESIGN.md. -->
 </head>
 <body>

--- a/custom_components/quizify/www/sw.js
+++ b/custom_components/quizify/www/sw.js
@@ -29,28 +29,37 @@ self.addEventListener('message', function (event) {
 });
 var MAX_CACHE_ITEMS = 60;
 
-// Critical assets to precache on install
+// Critical assets to precache on install. URLs carry the same
+// ?v={{ASSET_VER}} cache-buster the HTML pages use, so (a) the cache keys
+// match what pages actually request (caches.match is exact on the query
+// string — un-versioned precache entries were dead weight that never served
+// a versioned request) and (b) a release bump changes every URL.
 var PRECACHE_ASSETS = [
-    '/quizify/static/css/styles.css',
-    '/quizify/static/js/i18n.js',
-    '/quizify/static/js/utils.js',
-    '/quizify/static/js/admin.js',
-    '/quizify/static/js/player-utils.js',
-    '/quizify/static/js/player-core.js',
-    '/quizify/static/js/player-lobby.js',
-    '/quizify/static/js/player-game.js',
-    '/quizify/static/js/player-reveal.js',
-    '/quizify/static/js/player-end.js',
-    '/quizify/static/js/vendor/qrcode.min.js',
-    '/quizify/static/i18n/de.json',
-    '/quizify/static/i18n/en.json',
-    '/quizify/static/site.webmanifest',
-    '/quizify/static/img/icon-256.png',
-    '/quizify/static/img/icon-512.png'
+    '/quizify/static/css/styles.css?v={{ASSET_VER}}',
+    '/quizify/static/js/i18n.js?v={{ASSET_VER}}',
+    '/quizify/static/js/utils.js?v={{ASSET_VER}}',
+    '/quizify/static/js/icons.js?v={{ASSET_VER}}',
+    '/quizify/static/js/admin.js?v={{ASSET_VER}}',
+    '/quizify/static/js/pack-submit.js?v={{ASSET_VER}}',
+    '/quizify/static/js/player.bundle.js?v={{ASSET_VER}}',
+    '/quizify/static/js/sw-update.js?v={{ASSET_VER}}',
+    '/quizify/static/js/vendor/qrcode.min.js?v={{ASSET_VER}}',
+    '/quizify/static/i18n/de.json?v={{ASSET_VER}}',
+    '/quizify/static/i18n/en.json?v={{ASSET_VER}}',
+    '/quizify/static/site.webmanifest?v={{ASSET_VER}}',
+    '/quizify/static/img/icon-256.png?v={{ASSET_VER}}',
+    '/quizify/static/img/icon-512.png?v={{ASSET_VER}}'
 ];
 
 /**
- * Install event: Precache critical assets
+ * Install event: Precache critical assets.
+ *
+ * cache: 'reload' forces every precache request past the browser HTTP
+ * cache straight to the server. Without it, cache.add() uses the default
+ * cache mode, and HA serves /quizify/static/* with
+ * Cache-Control: public, max-age=2678400 (31 days) — so a brand-new
+ * release's cache got seeded with month-old bytes from the HTTP cache
+ * and the "new" install was stale from birth.
  */
 self.addEventListener('install', function(event) {
     event.waitUntil(
@@ -58,9 +67,10 @@ self.addEventListener('install', function(event) {
             .then(function(cache) {
                 return Promise.all(
                     PRECACHE_ASSETS.map(function(url) {
-                        return cache.add(url).catch(function(err) {
-                            console.warn('[SW] Failed to cache:', url, err);
-                        });
+                        return cache.add(new Request(url, { cache: 'reload' }))
+                            .catch(function(err) {
+                                console.warn('[SW] Failed to cache:', url, err);
+                            });
                     })
                 );
             })
@@ -171,10 +181,40 @@ function cacheFirst(request) {
 }
 
 /**
- * Network-First strategy
+ * Network-First strategy.
+ *
+ * Un-versioned same-origin URLs (no ?v= cache-buster) are fetched with
+ * cache: 'no-cache' so the browser revalidates with the server instead of
+ * answering from its HTTP cache. HA serves static assets with a 31-day
+ * max-age, so a plain fetch() would resolve from the HTTP cache without
+ * any network round-trip — "network-first" silently became
+ * "HTTP-cache-first" and stale assets survived release bumps.
+ * Versioned URLs (?v=<version>-<fingerprint>) keep the default cache mode:
+ * their URL changes on every release/asset change, so the HTTP cache entry
+ * is immutable-per-content and reusing it within a session is correct and
+ * fast.
+ *
+ * Offline fallback: exact cache match first; if the versioned request
+ * misses (e.g. cache holds a different ?v=), retry ignoring the query so
+ * the user gets *a* working asset offline rather than nothing.
  */
 function networkFirst(request) {
-    return fetch(request)
+    var fetchRequest = request;
+    try {
+        var reqUrl = new URL(request.url);
+        // Navigation (HTML) requests are excluded: re-wrapping a
+        // mode:'navigate' Request throws, and the HTML responses already
+        // carry server-side no-cache headers.
+        if (
+            request.mode !== 'navigate' &&
+            reqUrl.origin === location.origin &&
+            !reqUrl.searchParams.has('v')
+        ) {
+            fetchRequest = new Request(request, { cache: 'no-cache' });
+        }
+    } catch (e) { /* fall through with the original request */ }
+
+    return fetch(fetchRequest)
         .then(function(response) {
             if (response && response.ok) {
                 var clone = response.clone();
@@ -189,7 +229,13 @@ function networkFirst(request) {
             return response;
         })
         .catch(function() {
-            return caches.match(request);
+            return caches.match(request)
+                .then(function(cached) {
+                    if (cached) {
+                        return cached;
+                    }
+                    return caches.match(request, { ignoreSearch: true });
+                });
         });
 }
 

--- a/tests/test_version_cachebuster.py
+++ b/tests/test_version_cachebuster.py
@@ -11,6 +11,7 @@ prove the wiring stays connected.
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -158,6 +159,12 @@ class TestAssetFingerprint:
         assert av.startswith("9.9.9-")
         assert len(av) > len("9.9.9-")
 
+    def test_asset_version_changes_on_version_bump(self) -> None:
+        """The owner's invariant: a new release number (manifest.json version)
+        MUST move the cache-buster even when no asset file changed — the
+        version prefix guarantees that independent of the fingerprint."""
+        assert _get_asset_version("1.0.0") != _get_asset_version("1.0.1")
+
 
 # ---------- Integration: real view fns + real HTML / sw.js on disk ----------
 
@@ -235,9 +242,75 @@ class TestServiceWorkerSubstitution:
         assert resp.content_type == "application/javascript"
 
     async def test_sw_js_no_cache(self) -> None:
+        """sw.js MUST be non-cacheable. An HTTP-cached sw.js carries the old
+        CACHE_VERSION forever: the browser never re-fetches it, the old SW
+        keeps running, old caches never get deleted → stale assets survive
+        every release. This is the linchpin of the 'new release number resets
+        the client cache' invariant."""
         resp = await sw_view(_fake_request("9.9.9-test"))
         cache_control = resp.headers.get("Cache-Control", "")
         assert "no-cache" in cache_control
+        assert "no-store" in cache_control
+        assert "must-revalidate" in cache_control
+
+    async def test_sw_js_substitutes_asset_ver(self) -> None:
+        """{{ASSET_VER}} must never leak into the served SW — it feeds
+        CACHE_VERSION and the precache URLs."""
+        resp = await sw_view(_fake_request("9.9.9-test"))
+        assert "{{ASSET_VER}}" not in resp.text
+        # Precache URLs carry the substituted buster.
+        assert "?v=9.9.9-test-" in resp.text
+
+    async def test_sw_precache_bypasses_http_cache(self) -> None:
+        """Install-time precache must go to the server, not the browser HTTP
+        cache. HA serves /quizify/static/* with a 31-day max-age, so a plain
+        cache.add() would seed a brand-new release's cache with month-old
+        bytes from the HTTP cache (stale from birth)."""
+        resp = await sw_view(_fake_request("9.9.9-test"))
+        assert "cache: 'reload'" in resp.text
+
+
+class TestServiceWorkerSource:
+    """Static guards on the raw www/ sources (no view involved)."""
+
+    _WWW = _REPO_ROOT / "custom_components" / "quizify" / "www"
+
+    def test_precache_assets_are_versioned_and_exist(self) -> None:
+        """Every precache entry carries the ?v={{ASSET_VER}} buster (so the
+        cache key matches what versioned pages request — caches.match is
+        exact on the query string) and points at a real file (guards list
+        drift like the old player-core.js entries after the bundle switch)."""
+        sw_src = (self._WWW / "sw.js").read_text(encoding="utf-8")
+        urls = re.findall(r"'(/quizify/static/[^']+)'", sw_src)
+        precache = [u for u in urls if "{{ASSET_VER}}" in u or "?v=" in u]
+        assert precache, "no precache URLs found in sw.js"
+        for url in precache:
+            assert url.endswith("?v={{ASSET_VER}}"), (
+                f"precache URL missing cache-buster: {url}"
+            )
+            rel = url.split("?")[0].removeprefix("/quizify/static/")
+            assert (self._WWW / rel).is_file(), (
+                f"precache URL points at missing file: {url}"
+            )
+
+    def test_html_static_asset_refs_are_versioned(self) -> None:
+        """Every /quizify/static/ reference in every served HTML page must
+        carry the ?v={{ASSET_VER}} buster — one missed reference is one
+        asset pinned in the 31-day HTTP cache across releases."""
+        for page in self._WWW.glob("*.html"):
+            src = page.read_text(encoding="utf-8")
+            refs = re.findall(r"""["'](/quizify/static/[^"']+)["']""", src)
+            for ref in refs:
+                assert "?v={{ASSET_VER}}" in ref, (
+                    f"{page.name}: unversioned static reference {ref}"
+                )
+
+    def test_sw_registration_bypasses_http_cache(self) -> None:
+        """The SW registration must opt out of the HTTP cache for the worker
+        script (updateViaCache: 'none') — older browsers honored the HTTP
+        cache for up to 24h, which kept the old CACHE_VERSION alive."""
+        src = (self._WWW / "js" / "sw-update.js").read_text(encoding="utf-8")
+        assert "updateViaCache: 'none'" in src
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Users keep seeing stale JS/CSS after a new release — the app runs old code even though a new version deployed. Required invariant: **a new release number (manifest.json version) must reset the client cache — every asset re-fetched fresh; no stale service-worker or HTTP cache survives.**

## Root cause

The server side of the chain was already sound: `sw.js` is served by a Python view with `Cache-Control: no-cache, no-store, must-revalidate` (`server/views.py:232-251`, registered ahead of the static handler), and the `?v={{ASSET_VER}}` buster is `<version>-<asset fingerprint>` re-read from the live `manifest.json` on every request — it always moves on a release bump.

The staleness came from **the service worker's interaction with the browser HTTP cache**. HA serves `/quizify/static/*` with `cache_headers=True` (`__init__.py:130`), i.e. `Cache-Control: public, max-age=2678400` (31 days):

1. **Precache seeded from the HTTP cache (`www/sw.js` install handler).** `PRECACHE_ASSETS` were *un-versioned* URLs fetched via `cache.add()` with the default cache mode. The previous release's SW install had already put those same un-versioned URLs into the 31-day HTTP cache — so on a version bump, the brand-new `quizify-v<NEW>` cache was filled with month-old bytes **without ever touching the network**. The "fresh" cache was stale from birth.
2. **`networkFirst()` wasn't network-first.** Its plain `fetch(request)` used the default cache mode, so any same-origin request *without* a `?v=` buster resolved straight from the 31-day HTTP cache (a fetch served by the HTTP cache counts as success) — and the stale response was then re-written into the SW cache, entrenching it further.
3. **Precache list drift.** It still listed `player-core.js`/`player-lobby.js`/… although `player.html` loads `player.bundle.js`, and its un-versioned keys never matched the pages' versioned requests (`caches.match` is exact on the query string) — dead weight that only polluted the cache.
4. **SW registration without `updateViaCache: 'none'`** — older browsers honored the HTTP cache for the SW script for up to 24h; an HTTP-cached `sw.js` carries the *old* `CACHE_VERSION`, so the old caches were never deleted. Update checks also only ran on `visibilitychange`.
5. A few icon/webmanifest links in the HTML pages had no `?v=` buster.

## Changes

- **`www/sw.js`**
  - Precache URLs now carry `?v={{ASSET_VER}}` (templated at serve time) and are fetched with `new Request(url, { cache: 'reload' })` — install always pulls fresh bytes from the server, and the cache keys now match what the pages actually request (working offline fallback).
  - Precache list updated to the real asset set (`player.bundle.js`, `icons.js`, `pack-submit.js`, `sw-update.js`, …).
  - `networkFirst()`: un-versioned same-origin non-navigation requests are fetched with `cache: 'no-cache'` (server revalidation, 304-cheap). Versioned URLs keep the default mode — their URL changes per release/content, so reusing the HTTP cache entry within a session is correct and fast (no legitimate caching is defeated).
  - Offline fallback retries `caches.match(request, { ignoreSearch: true })` after an exact miss.
- **`www/js/sw-update.js`**: `register(..., { updateViaCache: 'none' })` + a deterministic `reg.update()` on every page load (no longer relies on the browser's possibly-throttled navigation check).
- **HTML pages**: remaining un-versioned `icon-256.png` / `site.webmanifest` links now carry `?v={{ASSET_VER}}`.

## Why the invariant now holds

On a release bump: every page load re-fetches `sw.js` (server no-cache + `updateViaCache: 'none'` + explicit `reg.update()`) → new `{{ASSET_VER}}` → new `CACHE_VERSION` → install precaches **from the server** (`cache: 'reload'`) → the existing `activate` handler deletes every `quizify-*` cache that doesn't match → `skipWaiting`/`clients.claim` + the existing idle-gated reload (#215) bring running pages onto the new assets. Every asset URL in every page carries `?v=<version>-<fingerprint>`, which always changes on a version bump, so the browser HTTP cache is keyed away from any stale entry. No path remains by which a pre-release byte can be served after the bump (except the explicit offline fallback).

## Tests

Extended `tests/test_version_cachebuster.py` (346 → **352 passing**):
- `sw.js` response must be `no-cache, no-store, must-revalidate` and have `{{ASSET_VER}}` substituted
- precache must bypass the HTTP cache (`cache: 'reload'`)
- every precache entry must end in `?v={{ASSET_VER}}` **and** point at an existing file (guards list drift)
- every `/quizify/static/` reference in every served HTML page must carry the buster
- the asset version must change on a manifest version bump even with unchanged assets
- registration must set `updateViaCache: 'none'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)