### PR TITLE
fix(admin): prevent a second self-join as player (Closes #244)

### DIFF
--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -403,6 +403,37 @@ class QuizifyWebSocketHandler:
             await self._conn.send_error(ws, ERR_NAME_INVALID, "Name is required")
             return
 
+        # Defense in depth against a second self-join (#244, cousin of #207).
+        #
+        # The admin "Join as Player" flow registers the host as a player on
+        # the SAME admin WebSocket. If the host taps "Join as Player" again,
+        # the client opens the modal afresh and (with a different typed name)
+        # would otherwise create a duplicate/ghost player from the one admin
+        # session. The client now hides the button after the first join, but
+        # a crafted message must not slip past either: if THIS connection
+        # already holds a connected player under a different name, reject the
+        # duplicate join. A re-join under the SAME name is idempotent and
+        # handled by the reconnect path in PlayerRegistry.add_player, so it is
+        # explicitly allowed here (no-op rejoin / lobby refresh).
+        existing = game_state.get_player_by_ws(ws)
+        if (
+            existing is not None
+            and existing.connected
+            and existing.name.lower() != name.lower()
+        ):
+            _LOGGER.warning(
+                "Duplicate self-join rejected: connection already holds "
+                "player %s, refusing second join as %s",
+                existing.name,
+                name,
+            )
+            await self._conn.send_error(
+                ws,
+                ERR_INVALID_ACTION,
+                "Already joined as a player",
+            )
+            return
+
         # Auto-append number if name is taken
         original_name = name
         counter = 2

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -1181,13 +1181,18 @@
         // different name. We don't strictly need the server state here —
         // _adminJoinedAs is set the moment we send the join message — but
         // we double-check the roster so the chip survives a reload.
-        if (els.participateBtn) {
-            var rosterHasMe = _adminJoinedAs && list.some(function (p) {
+        if (els.participateBtn && _adminJoinedAs) {
+            // #244: disable the "Join as Player" control the moment the admin
+            // has claimed a player slot — don't wait for the roster broadcast
+            // to round-trip, otherwise there's a window where a second tap
+            // creates a duplicate player. The confirmation chip ("Joined as
+            // …") still requires roster confirmation so it survives a reload.
+            els.participateBtn.disabled = true;
+            var rosterHasMe = list.some(function (p) {
                 var n = typeof p === 'string' ? p : (p && p.name);
                 return n === _adminJoinedAs;
             });
-            if (_adminJoinedAs && rosterHasMe) {
-                els.participateBtn.disabled = true;
+            if (rosterHasMe) {
                 els.participateBtn.classList.add('is-joined');
                 els.participateBtn.innerHTML =
                     '<span class="btn-icon" aria-hidden="true">✓</span>' +
@@ -1430,6 +1435,10 @@
         // actually answer questions.
         _adminJoinedAs = name;
         sessionStorage.setItem('quizify_admin_name', name);
+        // #244: disable the trigger immediately so a fast second tap (before
+        // the server's roster broadcast re-renders the lobby) can't open the
+        // modal again and create a duplicate self-join.
+        if (els.participateBtn) els.participateBtn.disabled = true;
         send('join', { name: name, is_admin: true });
         closeAdminJoinModal();
     }
@@ -1450,7 +1459,13 @@
     function setupAdminJoinModal() {
         // Participate button — opens the modal in "join" mode (game
         // is in lobby, admin choosing to play along, no fresh start).
-        on(els.participateBtn, 'click', function () { openAdminJoinModal('join'); });
+        on(els.participateBtn, 'click', function () {
+            // #244: once the admin has self-joined as a player, re-tapping
+            // must be a no-op — never open the modal again, otherwise the
+            // host can create a duplicate/ghost player from one admin session.
+            if (_adminJoinedAs) return;
+            openAdminJoinModal('join');
+        });
         on(els.adminCancelBtn, 'click', closeAdminJoinModal);
 
         var backdrop = els.adminJoinModal ? els.adminJoinModal.querySelector('.modal-backdrop') : null;

--- a/tests/test_admin_double_join_244.py
+++ b/tests/test_admin_double_join_244.py
@@ -1,0 +1,132 @@
+"""Regression test: issue #244 — admin must not double-join as a player.
+
+The bug:
+  - The admin "Join as Player" flow registers the host as a player on the
+    SAME admin WebSocket. After the admin joined once, the "Join as Player"
+    control stayed active, so a second tap (with a different typed name)
+    created a duplicate/ghost player from the one admin session.
+
+Expected (defense in depth, cousin of #207's connected-admin guard):
+  - The server rejects a second join over a connection that already holds a
+    connected player under a *different* name — no duplicate player is
+    created.
+  - The first admin-as-player join still succeeds.
+  - A re-join under the *same* name over a fresh connection (the admin's
+    /admin → /player redirect / lobby refresh) is still allowed.
+  - Normal players joining over their own connections are unaffected.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _ws(closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    ws.send_json = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    runtime = _FakeRuntime(tmp_path)
+    return QuizifyGameState(runtime=runtime, entry_id="test")
+
+
+@pytest.fixture
+def handler(game: QuizifyGameState) -> QuizifyWebSocketHandler:
+    runtime = _FakeRuntime(game._runtime.data_dir)  # type: ignore[attr-defined]
+    h = QuizifyWebSocketHandler(
+        runtime=runtime,
+        game_state_provider=lambda: game,
+    )
+    h._conn = ConnectionManager(runtime, lambda: game)
+    h._conn.broadcast = AsyncMock()
+    h._conn.send_error = AsyncMock()
+    return h
+
+
+def _names(game: QuizifyGameState) -> list[str]:
+    return [p.name for p in game.get_players()]
+
+
+class TestAdminDoubleJoin:
+    @pytest.mark.asyncio
+    async def test_second_self_join_rejected(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        # First admin-as-player join over the admin WS — succeeds.
+        admin_ws = _ws()
+        await handler._handle_join(
+            admin_ws, {"name": "Host", "is_admin": True}, game
+        )
+        assert _names(game) == ["Host"]
+        handler._conn.send_error.assert_not_called()
+
+        # Same connection tries to join AGAIN under a different name —
+        # must be rejected, no second/ghost player created.
+        await handler._handle_join(
+            admin_ws, {"name": "HostGhost", "is_admin": True}, game
+        )
+        assert _names(game) == ["Host"]
+        assert game.get_player("HostGhost") is None
+        handler._conn.send_error.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_first_self_join_still_works(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        admin_ws = _ws()
+        await handler._handle_join(
+            admin_ws, {"name": "Host", "is_admin": True}, game
+        )
+        assert game.get_player("Host") is not None
+        assert game.get_player("Host").is_admin is True
+        handler._conn.send_error.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejoin_same_name_new_connection_allowed(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        # /admin → /player redirect opens a fresh WS and re-joins under the
+        # same name — must stay a single player (idempotent), not rejected.
+        # The old admin WS has dropped by then (browser navigated away), so
+        # mark it closed before the re-join, mirroring the live flow.
+        ws1 = _ws()
+        await handler._handle_join(ws1, {"name": "Host", "is_admin": True}, game)
+        ws1.closed = True
+        host = game.get_player("Host")
+        host.connected = False
+        ws2 = _ws()
+        await handler._handle_join(ws2, {"name": "Host", "is_admin": True}, game)
+        assert _names(game) == ["Host"]
+        handler._conn.send_error.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_normal_players_unaffected(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        # Each player on their own connection — all join fine.
+        await handler._handle_join(_ws(), {"name": "Host", "is_admin": True}, game)
+        await handler._handle_join(_ws(), {"name": "Alice"}, game)
+        await handler._handle_join(_ws(), {"name": "Bob"}, game)
+        assert _names(game) == ["Host", "Alice", "Bob"]


### PR DESCRIPTION
## Problem
As admin, after tapping **Join as Player** and joining, the **Join as Player** control stayed visible/active — so the host could tap it again and join a **second time as a normal player**, producing a duplicate/ghost player from the one admin session. This is the front-of-house version of the re-claim gap in #207 (single-admin invariant / orphaned crown).

## Root cause
- **Client:** `#participate-btn` opened the join modal on *every* tap, and the button was only disabled once the server's roster broadcast round-tripped and confirmed the admin's name (`_adminJoinedAs && rosterHasMe`). That left a window where a fast second tap created another player.
- **Server:** `_handle_join` had no guard against a second `join` over the *same* admin WebSocket — a crafted message could create a duplicate even with the UI fixed.

## Fix (defense in depth, mirrors #207)
- **Client (`www/js/admin.js`):**
  - The participate-btn click is a **no-op** once `_adminJoinedAs` is set — it never re-opens the modal.
  - The button is **disabled immediately** on join (in `doJoinAsPlayer` and on the next lobby render) instead of waiting for roster confirmation. The "Joined as …" confirmation chip still waits for the roster so it survives a reload.
- **Server (`server/websocket.py`):** `_handle_join` rejects a join over a connection that already holds a **connected player under a different name** (duplicate self-join) with `INVALID_ACTION`. Legitimate paths are preserved:
  - A same-name re-join over a **fresh** connection (the `/admin → /player` redirect / lobby refresh) — idempotent, allowed.
  - The first admin-as-player join, and normal players on their own connections — unaffected.

## Test
`tests/test_admin_double_join_244.py` — 4 cases:
1. Second self-join over the same WS (different name) is rejected, no ghost player created.
2. First admin self-join still works.
3. Same-name re-join over a fresh connection is allowed (not rejected).
4. Normal players on their own connections join fine.

Full suite: **356 passing** (352 baseline + 4 new). `player.bundle.js` rebuilt (no change — `admin.js` is loaded directly, not bundled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)