### PR TITLE
fix(powerups): joker/steal/freeze shuffle & timing correctness (Closes #254)

### DIFF
--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -1076,24 +1076,29 @@ class QuizifyGameState:
                 self._player_registry.get_player(target_id) if target_id else None
             )
             if not target_id or target_id == player_id or not target_player or not target_player.is_active:
-                # For FREEZE the random fallback should also skip already-submitted
-                # players so the pause is actually useful (otherwise freezing a
-                # locked-in opponent burns the power-up for nothing).
+                # FREEZE: skip already-submitted players so the pause is actually
+                # useful (freezing a locked-in opponent burns the power-up).
+                # STEAL: the opposite — only a SUBMITTED target has a round_score
+                # worth stealing; an unsubmitted target yields 0 stolen points
+                # and burns the power-up for nothing (#254). So require submitted.
                 opponents = [
                     name
                     for name, p in self._player_registry.players.items()
                     if name != player_id and p.is_active
                     and (held != PowerUpType.FREEZE or not p.submitted)
+                    and (held != PowerUpType.STEAL or p.submitted)
                 ]
                 if not opponents:
                     return ERR_INVALID_ACTION
                 target_id = random.choice(opponents)
 
-        # FREEZE: explicit-target submitted-check (random fallback already
-        # filters submitted players above).
-        if held == PowerUpType.FREEZE and target_id:
+        # Explicit-target submitted-check (random fallback already filters above).
+        # FREEZE rejects submitted targets; STEAL rejects un-submitted targets.
+        if target_id:
             target_check = self._player_registry.get_player(target_id)
-            if target_check and target_check.submitted:
+            if held == PowerUpType.FREEZE and target_check and target_check.submitted:
+                return ERR_INVALID_ACTION
+            if held == PowerUpType.STEAL and target_check and not target_check.submitted:
                 return ERR_INVALID_ACTION
 
         # Determine wrong answer indices for joker

--- a/custom_components/quizify/game/timer.py
+++ b/custom_components/quizify/game/timer.py
@@ -17,12 +17,14 @@ class QuestionTimer:
         self._start_time: float | None = None
         self._bonus_time: float = 0.0
         self._pause_remaining: float = 0.0
+        self._pause_started_at: float | None = None
 
     def start(self) -> None:
         """Start the countdown timer."""
         self._start_time = time.monotonic()
         self._bonus_time = 0.0
         self._pause_remaining = 0.0
+        self._pause_started_at = None
 
     def get_remaining(self) -> float:
         """Get remaining time in seconds."""
@@ -40,9 +42,13 @@ class QuestionTimer:
     def pause_for_player(self, seconds: float) -> None:
         """Add pause credit — effectively freezes the timer for the given duration.
 
-        Used by the freeze power-up to penalize an opponent.
+        Used by the freeze power-up to penalize an opponent. Records the wall-clock
+        start of the freeze so the speed-bonus calculation can credit only the
+        portion of the freeze that has actually elapsed (see get_elapsed / #254).
         """
         self._pause_remaining += seconds
+        if self._pause_started_at is None:
+            self._pause_started_at = time.monotonic()
 
     def add_time(self, seconds: float) -> None:
         """Add bonus time to the timer.
@@ -54,12 +60,21 @@ class QuestionTimer:
     def get_elapsed(self) -> float:
         """Get effective elapsed time since start — used for speed bonus calculation.
 
-        Subtracts any accumulated pause credit (e.g. from Freeze power-up) so that
-        frozen players are not penalised with a lower speed bonus.
+        Subtracts accumulated pause credit (e.g. from Freeze power-up) so that
+        frozen players are not penalised with a lower speed bonus. Crucially it
+        credits only the portion of the freeze that has ACTUALLY elapsed in
+        wall-clock time, not the full 5s up front — otherwise a frozen player who
+        answers immediately would harvest up to 5s of free speed bonus (#254).
         """
         if self._start_time is None:
             return 0.0
-        return max(0.0, time.monotonic() - self._start_time - self._pause_remaining)
+        now = time.monotonic()
+        pause_credit = self._pause_remaining
+        if self._pause_started_at is not None:
+            # Only count the freeze time that has truly passed so far.
+            elapsed_pause = now - self._pause_started_at
+            pause_credit = min(self._pause_remaining, max(0.0, elapsed_pause))
+        return max(0.0, now - self._start_time - pause_credit)
 
     def reset(self, duration: float | None = None) -> None:
         """Reset the timer, optionally with a new duration."""
@@ -68,3 +83,4 @@ class QuestionTimer:
         self._start_time = None
         self._bonus_time = 0.0
         self._pause_remaining = 0.0
+        self._pause_started_at = None

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -844,9 +844,15 @@ class QuizifyWebSocketHandler:
 
             # For joker, send the removed answer to the using player only
             if result.type == PowerUpType.JOKER and result.joker_remove_index is not None:
-                # Map original index to shuffled index for the player
+                # Map the canonical original index to THIS player's shuffled
+                # position. The buttons are rendered in the per-player shuffle
+                # order, so mapping through the canonical shuffle_map would
+                # disable the wrong button — potentially the CORRECT answer
+                # (#254). get_player_shuffle falls back to the canonical map
+                # when the player has no per-player shuffle.
+                player_shuffle = game_state.get_player_shuffle(player.name)
                 shuffled_remove_idx = None
-                for shuffled_idx, orig_idx in enumerate(game_state.shuffle_map):
+                for shuffled_idx, orig_idx in enumerate(player_shuffle):
                     if orig_idx == result.joker_remove_index:
                         shuffled_remove_idx = shuffled_idx
                         break

--- a/tests/test_concurrency_167.py
+++ b/tests/test_concurrency_167.py
@@ -133,6 +133,7 @@ class TestStealPowerup:
     def test_steal_transfers_half_round_score(self, game: QuizifyGameState) -> None:
         _start_question(game, ["Alice", "Bob"])
         bob = game.get_player("Bob")
+        bob.submitted = True  # STEAL only targets submitted players (#254)
         bob.round_score = 10
         bob.score = 10
         game._powerup_manager._inventory["Alice"] = PowerUpType.STEAL
@@ -152,6 +153,7 @@ class TestStealPowerup:
         happened."""
         _start_question(game, ["Alice", "Bob"])
         bob = game.get_player("Bob")
+        bob.submitted = True  # STEAL only targets submitted players (#254)
         bob.round_score = 10
         bob.score = 10
         game._powerup_manager._inventory["Alice"] = PowerUpType.STEAL

--- a/tests/test_game_state.py
+++ b/tests/test_game_state.py
@@ -638,7 +638,9 @@ class TestPowerUpTargeting:
         state.start_game(language="de", num_rounds=3, difficulty="easy")
         state.start_next_question()
         # Give Bob some round score so there's something worth stealing.
+        # STEAL only targets submitted players (#254), so mark Bob submitted.
         bob = state.get_player("Bob")
+        bob.submitted = True
         bob.round_score = 100
         bob.score = 100
         _give(state, "Alice", PowerUpType.STEAL)
@@ -749,3 +751,56 @@ class TestPowerUpTargeting:
         result = state.use_powerup("Alice", target_id="Bob")
         assert isinstance(result, str), "Freeze on submitted target should be rejected"
         assert state._powerup_manager.get_powerup("Alice") == PowerUpType.FREEZE
+
+    def test_steal_rejects_explicit_unsubmitted_target(self, state: QuizifyGameState) -> None:
+        """STEAL on a target that hasn't submitted yet steals 0 points and burns
+        the power-up. The server must reject so the inventory survives (#254)."""
+        state.add_player("Alice", _fake_ws())
+        state.add_player("Bob", _fake_ws())
+        state.start_game(language="de", num_rounds=3, difficulty="easy")
+        state.start_next_question()
+        # Bob has NOT submitted — his round_score isn't locked in yet.
+        _give(state, "Alice", PowerUpType.STEAL)
+
+        result = state.use_powerup("Alice", target_id="Bob")
+        assert isinstance(result, str), "Steal on unsubmitted target should be rejected"
+        assert state._powerup_manager.get_powerup("Alice") == PowerUpType.STEAL
+        # No points moved.
+        assert state.get_player("Bob").score == state.get_player("Bob").round_score
+
+    def test_steal_random_pick_skips_unsubmitted_targets(
+        self, state: QuizifyGameState
+    ) -> None:
+        """Random STEAL fallback must skip players who haven't submitted (they'd
+        yield 0 stolen points) and choose a submitted opponent instead (#254)."""
+        state.add_player("Alice", _fake_ws())
+        state.add_player("Bob", _fake_ws())
+        state.add_player("Carol", _fake_ws())
+        state.start_game(language="de", num_rounds=3, difficulty="easy")
+        state.start_next_question()
+        # Only Carol has locked in (and has something worth stealing).
+        carol = state.get_player("Carol")
+        carol.submitted = True
+        carol.round_score = 80
+        carol.score = 80
+        _give(state, "Alice", PowerUpType.STEAL)
+
+        effect = state.use_powerup("Alice", target_id=None)
+        assert isinstance(effect, PowerUpEffect)
+        assert effect.target_player == "Carol", "Steal fallback must skip unsubmitted Bob"
+        assert effect.stolen_points == 40
+
+    def test_steal_with_no_submitted_opponents_returns_error_and_keeps_powerup(
+        self, state: QuizifyGameState
+    ) -> None:
+        """If no opponent has submitted, STEAL has no valid target. Reject and
+        keep the power-up rather than burning it for 0 points (#254)."""
+        state.add_player("Alice", _fake_ws())
+        state.add_player("Bob", _fake_ws())
+        state.start_game(language="de", num_rounds=3, difficulty="easy")
+        state.start_next_question()
+        _give(state, "Alice", PowerUpType.STEAL)
+
+        result = state.use_powerup("Alice", target_id=None)
+        assert isinstance(result, str)
+        assert state._powerup_manager.get_powerup("Alice") == PowerUpType.STEAL

--- a/tests/test_joker_shuffle_254.py
+++ b/tests/test_joker_shuffle_254.py
@@ -1,0 +1,123 @@
+"""Regression test for the Joker / per-player-shuffle mapping bug (#254).
+
+The Joker power-up greys out one WRONG answer. The chosen index is canonical
+(the question's original answer order), but each player sees the answers in
+their OWN per-player shuffle. The bug: websocket.py mapped the canonical index
+through the *canonical* shuffle_map instead of the player's shuffle, so the
+disabled button could land on the CORRECT answer in that player's order
+(1-in-3). The fix maps through get_player_shuffle(player.name).
+
+This test drives the real _handle_use_powerup handler and asserts that, for
+several distinct player shuffles, the button index the server tells the client
+to disable always points to a WRONG answer in THAT player's order.
+"""
+
+from __future__ import annotations
+
+import sys
+from itertools import permutations
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.powerups import PowerUpType  # noqa: E402
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    def create_task(self, coro):  # pragma: no cover - not exercised here
+        import asyncio
+
+        return asyncio.ensure_future(coro)
+
+
+def _fake_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+@pytest.fixture
+def state(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+def _handler(state: QuizifyGameState) -> QuizifyWebSocketHandler:
+    runtime = _FakeRuntime(state._runtime.data_dir)  # type: ignore[attr-defined]
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: state)
+    h._conn = ConnectionManager(runtime, lambda: state)
+    h._conn.broadcast = AsyncMock()
+    h._conn._safe_send = AsyncMock()
+    return h
+
+
+def _give(state: QuizifyGameState, name: str, powerup: PowerUpType) -> None:
+    state._powerup_manager._inventory[name] = powerup
+
+
+def _correct_original_index(state: QuizifyGameState) -> int:
+    q = state._current_question
+    assert q is not None
+    return next(i for i, a in enumerate(q.answers) if a.correct)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("perm_idx", range(6))
+async def test_joker_disables_wrong_answer_in_player_order(
+    state: QuizifyGameState, perm_idx
+) -> None:
+    """For several distinct player shuffles, the disabled button index must
+    point to a WRONG answer in that player's order — never the correct one
+    (#254)."""
+    ws = _fake_ws()
+    state.add_player("Alice", ws)
+    state.start_game(language="de", num_rounds=3, difficulty="easy")
+    state.start_next_question()
+
+    q = state._current_question
+    assert q is not None
+    n = len(q.answers)
+    correct_orig = _correct_original_index(state)
+
+    # Build the perm_idx-th permutation of this question's answer positions and
+    # force it as Alice's per-player shuffle. The canonical round shuffle is left
+    # as whatever start_next_question set, so canonical != player order (the bug
+    # surface). Skipping the identity perm guarantees a real mismatch.
+    perms = [p for p in permutations(range(n))]
+    player_shuffle = perms[perm_idx % len(perms)]
+    state.set_player_shuffle("Alice", list(player_shuffle))
+
+    h = _handler(state)
+    _give(state, "Alice", PowerUpType.JOKER)
+
+    await h._handle_use_powerup(ws, {}, state)
+
+    # The private send to Alice carries the button index to disable.
+    private_sends = [
+        c.args[1]
+        for c in h._conn._safe_send.call_args_list
+        if len(c.args) >= 2 and c.args[1].get("powerup_type") == "joker"
+    ]
+    assert private_sends, "expected a private joker send to the using player"
+    shuffled_idx = private_sends[-1]["joker_remove_index"]
+    assert shuffled_idx is not None
+
+    # Map the player's button position back to the original answer and assert
+    # it is a wrong answer in THAT player's order.
+    original_idx = player_shuffle[shuffled_idx]
+    assert original_idx != correct_orig, (
+        f"Joker disabled the correct answer (orig {correct_orig}) for shuffle "
+        f"{player_shuffle}: button {shuffled_idx} -> orig {original_idx}"
+    )
+    assert not q.answers[original_idx].correct

--- a/tests/test_timer_freeze_254.py
+++ b/tests/test_timer_freeze_254.py
@@ -1,0 +1,98 @@
+"""Regression tests for QuestionTimer freeze-credit accounting (#254).
+
+The freeze power-up adds a 5s pause credit to the target's timer. The
+speed-bonus calculation (get_elapsed) subtracts that credit so a frozen
+player isn't penalised. The bug: the FULL credit was subtracted up front,
+so a frozen player who answered immediately harvested up to 5s of free
+speed bonus. The fix credits only the portion of the freeze that has
+actually elapsed in wall-clock time.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.timer import QuestionTimer  # noqa: E402
+
+
+class _FakeClock:
+    """Deterministic monotonic clock so the tests don't sleep."""
+
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _timer_with_clock(monkeypatch, duration: float = 30.0) -> tuple[QuestionTimer, _FakeClock]:
+    clock = _FakeClock()
+    monkeypatch.setattr("custom_components.quizify.game.timer.time.monotonic", clock)
+    timer = QuestionTimer(duration=duration)
+    return timer, clock
+
+
+def test_freeze_credit_counts_only_elapsed_not_full(monkeypatch) -> None:
+    """A player frozen for 5s who answers 1s later must only get ~1s of
+    freeze credit on their speed bonus, not the full 5s (#254)."""
+    timer, clock = _timer_with_clock(monkeypatch)
+    timer.start()
+    clock.advance(2.0)  # 2s real elapsed before the freeze
+    timer.pause_for_player(5.0)  # 5s freeze applied
+    clock.advance(1.0)  # player answers 1s into the freeze
+
+    # Real elapsed = 3.0s; only 1.0s of the 5s freeze has truly passed.
+    # Effective elapsed for speed bonus = 3.0 - 1.0 = 2.0s.
+    assert timer.get_elapsed() == 2.0
+
+
+def test_freeze_credit_caps_at_full_duration(monkeypatch) -> None:
+    """Once the entire freeze window has elapsed, the full credit applies —
+    never more (no negative elapsed)."""
+    timer, clock = _timer_with_clock(monkeypatch)
+    timer.start()
+    clock.advance(1.0)
+    timer.pause_for_player(5.0)
+    clock.advance(10.0)  # well past the 5s freeze window
+
+    # Real elapsed = 11.0s; freeze credit capped at 5.0s.
+    assert timer.get_elapsed() == 6.0
+
+
+def test_no_free_speed_bonus_for_immediate_answer(monkeypatch) -> None:
+    """The exploit: answer the instant the freeze lands. Effective elapsed
+    must equal real elapsed (zero freeze credit yet)."""
+    timer, clock = _timer_with_clock(monkeypatch)
+    timer.start()
+    clock.advance(4.0)
+    timer.pause_for_player(5.0)
+    # No time advances — answer is instantaneous.
+
+    assert timer.get_elapsed() == 4.0
+
+
+def test_get_elapsed_without_freeze_is_plain_elapsed(monkeypatch) -> None:
+    """Sanity: with no freeze, elapsed is just wall-clock since start."""
+    timer, clock = _timer_with_clock(monkeypatch)
+    timer.start()
+    clock.advance(7.0)
+    assert timer.get_elapsed() == 7.0
+
+
+def test_reset_clears_freeze_credit(monkeypatch) -> None:
+    """Reset must wipe pause bookkeeping so a new round starts clean."""
+    timer, clock = _timer_with_clock(monkeypatch)
+    timer.start()
+    clock.advance(1.0)
+    timer.pause_for_player(5.0)
+    timer.reset()
+    timer.start()
+    clock.advance(3.0)
+    assert timer.get_elapsed() == 3.0


### PR DESCRIPTION
Fixes the three power-up correctness bugs from the 2026-06-11 code review (#252), tracked in [#254](https://github.com/mholzi/quizify/issues/254).

## Bugs fixed

### HIGH — Joker could grey out the CORRECT answer
The joker's removed-answer index is canonical (the question's original answer order), but each player's buttons render in their **own per-player shuffle**. The handler mapped the index through the canonical `shuffle_map` instead of the player's shuffle, so ~1-in-3 it disabled the **right** answer for that player. Now mapped through `get_player_shuffle(player.name)` (`server/websocket.py`), so the disabled button is always the intended wrong answer in THAT player's order.

### MEDIUM — STEAL stole 0 from a not-yet-submitted target + burned the power-up
A STEAL against a target that hadn't locked in yet had nothing to steal (`round_score` not finalized), so it transferred 0 points and consumed the power-up. STEAL is now restricted to **submitted** targets — both the random fallback (filtered) and explicit-target selection (rejected) — mirroring the existing FREEZE submitted guard (`game/state.py`).

### LOW — Freeze speed-bonus exploit
`get_elapsed` (speed-bonus input) subtracted the full 5s freeze credit immediately, so a frozen player who answered straight away harvested up to 5s of free speed bonus. It now credits only the portion of the freeze that has **actually elapsed** in wall-clock time, capped at the full duration (`game/timer.py`). The visible countdown pause is unchanged.

## Tests
- `tests/test_joker_shuffle_254.py` — joker disables a wrong answer across several distinct player shuffles (verified this fails against the canonical-map bug and passes with the fix).
- Steal regressions in `tests/test_game_state.py` — explicit unsubmitted target rejected & zero-safe, random fallback skips unsubmitted opponents, no-valid-target rejected (inventory preserved).
- `tests/test_timer_freeze_254.py` — freeze credit counts only elapsed time, caps at full duration, no free bonus on immediate answer, reset clears credit.
- Updated existing STEAL tests (`test_game_state.py`, `test_concurrency_167.py`) to mark the target submitted.

**370 passed** (356 baseline + 14 new/updated). No `www/js` touched, so no bundle rebuild. No HA deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)