### PR TITLE
fix(frontend): dead pack-banner + XSS, join-hang, listener leak, double-escape (Closes #257)

### DIFF
--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -1773,8 +1773,20 @@ async function checkPackUpdates() {
         const data = await resp.json();
         if (!data.upstream_available || !data.updates || data.updates.length === 0) return;
 
+        // checkPackUpdates lives outside the admin IIFE, so the IIFE-local
+        // _t/escapeHtml helpers are out of scope here. Use the global
+        // window.t (i18n) and window.QuizifyUtils.escapeHtml instead, and
+        // escape all pack metadata before it touches innerHTML (defends
+        // against a malicious pack name/version → stored XSS).
+        const tt = (key, params) => (window.t ? window.t(key, params) : key);
+        const esc = (s) => (window.QuizifyUtils && window.QuizifyUtils.escapeHtml
+            ? window.QuizifyUtils.escapeHtml(String(s == null ? '' : s))
+            : String(s == null ? '' : s));
+
         const updates = data.updates;
-        const names = updates.map(u => u.name + ' (' + u.installed_version + ' → ' + u.upstream_version + ')').join(', ');
+        const names = updates.map(u =>
+            esc(u.name) + ' (' + esc(u.installed_version) + ' → ' + esc(u.upstream_version) + ')'
+        ).join(', ');
 
         // Build banner
         const banner = document.createElement('div');
@@ -1797,12 +1809,12 @@ async function checkPackUpdates() {
         ].join(';');
 
         const packPath = '<code style="background:#F3EEDF;padding:1px 4px;border-radius:3px;font-family:\'JetBrains Mono\',monospace;color:#2A2820">custom_components/quizify/questions/</code>';
-        const bodyText = _t('admin.packUpdateBody', { path: packPath });
-        const dismissTitle = _t('common.close');
+        const bodyText = tt('admin.packUpdateBody', { path: packPath });
+        const dismissTitle = esc(tt('common.close'));
         banner.innerHTML =
             '<span style="font-size:1.2rem;flex-shrink:0">📦</span>' +
             '<div style="flex:1">' +
-                '<strong style="color:#E88A7F;font-family:\'Cabinet Grotesk\',sans-serif;font-weight:700">' + _t('admin.packUpdateTitle') + '</strong>' +
+                '<strong style="color:#E88A7F;font-family:\'Cabinet Grotesk\',sans-serif;font-weight:700">' + esc(tt('admin.packUpdateTitle')) + '</strong>' +
                 '<div style="margin-top:3px;color:#2A2820">' + names + '</div>' +
                 '<div style="margin-top:5px;font-size:0.8rem;color:#6E6A5C">' + bodyText + '</div>' +
             '</div>' +
@@ -1815,7 +1827,10 @@ async function checkPackUpdates() {
         if (setupScreen) {
             setupScreen.insertBefore(banner, setupScreen.firstChild);
         }
-    } catch (_e) {
-        // Silently ignore — offline or HA not ready
+    } catch (e) {
+        // Offline or HA not ready — log so a real error (e.g. a future
+        // refactor reintroducing an out-of-scope reference) is visible
+        // instead of being silently swallowed.
+        console.warn('[quizify] checkPackUpdates failed:', e);
     }
 }

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -47,6 +47,13 @@
     var _wsOpenTimeout = null;
 
     function connect() {
+        // Guard against reconnecting on top of a live socket — a stray
+        // connect() while state.ws is OPEN/CONNECTING would orphan the
+        // existing socket and double up message handlers.
+        if (state.ws && (state.ws.readyState === WebSocket.OPEN ||
+                         state.ws.readyState === WebSocket.CONNECTING)) {
+            return;
+        }
         state.ws = pu.createWebSocket('/api/quizify/ws', {
             onOpen: function () {
                 // Clear the connection timeout
@@ -208,6 +215,11 @@
                 state.playerName = null;
                 state.playerId = null;
                 state.isAdmin = false;
+                // Clear rank-delta memos (issue #257) so the next game's
+                // first leaderboard/reveal doesn't show phantom ▲/▼ deltas
+                // computed against the wiped game's standings.
+                if (game && game.resetRankMemo) game.resetRankMemo();
+                if (reveal && reveal.resetRankMemo) reveal.resetRankMemo();
                 pu.showView('join-view');
                 break;
 
@@ -292,10 +304,10 @@
                 handlePowerUpApplied(msg);
                 break;
 
-            case 'rematch_started':
-                state.reconnectAttempts = 0;
-                connect();
-                break;
+            // (Removed dead 'rematch_started' case: the server's
+            // _handle_play_again broadcasts a 'game_state' message, never
+            // 'rematch_started', so this branch was unreachable. The rematch
+            // flow is driven entirely by the game_state phase transition.)
 
             case 'reaction':
                 showFloatingReaction(msg.emoji, msg.player_name);
@@ -854,6 +866,12 @@
             }
             if (state.isAdmin) joinMsg.is_admin = true;
             send('join', joinMsg);
+        } else {
+            // WS not open at click time (initial connect still pending, or
+            // dropped) — kick off a (re)connect. state.playerName is now
+            // set, so the onOpen handler auto-sends the join. Without this
+            // the join button would hang on "Joining…" forever.
+            connect();
         }
     }
 

--- a/custom_components/quizify/www/js/player-end.js
+++ b/custom_components/quizify/www/js/player-end.js
@@ -93,7 +93,9 @@
             var player = leaderboard.find(function (p) { return p.rank === place; });
             var nameEl = document.getElementById('podium-' + place + '-name');
             var scoreEl = document.getElementById('podium-' + place + '-score');
-            if (nameEl) nameEl.textContent = player ? pu.escapeHtml(player.name) : '---';
+            // textContent already HTML-escapes; an extra escapeHtml() here
+            // double-encodes (e.g. "Tom & Jr" → "Tom &amp;amp; Jr").
+            if (nameEl) nameEl.textContent = player ? player.name : '---';
             if (scoreEl) scoreEl.textContent = player ? player.score : '0';
         });
 
@@ -101,7 +103,8 @@
         var champEl = document.getElementById('podium-champion-name');
         if (champEl) {
             var champion = leaderboard.find(function (p) { return p.rank === 1; });
-            champEl.textContent = champion ? pu.escapeHtml(champion.name) : '---';
+            // textContent escapes already — no escapeHtml (would double-encode).
+            champEl.textContent = champion ? champion.name : '---';
         }
 
         // Animate podium rise with delays: 2nd (0s), 1st (1s), 3rd (2s)

--- a/custom_components/quizify/www/js/player-game.js
+++ b/custom_components/quizify/www/js/player-game.js
@@ -490,6 +490,13 @@
      */
     var _prevLeaderboardRanks = {}; // name -> rank
 
+    // Clear the rank-delta memo (issue #257). Without this a game_reset
+    // leaves stale ranks behind, so the first leaderboard of the *next*
+    // game shows phantom ▲/▼ deltas against the previous game's standings.
+    function resetRankMemo() {
+        _prevLeaderboardRanks = {};
+    }
+
     function updateLeaderboard(data, targetListId) {
         var leaderboard = data.leaderboard || [];
         var listEl = document.getElementById(targetListId || 'leaderboard-list');
@@ -710,6 +717,14 @@
         var cancelBtn = document.getElementById('powerup-target-cancel');
         if (!modal || !listEl) return;
 
+        // If a previous picker is still open (double-open / re-entrant call),
+        // tear down its listeners first — otherwise the old onBackdrop/onKey
+        // handlers leak because _teardown is about to be overwritten below.
+        if (typeof modal._teardown === 'function') {
+            modal._teardown();
+            modal._teardown = null;
+        }
+
         var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
 
         // Active opponents = connected, not the local player.
@@ -872,6 +887,7 @@
         updateGameView: updateGameView,
         renderSubmissionTracker: renderSubmissionTracker,
         updateLeaderboard: updateLeaderboard,
+        resetRankMemo: resetRankMemo,
         renderLeaderboardEntry: renderLeaderboardEntry,
         updateLeaderboardSummary: updateLeaderboardSummary,
         renderPowerUp: renderPowerUp,

--- a/custom_components/quizify/www/js/player-lightning.js
+++ b/custom_components/quizify/www/js/player-lightning.js
@@ -68,7 +68,12 @@
 
         var img = document.getElementById('lightning-image');
         if (img) {
-            if (msg.image_url) { img.src = msg.image_url; img.hidden = false; }
+            // Same http(s)-only guard as player-game.js renderQuestion
+            // (issue #257) — reject javascript:/data: and other schemes
+            // before they reach img.src.
+            var safeImg = (typeof msg.image_url === 'string' && /^https?:\/\//i.test(msg.image_url))
+                ? msg.image_url : '';
+            if (safeImg) { img.src = safeImg; img.hidden = false; }
             else { img.hidden = true; img.removeAttribute('src'); }
         }
 

--- a/custom_components/quizify/www/js/player-lobby.js
+++ b/custom_components/quizify/www/js/player-lobby.js
@@ -409,8 +409,18 @@
             }
         }
 
-        var playerIsAdmin = currentPlayer && currentPlayer.is_admin === true;
-        state.isAdmin = playerIsAdmin;
+        // Only trust this roster's is_admin flag when our OWN entry is in it
+        // (issue #257). A broadcast that transiently omits us must not clobber
+        // state.isAdmin to false — otherwise the host loses admin controls on
+        // any roster snapshot that races their own (re)join. When our entry is
+        // absent we keep the prior state.isAdmin and hide the panel for now.
+        var playerIsAdmin;
+        if (currentPlayer) {
+            playerIsAdmin = currentPlayer.is_admin === true;
+            state.isAdmin = playerIsAdmin;
+        } else {
+            playerIsAdmin = false; // can't show controls without our entry
+        }
 
         if (playerIsAdmin) {
             adminControls.classList.remove('hidden');

--- a/custom_components/quizify/www/js/player-reveal.js
+++ b/custom_components/quizify/www/js/player-reveal.js
@@ -36,6 +36,13 @@
     // ("↑1", "↓1", "—") without server help. Keyed by lowercased player name.
     var _prevRanks = null;
 
+    // Clear the rank-delta memo on game_reset (issue #257) — otherwise the
+    // first reveal of the next game computes deltas against the previous
+    // game's final ranks.
+    function resetRankMemo() {
+        _prevRanks = null;
+    }
+
     function updateRevealView(data) {
         var players = data.players || [];
         var allAnswers = data.all_answers || [];
@@ -768,6 +775,7 @@
 
     window.QuizifyPlayerReveal = {
         updateRevealView: updateRevealView,
+        resetRankMemo: resetRankMemo,
         renderFunFact: renderFunFact,
         renderRevealEmotion: renderRevealEmotion,
         renderPersonalResult: renderPersonalResult,

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -1187,8 +1187,18 @@
             }
         }
 
-        var playerIsAdmin = currentPlayer && currentPlayer.is_admin === true;
-        state.isAdmin = playerIsAdmin;
+        // Only trust this roster's is_admin flag when our OWN entry is in it
+        // (issue #257). A broadcast that transiently omits us must not clobber
+        // state.isAdmin to false — otherwise the host loses admin controls on
+        // any roster snapshot that races their own (re)join. When our entry is
+        // absent we keep the prior state.isAdmin and hide the panel for now.
+        var playerIsAdmin;
+        if (currentPlayer) {
+            playerIsAdmin = currentPlayer.is_admin === true;
+            state.isAdmin = playerIsAdmin;
+        } else {
+            playerIsAdmin = false; // can't show controls without our entry
+        }
 
         if (playerIsAdmin) {
             adminControls.classList.remove('hidden');
@@ -1286,6 +1296,13 @@
     // Memo of the previous round's leaderboard so we can compute rank deltas
     // ("↑1", "↓1", "—") without server help. Keyed by lowercased player name.
     var _prevRanks = null;
+
+    // Clear the rank-delta memo on game_reset (issue #257) — otherwise the
+    // first reveal of the next game computes deltas against the previous
+    // game's final ranks.
+    function resetRankMemo() {
+        _prevRanks = null;
+    }
 
     function updateRevealView(data) {
         var players = data.players || [];
@@ -2019,6 +2036,7 @@
 
     window.QuizifyPlayerReveal = {
         updateRevealView: updateRevealView,
+        resetRankMemo: resetRankMemo,
         renderFunFact: renderFunFact,
         renderRevealEmotion: renderRevealEmotion,
         renderPersonalResult: renderPersonalResult,
@@ -2125,7 +2143,9 @@
             var player = leaderboard.find(function (p) { return p.rank === place; });
             var nameEl = document.getElementById('podium-' + place + '-name');
             var scoreEl = document.getElementById('podium-' + place + '-score');
-            if (nameEl) nameEl.textContent = player ? pu.escapeHtml(player.name) : '---';
+            // textContent already HTML-escapes; an extra escapeHtml() here
+            // double-encodes (e.g. "Tom & Jr" → "Tom &amp;amp; Jr").
+            if (nameEl) nameEl.textContent = player ? player.name : '---';
             if (scoreEl) scoreEl.textContent = player ? player.score : '0';
         });
 
@@ -2133,7 +2153,8 @@
         var champEl = document.getElementById('podium-champion-name');
         if (champEl) {
             var champion = leaderboard.find(function (p) { return p.rank === 1; });
-            champEl.textContent = champion ? pu.escapeHtml(champion.name) : '---';
+            // textContent escapes already — no escapeHtml (would double-encode).
+            champEl.textContent = champion ? champion.name : '---';
         }
 
         // Animate podium rise with delays: 2nd (0s), 1st (1s), 3rd (2s)
@@ -2519,7 +2540,12 @@
 
         var img = document.getElementById('lightning-image');
         if (img) {
-            if (msg.image_url) { img.src = msg.image_url; img.hidden = false; }
+            // Same http(s)-only guard as player-game.js renderQuestion
+            // (issue #257) — reject javascript:/data: and other schemes
+            // before they reach img.src.
+            var safeImg = (typeof msg.image_url === 'string' && /^https?:\/\//i.test(msg.image_url))
+                ? msg.image_url : '';
+            if (safeImg) { img.src = safeImg; img.hidden = false; }
             else { img.hidden = true; img.removeAttribute('src'); }
         }
 
@@ -3198,6 +3224,13 @@
      */
     var _prevLeaderboardRanks = {}; // name -> rank
 
+    // Clear the rank-delta memo (issue #257). Without this a game_reset
+    // leaves stale ranks behind, so the first leaderboard of the *next*
+    // game shows phantom ▲/▼ deltas against the previous game's standings.
+    function resetRankMemo() {
+        _prevLeaderboardRanks = {};
+    }
+
     function updateLeaderboard(data, targetListId) {
         var leaderboard = data.leaderboard || [];
         var listEl = document.getElementById(targetListId || 'leaderboard-list');
@@ -3418,6 +3451,14 @@
         var cancelBtn = document.getElementById('powerup-target-cancel');
         if (!modal || !listEl) return;
 
+        // If a previous picker is still open (double-open / re-entrant call),
+        // tear down its listeners first — otherwise the old onBackdrop/onKey
+        // handlers leak because _teardown is about to be overwritten below.
+        if (typeof modal._teardown === 'function') {
+            modal._teardown();
+            modal._teardown = null;
+        }
+
         var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
 
         // Active opponents = connected, not the local player.
@@ -3580,6 +3621,7 @@
         updateGameView: updateGameView,
         renderSubmissionTracker: renderSubmissionTracker,
         updateLeaderboard: updateLeaderboard,
+        resetRankMemo: resetRankMemo,
         renderLeaderboardEntry: renderLeaderboardEntry,
         updateLeaderboardSummary: updateLeaderboardSummary,
         renderPowerUp: renderPowerUp,
@@ -3647,6 +3689,13 @@
     var _wsOpenTimeout = null;
 
     function connect() {
+        // Guard against reconnecting on top of a live socket — a stray
+        // connect() while state.ws is OPEN/CONNECTING would orphan the
+        // existing socket and double up message handlers.
+        if (state.ws && (state.ws.readyState === WebSocket.OPEN ||
+                         state.ws.readyState === WebSocket.CONNECTING)) {
+            return;
+        }
         state.ws = pu.createWebSocket('/api/quizify/ws', {
             onOpen: function () {
                 // Clear the connection timeout
@@ -3808,6 +3857,11 @@
                 state.playerName = null;
                 state.playerId = null;
                 state.isAdmin = false;
+                // Clear rank-delta memos (issue #257) so the next game's
+                // first leaderboard/reveal doesn't show phantom ▲/▼ deltas
+                // computed against the wiped game's standings.
+                if (game && game.resetRankMemo) game.resetRankMemo();
+                if (reveal && reveal.resetRankMemo) reveal.resetRankMemo();
                 pu.showView('join-view');
                 break;
 
@@ -3892,10 +3946,10 @@
                 handlePowerUpApplied(msg);
                 break;
 
-            case 'rematch_started':
-                state.reconnectAttempts = 0;
-                connect();
-                break;
+            // (Removed dead 'rematch_started' case: the server's
+            // _handle_play_again broadcasts a 'game_state' message, never
+            // 'rematch_started', so this branch was unreachable. The rematch
+            // flow is driven entirely by the game_state phase transition.)
 
             case 'reaction':
                 showFloatingReaction(msg.emoji, msg.player_name);
@@ -4454,6 +4508,12 @@
             }
             if (state.isAdmin) joinMsg.is_admin = true;
             send('join', joinMsg);
+        } else {
+            // WS not open at click time (initial connect still pending, or
+            // dropped) — kick off a (re)connect. state.playerName is now
+            // set, so the onOpen handler auto-sends the join. Without this
+            // the join button would hang on "Joining…" forever.
+            connect();
         }
     }
 

--- a/custom_components/quizify/www/sw.js
+++ b/custom_components/quizify/www/sw.js
@@ -220,7 +220,13 @@ function networkFirst(request) {
                 var clone = response.clone();
                 caches.open(CACHE_VERSION)
                     .then(function(cache) {
-                        cache.put(request, clone);
+                        return cache.put(request, clone);
+                    })
+                    .then(function() {
+                        // Keep the runtime cache bounded (issue #257) —
+                        // networkFirst put on every fetch without ever
+                        // pruning, so the cache grew unbounded.
+                        pruneCache();
                     })
                     .catch(function(err) {
                         console.warn('[SW] Cache put failed:', err);


### PR DESCRIPTION
Fixes the frontend findings from the 2026-06-11 code review ([#257](https://github.com/mholzi/quizify/issues/257)), part of [#252](https://github.com/mholzi/quizify/issues/252). All changes are in `custom_components/quizify/www/js/` (+ `sw.js`); the player bundle is rebuilt.

## HIGH — dead pack-update banner + latent stored XSS (admin.js)
`checkPackUpdates` is defined *outside* the admin IIFE, so the IIFE-local `_t`/`escapeHtml` helpers were out of scope. The `_t(...)` call threw a `ReferenceError` that the blanket `catch` swallowed, so the update banner **never rendered**. The same code path also interpolated unescaped pack metadata into `innerHTML` — a latent stored XSS via a malicious pack name/version.

- Use the global `window.t` (i18n) and `window.QuizifyUtils.escapeHtml`.
- Escape all pack metadata (name, installed/upstream versions, title, close label) before it touches `innerHTML`. The trusted local `<code>` path label stays raw.
- The `catch` now `console.warn()`s instead of silently swallowing, so a future out-of-scope regression is visible.

## MEDIUM
- **Join button hung forever if the WS was dead at click (player-core.js).** `handleJoinClick` set `playerName` but, when the socket wasn't `OPEN`, never sent or reconnected → button stuck on "Joining…". Now it calls `connect()`; the `onOpen` path auto-joins because `playerName` is set.
- **Power-up target-picker listener leak on double-open (player-game.js).** `openTargetPicker` now runs any existing `modal._teardown` before re-wiring, so a re-entrant open no longer orphans the previous backdrop/keydown handlers.
- **Finale podium double-escaping (player-end.js).** `textContent` already HTML-escapes, so the extra `pu.escapeHtml()` double-encoded names (`Tom & Jr` → `&amp;amp;`). Now assigns the raw name.

## LOW
- **`updateAdminControls` clobbered `state.isAdmin` from every roster (player-lobby.js).** A broadcast that transiently omits our own entry no longer downgrades us to non-admin; we only trust the roster's `is_admin` when our entry is present.
- **Rank-delta memos survived reset (player-reveal.js, player-game.js).** Added `resetRankMemo()` to both modules, wired into the core `game_reset` handler, so the next game's first leaderboard/reveal shows no phantom ▲/▼ deltas.
- **Lightning image-URL skipped the scheme guard (player-lightning.js).** Now applies the same `^https?://` guard as `player-game.js renderQuestion` before assigning `img.src`.
- **SW `networkFirst` never pruned (sw.js).** Calls `pruneCache()` after a successful `cache.put` so the runtime cache stays bounded.
- **Dead `rematch_started` handler / unguarded `connect()` (player-core.js).** Removed the unreachable `rematch_started` case (the server's `_handle_play_again` broadcasts `game_state`, never `rematch_started`) and guarded `connect()` against an already `OPEN`/`CONNECTING` socket.

## Verification
- Rebuilt `player.bundle.js` (`build_bundle.py`).
- `python3 -m pytest -q` → **356 passed** (baseline).
- All edited JS files + `sw.js` + bundle pass `node --check`.

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)