### PR TITLE
fix(reconnect): project snapshot answers through the player shuffle + flat reveal (Closes #253)

### DIFF
--- a/custom_components/quizify/game/lightning.py
+++ b/custom_components/quizify/game/lightning.py
@@ -204,6 +204,27 @@ class LightningRound:
             return None
         return self._questions[self.index]
 
+    def ensure_shuffle(self, name: str) -> list[int]:
+        """Return this player's shuffle for the current Q, creating one if missing.
+
+        A player reconnecting mid-lightning never ran through ``_arm_current``
+        for the in-flight question, so they hold no shuffle. Without one, a
+        reconnect snapshot falls back to canonical order while
+        ``record_answer`` still maps the tapped index through this shuffle
+        (issue #253) — mis-scoring the tap. Creating the shuffle lazily here
+        keeps the snapshot answers and the submit mapping consistent.
+        """
+        q = self.current_question
+        if q is None:
+            return []
+        existing = self._shuffles.get(name)
+        if existing:
+            return existing
+        order = list(range(len(q.answers)))
+        random.shuffle(order)
+        self._shuffles[name] = order
+        return order
+
     def shuffled_answers_for(self, name: str) -> list[str]:
         """Answer texts in this player's shuffled order for the current Q."""
         q = self.current_question

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -1180,6 +1180,28 @@ class QuizifyGameState:
         """Wipe per-player shuffles. Called at round start."""
         self.player_shuffles = {}
 
+    def ensure_player_shuffle(self, player_name: str) -> list[int]:
+        """Return the player's shuffle, creating a fresh one if missing.
+
+        Late joiners and reconnecting players who arrive mid-question never
+        ran through the round-start per-player shuffle loop, so they have no
+        entry in ``player_shuffles``. Without one, a reconnect snapshot would
+        fall back to the canonical order — but ``submit_answer`` maps the
+        tapped index through ``get_player_shuffle`` (issue #253). If we then
+        also lazily create the shuffle here, the buttons the player rebuilds
+        from the snapshot match the order their submit expects. Mirrors the
+        round-start shuffle creation in ``_start_next_question``.
+        """
+        existing = self.player_shuffles.get(player_name)
+        if existing:
+            return existing
+        if not self._current_question:
+            return self.shuffle_map
+        order = list(range(len(self._current_question.answers)))
+        random.shuffle(order)
+        self.player_shuffles[player_name] = order
+        return order
+
     @property
     def round_duration(self) -> float:
         """Public accessor for current round duration."""

--- a/custom_components/quizify/server/round_message_builder.py
+++ b/custom_components/quizify/server/round_message_builder.py
@@ -157,6 +157,86 @@ class RoundMessageBuilder:
             }
         return substate
 
+    def project_snapshot_for_player(
+        self,
+        game_state: QuizifyGameState,
+        *,
+        snapshot: dict[str, Any],
+        player: PlayerSession,
+    ) -> dict[str, Any]:
+        """Re-shape a canonical state snapshot for one reconnecting PLAYER.
+
+        ``QuizifyGameState.get_state_snapshot()`` is player-agnostic — it
+        emits answers in canonical order and nests the reveal under
+        ``round_summary`` (issue #253). That is correct for the admin and the
+        TV dashboard, but a player rebuilds their answer buttons from this
+        snapshot and ``submit_answer`` maps the tapped index through the
+        player's OWN shuffle. Sending canonical order would mis-score ~2/3 of
+        taps after a reload. This projects a *copy* of the snapshot into the
+        recipient's frame:
+
+        * QUESTION_ACTIVE: project ``question.answers`` through the player's
+          shuffle (created on demand for a late joiner, as round-start does),
+          and use the player's own QuestionTimer for ``time_remaining`` so a
+          pause/freeze/boost is reflected on the reconnect clock.
+        * LIGHTNING: project ``lightning.question.answers`` through the
+          player's lightning shuffle (also created on demand).
+        * ANSWER_REVEAL: replace the nested ``round_summary`` with the same
+          FLAT shape the live ``round_summary`` broadcast uses (incl.
+          ``all_answers``), which the reveal view reads as flat fields.
+
+        The caller (``_handle_join`` / ``_handle_reconnect``) knows the
+        recipient identity; admin/dashboard recipients keep the canonical
+        snapshot untouched.
+        """
+        # Shallow copy is enough: we only replace top-level keys / nested
+        # dicts we build fresh here, never mutate the caller's sub-objects.
+        out = dict(snapshot)
+
+        phase = out.get("phase")
+
+        if phase == GamePhase.QUESTION_ACTIVE.value and "question" in out:
+            question = game_state.get_current_question()
+            if question is not None:
+                shuffle = game_state.ensure_player_shuffle(player.name)
+                projected = dict(out["question"])
+                projected["answers"] = [
+                    question.answers[i].text for i in shuffle
+                ]
+                # Prefer the player's own timer so pause/freeze/boost show
+                # the right remaining time; fall back to the wall-clock value
+                # already in the snapshot when no per-player timer exists.
+                timer = game_state.get_player_timer(player.name)
+                if timer is not None:
+                    projected["time_remaining"] = round(
+                        max(0.0, timer.get_remaining()), 1
+                    )
+                out["question"] = projected
+
+        if phase == GamePhase.LIGHTNING.value and out.get("lightning"):
+            lr = game_state.lightning
+            lightning = dict(out["lightning"])
+            if lr is not None and lr.current_question is not None:
+                shuffle = lr.ensure_shuffle(player.name)
+                q = lr.current_question
+                lq = dict(lightning["question"])
+                lq["answers"] = [q.answers[i].text for i in shuffle]
+                lightning["question"] = lq
+                out["lightning"] = lightning
+
+        if phase == GamePhase.ANSWER_REVEAL.value:
+            summary = self.build_round_summary(game_state)
+            if summary is not None:
+                # Drop the player-agnostic nested copy and merge the flat
+                # round_summary fields the reveal view reads (player-reveal.js).
+                out.pop("round_summary", None)
+                merged = dict(summary)
+                # Preserve the snapshot envelope keys the flat summary lacks.
+                merged.pop("type", None)
+                out.update(merged)
+
+        return out
+
     def build_round_summary(
         self,
         game_state: QuizifyGameState,

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -529,8 +529,16 @@ class QuizifyWebSocketHandler:
                 "is_admin": player_obj.is_admin if player_obj else False,
             })
 
-            # Send current state to the joining player
+            # Send current state to the joining player. Project the
+            # player-agnostic snapshot into THIS player's frame (#253): own
+            # shuffle order for the answer buttons, own timer, flat reveal —
+            # otherwise a mid-round joiner mis-scores their taps and sees an
+            # empty reveal.
             state = game_state.get_state_snapshot()
+            if player_obj is not None:
+                state = self._round_messages.project_snapshot_for_player(
+                    game_state, snapshot=state, player=player_obj
+                )
             state["type"] = "game_state"
             await self._conn._safe_send(ws, state)
 
@@ -615,8 +623,13 @@ class QuizifyWebSocketHandler:
             "powerup": powerup.value if powerup else None,
         })
 
-        # Send full game state
+        # Send full game state, projected into THIS player's frame (#253):
+        # the reconnect snapshot otherwise carries canonical answer order
+        # (mis-scoring taps) and a nested round_summary the reveal can't read.
         state = game_state.get_state_snapshot()
+        state = self._round_messages.project_snapshot_for_player(
+            game_state, snapshot=state, player=player
+        )
         state["type"] = "game_state"
         await self._conn._safe_send(ws, state)
 

--- a/tests/test_reconnect_snapshot_projection_253.py
+++ b/tests/test_reconnect_snapshot_projection_253.py
@@ -1,0 +1,317 @@
+"""Regression tests for issue #253 — reconnect/mid-join snapshot vs per-player state.
+
+The player-agnostic ``get_state_snapshot()`` disagreed with the per-player live
+game on the scoring-critical path:
+
+* QUESTION_ACTIVE / LIGHTNING: the snapshot emitted answers in CANONICAL order,
+  but ``submit_answer`` maps the tapped index through the player's OWN shuffle.
+  A reconnecting player rebuilt their buttons from the snapshot → the wrong
+  answer was recorded ~2/3 of the time.
+* ANSWER_REVEAL: the snapshot nested everything under ``round_summary`` and
+  omitted ``all_answers``; the reveal view reads FLAT fields → empty reveal.
+
+These tests pin the fix: ``RoundMessageBuilder.project_snapshot_for_player``
+re-shapes a copy of the canonical snapshot into the recipient player's frame.
+The decisive invariant is exercised with a real ``QuizifyGameState`` so it
+catches drift between the snapshot, the shuffle store, and the submit path.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+from custom_components.quizify.server.round_message_builder import (  # noqa: E402
+    RoundMessageBuilder,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _fake_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+@pytest.fixture
+def state(tmp_path: Path) -> QuizifyGameState:
+    runtime = _FakeRuntime(tmp_path)
+    return QuizifyGameState(runtime=runtime, entry_id="test")
+
+
+@pytest.fixture
+def builder() -> RoundMessageBuilder:
+    return RoundMessageBuilder()
+
+
+def _start_round_with_shuffles(state: QuizifyGameState) -> None:
+    """Drive into QUESTION_ACTIVE and seed canonical + per-player shuffles the
+    way ``_start_next_question`` does, so the snapshot/submit contract is live."""
+    import random
+
+    state.add_player("Alice", _fake_ws())
+    state.add_player("Bob", _fake_ws())
+    state.start_game(language="de", num_rounds=3, difficulty="easy")
+    question = state.start_next_question()
+    assert question is not None
+    # Canonical shuffle (admin/TV + submit fallback).
+    canonical = list(range(len(question.answers)))
+    random.shuffle(canonical)
+    state.set_round_shuffle(canonical, [question.answers[i].text for i in canonical])
+    # Per-player shuffles — but deliberately NOT for "Bob": he is the
+    # mid-round reconnecter who never got one, so the projection must mint it.
+    alice = list(range(len(question.answers)))
+    random.shuffle(alice)
+    state.set_player_shuffle("Alice", alice)
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL — QUESTION_ACTIVE answers must match the player's submit mapping
+# ---------------------------------------------------------------------------
+
+
+def test_question_snapshot_answers_match_player_submit_mapping(
+    state: QuizifyGameState, builder: RoundMessageBuilder
+) -> None:
+    """The visible index the player taps must score the visible answer.
+
+    This is the exact contract that was broken: the player rebuilds buttons
+    from the snapshot ``answers``, taps the index of the answer text they want,
+    and the server maps that index through ``get_player_shuffle`` in
+    ``submit_answer``. So for EVERY visible position i, the projected answer
+    text must equal the question's answer at ``get_player_shuffle[i]``.
+    """
+    _start_round_with_shuffles(state)
+    question = state.get_current_question()
+    player = state.get_player("Alice")
+
+    snapshot = state.get_state_snapshot()
+    projected = builder.project_snapshot_for_player(
+        state, snapshot=snapshot, player=player
+    )
+
+    visible_answers = projected["question"]["answers"]
+    shuffle = state.get_player_shuffle("Alice")  # what submit_answer uses
+
+    assert len(visible_answers) == len(question.answers)
+    for visible_index, visible_text in enumerate(visible_answers):
+        original_index = shuffle[visible_index]
+        assert visible_text == question.answers[original_index].text
+
+    # End-to-end: tapping the visible position of the correct answer scores it.
+    correct_text = next(a.text for a in question.answers if a.correct)
+    tapped_visible = visible_answers.index(correct_text)
+    original_index = state.get_player_shuffle("Alice")[tapped_visible]
+    result = state.submit_answer("Alice", original_index)
+    assert not isinstance(result, str)
+    assert result.correct is True
+
+
+def test_canonical_snapshot_still_mis_orders_for_a_player(
+    state: QuizifyGameState, builder: RoundMessageBuilder
+) -> None:
+    """Guard the bug itself: the raw (un-projected) snapshot order does NOT
+    line up with Alice's submit mapping whenever her shuffle differs from
+    canonical — which is the case the projection exists to fix."""
+    _start_round_with_shuffles(state)
+    question = state.get_current_question()
+    raw = state.get_state_snapshot()
+
+    canonical_answers = raw["question"]["answers"]
+    shuffle = state.get_player_shuffle("Alice")
+    projected_for_alice = [question.answers[i].text for i in shuffle]
+    # The two orders differ (the shuffles were randomised independently);
+    # the raw snapshot would mis-score Alice's taps.
+    assert canonical_answers != projected_for_alice
+
+
+def test_late_joiner_gets_a_minted_shuffle_on_reconnect(
+    state: QuizifyGameState, builder: RoundMessageBuilder
+) -> None:
+    """A mid-round joiner with no prior shuffle gets one created on demand,
+    and the projected answers match that fresh shuffle (round-start parity)."""
+    _start_round_with_shuffles(state)
+    question = state.get_current_question()
+    bob = state.get_player("Bob")
+    assert "Bob" not in state.player_shuffles  # no shuffle before projection
+
+    snapshot = state.get_state_snapshot()
+    projected = builder.project_snapshot_for_player(
+        state, snapshot=snapshot, player=bob
+    )
+
+    assert "Bob" in state.player_shuffles  # minted
+    shuffle = state.get_player_shuffle("Bob")
+    visible = projected["question"]["answers"]
+    for i, text in enumerate(visible):
+        assert text == question.answers[shuffle[i]].text
+
+
+def test_projection_does_not_mutate_canonical_snapshot(
+    state: QuizifyGameState, builder: RoundMessageBuilder
+) -> None:
+    """Admin/dashboard recipients still get canonical order — the projection
+    works on a copy and leaves the source snapshot intact."""
+    _start_round_with_shuffles(state)
+    snapshot = state.get_state_snapshot()
+    canonical_before = list(snapshot["question"]["answers"])
+
+    builder.project_snapshot_for_player(
+        state, snapshot=snapshot, player=state.get_player("Alice")
+    )
+
+    assert snapshot["question"]["answers"] == canonical_before
+
+
+# ---------------------------------------------------------------------------
+# MEDIUM — snapshot time_remaining must follow the player's own timer
+# ---------------------------------------------------------------------------
+
+
+def test_question_snapshot_time_remaining_uses_player_timer(
+    state: QuizifyGameState, builder: RoundMessageBuilder
+) -> None:
+    """``time_remaining`` must come from the reconnecting player's own
+    QuestionTimer (which tracks freeze/boost/pause), not the player-agnostic
+    wall-clock ``time_remaining_for_snapshot()``. A time-boost added to one
+    player's timer must lift their projected clock above the canonical one."""
+    _start_round_with_shuffles(state)
+    alice = state.get_player("Alice")
+    timer = state.get_player_timer("Alice")
+    assert timer is not None
+    timer.add_time(15.0)  # time_boost power-up: extends only Alice's clock
+
+    snapshot = state.get_state_snapshot()
+    canonical_remaining = snapshot["question"]["time_remaining"]
+    projected = builder.project_snapshot_for_player(
+        state, snapshot=snapshot, player=alice
+    )
+
+    # Alice's boosted timer shows clearly more time than the wall-clock value.
+    assert projected["question"]["time_remaining"] > canonical_remaining + 10
+
+
+# ---------------------------------------------------------------------------
+# HIGH — reveal snapshot must carry the FLAT round_summary shape + all_answers
+# ---------------------------------------------------------------------------
+
+
+def test_reveal_snapshot_is_flat_with_all_answers(
+    state: QuizifyGameState, builder: RoundMessageBuilder
+) -> None:
+    """After evaluate_round the reconnect snapshot must expose the same flat
+    fields the live ``round_summary`` broadcast does (player-reveal.js reads
+    them flat), including a populated ``all_answers`` table — not a nested
+    ``round_summary`` blob."""
+    _start_round_with_shuffles(state)
+    question = state.get_current_question()
+    correct_idx = next(i for i, a in enumerate(question.answers) if a.correct)
+    state.submit_answer("Alice", correct_idx)
+    state.evaluate_round()
+    assert state.phase == GamePhase.ANSWER_REVEAL
+
+    snapshot = state.get_state_snapshot()
+    # The raw snapshot nests under round_summary (the bug).
+    assert "round_summary" in snapshot
+
+    projected = builder.project_snapshot_for_player(
+        state, snapshot=snapshot, player=state.get_player("Alice")
+    )
+
+    # Flat fields the reveal view reads.
+    assert "round_summary" not in projected
+    assert projected["correct_answer"]
+    assert isinstance(projected["all_answers"], list)
+    assert projected["all_answers"]  # populated, not empty
+    names = {entry["player_name"] for entry in projected["all_answers"]}
+    assert "Alice" in names
+    alice_entry = next(
+        e for e in projected["all_answers"] if e["player_name"] == "Alice"
+    )
+    assert alice_entry["correct"] is True
+    # Other flat keys the client consumes.
+    assert "leaderboard" in projected
+    assert "players" in projected
+    assert "fun_fact" in projected
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL — Lightning answers must match the player's lightning submit mapping
+# ---------------------------------------------------------------------------
+
+
+def test_lightning_snapshot_answers_match_player_shuffle(
+    state: QuizifyGameState, builder: RoundMessageBuilder
+) -> None:
+    """Same scoring contract for lightning: the projected lightning answers
+    must line up with the shuffle ``record_answer`` uses for that player."""
+    state.add_player("Alice", _fake_ws())
+    assert state.start_lightning_round() is True
+    assert state.begin_lightning_questions() is True
+    assert state.phase == GamePhase.LIGHTNING
+
+    lr = state.lightning
+    q = lr.current_question
+    assert q is not None
+    alice = state.get_player("Alice")
+
+    snapshot = state.get_state_snapshot()
+    projected = builder.project_snapshot_for_player(
+        state, snapshot=snapshot, player=alice
+    )
+
+    visible = projected["lightning"]["question"]["answers"]
+    shuffle = lr.ensure_shuffle("Alice")
+    assert len(visible) == len(q.answers)
+    for i, text in enumerate(visible):
+        assert text == q.answers[shuffle[i]].text
+
+    # Tapping the visible position of the correct answer records correct.
+    correct_text = next(a.text for a in q.answers if a.correct)
+    tapped_visible = visible.index(correct_text)
+    assert lr.record_answer("Alice", tapped_visible) is True
+
+
+def test_lightning_late_joiner_gets_minted_shuffle(
+    state: QuizifyGameState, builder: RoundMessageBuilder
+) -> None:
+    """A player reconnecting mid-lightning with no shuffle gets one created and
+    the projected answers match it."""
+    state.add_player("Alice", _fake_ws())
+    assert state.start_lightning_round() is True
+    assert state.begin_lightning_questions() is True
+    lr = state.lightning
+    q = lr.current_question
+    assert q is not None
+
+    # Simulate a brand-new mid-round joiner registered after arming.
+    state.add_player("Zoe", _fake_ws())
+    lr.add_player("Zoe")
+    # Force the "no shuffle yet" state to prove on-demand minting.
+    lr._shuffles.pop("Zoe", None)
+    assert "Zoe" not in lr._shuffles
+
+    snapshot = state.get_state_snapshot()
+    projected = builder.project_snapshot_for_player(
+        state, snapshot=snapshot, player=state.get_player("Zoe")
+    )
+
+    assert "Zoe" in lr._shuffles
+    visible = projected["lightning"]["question"]["answers"]
+    shuffle = lr.ensure_shuffle("Zoe")
+    for i, text in enumerate(visible):
+        assert text == q.answers[shuffle[i]].text


### PR DESCRIPTION
## Root cause

The player-agnostic state snapshot (`QuizifyGameState.get_state_snapshot()`) diverged from the per-player live game on the scoring-critical path. The snapshot is the right shape for the admin and the TV dashboard (canonical answer order, nested `round_summary`), but a **player** rebuilds their answer buttons from this same snapshot on reconnect/mid-join — and `submit_answer` maps the tapped index through that player's **own** shuffle (`get_player_shuffle`). Sending canonical order to a player therefore mis-scores their taps, and the reveal snapshot's nested shape is unreadable by the flat reveal view.

## The three fixes

1. **CRITICAL — mis-scored answers on reconnect/mid-join.** The snapshot emitted `question.answers` in canonical order while the player's submit path maps through `get_player_shuffle`, so ~2/3 of taps after a reload recorded a different answer. Same bug in Lightning (`record_answer` uses the player's lightning shuffle). **Fix:** new `RoundMessageBuilder.project_snapshot_for_player` re-shapes a *copy* of the canonical snapshot into the recipient player's frame — `QUESTION_ACTIVE` and `LIGHTNING` answers are projected through that player's shuffle (minted on demand for a late joiner, exactly as round-start does). The projection runs in the WS layer (`_handle_join` / `_handle_reconnect`) where the recipient identity is known; admin/dashboard recipients keep the untouched canonical snapshot.

2. **HIGH — broken reveal on reconnect.** The `ANSWER_REVEAL` snapshot nested everything under `round_summary` and omitted `all_answers`; `player-reveal.js` reads flat fields → empty reveal. **Fix:** the projection drops the nested blob and merges the same **flat** shape (incl. `all_answers`, `correct_answer`, `players`, `leaderboard`, `fun_fact`) that the live `round_summary` broadcast emits, reusing `build_round_summary`.

3. **MEDIUM — snapshot `time_remaining` ignored pause/freeze/boost.** It was derived from a wall-clock `round_duration - (now - round_start_time)`. **Fix:** the projection takes `time_remaining` from the reconnecting player's own `QuestionTimer` when present (which already tracks freeze/boost/pause), falling back to the wall-clock value otherwise.

New helpers `state.ensure_player_shuffle` and `lightning.ensure_shuffle` create a per-player shuffle on demand so reconnecting/late players' snapshot answers and submit mapping stay consistent.

No `www/js` change is required — `player-core.js` / `player-reveal.js` already read the flat reveal fields; the fix makes the snapshot deliver them. (No bundle rebuild needed.)

## Tests

New `tests/test_reconnect_snapshot_projection_253.py` (8 tests) proves:
- a reconnecting player's snapshot answers match the order their submit expects — the tapped visible index scores the visible answer (QUESTION_ACTIVE + Lightning, end-to-end through `submit_answer` / `record_answer`);
- the raw un-projected snapshot would mis-order for that player (guards the bug);
- a late joiner with no shuffle gets one minted, and the projection leaves the canonical snapshot intact for admin/dashboard;
- the reveal snapshot carries the flat fields incl. a populated `all_answers`;
- `time_remaining` follows the player's own timer (a boost lifts it above the wall-clock value).

**364 tests green** (356 baseline + 8 new).

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)