### PR TITLE
fix(pack-submit): enforce worker auth + store lock + contract test (Closes #256)

### DIFF
--- a/cf-workers/README.md
+++ b/cf-workers/README.md
@@ -12,10 +12,18 @@ Cloudflare dashboard, which made a token-drift outage hard to diagnose).
 ## Contract
 
 ```
-POST /            { "pack": { name, language, questions: [{question, answers[3], correct}], theme? } }
+POST /            { "pack": { name, language, questions: [{id, question, answers[3], correct}], theme? } }
+                  header X-Quizify-Secret: <secret>   (only when SHARED_SECRET is set; see below)
 200               { "issue_number": <int>, "issue_url": "<html_url>" }
 4xx/5xx           { "code": "INVALID_FORMAT" | "GITHUB_ERROR", "message": "<text>" }
 ```
+
+The pack schema accepted by the worker's `validatePack` is pinned by a shared
+fixture, `tests/fixtures/community_pack.json`, asserted valid by **both** the
+worker (`validatePack`) and the integration (`server/pack_submission.py::validate_pack`)
+in `tests/test_worker_contract_256.py`. If the two schemas drift, that test
+fails CI — this is how the original "worker validated the wrong schema" bug
+(#256) is kept from recurring.
 
 ## Deploy (one-time)
 
@@ -30,6 +38,31 @@ Then in Home Assistant → Quizify integration → **Configure** → set
 **"Community pack submission URL"** to the deployed worker URL. The in-app
 submission UI appears once the URL is set (the `/api/quizify/pack-submit/config`
 endpoint flips to `enabled: true`).
+
+## Closing the open proxy (`SHARED_SECRET`)
+
+By default the worker is an **unauthenticated** issue-creation proxy: anyone who
+learns the URL can POST packs and file (or spam) issues against `mholzi/quizify`,
+burning the PAT. To lock it down, set a shared secret on **both** ends — the
+worker rejects any request whose `X-Quizify-Secret` header doesn't match:
+
+```bash
+cd cf-workers
+# generate a random secret, e.g.: openssl rand -hex 24
+npx wrangler secret put SHARED_SECRET   # paste the secret
+npx wrangler deploy
+```
+
+Then in Home Assistant → Quizify integration → **Configure** → set
+**"Community pack submission secret"** to the *same* value. The integration
+sends it as `X-Quizify-Secret` on every submission.
+
+This is **optional and back-compatible**: with no `SHARED_SECRET` set on the
+worker the gate is skipped, and with no secret configured in HA the header is
+omitted — existing installs keep working unchanged. Set both, or neither;
+setting only the worker secret will reject all submissions until the HA option
+matches. (Cloudflare dashboard rate-limiting on the route is still recommended
+as defence-in-depth.)
 
 ## Token
 

--- a/cf-workers/contract-check.mjs
+++ b/cf-workers/contract-check.mjs
@@ -1,0 +1,74 @@
+// Contract check for the worker's pack validator (#256).
+//
+// The worker (quizify-api.js) is written for the Cloudflare Workers runtime
+// (Response.json, fetch, env bindings), so it can't be imported wholesale under
+// plain node. Instead we extract the pure `validatePack` function plus the four
+// schema constants it closes over, eval them in isolation, and assert that:
+//   1. the shared fixture pack (tests/fixtures/community_pack.json) is ACCEPTED
+//      (validatePack returns null), exactly as the integration's
+//      server/pack_submission.py::validate_pack accepts it; and
+//   2. an obviously malformed pack is REJECTED (returns an error string).
+//
+// Run: node cf-workers/contract-check.mjs
+// Exits 0 on success, non-zero with a message on any failure. Invoked from
+// tests/test_worker_contract_256.py so schema drift fails CI on both sides.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, '..');
+
+const workerSrc = readFileSync(join(here, 'quizify-api.js'), 'utf8');
+const fixture = JSON.parse(
+  readFileSync(join(repoRoot, 'tests', 'fixtures', 'community_pack.json'), 'utf8'),
+);
+
+function fail(msg) {
+  console.error(`contract-check FAILED: ${msg}`);
+  process.exit(1);
+}
+
+// Pull the four schema constants out of the worker source so this check can't
+// silently use stale values.
+function extractConst(name) {
+  const m = workerSrc.match(new RegExp(`const ${name}\\s*=\\s*([^;]+);`));
+  if (!m) fail(`could not find const ${name} in quizify-api.js`);
+  // eslint-disable-next-line no-eval
+  return eval(m[1].replace(/_/g, '')); // 1_048_576 -> 1048576
+}
+const MIN_QUESTIONS = extractConst('MIN_QUESTIONS');
+const MAX_QUESTIONS = extractConst('MAX_QUESTIONS');
+const ANSWERS_PER_QUESTION = extractConst('ANSWERS_PER_QUESTION');
+
+// Extract the validatePack function definition verbatim.
+const fnMatch = workerSrc.match(/function validatePack\(pack\)\s*\{[\s\S]*?\n\}/);
+if (!fnMatch) fail('could not extract validatePack from quizify-api.js');
+
+// eslint-disable-next-line no-new-func
+const makeValidator = new Function(
+  'MIN_QUESTIONS',
+  'MAX_QUESTIONS',
+  'ANSWERS_PER_QUESTION',
+  `${fnMatch[0]}\nreturn validatePack;`,
+);
+const validatePack = makeValidator(MIN_QUESTIONS, MAX_QUESTIONS, ANSWERS_PER_QUESTION);
+
+// 1. Canonical fixture must be accepted.
+const okErr = validatePack(fixture);
+if (okErr !== null) {
+  fail(`worker rejected the canonical fixture pack: ${okErr}`);
+}
+
+// 2. A malformed pack must be rejected. Drop the third answer so the question
+//    no longer has exactly ANSWERS_PER_QUESTION answers.
+const malformed = JSON.parse(JSON.stringify(fixture));
+malformed.questions[0].answers = malformed.questions[0].answers.slice(0, 2);
+const badErr = validatePack(malformed);
+if (badErr === null) {
+  fail('worker accepted a malformed pack (only 2 answers) — schema too loose');
+}
+
+console.log('contract-check OK: worker validatePack accepts the fixture and rejects malformed input');
+process.exit(0);

--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -38,6 +38,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     from .analytics import QuizifyAnalytics  # noqa: PLC0415
     from .const import (  # noqa: PLC0415
+        CONF_COMMUNITY_SUBMIT_SECRET,
         CONF_COMMUNITY_SUBMIT_URL,
         CONF_LOBBY_MUSIC_URL,
         CONF_MEDIA_PLAYER_ENTITY,
@@ -98,6 +99,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # (#180). Empty/unset → the in-app submit UI hides itself.
         community_submit_url=(
             (entry.options or {}).get(CONF_COMMUNITY_SUBMIT_URL) or ""
+        ).strip()
+        or None,
+        # Shared secret sent as X-Quizify-Secret to the worker (#256). Empty →
+        # header omitted (back-compatible); set it alongside the worker's
+        # SHARED_SECRET to close the open-proxy hole.
+        community_submit_secret=(
+            (entry.options or {}).get(CONF_COMMUNITY_SUBMIT_SECRET) or ""
         ).strip()
         or None,
     )
@@ -206,6 +214,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Toggle the community-pack submit feature live (#180) — no HA restart.
         ctx.community_submit_url = (
             opts.get(CONF_COMMUNITY_SUBMIT_URL) or ""
+        ).strip() or None
+        ctx.community_submit_secret = (
+            opts.get(CONF_COMMUNITY_SUBMIT_SECRET) or ""
         ).strip() or None
         domain_data = _hass.data.get(DOMAIN, {})
         pl: QuizifyPartyLights | None = domain_data.get("party_lights")

--- a/custom_components/quizify/config_flow.py
+++ b/custom_components/quizify/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.core import callback
 from homeassistant.helpers import selector
 
 from .const import (
+    CONF_COMMUNITY_SUBMIT_SECRET,
     CONF_COMMUNITY_SUBMIT_URL,
     CONF_LOBBY_MUSIC_URL,
     CONF_MEDIA_PLAYER_ENTITY,
@@ -112,6 +113,16 @@ class QuizifyOptionsFlow(OptionsFlow):
                 default=current.get(CONF_COMMUNITY_SUBMIT_URL, ""),
             ): selector.TextSelector(
                 selector.TextSelectorConfig(type=selector.TextSelectorType.URL),
+            ),
+            # Shared secret paired with the worker's SHARED_SECRET (#256). When
+            # set, it's sent as the X-Quizify-Secret header so the worker can
+            # reject unauthenticated requests, closing the open-proxy hole.
+            # Empty = header omitted (fully back-compatible).
+            vol.Optional(
+                CONF_COMMUNITY_SUBMIT_SECRET,
+                default=current.get(CONF_COMMUNITY_SUBMIT_SECRET, ""),
+            ): selector.TextSelector(
+                selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD),
             ),
         })
         return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/quizify/const.py
+++ b/custom_components/quizify/const.py
@@ -69,6 +69,15 @@ CONF_LOBBY_MUSIC_URL = "lobby_music_url"  # str, single, free-text URL
 # integration; the worker is separate infrastructure (see issue #180, step 5).
 CONF_COMMUNITY_SUBMIT_URL = "community_submit_url"  # str, single, free-text URL
 
+# Shared secret the integration sends as an ``X-Quizify-Secret`` header on every
+# pack submission (#256). When the worker has a matching ``SHARED_SECRET`` env
+# secret set it rejects any request without this header, closing the open-proxy
+# hole. Empty by default and fully back-compatible: with no secret configured
+# the header is omitted and the worker (which only enforces when *its* secret is
+# set) behaves exactly as before. Set BOTH the worker secret and this option to
+# lock the endpoint down. See cf-workers/README.md.
+CONF_COMMUNITY_SUBMIT_SECRET = "community_submit_secret"  # str, single, free-text
+
 # ---------------------------------------------------------------------------
 # Community pack submission (#180)
 # ---------------------------------------------------------------------------

--- a/custom_components/quizify/server/context.py
+++ b/custom_components/quizify/server/context.py
@@ -78,3 +78,9 @@ class AppContext:
     # submission feature hidden and inert. Mutable so an options-flow change
     # toggles the feature without an HA restart.
     community_submit_url: str | None = None
+    # Shared secret sent as the ``X-Quizify-Secret`` header on the worker POST
+    # (#256). When set (and the worker has a matching ``SHARED_SECRET``), it
+    # closes the open-proxy hole. ``None``/empty → header omitted, fully
+    # back-compatible. Mutable so an options-flow change applies without an HA
+    # restart, mirroring ``community_submit_url``.
+    community_submit_secret: str | None = None

--- a/custom_components/quizify/server/pack_submission.py
+++ b/custom_components/quizify/server/pack_submission.py
@@ -26,6 +26,7 @@ server runs them unchanged.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import re
@@ -69,6 +70,25 @@ _GITHUB_ISSUES_API = "https://api.github.com/repos/mholzi/quizify/issues"
 _RATE_LIMIT_REQUESTS = 5
 _RATE_LIMIT_WINDOW = 60  # seconds
 _rate_buckets: dict[str, list[float]] = {}
+
+# Per-records-file lock so the load-modify-save in get_with_reconcile() / add()
+# can't interleave (#256): a submit landing mid-reconcile would otherwise read a
+# stale snapshot and clobber the other writer's record. PackSubmissionStore is
+# instantiated per-request, so the lock can't live on the instance — it's keyed
+# on the records-file path here, mirroring TokenStore._lock. asyncio.Lock is the
+# right primitive (these are coroutines on one event loop; the actual file I/O
+# runs in the executor but the read-decide-write critical section is async).
+_store_locks: dict[str, asyncio.Lock] = {}
+
+
+def _store_lock(path: object) -> asyncio.Lock:
+    """Return the shared lock for a given records-file path."""
+    key = str(path)
+    lock = _store_locks.get(key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _store_locks[key] = lock
+    return lock
 
 
 def _check_rate_limit(client_ip: str) -> bool:
@@ -189,6 +209,9 @@ class PackSubmissionStore:
     def __init__(self, ctx: "AppContext") -> None:
         self._ctx = ctx
         self._path = ctx.runtime.data_dir / SUBMIT_RECORDS_FILE
+        # Shared across all stores pointing at the same file (this class is
+        # instantiated per-request) so concurrent load-modify-save can't race.
+        self._lock = _store_lock(self._path)
 
     # --- blocking helpers (run in executor) ---------------------------------
 
@@ -301,22 +324,33 @@ class PackSubmissionStore:
     # --- public async API ---------------------------------------------------
 
     async def get_with_reconcile(self) -> dict:
-        """Load records, reconcile against GitHub if the poll is due, persist."""
-        data = await self._ctx.runtime.run_in_executor(self._load)
-        if self._poll_due(data):
-            data = await self.reconcile(data)
-            await self._ctx.runtime.run_in_executor(self._save, data)
-        return data
+        """Load records, reconcile against GitHub if the poll is due, persist.
+
+        The whole load-modify-save runs under the per-file lock (#256) so a
+        concurrent ``add()`` can't slip a fresh record in between this load and
+        save — which would otherwise be silently dropped on persist.
+        """
+        async with self._lock:
+            data = await self._ctx.runtime.run_in_executor(self._load)
+            if self._poll_due(data):
+                data = await self.reconcile(data)
+                await self._ctx.runtime.run_in_executor(self._save, data)
+            return data
 
     async def add(self, record: dict) -> None:
-        """Append a submission record (newest first), capped, then persist."""
-        data = await self._ctx.runtime.run_in_executor(self._load)
-        submissions = data.get("submissions")
-        if not isinstance(submissions, list):
-            submissions = []
-        submissions.insert(0, record)
-        data["submissions"] = submissions[:SUBMIT_MAX_RECORDS]
-        await self._ctx.runtime.run_in_executor(self._save, data)
+        """Append a submission record (newest first), capped, then persist.
+
+        Held under the per-file lock (#256) so it can't interleave with a
+        reconcile's load-modify-save and lose the new record.
+        """
+        async with self._lock:
+            data = await self._ctx.runtime.run_in_executor(self._load)
+            submissions = data.get("submissions")
+            if not isinstance(submissions, list):
+                submissions = []
+            submissions.insert(0, record)
+            data["submissions"] = submissions[:SUBMIT_MAX_RECORDS]
+            await self._ctx.runtime.run_in_executor(self._save, data)
 
 
 # ---------------------------------------------------------------------------
@@ -419,11 +453,21 @@ async def submit_pack_view(request: web.Request) -> web.Response:
         )
 
     # Proxy to the worker, which holds the GitHub token and creates the issue.
+    # When a shared secret is configured, send it as the X-Quizify-Secret header
+    # so the worker can reject unauthenticated requests, closing the open-proxy
+    # hole (#256). No secret → no header, and the worker (which only enforces
+    # when its SHARED_SECRET is set) behaves exactly as before — back-compatible.
+    submit_secret = (ctx.community_submit_secret or "").strip()
+    submit_headers: dict[str, str] | None = (
+        {"X-Quizify-Secret": submit_secret} if submit_secret else None
+    )
     timeout = aiohttp.ClientTimeout(total=SUBMIT_POLL_TIMEOUT_SECONDS)
     worker_payload: dict[str, Any]
     try:
         async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.post(submit_url, json={"pack": pack}) as resp:
+            async with session.post(
+                submit_url, json={"pack": pack}, headers=submit_headers
+            ) as resp:
                 try:
                     worker_payload = await resp.json(content_type=None)
                 except (ValueError, aiohttp.ClientError):

--- a/custom_components/quizify/translations/de.json
+++ b/custom_components/quizify/translations/de.json
@@ -23,14 +23,16 @@
                     "tts_entity": "Text-zu-Sprache-Dienst",
                     "media_player_entity": "Mediaplayer für TTS",
                     "lobby_music_url": "Lobby-Musik-URL",
-                    "community_submit_url": "URL für Community-Pack-Einsendung"
+                    "community_submit_url": "URL für Community-Pack-Einsendung",
+                    "community_submit_secret": "Geheimnis für Community-Pack-Einsendung"
                 },
                 "data_description": {
                     "party_light_entities": "Lichter, die mit der Spielphase mitleuchten (Koralle bei Frage, Salbei bei Auflösung, Sonne im Finale).",
                     "tts_entity": "TTS-Entity (z. B. tts.google_translate_say) für Ansagen bei Meilensteinen und Rundenergebnissen.",
                     "media_player_entity": "Lautsprecher, über den die TTS-Ansage abgespielt wird. Pflicht, wenn ein TTS-Dienst gesetzt ist.",
                     "lobby_music_url": "Optionale URL einer Audiodatei (z. B. /local/quizify-lobby.mp3 aus deinem config/www-Ordner), die in der Lobby über den oben gewählten Mediaplayer in Schleife läuft. Sie stoppt beim Spielstart, damit sie sich nicht mit den TTS-Ansagen über denselben Lautsprecher überlagert. Leer lassen = keine Musik. Es ist keine Audiodatei enthalten — du musst eine eigene angeben.",
-                    "community_submit_url": "Optionaler Worker-Endpunkt, der eine in der App eingereichte Community-Pack-Einsendung in ein GitHub-Issue zur Begutachtung umwandelt. Leer lassen, um die Einsende-Funktion komplett auszublenden. Das GitHub-Token liegt in diesem Worker, nie im Browser oder in Home Assistant."
+                    "community_submit_url": "Optionaler Worker-Endpunkt, der eine in der App eingereichte Community-Pack-Einsendung in ein GitHub-Issue zur Begutachtung umwandelt. Leer lassen, um die Einsende-Funktion komplett auszublenden. Das GitHub-Token liegt in diesem Worker, nie im Browser oder in Home Assistant.",
+                    "community_submit_secret": "Optionales gemeinsames Geheimnis, das als X-Quizify-Secret-Header an den Worker gesendet wird. Setze es passend zum SHARED_SECRET des Workers, damit nicht jeder mit der URL Issues anlegen kann. Leer lassen, wenn der Worker kein Geheimnis hat (Standard)."
                 }
             }
         }

--- a/custom_components/quizify/translations/en.json
+++ b/custom_components/quizify/translations/en.json
@@ -23,14 +23,16 @@
                     "tts_entity": "Text-to-speech provider",
                     "media_player_entity": "Media player for TTS",
                     "lobby_music_url": "Lobby music URL",
-                    "community_submit_url": "Community pack submission URL"
+                    "community_submit_url": "Community pack submission URL",
+                    "community_submit_secret": "Community pack submission secret"
                 },
                 "data_description": {
                     "party_light_entities": "Lights that should glow with the round phase (coral on question, sage on reveal, sun on finale).",
                     "tts_entity": "TTS entity (e.g. tts.google_translate_say) used to announce milestones and round results.",
                     "media_player_entity": "Speaker the TTS audio plays through. Required if TTS provider is set.",
                     "lobby_music_url": "Optional URL of an audio file (e.g. /local/quizify-lobby.mp3, served from your config/www folder) looped on the media player above while waiting in the lobby. It stops when the game starts, so it never overlaps the TTS announcements that share the same speaker. Leave blank for no music. No audio file is included — supply your own.",
-                    "community_submit_url": "Optional worker endpoint that turns an in-app community-pack submission into a GitHub issue for review. Leave blank to hide the submission feature entirely. The GitHub token lives in that worker, never in your browser or Home Assistant."
+                    "community_submit_url": "Optional worker endpoint that turns an in-app community-pack submission into a GitHub issue for review. Leave blank to hide the submission feature entirely. The GitHub token lives in that worker, never in your browser or Home Assistant.",
+                    "community_submit_secret": "Optional shared secret sent to the worker as an X-Quizify-Secret header. Set this to match the worker's SHARED_SECRET to stop anyone with the URL from filing issues. Leave blank if the worker has no secret (the default)."
                 }
             }
         }

--- a/custom_components/quizify/translations/es.json
+++ b/custom_components/quizify/translations/es.json
@@ -23,14 +23,16 @@
                     "tts_entity": "Proveedor de texto a voz",
                     "media_player_entity": "Reproductor para TTS",
                     "lobby_music_url": "URL de música de la sala",
-                    "community_submit_url": "URL de envío de paquetes de la comunidad"
+                    "community_submit_url": "URL de envío de paquetes de la comunidad",
+                    "community_submit_secret": "Secreto de envío de paquetes de la comunidad"
                 },
                 "data_description": {
                     "party_light_entities": "Luces que cambian de color con la fase de la ronda (coral en pregunta, salvia en revelación, sol en final).",
                     "tts_entity": "Entidad TTS (p. ej. tts.google_translate_say) para anuncios de hitos y resultados.",
                     "media_player_entity": "Altavoz por el que se reproduce el audio TTS. Obligatorio si se configura un proveedor TTS.",
                     "lobby_music_url": "URL opcional de un archivo de audio (p. ej. /local/quizify-lobby.mp3, desde tu carpeta config/www) que se reproduce en bucle en el reproductor multimedia de arriba mientras se espera en la sala. Se detiene al empezar la partida, para no solaparse con los anuncios TTS que comparten el mismo altavoz. Déjalo vacío para no tener música. No se incluye ningún archivo de audio: usa el tuyo.",
-                    "community_submit_url": "Endpoint opcional de un worker que convierte un envío de paquete de la comunidad hecho en la app en una incidencia de GitHub para revisión. Déjalo en blanco para ocultar por completo la función de envío. El token de GitHub reside en ese worker, nunca en tu navegador ni en Home Assistant."
+                    "community_submit_url": "Endpoint opcional de un worker que convierte un envío de paquete de la comunidad hecho en la app en una incidencia de GitHub para revisión. Déjalo en blanco para ocultar por completo la función de envío. El token de GitHub reside en ese worker, nunca en tu navegador ni en Home Assistant.",
+                    "community_submit_secret": "Secreto compartido opcional que se envía al worker como cabecera X-Quizify-Secret. Configúralo para que coincida con el SHARED_SECRET del worker y así evitar que cualquiera con la URL cree incidencias. Déjalo en blanco si el worker no tiene secreto (predeterminado)."
                 }
             }
         }

--- a/custom_components/quizify/translations/fr.json
+++ b/custom_components/quizify/translations/fr.json
@@ -23,14 +23,16 @@
                     "tts_entity": "Fournisseur de synthèse vocale",
                     "media_player_entity": "Lecteur multimédia pour TTS",
                     "lobby_music_url": "URL de la musique du salon",
-                    "community_submit_url": "URL de soumission de pack communautaire"
+                    "community_submit_url": "URL de soumission de pack communautaire",
+                    "community_submit_secret": "Secret de soumission de pack communautaire"
                 },
                 "data_description": {
                     "party_light_entities": "Lumières qui changent de couleur selon la phase de la manche (corail pendant la question, sauge pendant la révélation, soleil au final).",
                     "tts_entity": "Entité TTS (p. ex. tts.google_translate_say) pour les annonces de jalons et de résultats.",
                     "media_player_entity": "Haut-parleur sur lequel le TTS est diffusé. Obligatoire si un fournisseur TTS est défini.",
                     "lobby_music_url": "URL facultative d'un fichier audio (p. ex. /local/quizify-lobby.mp3, depuis votre dossier config/www) joué en boucle sur le lecteur multimédia ci-dessus pendant l'attente dans le salon. Elle s'arrête au démarrage de la partie, pour ne pas chevaucher les annonces TTS qui partagent le même haut-parleur. Laissez vide pour aucune musique. Aucun fichier audio n'est fourni — utilisez le vôtre.",
-                    "community_submit_url": "Point de terminaison de worker facultatif qui transforme une soumission de pack communautaire faite dans l'application en une issue GitHub à examiner. Laissez vide pour masquer entièrement la fonction de soumission. Le jeton GitHub réside dans ce worker, jamais dans votre navigateur ni dans Home Assistant."
+                    "community_submit_url": "Point de terminaison de worker facultatif qui transforme une soumission de pack communautaire faite dans l'application en une issue GitHub à examiner. Laissez vide pour masquer entièrement la fonction de soumission. Le jeton GitHub réside dans ce worker, jamais dans votre navigateur ni dans Home Assistant.",
+                    "community_submit_secret": "Secret partagé facultatif envoyé au worker dans l'en-tête X-Quizify-Secret. Définissez-le pour qu'il corresponde au SHARED_SECRET du worker afin d'empêcher quiconque possédant l'URL de créer des issues. Laissez vide si le worker n'a pas de secret (par défaut)."
                 }
             }
         }

--- a/custom_components/quizify/translations/nl.json
+++ b/custom_components/quizify/translations/nl.json
@@ -23,14 +23,16 @@
                     "tts_entity": "Tekst-naar-spraakprovider",
                     "media_player_entity": "Mediaspeler voor TTS",
                     "lobby_music_url": "URL lobbymuziek",
-                    "community_submit_url": "URL voor inzending community-pack"
+                    "community_submit_url": "URL voor inzending community-pack",
+                    "community_submit_secret": "Geheim voor inzending community-pack"
                 },
                 "data_description": {
                     "party_light_entities": "Lampen die meekleuren met de rondefase (koraal bij vraag, salie bij onthulling, zon bij finale).",
                     "tts_entity": "TTS-entiteit (bv. tts.google_translate_say) voor aankondigingen van mijlpalen en uitslagen.",
                     "media_player_entity": "Luidspreker waar de TTS wordt afgespeeld. Verplicht als er een TTS-provider is ingesteld.",
                     "lobby_music_url": "Optionele URL van een audiobestand (bv. /local/quizify-lobby.mp3 uit je config/www-map) dat tijdens het wachten in de lobby in een lus wordt afgespeeld op de mediaspeler hierboven. Het stopt zodra het spel begint, zodat het de TTS-aankondigingen die dezelfde speaker delen niet overlapt. Laat leeg voor geen muziek. Er wordt geen audiobestand meegeleverd — gebruik je eigen bestand.",
-                    "community_submit_url": "Optioneel worker-eindpunt dat een in de app ingediende community-pack-inzending omzet in een GitHub-issue ter beoordeling. Laat leeg om de inzendfunctie volledig te verbergen. Het GitHub-token bevindt zich in die worker, nooit in je browser of in Home Assistant."
+                    "community_submit_url": "Optioneel worker-eindpunt dat een in de app ingediende community-pack-inzending omzet in een GitHub-issue ter beoordeling. Laat leeg om de inzendfunctie volledig te verbergen. Het GitHub-token bevindt zich in die worker, nooit in je browser of in Home Assistant.",
+                    "community_submit_secret": "Optioneel gedeeld geheim dat als X-Quizify-Secret-header naar de worker wordt gestuurd. Stel het in zodat het overeenkomt met de SHARED_SECRET van de worker, zodat niet iedereen met de URL issues kan aanmaken. Laat leeg als de worker geen geheim heeft (standaard)."
                 }
             }
         }

--- a/tests/fixtures/community_pack.json
+++ b/tests/fixtures/community_pack.json
@@ -1,0 +1,27 @@
+{
+  "name": "Contract Fixture Pack",
+  "language": "en",
+  "version": "1.0",
+  "questions": [
+    {
+      "id": "q1",
+      "question": "Which planet is known as the Red Planet?",
+      "answers": [
+        { "text": "Mars", "correct": true },
+        { "text": "Venus", "correct": false },
+        { "text": "Jupiter", "correct": false }
+      ],
+      "difficulty": "easy"
+    },
+    {
+      "id": "q2",
+      "question": "What is the chemical symbol for water?",
+      "answers": [
+        { "text": "H2O", "correct": true },
+        { "text": "CO2", "correct": false },
+        { "text": "O2", "correct": false }
+      ],
+      "difficulty": "easy"
+    }
+  ]
+}

--- a/tests/test_pack_submission_secret_256.py
+++ b/tests/test_pack_submission_secret_256.py
@@ -1,0 +1,253 @@
+"""Tests for the #256 submission hardening:
+
+  1. The X-Quizify-Secret header is sent on the worker POST when a secret is
+     configured, and omitted when it is not (open-proxy close, back-compat).
+  2. The PackSubmissionStore per-file asyncio.Lock serialises the
+     load-modify-save in get_with_reconcile()/add() so a submit landing
+     mid-reconcile can't drop records.
+
+No HA, no real network: the worker POST is intercepted with a fake aiohttp
+ClientSession so we can capture the headers the integration sends.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.server import pack_submission as ps  # noqa: E402
+from custom_components.quizify.server.pack_submission import (  # noqa: E402
+    PackSubmissionStore,
+    submit_pack_view,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeRuntime:
+    def __init__(self, data_dir: Path) -> None:
+        self.data_dir = data_dir
+
+    async def run_in_executor(self, func, *args) -> Any:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func, *args)
+
+
+class _FakeCtx:
+    def __init__(
+        self,
+        data_dir: Path,
+        submit_url: str | None = None,
+        submit_secret: str | None = None,
+    ) -> None:
+        self.runtime = _FakeRuntime(data_dir)
+        self.community_submit_url = submit_url
+        self.community_submit_secret = submit_secret
+
+
+class _FakeRequest:
+    """Just enough of aiohttp.web.Request for submit_pack_view."""
+
+    def __init__(self, ctx: _FakeCtx, body: dict) -> None:
+        self.app = {ps.APP_CTX_KEY: ctx}
+        self.remote = "1.2.3.4"
+        self._body = body
+
+    async def json(self) -> dict:
+        return self._body
+
+
+class _FakeResponse:
+    def __init__(self) -> None:
+        self.status = 200
+
+    async def json(self, content_type=None) -> dict:
+        return {"issue_number": 42, "issue_url": "https://github.com/mholzi/quizify/issues/42"}
+
+    async def __aenter__(self) -> "_FakeResponse":
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        return None
+
+
+class _CapturingSession:
+    """Captures the headers passed to .post() so we can assert on them."""
+
+    captured_headers: Any = "<unset>"
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    async def __aenter__(self) -> "_CapturingSession":
+        return self
+
+    async def __aexit__(self, *exc) -> None:
+        return None
+
+    def post(self, url, json=None, headers=None):  # noqa: A002
+        type(self).captured_headers = headers
+        return _FakeResponse()
+
+
+def _good_pack() -> dict:
+    return {
+        "name": "Secret Test Pack",
+        "language": "en",
+        "questions": [
+            {
+                "id": "q1",
+                "question": "Which planet is the Red Planet?",
+                "answers": [
+                    {"text": "Mars", "correct": True},
+                    {"text": "Venus", "correct": False},
+                    {"text": "Jupiter", "correct": False},
+                ],
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Secret-header wiring
+# ---------------------------------------------------------------------------
+
+
+def _run_submit(ctx: _FakeCtx, monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Drive submit_pack_view with the worker POST stubbed; return captured headers."""
+    _CapturingSession.captured_headers = "<unset>"
+    monkeypatch.setattr(ps.aiohttp, "ClientSession", _CapturingSession)
+    # Reset the module-level rate-limit buckets so repeated submits in the
+    # suite (same fake client IP) never trip the limiter.
+    ps._rate_buckets.clear()
+    request = _FakeRequest(ctx, {"pack": _good_pack()})
+
+    async def _go() -> None:
+        resp = await submit_pack_view(request)  # type: ignore[arg-type]
+        assert resp.status == 200
+
+    asyncio.run(_go())
+    return _CapturingSession.captured_headers
+
+
+def test_secret_header_sent_when_configured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ctx = _FakeCtx(
+        tmp_path,
+        submit_url="https://worker.example/submit",
+        submit_secret="s3cr3t-token",
+    )
+    headers = _run_submit(ctx, monkeypatch)
+    assert headers == {"X-Quizify-Secret": "s3cr3t-token"}
+
+
+def test_secret_header_absent_when_not_configured(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ctx = _FakeCtx(
+        tmp_path,
+        submit_url="https://worker.example/submit",
+        submit_secret=None,
+    )
+    headers = _run_submit(ctx, monkeypatch)
+    # No secret → headers omitted entirely (None), preserving today's behaviour.
+    assert headers is None
+
+
+def test_secret_header_absent_when_blank(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ctx = _FakeCtx(
+        tmp_path,
+        submit_url="https://worker.example/submit",
+        submit_secret="   ",
+    )
+    headers = _run_submit(ctx, monkeypatch)
+    assert headers is None
+
+
+def test_submit_persists_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sanity: a successful submit still records the submission (so the store
+    path that the lock now wraps is exercised end-to-end)."""
+    ctx = _FakeCtx(
+        tmp_path,
+        submit_url="https://worker.example/submit",
+        submit_secret="abc",
+    )
+    _run_submit(ctx, monkeypatch)
+    records = json.loads((tmp_path / "pack_submissions.json").read_text())
+    assert len(records["submissions"]) == 1
+    assert records["submissions"][0]["issue_number"] == 42
+
+
+# ---------------------------------------------------------------------------
+# 2. Store load-modify-save lock
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_adds_keep_all_records(tmp_path: Path) -> None:
+    """Without the lock, two adds that both load the same empty snapshot would
+    each persist a single-record file and one record would be lost. With the
+    lock they serialise and both survive."""
+
+    async def _run() -> dict:
+        ctx = _FakeCtx(tmp_path)
+        store = PackSubmissionStore(ctx)
+        records = [
+            {"id": str(i), "name": f"pack {i}", "issue_number": i, "status": "pending"}
+            for i in range(10)
+        ]
+        await asyncio.gather(*(store.add(r) for r in records))
+        return await store.get_with_reconcile()
+
+    data = asyncio.run(_run())
+    ids = {s["id"] for s in data["submissions"]}
+    assert ids == {str(i) for i in range(10)}, "the lock must not drop any record"
+
+
+def test_two_stores_share_one_lock(tmp_path: Path) -> None:
+    """The lock is keyed on the records-file path, so per-request store
+    instances pointing at the same file share it (otherwise it wouldn't
+    serialise anything)."""
+
+    async def _run() -> bool:
+        ctx = _FakeCtx(tmp_path)
+        a = PackSubmissionStore(ctx)
+        b = PackSubmissionStore(ctx)
+        return a._lock is b._lock
+
+    assert asyncio.run(_run()) is True
+
+
+def test_add_during_reconcile_not_lost(tmp_path: Path) -> None:
+    """An add() racing a get_with_reconcile() (no pending items, so reconcile
+    just stamps last_poll and persists) must not be clobbered."""
+
+    async def _run() -> dict:
+        ctx = _FakeCtx(tmp_path)
+        store = PackSubmissionStore(ctx)
+        # Seed one accepted record so reconcile has nothing to fetch.
+        await store.add({"id": "seed", "issue_number": 1, "status": "accepted"})
+        await asyncio.gather(
+            store.get_with_reconcile(),
+            store.add({"id": "racing", "issue_number": 2, "status": "pending"}),
+        )
+        return await store.get_with_reconcile()
+
+    data = asyncio.run(_run())
+    ids = {s["id"] for s in data["submissions"]}
+    assert {"seed", "racing"} <= ids

--- a/tests/test_worker_contract_256.py
+++ b/tests/test_worker_contract_256.py
@@ -1,0 +1,118 @@
+"""Worker ⇄ integration pack-schema contract tests (#256).
+
+The submission worker (``cf-workers/quizify-api.js``) and the integration
+(``server/pack_submission.py``) each carry their own copy of the #179 community
+pack validator. They MUST agree: a pack the integration accepts must not be
+rejected at the worker (the last hop), and vice versa. The original review found
+the worker validating the *wrong* schema, which would have rejected every
+legitimate submission — and there were no tests, so it went unnoticed.
+
+These tests pin the contract with a single shared fixture
+(``tests/fixtures/community_pack.json``):
+
+  * the Python side asserts ``validate_pack`` accepts the fixture;
+  * a small JS check (``cf-workers/contract-check.mjs``) asserts the worker's
+    ``validatePack`` accepts the same fixture and rejects a malformed one;
+  * ``node --check`` proves the worker source still parses.
+
+If either schema drifts, one of these fails CI.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.const import (  # noqa: E402
+    SUBMIT_ANSWERS_PER_QUESTION,
+)
+from custom_components.quizify.server.pack_submission import (  # noqa: E402
+    validate_pack,
+)
+
+_FIXTURE = _REPO_ROOT / "tests" / "fixtures" / "community_pack.json"
+_WORKER = _REPO_ROOT / "cf-workers" / "quizify-api.js"
+_CONTRACT_CHECK = _REPO_ROOT / "cf-workers" / "contract-check.mjs"
+
+
+def _load_fixture() -> dict:
+    return json.loads(_FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_fixture_exists() -> None:
+    assert _FIXTURE.exists(), "shared community_pack.json fixture is missing"
+
+
+def test_python_validator_accepts_canonical_fixture() -> None:
+    """The integration's validate_pack must accept the shared fixture — this is
+    the canonical shape both sides pin to."""
+    pack = _load_fixture()
+    ok, errors = validate_pack(pack)
+    assert ok, f"Python validate_pack rejected the canonical fixture: {errors}"
+    assert errors == []
+
+
+def test_fixture_matches_expected_shape() -> None:
+    """Guard the fixture itself so a careless edit can't quietly weaken the
+    contract both validators are pinned to."""
+    pack = _load_fixture()
+    assert isinstance(pack.get("name"), str) and pack["name"].strip()
+    assert isinstance(pack.get("language"), str) and pack["language"].strip()
+    questions = pack.get("questions")
+    assert isinstance(questions, list) and questions
+    seen_ids: set[str] = set()
+    for q in questions:
+        assert isinstance(q.get("id"), str) and q["id"].strip()
+        assert q["id"] not in seen_ids
+        seen_ids.add(q["id"])
+        assert isinstance(q.get("question"), str) and q["question"].strip()
+        answers = q.get("answers")
+        assert isinstance(answers, list)
+        assert len(answers) == SUBMIT_ANSWERS_PER_QUESTION
+        assert sum(1 for a in answers if a.get("correct") is True) == 1
+
+
+def test_python_validator_rejects_malformed_fixture() -> None:
+    """The same malformation the JS check uses (a question with too few answers)
+    must be rejected on the Python side too, proving the two validators reject
+    in lockstep, not just accept."""
+    pack = _load_fixture()
+    pack["questions"][0]["answers"] = pack["questions"][0]["answers"][:2]
+    ok, errors = validate_pack(pack)
+    assert not ok
+    assert errors
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_worker_source_parses() -> None:
+    """`node --check` proves the worker source still parses — a syntax error
+    would otherwise only surface at deploy time."""
+    result = subprocess.run(
+        ["node", "--check", str(_WORKER)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"node --check failed:\n{result.stderr}"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+def test_worker_validator_matches_contract() -> None:
+    """Run the JS contract check: the worker's validatePack must accept the
+    shared fixture and reject a malformed pack. This is the cross-language pin —
+    if the worker schema drifts from the fixture, this fails CI."""
+    result = subprocess.run(
+        ["node", str(_CONTRACT_CHECK)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"contract-check.mjs failed:\n{result.stdout}\n{result.stderr}"
+    )


### PR DESCRIPTION
Remaining hardening from the 2026-06-11 review (#256) of the community-pack submission worker (`cf-workers/quizify-api.js`) and the integration proxy. The worker already carries the schema fix, markdown/mention escaping, and an optional `SHARED_SECRET` gate; this PR finishes the three open items.

## 1. Close the open proxy (HIGH)
The worker enforces `SHARED_SECRET` only when set, but nothing was sending it — so the gate could never actually engage. The integration now sends the matching secret:

- New **`community_submit_secret`** option in the Options flow (`config_flow.py`, password field), `const.py` (`CONF_COMMUNITY_SUBMIT_SECRET`), and `AppContext.community_submit_secret` (`server/context.py`), wired through `__init__.py` (initial setup + live options-update listener, no restart needed).
- `submit_pack_view` sends it as the **`X-Quizify-Secret`** header on the worker POST when configured.
- **Back-compatible:** no secret configured → header omitted, and the worker (which only enforces when its `SHARED_SECRET` is set) behaves exactly as today. Set both ends to lock the endpoint down.
- Pairing + setup documented in `cf-workers/README.md` (new "Closing the open proxy" section).
- Translations added for all 5 languages (en/de/es/fr/nl).

## 2. PackSubmissionStore load-modify-save lock (MEDIUM)
`get_with_reconcile()` and `add()` did an unguarded read-modify-write, so a submit landing mid-reconcile could read a stale snapshot and clobber the other writer's record. Added a per-records-file `asyncio.Lock` (keyed on the file path — the store is instantiated per-request, so a per-instance lock wouldn't serialise anything), mirroring `TokenStore._lock`. Both methods now run their critical section under it.

## 3. Worker contract tests (MEDIUM)
The schema drift went unnoticed because the worker had no tests. Pinned the contract with a single shared fixture `tests/fixtures/community_pack.json`, asserted valid by **both** sides:
- Python `validate_pack` accepts the fixture (and rejects the same malformation).
- `cf-workers/contract-check.mjs` extracts the worker's `validatePack` and asserts it accepts the fixture and rejects a malformed pack.
- `node --check` proves the worker source still parses.

If the two validators drift, CI fails (the node-backed tests skip gracefully if `node` is unavailable).

## Tests
+13 tests (secret header sent-when-configured / absent-when-blank-or-unset, store lock keeps all records under concurrent adds + add-during-reconcile, two stores share one lock, cross-language contract). Baseline **356 → 369 green**. No HA deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)