### PR TITLE
fix(rounds): late-join scoring, all-disconnect hang, end_game guard, comeback/wager (Closes #255)

### DIFF
--- a/custom_components/quizify/game/highlights.py
+++ b/custom_components/quizify/game/highlights.py
@@ -158,6 +158,13 @@ def compute_superlatives(players: list[PlayerSession]) -> list[Superlative]:
         )
 
     # --- Comeback King: biggest score improvement second half vs first half ---
+    # Compare per-round *averages* of the two halves, not raw sums. With an odd
+    # round count the second half holds one extra round (mid = len // 2), so a
+    # player with flat per-round scores would show a positive sum-improvement
+    # and win Comeback King even though they never improved — a false positive.
+    # Averaging normalises for the uneven split, and the displayed delta is the
+    # average-based improvement projected back onto the (larger) second half so
+    # the "+N pts" copy stays meaningful. (#255.)
     best_comeback: int | None = None
     comeback_player: str | None = None
     for p in players:
@@ -167,9 +174,13 @@ def compute_superlatives(players: list[PlayerSession]) -> list[Superlative]:
         if len(scores) < 4:
             continue
         mid = len(scores) // 2
-        first_half = sum(scores[:mid])
-        second_half = sum(scores[mid:])
-        improvement = second_half - first_half
+        first_half = scores[:mid]
+        second_half = scores[mid:]
+        first_avg = sum(first_half) / len(first_half)
+        second_avg = sum(second_half) / len(second_half)
+        if second_avg <= first_avg:
+            continue
+        improvement = round((second_avg - first_avg) * len(second_half))
         if improvement > 0 and (best_comeback is None or improvement > best_comeback):
             best_comeback = improvement
             comeback_player = p.name

--- a/custom_components/quizify/game/phase_controller.py
+++ b/custom_components/quizify/game/phase_controller.py
@@ -208,6 +208,24 @@ class PhaseController:
         ]
         return bool(timers) and all(timer.is_expired() for timer in timers)
 
+    def round_wall_clock_expired(self) -> bool:
+        """Whether the round's wall-clock has run out, regardless of timers.
+
+        Fallback stop condition for the countdown loop: when every player has
+        disconnected mid-question there are no connected per-player timers left
+        to expire, so ``all_timers_expired`` (which needs at least one live
+        timer) can never break the loop and it spins until the admin force-ends
+        the game. This compares the shared round wall-clock — the same
+        ``round_duration - (now - round_start_time)`` used for snapshots — so
+        the round still evaluates (and the admin can advance) once the nominal
+        duration has elapsed even with zero connected players. (#255.)
+
+        Returns False before a round has started (no ``round_start_time``).
+        """
+        if self.round_start_time is None:
+            return False
+        return self.time_remaining_for_snapshot() <= 0.0
+
     def time_remaining_for_snapshot(self) -> float:
         """Remaining time for a mid-round joiner's state snapshot.
 

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -164,6 +164,7 @@ class QuizifyGameState:
         # Cached finale data (computed once in end_game, cleared in reset_to_lobby)
         self._finale_podium: list | None = None
         self._finale_superlatives: list | None = None
+        self._finale_data: dict[str, Any] | None = None
 
         # Active LightningRound (issue #42), or None when not in a lightning
         # round. Owns its own questions/scores/recap; this class only holds
@@ -775,6 +776,17 @@ class QuizifyGameState:
             except Exception:  # noqa: BLE001
                 _LOGGER.exception("Failed to record question stats")
 
+        # Clear the late-joiner flag now that this round (the one they
+        # joined into) has been evaluated. The flag only exists to keep a
+        # mid-round arrival from forcing the full timer on the round they
+        # entered — from their *next* round on they're a full participant
+        # and must count toward all_submitted(). Without this reset the flag
+        # persisted for the rest of the game and late joiners were scored 0
+        # (timeout) every round because all_submitted() never waited for
+        # them. (#255.)
+        for player in self._player_registry.players.values():
+            player.joined_late = False
+
         _LOGGER.info("Round %d evaluated, transitioning to ANSWER_REVEAL", self.round)
         self._fire_broadcast("round_evaluated")
 
@@ -808,7 +820,18 @@ class QuizifyGameState:
         return getattr(self, "_pause_reason", None)
 
     def end_game(self) -> dict[str, Any]:
-        """End the game and transition to FINALE."""
+        """End the game and transition to FINALE.
+
+        Idempotent: re-entry while already in FINALE returns the cached
+        finale payload without recomputing the podium/superlatives, firing
+        a second ``game_ended`` broadcast, or recording analytics again.
+        Two WS code paths (end-of-last-round + explicit end-game) could
+        otherwise reach this and double-broadcast the finale + record the
+        game twice in analytics. (#255.)
+        """
+        if self.phase == GamePhase.FINALE and self._finale_data is not None:
+            return self._finale_data
+
         self.phase = GamePhase.FINALE
         self._current_question = None
 
@@ -827,6 +850,7 @@ class QuizifyGameState:
             ],
             "total_rounds": self.round,
         }
+        self._finale_data = finale_data
 
         # Record to analytics
         self._record_analytics()
@@ -948,6 +972,7 @@ class QuizifyGameState:
         self._powerup_manager.reset()
         self._finale_podium = None
         self._finale_superlatives = None
+        self._finale_data = None
         self.shuffle_map = []
         self.shuffled_answers = []
         self._timer_override = None
@@ -1209,6 +1234,16 @@ class QuizifyGameState:
         The countdown loop's stop condition, delegated to the PhaseController.
         """
         return self._phase_controller.all_timers_expired(player_names)
+
+    def round_wall_clock_expired(self) -> bool:
+        """Whether the round wall-clock has elapsed (#255).
+
+        Fallback stop condition for the countdown loop when every player has
+        disconnected mid-question and there are no live per-player timers left
+        for ``all_timers_expired`` to break on. Delegated to the
+        PhaseController.
+        """
+        return self._phase_controller.round_wall_clock_expired()
 
     def get_player_powerup(self, player_name: str):
         """Get the power-up held by a player."""

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -805,6 +805,17 @@ class QuizifyWebSocketHandler:
         if game_state.round != game_state.total_rounds:
             return  # only final round accepts a wager
 
+        # A wager only makes sense *before* the answer is locked in — the wager
+        # stakes points on getting that answer right. Once the player has
+        # submitted, accepting a new wager silently mutated the stake on an
+        # already-locked answer (and the client never learned it was a no-op).
+        # Reject explicitly so the player isn't misled. (#255.)
+        if player.submitted:
+            await self._conn.send_error(
+                ws, ERR_INVALID_ACTION, "Wager locked after answering"
+            )
+            return
+
         wager = data.get("wager")
         try:
             wager_int = int(wager)
@@ -980,8 +991,12 @@ class QuizifyWebSocketHandler:
     ) -> None:
         """Handle admin end_game command."""
         self._cancel_timer_tick()
+        # end_game() fires the ``game_ended`` state event, which the
+        # BroadcastDispatcher routes to _broadcast_finale — that's the single
+        # finale broadcast source. Calling _broadcast_finale here too would
+        # double-broadcast the podium. (#255.) end_game() is idempotent, so a
+        # repeated admin end-game is a harmless no-op.
         game_state.end_game()
-        await self._broadcast_finale(game_state)
 
     # ------------------------------------------------------------------
     # Admin: reset game
@@ -1377,9 +1392,10 @@ class QuizifyWebSocketHandler:
 
         question = game_state.start_next_question()
         if question is None:
-            # Game ended (no more questions or round limit reached)
-            if game_state.phase == GamePhase.FINALE:
-                await self._broadcast_finale(game_state)
+            # Game ended (no more questions or round limit reached).
+            # start_next_question() already called end_game(), which fired the
+            # ``game_ended`` event → dispatcher → _broadcast_finale (the single
+            # finale broadcast source). No direct broadcast here. (#255.)
             return
 
         # Canonical shuffle — used by admin/dashboard and as a fallback.
@@ -1502,6 +1518,14 @@ class QuizifyWebSocketHandler:
                     # round before their per-player timer exists.
                     connected = [p.name for p in players if p.connected]
                     if connected and game_state.all_timers_expired(connected):
+                        break
+                    # Fallback: when every player has disconnected mid-question
+                    # there are no live timers left for all_timers_expired to
+                    # break on, so the loop would spin forever and the admin
+                    # couldn't advance. Break once the round wall-clock has run
+                    # out, so the round still auto-evaluates with zero connected
+                    # players. (#255.)
+                    if not connected and game_state.round_wall_clock_expired():
                         break
 
                 # Timer expired globally

--- a/tests/test_game_state.py
+++ b/tests/test_game_state.py
@@ -153,9 +153,14 @@ class TestLateJoin:
         state.start_next_question()
         state.add_player("Charlie", _fake_ws())  # late
         state.submit_answer("Alice", 0)
+        # Before the last real participant submits, the round is still open and
+        # all_submitted() excludes the late joiner (it does not block on him).
+        assert state._player_registry.all_submitted() is False
         state.submit_answer("Bob", 0)
-        # Round should be ready to evaluate even though Charlie didn't submit
-        assert state._player_registry.all_submitted() is True
+        # Once both real participants have answered the round auto-evaluates
+        # (advances past QUESTION_ACTIVE) without waiting on the late joiner —
+        # i.e. the late joiner never forced the room to run the full timer.
+        assert state.phase is not GamePhase.QUESTION_ACTIVE
 
 
 # ---------- Scoring ----------

--- a/tests/test_round_lifecycle_255.py
+++ b/tests/test_round_lifecycle_255.py
@@ -1,0 +1,287 @@
+"""Regression tests for the round-lifecycle & scoring edge-cases in #255.
+
+Covers:
+- HIGH: ``joined_late`` is cleared at the end of the round the player joined
+  into, so from their next round on they count toward ``all_submitted()``.
+- MEDIUM: a round where every player has disconnected still evaluates once the
+  round wall-clock has elapsed (no infinite tick-loop spin).
+- MEDIUM: ``end_game()`` is idempotent — a second call records analytics once
+  and emits a single finale broadcast, reusing the cached payload.
+- LOW: Comeback King is not a false-positive on flat per-round scores with an
+  odd round count.
+- LOW: a wager submitted after the answer is rejected with an error.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.highlights import (  # noqa: E402
+    compute_superlatives,
+)
+from custom_components.quizify.game.phase_controller import (  # noqa: E402
+    PhaseController,
+)
+from custom_components.quizify.game.player import PlayerSession  # noqa: E402
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+
+
+def _fake_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+class _Runtime:
+    """Minimal runtime: runs scheduled coroutines on the live loop."""
+
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+    def create_task(self, coro):  # noqa: ANN001
+        return asyncio.ensure_future(coro)
+
+
+# ---------- HIGH: joined_late cleared after the joined round ----------
+
+
+class TestLateJoinerFlagCleared:
+    def test_late_joiner_counts_from_their_second_round(
+        self, tmp_path: Path
+    ) -> None:
+        """A player who joins mid-round is excluded from all_submitted() for
+        that one round, but once it evaluates the flag is cleared and they
+        block the *next* round's early-reveal until they answer too — instead
+        of being silently scored 0 (timeout) every remaining round."""
+        gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+        gs.add_player("Alice", _fake_ws())
+        gs.add_player("Bob", _fake_ws())
+        gs.start_game(language="de", num_rounds=5)
+        gs.start_next_question()
+
+        # Charlie joins mid-round 1 → flagged late.
+        gs.add_player("Charlie", _fake_ws())
+        assert gs.get_player("Charlie").joined_late is True
+
+        # Round 1: only the original two answer; the late joiner doesn't block.
+        gs.submit_answer("Alice", 0)
+        gs.submit_answer("Bob", 0)
+        assert gs.phase is not GamePhase.QUESTION_ACTIVE
+
+        # The flag was cleared by the round evaluation.
+        assert gs.get_player("Charlie").joined_late is False
+
+        # Round 2: Charlie is now a full participant — Alice+Bob answering is
+        # NOT enough to close the round; it stays open until Charlie answers.
+        gs.start_next_question()
+        gs.submit_answer("Alice", 0)
+        gs.submit_answer("Bob", 0)
+        assert gs.phase is GamePhase.QUESTION_ACTIVE
+        assert gs._player_registry.all_submitted() is False
+
+        gs.submit_answer("Charlie", 0)
+        assert gs.phase is not GamePhase.QUESTION_ACTIVE
+
+
+# ---------- MEDIUM: all-disconnect round still evaluates ----------
+
+
+class TestAllDisconnectEvaluates:
+    def test_round_wall_clock_expired_after_duration(self) -> None:
+        """With no live per-player timers (everyone disconnected), the round
+        wall-clock is the fallback break condition for the tick loop."""
+        pc = PhaseController(players_fn=lambda: [])
+        # Before a round starts there is no wall-clock to expire.
+        assert pc.round_wall_clock_expired() is False
+
+        pc.begin_round(round_duration=10.0)
+        assert pc.round_wall_clock_expired() is False
+
+        # Simulate the wall-clock having fully elapsed.
+        pc.round_start_time = time.monotonic() - 11.0
+        assert pc.round_wall_clock_expired() is True
+
+    def test_all_timers_expired_needs_a_live_timer(self) -> None:
+        """all_timers_expired() can't break when there are no timers left —
+        which is exactly why round_wall_clock_expired() exists as a fallback."""
+        pc = PhaseController(players_fn=lambda: [])
+        pc.begin_round(round_duration=10.0)
+        # No connected players → empty list → never "all expired".
+        assert pc.all_timers_expired([]) is False
+        # And the wall-clock is the path that actually ends the round.
+        pc.round_start_time = time.monotonic() - 11.0
+        assert pc.round_wall_clock_expired() is True
+
+    def test_state_delegates_wall_clock(self, tmp_path: Path) -> None:
+        gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+        gs.add_player("Alice", _fake_ws())
+        gs.start_game(language="de", num_rounds=3)
+        gs.start_next_question()
+        # Force the shared round wall-clock past the duration.
+        gs._phase_controller.round_start_time = time.monotonic() - 9999.0
+        assert gs.round_wall_clock_expired() is True
+
+
+# ---------- MEDIUM: end_game idempotency ----------
+
+
+class TestEndGameIdempotent:
+    @pytest.mark.asyncio
+    async def test_double_end_game_records_analytics_once(
+        self, tmp_path: Path
+    ) -> None:
+        """A re-entry into end_game() while already in FINALE must not record
+        the game to analytics a second time, and must reuse the cached payload."""
+        gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+
+        record_calls: list[dict] = []
+
+        class _Stats:
+            async def record_game(self, **kwargs):  # noqa: ANN003
+                record_calls.append(kwargs)
+
+        gs._stats_service = _Stats()
+        gs.add_player("Alice", _fake_ws())
+        gs.add_player("Bob", _fake_ws())
+        gs.start_game(language="de", num_rounds=2)
+        gs.start_next_question()
+
+        first = gs.end_game()
+        second = gs.end_game()
+
+        # Same cached payload object returned on re-entry.
+        assert second is first
+        assert gs.phase is GamePhase.FINALE
+
+        # Let the scheduled record_game coroutine(s) run.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert len(record_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_double_end_game_single_finale_broadcast(
+        self, tmp_path: Path
+    ) -> None:
+        """The game_ended state event (→ finale broadcast) fires exactly once
+        across two end_game() calls."""
+        gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+
+        events: list[str] = []
+
+        async def _broadcast(payload: dict) -> None:
+            events.append(payload.get("event", ""))
+
+        gs.set_broadcast_callback(_broadcast)
+        gs.add_player("Alice", _fake_ws())
+        gs.add_player("Bob", _fake_ws())
+        gs.start_game(language="de", num_rounds=2)
+        gs.start_next_question()
+
+        gs.end_game()
+        gs.end_game()
+
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert events.count("game_ended") == 1
+
+
+# ---------- LOW: Comeback King false-positive on odd rounds ----------
+
+
+def _mk_player(name: str, round_scores: list[int]) -> PlayerSession:
+    p = PlayerSession(name=name, ws=MagicMock())
+    p.round_scores = list(round_scores)
+    p.round_history = ["correct"] * len(round_scores)
+    return p
+
+
+class TestComebackKingOddRounds:
+    def test_flat_odd_round_scores_no_comeback(self) -> None:
+        """Five identical per-round scores must NOT trigger Comeback King.
+
+        With an odd round count the second half held one extra round, so the
+        raw-sum comparison (sum(scores[2:]) > sum(scores[:2])) falsely fired."""
+        players = [
+            _mk_player("Flat", [10, 10, 10, 10, 10]),  # 5 rounds, all equal
+            _mk_player("AlsoFlat", [5, 5, 5, 5, 5]),
+        ]
+        awards = compute_superlatives(players)
+        names = {a.award for a in awards}
+        assert "Comeback King" not in names
+
+    def test_genuine_comeback_still_awarded(self) -> None:
+        """A real second-half surge still earns the award (no regression).
+
+        ``TopDog`` carries the single highest round so it claims Top Score
+        first (awards are exclusive), leaving Comeback King free for the player
+        whose per-round average genuinely climbs in the back half."""
+        players = [
+            _mk_player("TopDog", [50, 5, 5, 5, 5]),
+            _mk_player("Steady", [10, 10, 10, 10, 10]),
+            _mk_player("Riser", [0, 5, 5, 20, 20]),  # weak start, strong finish
+        ]
+        awards = compute_superlatives(players)
+        comeback = [a for a in awards if a.award == "Comeback King"]
+        assert len(comeback) == 1
+        assert comeback[0].winner == "Riser"
+
+
+# ---------- LOW: wager after answer rejected ----------
+
+
+class TestWagerAfterAnswerRejected:
+    @pytest.mark.asyncio
+    async def test_wager_rejected_when_already_submitted(
+        self, tmp_path: Path
+    ) -> None:
+        """A wager arriving after the player has locked in their answer is
+        rejected with an error rather than silently mutating the stake."""
+        from custom_components.quizify.server.websocket import (  # noqa: PLC0415
+            ERR_INVALID_ACTION,
+            QuizifyWebSocketHandler,
+        )
+
+        gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+        ws = _fake_ws()
+        gs.add_player("Alice", ws)
+        # A second player keeps the round in QUESTION_ACTIVE after Alice
+        # answers (so the wager phase-guard doesn't short-circuit first).
+        gs.add_player("Bob", _fake_ws())
+        # Final round (round == total_rounds) so the wager path is reachable.
+        gs.start_game(language="de", num_rounds=1)
+        gs.start_next_question()
+        gs.submit_answer("Alice", 0)
+        assert gs.get_player("Alice").submitted is True
+        assert gs.phase is GamePhase.QUESTION_ACTIVE
+
+        # Build a handler with a stubbed connection so we can capture errors.
+        handler = QuizifyWebSocketHandler.__new__(QuizifyWebSocketHandler)
+        sent_errors: list[tuple] = []
+
+        class _Conn:
+            async def send_error(self, ws, code, msg):  # noqa: ANN001
+                sent_errors.append((code, msg))
+
+        handler._conn = _Conn()
+
+        await handler._handle_submit_wager(ws, {"wager": 50}, gs)
+
+        assert len(sent_errors) == 1
+        assert sent_errors[0][0] == ERR_INVALID_ACTION
+        # The stale wager was not applied.
+        assert gs.get_player("Alice").wager in (None, 0)


### PR DESCRIPTION
Fixes the round-lifecycle & scoring edge-cases from the 2026-06-11 review. Closes #255.

## Changes

### [HIGH] `joined_late` never cleared → late joiners scored 0 every round
`game/state.py::_do_evaluate_round` now clears `joined_late` for all players at the end of each evaluated round. The flag only exists to stop a mid-round arrival from forcing the full timer on the round they entered; it was set on join and never cleared mid-game, so `all_submitted()` excluded late joiners for the rest of the match and they were recorded as timeouts (0 pts) every round. They now count from their second round on.

### [MEDIUM] All players disconnect mid-question → tick loop spins forever
Added `PhaseController.round_wall_clock_expired()` (delegated via `state.round_wall_clock_expired()`), and the countdown tick loop in `server/websocket.py` now also breaks on it when no connected player remains. Previously `all_timers_expired()` required at least one live timer, so an all-disconnect left the loop spinning and the admin unable to advance. The round now auto-evaluates once the shared round wall-clock elapses.

### [MEDIUM] `end_game()` no phase guard → finale double-broadcast + duplicate analytics
`state.end_game()` is now idempotent: re-entry while already in `FINALE` returns the cached payload without recomputing podium/superlatives, re-firing `game_ended`, or recording analytics again. The two direct `_broadcast_finale` calls in the WS layer (`_handle_end_game`, `_start_next_question`) are dropped so the `game_ended` state event → `BroadcastDispatcher` → `_broadcast_finale` is the single finale broadcast source.

### [LOW] Comeback King false-positive in odd-round games
`game/highlights.py` now compares per-round **averages** of the two halves rather than raw sums. With an odd round count the second half held one extra round, so a player with flat per-round scores showed a positive sum-improvement and falsely won the award.

### [LOW] Wager accepted after answer is a silent no-op
`server/websocket.py::_handle_submit_wager` now rejects a wager with `ERR_INVALID_ACTION` ("Wager locked after answering") when the player has already submitted, instead of silently mutating the stake on a locked answer.

## Tests
- New `tests/test_round_lifecycle_255.py`: late joiner counts toward `all_submitted` from their 2nd round; all-disconnect round wall-clock evaluation; double `end_game` records analytics once + single finale broadcast; Comeback King not awarded on flat odd-round scores (and still awarded on a genuine surge); wager after answer rejected.
- Updated the existing late-joiner `all_submitted` assertion to check the round actually auto-evaluated without the late joiner (the previous proxy assertion became stale once the flag is cleared on eval).
- Full suite: **365 passed** (356 baseline + 9 new).

No HA deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)