### PR TITLE
fix(security): constant-time token compare + proxy-aware rate-limit + remote-exposure docs (Closes #259)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -255,6 +255,60 @@ Warm, soft, welcoming. Easings are longer than Broadcast Living Room, transforms
 - Quizify wordmark uses Cabinet Grotesk 800 for "Quiz" and Cabinet Grotesk 800 for `ify` in coral.
 - No mascot, no secondary brand character. The typography + palette IS the branding.
 
+## Security model (LAN-first; remote exposure caveats)
+
+> Reviewed 2026-06-11 (#259, part of the #252 code review). Captures the
+> *intentional* exposure posture so future changes don't accidentally weaken it
+> or "fix" something that is a deliberate trade-off.
+
+**Threat model: a trusted home LAN.** Quizify is a party game played by people
+in the same room. Players join from their own phones by scanning a QR / opening
+a URL — **they have no Home Assistant login** and must not need one. Because of
+that, the player-facing HTTP and WebSocket endpoints are intentionally **open on
+the LAN**: they are registered directly on HA's aiohttp router (not as
+auth-gated `HomeAssistantView`s), so they answer without HA credentials. This is
+by design and must stay that way — gating the game WebSocket, `flag-question`,
+or `pack-submit` behind HA auth would lock every player out of the game.
+
+**Endpoint exposure map** (all reachable without HA auth on the LAN):
+
+| Endpoint | Method | Effect | Why it stays open |
+|----------|--------|--------|-------------------|
+| `/quizify/api/.../ws` (game WebSocket) | WS | Play the game; admin-as-player join (see below) | Players have no HA login. |
+| `/api/quizify/flag-question` | POST | **Writes** a flag record to disk | A player must be able to report a bad question mid-game. |
+| `/api/quizify/flags` | GET | **Discloses** flagged questions | Low-sensitivity game metadata; host reads it from the same un-authed admin page. |
+| `/api/quizify/pack-submit` | POST | Proxies a composed pack to the worker (rate-limited, optional shared secret) | Composed by the host in the un-authed admin UI; inert until `community_submit_url` is configured. |
+| `/api/quizify/analytics/data`, `/all-time`, `/question-stats` | GET | **Discloses** game/leaderboard analytics | Shown on the un-authed TV/analytics surfaces. |
+
+**Remote exposure rule (CRITICAL).** Because these endpoints are un-authed,
+**remote exposure must be fronted by Home Assistant auth — or not done at all.**
+- **Nabu Casa Remote UI** already requires HA login to reach *any* integration
+  HTTP path, so it satisfies this requirement out of the box.
+- A **self-hosted reverse proxy** (nginx / Traefik / Cloudflare Tunnel) that
+  forwards `/quizify/*` or `/api/quizify/*` to HA **without** an auth layer in
+  front would expose the write/disclosure endpoints above to the internet. Do
+  not do this. If you proxy, require auth at the proxy (or rely on Nabu Casa).
+- When a reverse proxy *is* in play, configure HA's
+  `http.use_x_forwarded_for` + `trusted_proxies` so the pack-submit rate-limiter
+  keys on the real client IP rather than the proxy's single address. We
+  deliberately do **not** parse `X-Forwarded-For` ourselves (an attacker-set
+  header would let any client spoof the bucket key) — see
+  `server/pack_submission.py`.
+
+**Admin-as-player join (`is_admin: true`) — accepted #208 trade-off.** The
+server trusts `is_admin: true` in the join message at face value rather than
+requiring the admin session token on the player join (see the 2026-04-28
+Decisions Log entry). A malicious LAN client can therefore claim the single
+admin slot. This is an accepted LAN trade-off, not a bug: the home LAN is
+trusted, remote access is gated by HA auth per the rule above, and only one
+admin slot exists per game. Behaviour is intentionally left unchanged.
+
+**Hardened in #259** (defence-in-depth, no behaviour change for legitimate use):
+the admin session-token comparison now uses `hmac.compare_digest`
+(constant-time, no timing oracle — `server/connection.py`), and the pack-submit
+rate-limit IP resolution is documented as proxy-aware via HA's trusted-proxy
+config.
+
 ## Decisions Log
 
 | Date | Decision | Rationale |
@@ -269,4 +323,5 @@ Warm, soft, welcoming. Easings are longer than Broadcast Living Room, transforms
 | 2026-06-09 | Welcome/setup hero → "Categories-forward" (SVG-icon tinted category tiles + F1 featured spotlight) | Design-shotgun explored category-pill directions, then full welcome-screen directions; user picked A (categories-forward) with SVG icons (no emoji) and the F1 "Soft Spotlight" featured card. Category icons are now SVG line glyphs keyed by theme, in per-theme accent-tinted discs. |
 | 2026-06-10 | App-wide icon system → **"Rounded Duotone" SVG line icons** (#212) | Follow-up to #211's hero icons: the rest of the app still used emoji as UI icons (inconsistent per-OS, off-palette, clash with the SVG hero). A shared icon helper (`www/js/icons.js`, `window.QuizifyIcons`) now serves the theme glyph set to both admin and player JS. Style = Option 2 from the #212 shotgun: 2px rounded strokes over a soft accent-tinted backing disc (warmer than Option 1 hairline, softer than Option 3 geometric-bold). P1 surfaces (pack cards + theme tabs) shipped first; emoji pulled out of `theme.*` i18n strings (text-only). P2 (presets/awards) + P3 (reveal-feedback strings) descoped to follow-ups. |
 | 2026-06-09 | Player-phone podium → "Podium Reborn" (gradient rising blocks) | Design-shotgun explored 4 phone-finale directions; user picked B over the shipped cream-shelf ("Family Trophy Shelf"). Player phone now uses rising blocks with muted single-hue tonal gradient fills + a halo rising from the champion, for a more celebratory finale payoff. Admin/TV keeps the cream shelf. Tonal gradients are a scoped, user-approved exception to the no-gradient rule. |
+| 2026-06-11 | Security model documented; constant-time admin-token compare (#259) | Code review (#252/#259) confirmed the LAN-first exposure posture is intentional: player endpoints stay un-authed (players have no HA login), remote exposure must be fronted by HA auth (Nabu Casa or a proxy auth layer). Added a "Security model" section with an endpoint exposure map + remote-exposure rule. Hardened the admin session-token compare with `hmac.compare_digest` and documented the proxy-aware rate-limit IP resolution. No player-facing behaviour changed. |
 | 2026-04-28 | Admin-as-player trust model (Beatify pattern) | Server trusts `is_admin: true` in the join message at face value. No more cryptographic token threading through player joins. The persisted admin token is still validated for the pure admin-dashboard WebSocket connect (`?role=admin&token=...`), but player joins are simpler. **Trade-off:** a malicious LAN client can spoof admin by sending `is_admin: true`. Mitigations: (a) the user's home LAN is generally trusted; (b) Nabu Casa already requires HA auth to reach the integration; (c) "first admin claims it" still applies — only one admin slot per game. Adopting the same pattern as Beatify (which has shipped this without issues for years) closed 8 betas worth of admin-as-player lockout bugs. v1.1.2. |

--- a/custom_components/quizify/server/connection.py
+++ b/custom_components/quizify/server/connection.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import hmac
 import json
 import logging
 import time
@@ -134,8 +135,17 @@ class ConnectionManager:
         return self._admin_session_token
 
     def validate_admin_token(self, token: str) -> bool:
-        """Return True if *token* matches the current admin session token."""
-        return bool(token and token == self._admin_session_token)
+        """Return True if *token* matches the current admin session token.
+
+        The comparison uses :func:`hmac.compare_digest` so it runs in constant
+        time and doesn't leak the token byte-by-byte through response timing
+        (#259). The empty-token / no-token-set guards short-circuit *before* the
+        compare: ``compare_digest`` requires both operands to be set strings of
+        the same type, and a None/empty admin token must never validate.
+        """
+        if not token or not self._admin_session_token:
+            return False
+        return hmac.compare_digest(token, self._admin_session_token)
 
     async def try_bootstrap_admin(self) -> bool:
         """Atomically grant + persist the admin token on a fresh install.

--- a/custom_components/quizify/server/pack_submission.py
+++ b/custom_components/quizify/server/pack_submission.py
@@ -413,6 +413,20 @@ async def submit_pack_view(request: web.Request) -> web.Response:
             status=403,
         )
 
+    # Rate-limit bucket key. We use ``request.remote`` rather than parsing the
+    # ``X-Forwarded-For`` header ourselves: behind a reverse proxy, a raw
+    # forwarded header is attacker-controlled, so trusting it would let any
+    # client spoof an arbitrary IP and either evade the limit or poison another
+    # client's bucket (#259). Home Assistant already resolves the real client IP
+    # for us when it is configured with ``http.use_x_forwarded_for`` +
+    # ``trusted_proxies`` — its ``XForwardedRelaxed`` middleware rewrites
+    # ``request.remote`` to the left-most untrusted hop *before* the request
+    # reaches this handler. So ``request.remote`` is the correct, proxy-aware
+    # key when HA is configured for a proxy, and the safe direct-peer IP when it
+    # is not. Without that config behind a proxy the limit collapses to the
+    # proxy's single IP — an accepted LAN trade-off (see DESIGN.md security
+    # note); the limiter is a courtesy throttle on an already-shared-secret
+    # endpoint, not an auth boundary.
     client_ip = request.remote or "unknown"
     if not _check_rate_limit(client_ip):
         return web.json_response(

--- a/tests/test_security_168.py
+++ b/tests/test_security_168.py
@@ -92,6 +92,63 @@ class TestAdminBootstrapRace:
 
 
 # ---------------------------------------------------------------------------
+# 1b. Constant-time admin-token validation (#259)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateAdminToken:
+    """validate_admin_token must validate the right token via the new
+    constant-time (hmac.compare_digest) path and reject everything else."""
+
+    @pytest.mark.asyncio
+    async def test_correct_token_validates(self, conn: ConnectionManager) -> None:
+        await conn.try_bootstrap_admin()
+        token = conn._admin_session_token
+        assert conn.validate_admin_token(token) is True
+
+    @pytest.mark.asyncio
+    async def test_wrong_token_rejected(self, conn: ConnectionManager) -> None:
+        await conn.try_bootstrap_admin()
+        assert conn.validate_admin_token("not-the-token") is False
+
+    @pytest.mark.asyncio
+    async def test_empty_token_rejected(self, conn: ConnectionManager) -> None:
+        await conn.try_bootstrap_admin()
+        assert conn.validate_admin_token("") is False
+
+    def test_no_admin_token_set_rejects_everything(
+        self, conn: ConnectionManager
+    ) -> None:
+        # No token has been created yet → even a plausible value must not pass,
+        # and the guard must short-circuit before compare_digest (which would
+        # raise on a None operand).
+        assert conn._admin_session_token is None
+        assert conn.validate_admin_token("anything") is False
+        assert conn.validate_admin_token("") is False
+
+    @pytest.mark.asyncio
+    async def test_uses_constant_time_compare(
+        self, conn: ConnectionManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The compare must route through hmac.compare_digest, not `==`,
+        so the validation has no early-exit timing oracle (#259)."""
+        import custom_components.quizify.server.connection as conn_mod
+
+        await conn.try_bootstrap_admin()
+        token = conn._admin_session_token
+        calls: list[tuple[str, str]] = []
+        real = conn_mod.hmac.compare_digest
+
+        def _spy(a, b):  # noqa: ANN001
+            calls.append((a, b))
+            return real(a, b)
+
+        monkeypatch.setattr(conn_mod.hmac, "compare_digest", _spy)
+        assert conn.validate_admin_token(token) is True
+        assert calls, "validate_admin_token did not use hmac.compare_digest"
+
+
+# ---------------------------------------------------------------------------
 # 2. Passive session-token expiry
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Conservative security hardening from the #252 / #259 code review. The guiding decision: **harden what is safe and document the remote-exposure trade-off; do NOT gate player-facing endpoints behind HA auth** — players join from their own phones with no Home Assistant login, so requiring auth on the game WebSocket / `flag-question` / `pack-submit` would break the game.

## Hardened (behaviour-preserving)

- **[LOW] Constant-time admin-token compare** — `server/connection.py`: `validate_admin_token` now uses `hmac.compare_digest` instead of `==`, removing the byte-by-byte timing oracle on the admin session token. The empty-token / no-token-set guards short-circuit *before* the compare so a `None`/empty admin token never validates.
- **[LOW] Proxy-aware rate-limit IP** — `server/pack_submission.py`: documented that the rate-limit bucket key (`request.remote`) is **already** the real client IP when HA is configured with `http.use_x_forwarded_for` + `trusted_proxies` (HA's `XForwardedRelaxed` middleware rewrites `request.remote` before the handler runs). We deliberately do **not** parse `X-Forwarded-For` ourselves: a raw forwarded header is attacker-controlled and would let any client spoof the bucket key (evade the limit or poison another client's bucket). Minimal + correct: trust HA's resolution, document the without-proxy-config limitation.

## Documented (the MEDIUM findings — intentional LAN trade-offs)

- **[MEDIUM] Endpoints bypass HA auth** & **[MEDIUM] `is_admin:true` join without token (#208)** — added a **Security model** section to `DESIGN.md` instead of changing behaviour:
  - Endpoint exposure map of every un-authed write/disclosure path: game WS, `flag-question` (disk write), `flags` (disclosure), `pack-submit`, analytics — with *why each stays open*.
  - **Remote-exposure rule (CRITICAL):** remote access must be fronted by HA auth or not done. Nabu Casa Remote UI satisfies this out of the box; a self-hosted reverse proxy must add an auth layer (do not expose un-authed). When proxied, configure `use_x_forwarded_for` + `trusted_proxies` for correct rate-limit keying.
  - The `is_admin:true` admin-as-player join is reaffirmed as an accepted #208 LAN trade-off (unchanged).

## Why player endpoints stay open

Players have no HA account. Gating the game WebSocket, `flag-question`, or `pack-submit` behind `HomeAssistantView(requires_auth=True)` would lock every player out. The correct boundary for remote exposure is at the HA-auth / proxy layer, which is now documented as a hard requirement rather than enforced in a way that breaks LAN play.

## Tests

- `tests/test_security_168.py::TestValidateAdminToken` — correct token validates, wrong/empty rejected, no-token-set rejects everything, and the compare is asserted to route through `hmac.compare_digest`.
- Full suite green (410 passed; 1 pre-existing random-shuffle flake in `test_reconnect_snapshot_projection_253.py` is unrelated to this change). No HA deploy.

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)