### PR TITLE
refactor: promote shared surface, remove private-attribute reach-ins (Closes #269)

### DIFF
--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -88,7 +88,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Load persisted admin session token (survives HA restarts).
     # Without this, any LAN client could seize admin after every restart.
-    await ws_handler._conn.async_load_admin_token()
+    await ws_handler.conn.async_load_admin_token()
 
     # Wire broadcast callback so game state can push events to clients.
     game_state.set_broadcast_callback(ws_handler.broadcast_state)
@@ -163,7 +163,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if domain_data:
             handler = domain_data.get("ws_handler")
             if handler:
-                await handler._conn.async_clear_admin_token()
+                await handler.conn.async_clear_admin_token()
                 _LOGGER.warning(
                     "Quizify admin session token RESET via HA service. "
                     "Next admin connection will bootstrap a fresh token."

--- a/custom_components/quizify/game/questions.py
+++ b/custom_components/quizify/game/questions.py
@@ -148,6 +148,21 @@ class QuestionBank:
         # Questions shown in the current game (to record at end)
         self._shown_this_game: list[str] = []
 
+    @property
+    def categories(self) -> dict[str, list[Question]]:
+        """Loaded categories mapping slug -> questions.
+
+        A shallow copy so callers can read the per-category question lists
+        (e.g. featured-pack difficulty aggregation) without mutating the
+        bank's internal store. Use :meth:`get_categories` for just the slugs.
+        """
+        return dict(self._categories)
+
+    @property
+    def questions_dir(self) -> Path:
+        """Directory the question-pack JSON files are loaded from."""
+        return self._questions_dir
+
     def load_category(self, category: str) -> list[Question]:
         """Load questions for a single category from its JSON file."""
         file_path = self._questions_dir / f"{category}.json"

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -253,6 +253,15 @@ class QuizifyGameState:
     def _pause_reason(self, value: str | None) -> None:
         self._phase_controller.pause_reason = value
 
+    @property
+    def last_settings(self) -> "dict[str, Any] | None":
+        """Settings of the most recent start_game, or None if never started.
+
+        Used by the one-tap rematch path to restart with the previous game's
+        configuration instead of re-prompting the admin.
+        """
+        return self._last_settings
+
     # ------------------------------------------------------------------
     # Player registry delegation
     # ------------------------------------------------------------------

--- a/custom_components/quizify/question_stats.py
+++ b/custom_components/quizify/question_stats.py
@@ -108,6 +108,24 @@ class QuestionStatsService:
                 q["total_time_correct"] += float(elapsed)
         self._dirty = True
 
+    def aggregate_for_questions(self, ids) -> "tuple[int, int]":
+        """Sum (shown_count, correct_count) over the given question *ids*.
+
+        Public read accessor used by the featured-pack difficulty ranking so
+        callers don't reach into the internal ``_data`` store. Questions with
+        no recorded stats contribute zero. Returns ``(total_shown,
+        total_correct)``.
+        """
+        questions = self._data["questions"]
+        shown = 0
+        correct = 0
+        for qid in ids:
+            s = questions.get(qid)
+            if s and s.get("shown_count", 0) >= 1:
+                shown += s["shown_count"]
+                correct += s.get("correct_count", 0)
+        return shown, correct
+
     def get_hardest(self, limit: int = 25, min_shown: int = 3) -> list[dict[str, Any]]:
         """Questions with the LOWEST correct rate, gated by min_shown so a
         one-time miss doesn't dominate the list."""

--- a/custom_components/quizify/server/connection.py
+++ b/custom_components/quizify/server/connection.py
@@ -90,6 +90,25 @@ class ConnectionManager:
         """Return True if *ws* is an admin connection."""
         return ws in self._admin_connections
 
+    def has_admin_connections(self) -> bool:
+        """Return True if at least one admin connection is registered."""
+        return bool(self._admin_connections)
+
+    def iter_admin_and_dashboard_ws(
+        self,
+    ) -> "list[tuple[web.WebSocketResponse, bool]]":
+        """Yield (ws, is_admin) for every admin and dashboard connection.
+
+        Lets callers fan out to admin + TV-dashboard spectator sockets
+        without reaching into the private ``_admin_connections`` /
+        ``_dashboard_connections`` sets. ``is_admin`` lets the caller apply
+        the admin-only filter (e.g. excluding an admin who is also a player)
+        while treating dashboards unconditionally.
+        """
+        return [(ws, True) for ws in list(self._admin_connections)] + [
+            (ws, False) for ws in list(self._dashboard_connections)
+        ]
+
     # ------------------------------------------------------------------
     # Admin session token (persisted across restarts)
     # ------------------------------------------------------------------
@@ -171,6 +190,12 @@ class ConnectionManager:
         # Mark as loaded so any later async_load is a no-op (file is gone).
         self._admin_token_loaded = True
 
+    def has_pending_admin_disconnect(self) -> bool:
+        """Return True if an admin-disconnect grace-period task is running."""
+        return bool(
+            self._admin_disconnect_task and not self._admin_disconnect_task.done()
+        )
+
     def cancel_admin_disconnect(self) -> None:
         """Cancel a running admin-disconnect grace-period task."""
         if self._admin_disconnect_task and not self._admin_disconnect_task.done():
@@ -221,6 +246,10 @@ class ConnectionManager:
         """Revoke *old_token* and issue a fresh one for *player_name*."""
         self._session_tokens.pop(old_token, None)
         return self.create_session_token(player_name)
+
+    def revoke_token(self, token: str) -> None:
+        """Revoke a single session *token* (no-op if unknown)."""
+        self._session_tokens.pop(token, None)
 
     def get_player_for_token(self, token: str) -> str | None:
         """Return the player name associated with *token*, or None."""
@@ -312,12 +341,20 @@ class ConnectionManager:
         if tasks:
             await asyncio.gather(*tasks)
 
-    async def _safe_send(self, ws: web.WebSocketResponse, message: dict) -> None:
-        """Send *message* to *ws*, swallowing any send errors."""
+    async def send(self, ws: web.WebSocketResponse, message: dict) -> None:
+        """Send *message* to *ws*, swallowing any send errors.
+
+        The public single-socket send primitive. Errors are intentionally
+        swallowed (and logged) so one dead/slow client can't break a fan-out.
+        """
         try:
             await ws.send_json(message)
         except Exception as err:  # noqa: BLE001
             _LOGGER.warning("Failed to send to WebSocket: %s", err)
+
+    # Backwards-compatible alias for the former private name. Some tests still
+    # patch ``_safe_send``; keep it pointing at the public method.
+    _safe_send = send
 
     async def _safe_send_str(self, ws: web.WebSocketResponse, payload: str) -> None:
         """Send a pre-serialized JSON *payload* to *ws*, swallowing errors.
@@ -334,7 +371,7 @@ class ConnectionManager:
         self, ws: web.WebSocketResponse, code: str, message: str
     ) -> None:
         """Send a structured error message to *ws*."""
-        await self._safe_send(ws, {"type": "error", "code": code, "message": message})
+        await self.send(ws, {"type": "error", "code": code, "message": message})
 
     # ------------------------------------------------------------------
     # Cleanup

--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -372,16 +372,12 @@ async def featured_pack_view(request: web.Request) -> web.Response:
             chosen = None
     elif logic == "most-difficult" and ctx.question_stats is not None:
         try:
-            qstats = ctx.question_stats._data["questions"]
+            bank_categories = bank.categories
             pack_rates: dict[str, float] = {}
             for cat in lang_packs:
-                shown = 0
-                correct = 0
-                for q in bank._categories.get(cat, []):
-                    s = qstats.get(q.id)
-                    if s and s.get("shown_count", 0) >= 1:
-                        shown += s["shown_count"]
-                        correct += s.get("correct_count", 0)
+                shown, correct = ctx.question_stats.aggregate_for_questions(
+                    q.id for q in bank_categories.get(cat, [])
+                )
                 if shown >= _FEATURED_MIN_SHOWN:
                     pack_rates[cat] = correct / shown
             if pack_rates:
@@ -400,7 +396,7 @@ async def featured_pack_view(request: web.Request) -> web.Response:
     meta = lang_packs[chosen]
     # Read pack JSON once for theme (icon lookup). Cheap — packs are
     # already on disk and aiohttp's executor handles the blocking read.
-    pack_path = bank._questions_dir / f"{chosen}.json"
+    pack_path = bank.questions_dir / f"{chosen}.json"
     try:
         raw = await ctx.runtime.run_in_executor(
             pack_path.read_text, "utf-8"

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -88,6 +88,10 @@ class QuizifyWebSocketHandler:
         self._runtime = runtime
         self._get_game_state = game_state_provider
         self._conn = ConnectionManager(runtime, game_state_provider)
+        # Public alias for the connection manager so collaborators (e.g.
+        # __init__.py setup/teardown) use a contract-bearing accessor instead
+        # of reaching into the private ``_conn`` attribute. Backed by
+        # ``_conn`` so test fixtures that assign ``handler._conn`` still work.
         self._timer_tick_task: asyncio.Task | None = None
         # Deferred-pause task scheduled by _handle_disconnect when the
         # admin-as-player WS closes mid-question. Cancelled by reconnect
@@ -122,6 +126,11 @@ class QuizifyWebSocketHandler:
         # builder produces the exact message dicts to hand to the connection
         # manager. Behaviour-preserving — identical wire shapes.
         self._round_messages = RoundMessageBuilder()
+
+    @property
+    def conn(self) -> ConnectionManager:
+        """The connection manager owned by this handler (public accessor)."""
+        return self._conn
 
     def _check_rate_limit(self, ws: web.WebSocketResponse) -> bool:
         """Record a message for ``ws`` and report whether it is within the
@@ -365,7 +374,7 @@ class QuizifyWebSocketHandler:
         elif msg_type == "get_state":
             state_msg = game_state.get_state_snapshot()
             state_msg["type"] = "game_state"
-            await self._conn._safe_send(ws, state_msg)
+            await self._conn.send(ws, state_msg)
 
         elif msg_type == "reaction":
             await self._handle_reaction(ws, data, game_state)
@@ -386,7 +395,7 @@ class QuizifyWebSocketHandler:
     ) -> None:
         """Send full state to admin on connect."""
         # Cancel admin disconnect task if reconnecting
-        if self._conn._admin_disconnect_task and not self._conn._admin_disconnect_task.done():
+        if self._conn.has_pending_admin_disconnect():
             self._conn.cancel_admin_disconnect()
             _LOGGER.info("Admin reconnected, cancelled disconnect timeout")
 
@@ -396,7 +405,7 @@ class QuizifyWebSocketHandler:
         state["type"] = "game_state"
         state["join_url"] = "/quizify/player"
         state["admin_session_token"] = admin_token
-        await self._conn._safe_send(ws, state)
+        await self._conn.send(ws, state)
 
     # ------------------------------------------------------------------
     # Player join
@@ -529,7 +538,7 @@ class QuizifyWebSocketHandler:
 
             # Send join confirmation with session token and assigned color
             powerup = game_state.get_player_powerup(name)
-            await self._conn._safe_send(ws, {
+            await self._conn.send(ws, {
                 "type": "joined",
                 "player_id": name,
                 "powerup": powerup.value if powerup else None,
@@ -549,7 +558,7 @@ class QuizifyWebSocketHandler:
                     game_state, snapshot=state, player=player_obj
                 )
             state["type"] = "game_state"
-            await self._conn._safe_send(ws, state)
+            await self._conn.send(ws, state)
 
             # Broadcast player list to everyone
             players = game_state.get_players()
@@ -584,14 +593,14 @@ class QuizifyWebSocketHandler:
 
         if not name:
             # Token not found — treat as unknown, client should show join form
-            await self._conn._safe_send(ws, {"type": "reconnect_failed"})
+            await self._conn.send(ws, {"type": "reconnect_failed"})
             return
 
         player = game_state.get_player(name)
         if not player:
             # Player was fully removed — token stale
-            self._conn._session_tokens.pop(token, None)
-            await self._conn._safe_send(ws, {"type": "reconnect_failed"})
+            self._conn.revoke_token(token)
+            await self._conn.send(ws, {"type": "reconnect_failed"})
             return
 
         # Restore player connection
@@ -628,7 +637,7 @@ class QuizifyWebSocketHandler:
 
         # Send reconnect success with new token
         powerup = game_state.get_player_powerup(name)
-        await self._conn._safe_send(ws, {
+        await self._conn.send(ws, {
             "type": "reconnected",
             "player_id": name,
             "session_token": new_token,
@@ -643,7 +652,7 @@ class QuizifyWebSocketHandler:
             game_state, snapshot=state, player=player
         )
         state["type"] = "game_state"
-        await self._conn._safe_send(ws, state)
+        await self._conn.send(ws, state)
 
         # Broadcast updated player list
         players = game_state.get_players()
@@ -686,7 +695,7 @@ class QuizifyWebSocketHandler:
         result = game_state.submit_answer(player.name, original_index)
 
         if isinstance(result, AnswerResult):
-            await self._conn._safe_send(ws, {
+            await self._conn.send(ws, {
                 "type": "answer_result",
                 "correct": result.correct,
                 "points_earned": result.points_earned,
@@ -853,7 +862,7 @@ class QuizifyWebSocketHandler:
             return
 
         player.wager = wager_int
-        await self._conn._safe_send(ws, {
+        await self._conn.send(ws, {
             "type": "wager_accepted",
             "wager": wager_int,
         })
@@ -894,7 +903,7 @@ class QuizifyWebSocketHandler:
                         shuffled_remove_idx = shuffled_idx
                         break
 
-                await self._conn._safe_send(ws, {
+                await self._conn.send(ws, {
                     "type": "powerup_applied",
                     "powerup_type": "joker",
                     "source_player": result.source_player,
@@ -1069,10 +1078,10 @@ class QuizifyWebSocketHandler:
         with the cached settings. If we don't have a snapshot yet (server
         never saw a start_game on this instance), fall back to reset.
         """
-        if not getattr(game_state, "_last_settings", None):
+        if not game_state.last_settings:
             await self._handle_reset_game(ws, game_state)
             return
-        settings = game_state._last_settings
+        settings = game_state.last_settings
         self._cancel_timer_tick()
         # Reset to LOBBY first so start_game's phase guard passes; keeps
         # players (reset_to_lobby leaves connected players in place).
@@ -1294,7 +1303,7 @@ class QuizifyWebSocketHandler:
         if result is None:
             return  # rejected (already answered / expired) — stay silent
         # Lightweight ack: lock the player's buttons + show right/wrong.
-        await self._conn._safe_send(ws, {
+        await self._conn.send(ws, {
             "type": "lightning_answer_result",
             "correct": bool(result),
             "index": lr.index,
@@ -1380,7 +1389,7 @@ class QuizifyWebSocketHandler:
         for player in game_state.get_players():
             if not player.connected:
                 continue
-            lightning_sends.append(self._conn._safe_send(player.ws, {
+            lightning_sends.append(self._conn.send(player.ws, {
                 "type": "lightning_question",
                 "question_text": q.question,
                 "answers": lr.shuffled_answers_for(player.name),
@@ -1468,7 +1477,7 @@ class QuizifyWebSocketHandler:
             player_msg = self._round_messages.build_player_question(
                 game_state, question=question, player=player, is_final=is_final
             )
-            question_sends.append(self._conn._safe_send(player.ws, player_msg))
+            question_sends.append(self._conn.send(player.ws, player_msg))
         if question_sends:
             await asyncio.gather(*question_sends)
 
@@ -1490,7 +1499,7 @@ class QuizifyWebSocketHandler:
         for player in players:
             powerup = game_state.get_player_powerup(player.name)
             if powerup and player.connected:
-                powerup_sends.append(self._conn._safe_send(player.ws, {
+                powerup_sends.append(self._conn.send(player.ws, {
                     "type": "powerup_assigned",
                     "powerup_type": powerup.value,
                 }))
@@ -1534,33 +1543,32 @@ class QuizifyWebSocketHandler:
                     tick = game_state.resolve_tick([p.name for p in players])
                     # Build the full (ws, payload) fan-out, then deliver it in
                     # parallel via gather (#258). A single stalled client no
-                    # longer delays the whole room — _safe_send swallows errors
-                    # so a plain gather is safe.
+                    # longer delays the whole room — ConnectionManager.send
+                    # swallows errors so a plain gather is safe.
                     sends = []
                     # Each connected player gets their authoritative remaining.
                     for name, remaining in tick.per_player:
                         p = by_name.get(name)
                         if p is None or not p.connected:
                             continue
-                        sends.append(self._conn._safe_send(p.ws, {
+                        sends.append(self._conn.send(p.ws, {
                             "type": "timer_tick",
                             "remaining": round(remaining, 1),
                         }))
                     # Broadcast the minimum remaining to dashboards/admins so
                     # the TV view shows a consistent countdown.
                     min_remaining = tick.dashboard_remaining
-                    for ws in list(self._conn._admin_connections):
-                        if not ws.closed and not any(p.ws is ws for p in players):
-                            sends.append(self._conn._safe_send(ws, {
-                                "type": "timer_tick",
-                                "remaining": round(min_remaining, 1),
-                            }))
-                    for ws in list(self._conn._dashboard_connections):
-                        if not ws.closed:
-                            sends.append(self._conn._safe_send(ws, {
-                                "type": "timer_tick",
-                                "remaining": round(min_remaining, 1),
-                            }))
+                    for ws, is_admin in self._conn.iter_admin_and_dashboard_ws():
+                        if ws.closed:
+                            continue
+                        # An admin who is also a player already got their
+                        # per-player tick above — don't double-send.
+                        if is_admin and any(p.ws is ws for p in players):
+                            continue
+                        sends.append(self._conn.send(ws, {
+                            "type": "timer_tick",
+                            "remaining": round(min_remaining, 1),
+                        }))
                     if sends:
                         await asyncio.gather(*sends)
                     await asyncio.sleep(TICK_INTERVAL)
@@ -1632,7 +1640,7 @@ class QuizifyWebSocketHandler:
         # Strictly gated on real admin connection (was: OR clause allowed
         # dashboard disconnects to trigger the timeout, see #2 in review).
         if self._conn.is_admin_connection(ws):
-            if not self._conn._admin_connections:
+            if not self._conn.has_admin_connections():
                 _LOGGER.info(
                     "Admin disconnected, keeping game alive for %ds",
                     self._conn.ADMIN_SESSION_GRACE,

--- a/tests/test_featured_pack_260.py
+++ b/tests/test_featured_pack_260.py
@@ -46,6 +46,14 @@ class _FakeBank:
         self._pack_versions = pack_versions
         self._categories = categories
 
+    @property
+    def categories(self) -> dict:
+        return dict(self._categories)
+
+    @property
+    def questions_dir(self) -> Path:
+        return self._questions_dir
+
     def get_pack_versions(self) -> dict:
         return dict(self._pack_versions)
 
@@ -61,6 +69,17 @@ class _FakeAnalytics:
 class _FakeQuestionStats:
     def __init__(self, questions: dict) -> None:
         self._data = {"questions": questions}
+
+    def aggregate_for_questions(self, ids) -> tuple:  # noqa: ANN001
+        questions = self._data["questions"]
+        shown = 0
+        correct = 0
+        for qid in ids:
+            s = questions.get(qid)
+            if s and s.get("shown_count", 0) >= 1:
+                shown += s["shown_count"]
+                correct += s.get("correct_count", 0)
+        return shown, correct
 
 
 class _FakeRequest:

--- a/tests/test_joker_shuffle_254.py
+++ b/tests/test_joker_shuffle_254.py
@@ -58,7 +58,7 @@ def _handler(state: QuizifyGameState) -> QuizifyWebSocketHandler:
     h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: state)
     h._conn = ConnectionManager(runtime, lambda: state)
     h._conn.broadcast = AsyncMock()
-    h._conn._safe_send = AsyncMock()
+    h._conn.send = AsyncMock()
     return h
 
 
@@ -106,7 +106,7 @@ async def test_joker_disables_wrong_answer_in_player_order(
     # The private send to Alice carries the button index to disable.
     private_sends = [
         c.args[1]
-        for c in h._conn._safe_send.call_args_list
+        for c in h._conn.send.call_args_list
         if len(c.args) >= 2 and c.args[1].get("powerup_type") == "joker"
     ]
     assert private_sends, "expected a private joker send to the using player"

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -316,7 +316,7 @@ def _handler(state: QuizifyGameState) -> QuizifyWebSocketHandler:
     h._conn = ConnectionManager(runtime, lambda: state)
     h._conn.broadcast = AsyncMock()
     h._conn.broadcast_to_admins_and_dashboards = AsyncMock()
-    h._conn._safe_send = AsyncMock()
+    h._conn.send = AsyncMock()
     return h
 
 

--- a/tests/test_reconnect_failed_227.py
+++ b/tests/test_reconnect_failed_227.py
@@ -64,7 +64,7 @@ def handler(game: QuizifyGameState) -> QuizifyWebSocketHandler:
 
 
 def _sent_types(ws: MagicMock) -> list[str]:
-    """Message ``type`` strings the server sent on *ws* (via _safe_send)."""
+    """Message ``type`` strings the server sent on *ws* (via ConnectionManager.send)."""
     return [
         call.args[0].get("type")
         for call in ws.send_json.await_args_list

--- a/tests/test_reset_game_207.py
+++ b/tests/test_reset_game_207.py
@@ -208,11 +208,11 @@ def _auth_handler(game: QuizifyGameState, tmp_path: Path) -> QuizifyWebSocketHan
     async def _noop_broadcast(message: dict) -> None:
         return None
 
-    async def _safe_send(ws, message: dict) -> None:
+    async def _send(ws, message: dict) -> None:
         sent.setdefault(id(ws), []).append(message)
 
     h._conn.broadcast = _noop_broadcast  # type: ignore[assignment]
-    h._conn._safe_send = _safe_send  # type: ignore[assignment]
+    h._conn.send = _send  # type: ignore[assignment]
     h._sent = sent  # type: ignore[attr-defined]
     return h
 

--- a/tests/test_security_168.py
+++ b/tests/test_security_168.py
@@ -243,8 +243,8 @@ class TestFeaturedPackMalformed:
         bank.get_pack_versions.return_value = {
             "geographie": {"language": "de", "question_count": 5, "name": "Geo"},
         }
-        bank._questions_dir = tmp_path
-        bank._categories = {}
+        bank.questions_dir = tmp_path
+        bank.categories = {}
 
         ctx = MagicMock()
         ctx.game._question_bank = bank


### PR DESCRIPTION
Non-functional refactor for #269. The websocket handler and views reached into the *private* state of their collaborators at 20+ sites, defeating the #184/#187/#188/#189 layering work — the underscore-prefixed members were de-facto public API with no contract. This promotes the genuinely shared surface to real, contract-bearing public methods and updates every call site. **No behaviour or wire-shape change.**

## Promoted

`ConnectionManager` (`server/connection.py`):
- `_safe_send` → `send` (public single-socket send primitive; a thin `_safe_send = send` alias is kept so any test patching the old name still works)
- `iter_admin_and_dashboard_ws()` — yields `(ws, is_admin)` so the timer-tick loop fans out without touching `_admin_connections` / `_dashboard_connections`
- `revoke_token(token)` — replaces the handler popping `_session_tokens`
- `has_admin_connections()` and `has_pending_admin_disconnect()` predicates

`QuizifyGameState` (`game/state.py`): `last_settings` property (replaces `_last_settings` reach-in in the rematch path).

`QuestionBank` (`game/questions.py`): `categories` and `questions_dir` properties (replace `_categories` / `_questions_dir` reach-ins in the featured-pack view).

`QuestionStats` (`question_stats.py`): `aggregate_for_questions(ids)` read accessor (replaces reaching into `_data["questions"]`).

`QuizifyWebSocketHandler` (`server/websocket.py`): public `conn` property, backed by `_conn`, so `__init__.py` setup/teardown uses a contract-bearing accessor.

## Call sites updated
- `server/websocket.py`: 18× `_safe_send` → `send`, the timer-tick admin+dashboard fan-out, the `_session_tokens` pop, the `_admin_disconnect_task` check, the `_last_settings` reads, and the "no admins left" guard.
- `server/views.py`: featured-pack difficulty ranking and pack-path lookup now go through `categories` / `questions_dir` / `aggregate_for_questions`.
- `__init__.py`: `ws_handler._conn` → `ws_handler.conn` (load + clear admin token).

## Behaviour / tests
Purely mechanical — no logic or message shapes changed. A few test doubles that were written against the old private members were updated to the new public surface (`_FakeBank`, `_FakeQuestionStats`, the malformed-pack MagicMock, and three fixtures that patched `_safe_send`).

**All 442 tests pass** (`/usr/bin/python3 -m pytest -q`).

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)