### PR TITLE
feat(packs): seasonal packs with auto-surfacing (Closes #276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to Quizify are documented here. This project follows
 
 ## [Unreleased]
 
+### Added
+
+- **Seasonal packs with auto-surfacing (#276).** A pack may carry an optional
+  recurring `season` window (`{"start": "MM-DD", "end": "MM-DD", "label": "…"}`,
+  both bounds inclusive, wrap-around across the new year supported). While the
+  window is active *today* the Featured Spotlight pins the seasonal pack
+  (deterministic soonest-ending-first when several overlap) and the admin pack
+  picker badges it with the label (e.g. "🎄 Weihnachten"). Outside every window
+  behaviour is unchanged; packs without a `season` field are fully
+  back-compatible. The World Cup / Weltmeisterschaft packs ship a June–July
+  window as the first seasonal packs.
+
 ## [1.3.0-RC14] — 2026-06-11
 
 Fourteenth release candidate for 1.3.0 — the three deferred refactors from the

--- a/custom_components/quizify/game/questions.py
+++ b/custom_components/quizify/game/questions.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from ..const import ANSWERS_PER_QUESTION
+from .seasons import parse_season
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,6 +86,26 @@ def _sanitize_image_url(raw: object, question_id: str) -> str:
         url[:60],
     )
     return ""
+
+
+def _normalize_season(raw: object) -> dict | None:
+    """Validate a pack's ``season`` field, returning a normalised dict or None.
+
+    Delegates parsing/validation to :func:`.seasons.parse_season` (which logs
+    and tolerates anything malformed), then re-emits the *normalised* MM-DD
+    window as a plain JSON-serialisable dict so it can be stored on the pack
+    metadata and shipped over the ``/api/quizify/packs`` endpoint unchanged.
+    Returns ``None`` when there is no (valid) season, keeping packs without the
+    field fully back-compatible.
+    """
+    season = parse_season(raw)
+    if season is None:
+        return None
+    return {
+        "start": f"{season.start[0]:02d}-{season.start[1]:02d}",
+        "end": f"{season.end[0]:02d}-{season.end[1]:02d}",
+        "label": season.label,
+    }
 
 
 def _parse_question(data: dict, category_name: str) -> Question | None:
@@ -189,12 +210,20 @@ class QuestionBank:
                 questions.append(q)
 
         self._categories[category] = questions
-        self._pack_versions[category] = {
+        meta: dict = {
             "version": pack_version,
             "name": category_name,
             "language": pack_language,
             "question_count": len(questions),
         }
+        # Optional recurring seasonal window (#276). Parsed + validated here so
+        # a malformed window is dropped at load time; the normalised MM-DD form
+        # is stored on the pack metadata (date-agnostic) and the date check
+        # happens later in the featured-pack view against the current clock.
+        season_meta = _normalize_season(raw.get("season"))
+        if season_meta is not None:
+            meta["season"] = season_meta
+        self._pack_versions[category] = meta
         _LOGGER.debug("Loaded %d questions for category '%s' (v%s)", len(questions), category, pack_version)
         return questions
 
@@ -356,13 +385,17 @@ class QuestionBank:
                 continue
 
             self._categories[slug] = questions
-            self._pack_versions[slug] = {
+            community_meta: dict = {
                 "version": str(pack_version),
                 "name": category_name,
                 "language": pack_language,
                 "question_count": len(questions),
                 "community": True,
             }
+            community_season = _normalize_season(raw.get("season"))
+            if community_season is not None:
+                community_meta["season"] = community_season
+            self._pack_versions[slug] = community_meta
             loaded[slug] = questions
             _LOGGER.info(
                 "Loaded community pack '%s' (%d questions) as '%s'",

--- a/custom_components/quizify/game/seasons.py
+++ b/custom_components/quizify/game/seasons.py
@@ -1,0 +1,170 @@
+"""Seasonal-pack metadata: recurring month-day windows + active-window checks.
+
+A pack may carry an optional ``season`` field describing a *recurring*
+calendar window (it surfaces every year, independent of year):
+
+    "season": {"start": "12-01", "end": "12-26", "label": "🎄 Weihnachten"}
+
+``start``/``end`` are ``MM-DD`` strings, both bounds inclusive. Wrap-around
+windows that span the new year are supported:
+
+    "season": {"start": "12-20", "end": "01-06", "label": "🎄 Festtage"}
+
+This module never touches the real clock — the "current date" is always passed
+in by the caller (see ``is_in_season`` / ``active_season_label``) so the
+behaviour is fully testable with an injected date. Packs without a ``season``
+field are fully back-compatible: :func:`parse_season` returns ``None`` and every
+``is_in_season(None, ...)`` is ``False``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import date
+
+_LOGGER = logging.getLogger(__name__)
+
+# Label cap so a hostile/malformed community pack can't flood the picker badge.
+_MAX_LABEL_LEN = 40
+
+
+@dataclass(frozen=True)
+class Season:
+    """A parsed, validated recurring seasonal window.
+
+    ``start``/``end`` are ``(month, day)`` tuples, both inclusive. The window
+    wraps around the new year when ``start > end`` (e.g. Dec 20 → Jan 6).
+    """
+
+    start: tuple[int, int]
+    end: tuple[int, int]
+    label: str
+
+
+def _parse_md(raw: object) -> tuple[int, int] | None:
+    """Parse a ``"MM-DD"`` string into a validated ``(month, day)`` tuple.
+
+    Returns ``None`` for anything malformed (wrong type, wrong shape, or a
+    month/day outside a sane calendar range). Day validity is checked against a
+    leap year (2024) so Feb 29 is accepted as a legitimate window edge.
+    """
+    if not isinstance(raw, str):
+        return None
+    parts = raw.strip().split("-")
+    if len(parts) != 2:
+        return None
+    try:
+        month = int(parts[0])
+        day = int(parts[1])
+    except ValueError:
+        return None
+    if not (1 <= month <= 12):
+        return None
+    # Validate the day against a leap year so 02-29 is allowed.
+    try:
+        date(2024, month, day)
+    except ValueError:
+        return None
+    return (month, day)
+
+
+def parse_season(raw: object) -> Season | None:
+    """Parse + validate a pack's ``season`` field into a :class:`Season`.
+
+    Tolerant by design — any malformed shape (not a dict, missing/invalid
+    ``start``/``end``, non-string ``label``) is logged and yields ``None`` so a
+    bad pack simply behaves as a non-seasonal pack rather than breaking the
+    loader. A pack with no ``season`` field passes ``raw is None`` and returns
+    ``None`` silently.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        _LOGGER.warning("Ignoring 'season': expected an object, got %s", type(raw).__name__)
+        return None
+
+    start = _parse_md(raw.get("start"))
+    end = _parse_md(raw.get("end"))
+    if start is None or end is None:
+        _LOGGER.warning(
+            "Ignoring 'season': invalid start/end (%r → %r); expected 'MM-DD'",
+            raw.get("start"),
+            raw.get("end"),
+        )
+        return None
+
+    label_raw = raw.get("label", "")
+    label = label_raw.strip() if isinstance(label_raw, str) else ""
+    if not label:
+        _LOGGER.warning("Season window %s–%s has no label; using a generic one", start, end)
+        label = "Seasonal"
+    label = label[:_MAX_LABEL_LEN]
+
+    return Season(start=start, end=end, label=label)
+
+
+def is_in_season(season: Season | None, today: date) -> bool:
+    """Return whether ``today`` falls inside the recurring window (inclusive).
+
+    Year-agnostic: only ``today``'s month/day matter. Handles the wrap-around
+    case (window spanning the new year) by inverting the comparison. ``None``
+    (no season / unparseable) is always out of season.
+    """
+    if season is None:
+        return False
+
+    cur = (today.month, today.day)
+    start = season.start
+    end = season.end
+
+    if start <= end:
+        # Normal window within a single calendar year, e.g. 10-25 → 11-01.
+        return start <= cur <= end
+    # Wrap-around window, e.g. 12-20 → 01-06: in-season if on/after start OR
+    # on/before end.
+    return cur >= start or cur <= end
+
+
+def _days_until_end(season: Season, today: date) -> int:
+    """Days from ``today`` to the window's end (inclusive), for tie-breaking.
+
+    Used only when several seasons are active at once: the soonest-ending one
+    wins so a short, specific window (e.g. a single holiday) takes priority over
+    a long one. Year-agnostic — counts forward from today to the next occurrence
+    of the end month/day.
+    """
+    end_month, end_day = season.end
+    year = today.year
+    try:
+        end_date = date(year, end_month, end_day)
+    except ValueError:
+        # Feb 29 in a non-leap year: treat as Mar 1 for ordering purposes.
+        end_date = date(year, 3, 1)
+    if end_date < today:
+        try:
+            end_date = date(year + 1, end_month, end_day)
+        except ValueError:
+            end_date = date(year + 1, 3, 1)
+    return (end_date - today).days
+
+
+def pick_active_season(
+    seasons: dict[str, Season | None], today: date
+) -> str | None:
+    """Pick the single seasonal pack to pin from ``{slug: Season}``.
+
+    Returns the slug of the in-season pack to feature, or ``None`` if none are
+    active. When multiple windows overlap, selection is deterministic:
+    soonest-ending first (so a tight holiday window beats a broad one), then by
+    slug as a final stable tie-breaker.
+    """
+    active = [
+        (slug, season)
+        for slug, season in seasons.items()
+        if season is not None and is_in_season(season, today)
+    ]
+    if not active:
+        return None
+    active.sort(key=lambda item: (_days_until_end(item[1], today), item[0]))
+    return active[0][0]

--- a/custom_components/quizify/questions/weltmeisterschaft.json
+++ b/custom_components/quizify/questions/weltmeisterschaft.json
@@ -3,6 +3,7 @@
   "language": "de",
   "version": "1.0",
   "theme": "worldcup",
+  "season": {"start": "06-01", "end": "07-31", "label": "⚽ WM-Saison"},
   "questions": [
     {
       "id": "world_cup_de_001",

--- a/custom_components/quizify/questions/world-cup.json
+++ b/custom_components/quizify/questions/world-cup.json
@@ -3,6 +3,7 @@
   "language": "en",
   "version": "1.0",
   "theme": "worldcup",
+  "season": {"start": "06-01", "end": "07-31", "label": "⚽ World Cup season"},
   "questions": [
     {
       "id": "world_cup_en_001",

--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -18,6 +18,7 @@ import time
 import aiohttp
 from aiohttp import web
 
+from ..game.seasons import is_in_season, parse_season, pick_active_season
 from .context import APP_CTX_KEY
 from .pack_submission import (
     submissions_list_view,
@@ -354,8 +355,23 @@ async def featured_pack_view(request: web.Request) -> web.Response:
     if not lang_packs:
         return web.json_response({})
 
+    # Seasonal auto-surfacing (#276) takes priority over the day-rotation:
+    # if a pack's recurring season window is active *today*, it is pinned as
+    # the Featured Spotlight regardless of most-played/most-difficult. Outside
+    # every window this is a no-op and behaviour is exactly as before.
+    today = _dt.date.today()
+    seasons = {
+        cat: parse_season(meta.get("season"))
+        for cat, meta in lang_packs.items()
+    }
+    seasonal_slug = pick_active_season(seasons, today)
+
     chosen: str | None = None
-    if logic == "most-played" and ctx.analytics is not None:
+    seasonal_active = False
+    if seasonal_slug is not None:
+        chosen = seasonal_slug
+        seasonal_active = True
+    elif logic == "most-played" and ctx.analytics is not None:
         try:
             metrics = ctx.analytics.compute_metrics("30d")
             cat_plays = {
@@ -385,13 +401,20 @@ async def featured_pack_view(request: web.Request) -> web.Response:
         except (KeyError, AttributeError, TypeError):
             chosen = None
 
-    if chosen is None:
+    if seasonal_active:
+        logic_used = "seasonal"
+    elif chosen is None:
         # Fallback: prefer Geographie/Geography if present, else first pack.
         default = _FEATURED_DEFAULT_EN if lang == "en" else _FEATURED_DEFAULT_DE
         chosen = default if default in lang_packs else next(iter(lang_packs))
         logic_used = "default"
     else:
         logic_used = logic
+
+    # The pinned pack's label (e.g. "🎄 Weihnachten") for the spotlight subtitle
+    # and the picker badge. ``season_label`` is the active label or "".
+    chosen_season = seasons.get(chosen)
+    season_label = chosen_season.label if (seasonal_active and chosen_season) else ""
 
     meta = lang_packs[chosen]
     # Read pack JSON once for theme (icon lookup). Cheap — packs are
@@ -419,6 +442,9 @@ async def featured_pack_view(request: web.Request) -> web.Response:
             "most-played": "Beliebt diese Woche",
             "most-difficult": "Härteste Herausforderung",
             "default": "Familienfreundlich",
+            # In-season packs show their own label (e.g. "🎄 Weihnachten") as
+            # the spotlight subtitle instead of a generic rotation reason.
+            "seasonal": season_label or "Saisonal",
         }[logic_used]
     else:
         unit = "questions"
@@ -426,6 +452,7 @@ async def featured_pack_view(request: web.Request) -> web.Response:
             "most-played": "Popular this week",
             "most-difficult": "Hardest challenge",
             "default": "Family-friendly",
+            "seasonal": season_label or "Seasonal",
         }[logic_used]
 
     return web.json_response({
@@ -433,6 +460,8 @@ async def featured_pack_view(request: web.Request) -> web.Response:
         "title": f"{icon} {meta.get('name', chosen)}",
         "meta": f"{count} {unit} · {sub}",
         "logic": logic_used,
+        "is_seasonal": seasonal_active,
+        "season_label": season_label,
     })
 
 
@@ -500,11 +529,33 @@ async def all_time_leaderboard_view(request: web.Request) -> web.Response:
 
 
 async def pack_versions_view(request: web.Request) -> web.Response:
-    """Return installed pack version metadata."""
+    """Return installed pack version metadata.
+
+    Seasonal packs (#276) are annotated per request with ``is_seasonal``
+    (whether the recurring window is active *today*) and ``season_label`` (the
+    label to badge, e.g. "🎄 Weihnachten") so the admin picker can render the
+    badge without re-implementing the date math client-side.
+    """
+    import datetime as _dt
+
     ctx = _get_ctx(request)
     await ctx.runtime.run_in_executor(ctx.game._question_bank.load_all_categories)
     installed = ctx.game._question_bank.get_pack_versions()
-    return web.json_response(installed)
+
+    today = _dt.date.today()
+    # ``get_pack_versions`` returns a shallow copy: the inner meta dicts are the
+    # bank's own objects. Copy each before annotating so the per-request season
+    # flags never leak into the cached pack metadata.
+    annotated = {}
+    for slug, meta in installed.items():
+        meta = dict(meta)
+        season = parse_season(meta.get("season"))
+        in_season = season is not None and is_in_season(season, today)
+        meta["is_seasonal"] = in_season
+        meta["season_label"] = season.label if (in_season and season) else ""
+        annotated[slug] = meta
+
+    return web.json_response(annotated)
 
 
 async def pack_update_check_view(request: web.Request) -> web.Response:

--- a/custom_components/quizify/www/css/src/02-shared.css
+++ b/custom_components/quizify/www/css/src/02-shared.css
@@ -486,6 +486,28 @@ button, .btn {
     letter-spacing: 0.04em;
 }
 
+/* Seasonal pack badge (#276): a small accent pill flowing inline at the
+   bottom of an in-season pack card (e.g. "🎄 Weihnachten"). Sits in the card's
+   normal flex column under the count, so it never overlaps the top-right
+   ✓-check and never clips at mobile widths. Only present when admin.js marks
+   the pack in-season. */
+#category-chips.chip-group--cards .pack-card-season-badge {
+    margin-top: 2px;
+    align-self: flex-start;
+    max-width: 100%;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: var(--color-accent-brand-bg);
+    color: var(--color-accent-primary);
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 0.66rem;
+    font-weight: 700;
+    line-height: 1.3;
+    letter-spacing: 0.02em;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
 /* Tablet+: 3-col grid feels more balanced. */
 @media (min-width: 600px) {
     #category-chips.chip-group--cards {

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -1273,6 +1273,28 @@ button, .btn {
     letter-spacing: 0.04em;
 }
 
+/* Seasonal pack badge (#276): a small accent pill flowing inline at the
+   bottom of an in-season pack card (e.g. "🎄 Weihnachten"). Sits in the card's
+   normal flex column under the count, so it never overlaps the top-right
+   ✓-check and never clips at mobile widths. Only present when admin.js marks
+   the pack in-season. */
+#category-chips.chip-group--cards .pack-card-season-badge {
+    margin-top: 2px;
+    align-self: flex-start;
+    max-width: 100%;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: var(--color-accent-brand-bg);
+    color: var(--color-accent-primary);
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 0.66rem;
+    font-weight: 700;
+    line-height: 1.3;
+    letter-spacing: 0.02em;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
 /* Tablet+: 3-col grid feels more balanced. */
 @media (min-width: 600px) {
     #category-chips.chip-group--cards {

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -325,6 +325,43 @@
         return key;
     }
 
+    // ---- Seasonal pack badges (#276) ----
+    // Packs may carry a recurring season window (e.g. Christmas). The
+    // /api/quizify/packs endpoint resolves which packs are in-season *today*
+    // (server-side date math) and returns is_seasonal + season_label per slug.
+    // For each in-season pack we badge its picker card with that label. Purely
+    // additive: packs that aren't seasonal are untouched, and a failed fetch
+    // just means no badges (the picker still works).
+    function _applySeasonalBadge(chip, label) {
+        if (!chip) return;
+        // Idempotent: never stack badges across re-renders / lang toggles.
+        var existing = chip.querySelector('.pack-card-season-badge');
+        if (existing) existing.remove();
+        var badge = document.createElement('span');
+        badge.className = 'pack-card-season-badge';
+        badge.textContent = label;
+        chip.appendChild(badge);
+    }
+
+    function applySeasonalBadges() {
+        if (!els.categoryChips) return;
+        fetch('/api/quizify/packs')
+            .then(function (resp) { return resp.ok ? resp.json() : null; })
+            .then(function (packs) {
+                if (!packs) return;
+                Object.keys(packs).forEach(function (slug) {
+                    var meta = packs[slug];
+                    if (!meta || !meta.is_seasonal || !meta.season_label) return;
+                    var chip = els.categoryChips.querySelector(
+                        '.chip[data-value="' + slug + '"]');
+                    _applySeasonalBadge(chip, meta.season_label);
+                });
+            })
+            .catch(function (e) {
+                console.warn('[quizify] applySeasonalBadges failed:', e);
+            });
+    }
+
     // ---- Phase 2: Pack-UI (Featured-Spotlight + Theme-Tabs) ----
     // Always-on per the approved mockup
     // (~/.gstack/designs/pack-ui-2026-05-27/phase2-themes.html). The
@@ -1693,6 +1730,9 @@
 
     // ---- Question pack update check ----
     checkPackUpdates();
+
+    // ---- Seasonal pack badges (#276) ----
+    applySeasonalBadges();
 
     // ---- PWA install button ----
     // Android Chrome / Edge / Samsung Browser: fire beforeinstallprompt

--- a/tests/test_seasonal_packs_276.py
+++ b/tests/test_seasonal_packs_276.py
@@ -1,0 +1,394 @@
+"""Tests for seasonal packs with auto-surfacing (#276).
+
+Covers four layers, all with an *injected* date so the suite never depends on
+the real clock:
+
+1. The :mod:`seasons` helper: parsing/validation, the active-window check
+   (normal + wrap-around), multi-active deterministic pick, and back-compat
+   (no ``season`` field).
+2. The pack loader: a ``season`` field on a pack JSON is parsed onto the pack
+   metadata; a pack without it is unchanged.
+3. ``featured_pack_view``: an in-season pack is pinned over the day-rotation
+   logic; outside the window behaviour is exactly as before.
+4. ``pack_versions_view``: per-pack ``is_seasonal`` / ``season_label``
+   annotation for the picker badge.
+
+Dates are injected two ways: the pure helpers take a ``date`` argument
+directly; the views call ``datetime.date.today()`` via a local
+``import datetime``, so those tests monkeypatch ``datetime.date`` with a
+fixed-``today`` subclass.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from datetime import date
+from pathlib import Path
+from types import SimpleNamespace
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game import seasons  # noqa: E402
+from custom_components.quizify.game.questions import QuestionBank  # noqa: E402
+from custom_components.quizify.game.seasons import (  # noqa: E402
+    Season,
+    is_in_season,
+    parse_season,
+    pick_active_season,
+)
+from custom_components.quizify.server.context import APP_CTX_KEY  # noqa: E402
+from custom_components.quizify.server.views import (  # noqa: E402
+    featured_pack_view,
+    pack_versions_view,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. seasons helper — parsing / validation
+# ---------------------------------------------------------------------------
+
+
+def test_parse_season_valid_window() -> None:
+    s = parse_season({"start": "12-01", "end": "12-26", "label": "🎄 Weihnachten"})
+    assert s == Season(start=(12, 1), end=(12, 26), label="🎄 Weihnachten")
+
+
+def test_parse_season_none_is_back_compat() -> None:
+    """A pack with no season field → None, never raises."""
+    assert parse_season(None) is None
+
+
+def test_parse_season_rejects_garbage() -> None:
+    assert parse_season("not a dict") is None
+    assert parse_season({"start": "13-01", "end": "12-26"}) is None  # month 13
+    assert parse_season({"start": "12-32", "end": "12-26"}) is None  # day 32
+    assert parse_season({"start": "12-01"}) is None                  # missing end
+    assert parse_season({"start": "12/01", "end": "12-26"}) is None  # wrong sep
+
+
+def test_parse_season_accepts_feb_29() -> None:
+    s = parse_season({"start": "02-15", "end": "02-29", "label": "Leap"})
+    assert s is not None and s.end == (2, 29)
+
+
+def test_parse_season_missing_label_gets_generic() -> None:
+    s = parse_season({"start": "01-01", "end": "01-05"})
+    assert s is not None and s.label == "Seasonal"
+
+
+# ---------------------------------------------------------------------------
+# 1b. seasons helper — active-window check (injected date)
+# ---------------------------------------------------------------------------
+
+
+def test_is_in_season_normal_window() -> None:
+    s = parse_season({"start": "06-01", "end": "07-31", "label": "Summer"})
+    assert is_in_season(s, date(2026, 6, 1))    # inclusive start
+    assert is_in_season(s, date(2026, 7, 1))    # middle
+    assert is_in_season(s, date(2026, 7, 31))   # inclusive end
+    assert not is_in_season(s, date(2026, 5, 31))
+    assert not is_in_season(s, date(2026, 8, 1))
+
+
+def test_is_in_season_is_year_agnostic() -> None:
+    """Recurring window: same month-day surfaces in any year."""
+    s = parse_season({"start": "10-25", "end": "11-01", "label": "🎃"})
+    assert is_in_season(s, date(2026, 10, 31))
+    assert is_in_season(s, date(2099, 10, 31))
+
+
+def test_is_in_season_wrap_around_window() -> None:
+    """A window spanning the new year (Dec 20 → Jan 6) is handled."""
+    s = parse_season({"start": "12-20", "end": "01-06", "label": "🎄 Festtage"})
+    assert is_in_season(s, date(2026, 12, 20))   # start edge
+    assert is_in_season(s, date(2026, 12, 31))   # before new year
+    assert is_in_season(s, date(2027, 1, 1))     # after new year
+    assert is_in_season(s, date(2027, 1, 6))     # end edge
+    assert not is_in_season(s, date(2027, 1, 7))
+    assert not is_in_season(s, date(2026, 12, 19))
+    assert not is_in_season(s, date(2026, 7, 1))  # mid-year, clearly outside
+
+
+def test_is_in_season_none_always_false() -> None:
+    assert not is_in_season(None, date(2026, 12, 25))
+
+
+# ---------------------------------------------------------------------------
+# 1c. seasons helper — multi-active deterministic pick
+# ---------------------------------------------------------------------------
+
+
+def test_pick_active_season_none_when_no_window_active() -> None:
+    seasons_map = {
+        "xmas": parse_season({"start": "12-01", "end": "12-26", "label": "🎄"}),
+    }
+    assert pick_active_season(seasons_map, date(2026, 7, 1)) is None
+
+
+def test_pick_active_season_soonest_ending_wins() -> None:
+    """Two overlapping windows → the one ending sooner is pinned."""
+    seasons_map = {
+        "broad": parse_season({"start": "06-01", "end": "08-31", "label": "Broad"}),
+        "tight": parse_season({"start": "06-10", "end": "06-15", "label": "Tight"}),
+    }
+    assert pick_active_season(seasons_map, date(2026, 6, 12)) == "tight"
+
+
+def test_pick_active_season_tiebreak_by_slug() -> None:
+    """Identical end dates → stable alphabetical slug tie-break."""
+    seasons_map = {
+        "bbb": parse_season({"start": "06-01", "end": "06-30", "label": "B"}),
+        "aaa": parse_season({"start": "06-01", "end": "06-30", "label": "A"}),
+    }
+    assert pick_active_season(seasons_map, date(2026, 6, 15)) == "aaa"
+
+
+# ---------------------------------------------------------------------------
+# 2. pack loader — season parsed onto metadata; back-compat preserved
+# ---------------------------------------------------------------------------
+
+
+def _write_pack(qdir: Path, slug: str, extra: dict) -> None:
+    qdir.mkdir(parents=True, exist_ok=True)
+    pack = {
+        "name": slug.title(),
+        "language": "de",
+        "version": "1.0",
+        "questions": [
+            {
+                "id": f"{slug}_1",
+                "question": "Q?",
+                "answers": [
+                    {"text": "a", "correct": True},
+                    {"text": "b", "correct": False},
+                    {"text": "c", "correct": False},
+                ],
+            }
+        ],
+    }
+    pack.update(extra)
+    (qdir / f"{slug}.json").write_text(json.dumps(pack))
+
+
+def test_loader_parses_season_onto_metadata(tmp_path: Path) -> None:
+    _write_pack(
+        tmp_path, "xmas",
+        {"season": {"start": "12-01", "end": "12-26", "label": "🎄 Weihnachten"}},
+    )
+    bank = QuestionBank(tmp_path)
+    bank.load_all_categories()
+    meta = bank.get_pack_versions()["xmas"]
+    assert meta["season"] == {
+        "start": "12-01", "end": "12-26", "label": "🎄 Weihnachten",
+    }
+
+
+def test_loader_normalizes_unpadded_window(tmp_path: Path) -> None:
+    _write_pack(tmp_path, "x", {"season": {"start": "1-5", "end": "1-9", "label": "L"}})
+    bank = QuestionBank(tmp_path)
+    bank.load_all_categories()
+    assert bank.get_pack_versions()["x"]["season"]["start"] == "01-05"
+
+
+def test_loader_pack_without_season_unchanged(tmp_path: Path) -> None:
+    """Back-compat: no season field → no 'season' key on metadata."""
+    _write_pack(tmp_path, "plain", {})
+    bank = QuestionBank(tmp_path)
+    bank.load_all_categories()
+    assert "season" not in bank.get_pack_versions()["plain"]
+
+
+def test_loader_drops_malformed_season(tmp_path: Path) -> None:
+    """A malformed window is dropped (logged), pack still loads."""
+    _write_pack(tmp_path, "bad", {"season": {"start": "99-99", "end": "12-26"}})
+    bank = QuestionBank(tmp_path)
+    bank.load_all_categories()
+    meta = bank.get_pack_versions()["bad"]
+    assert "season" not in meta
+    assert meta["question_count"] == 1  # questions still loaded
+
+
+# ---------------------------------------------------------------------------
+# 3 + 4. views — date injected via a fixed-today datetime.date subclass
+# ---------------------------------------------------------------------------
+
+
+class _FakeRuntime:
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+
+class _FakeBank:
+    def __init__(self, qdir: Path, pack_versions: dict, categories: dict) -> None:
+        self._qdir = qdir
+        self._pack_versions = pack_versions
+        self._categories = categories
+
+    @property
+    def categories(self) -> dict:
+        return dict(self._categories)
+
+    @property
+    def questions_dir(self) -> Path:
+        return self._qdir
+
+    def get_pack_versions(self) -> dict:
+        return {k: dict(v) for k, v in self._pack_versions.items()}
+
+    def load_all_categories(self) -> dict:
+        return dict(self._categories)
+
+
+class _FakeRequest:
+    def __init__(self, ctx, query: dict) -> None:  # noqa: ANN001
+        self.app = {APP_CTX_KEY: ctx}
+        self.query = query
+
+
+def _freeze_today(monkeypatch, year: int, month: int, day: int) -> None:
+    """Pin ``datetime.date.today()`` to a fixed date for the views.
+
+    Both views do a local ``import datetime as _dt`` then call
+    ``_dt.date.today()``; patching the real module's ``date`` attribute with a
+    subclass overriding ``today`` makes the injected date flow through.
+    """
+    import datetime as _real_dt
+
+    fixed = _real_dt.date(year, month, day)
+
+    class _FixedDate(_real_dt.date):
+        @classmethod
+        def today(cls):
+            return fixed
+
+    monkeypatch.setattr(_real_dt, "date", _FixedDate)
+
+
+def _write_pack_file(qdir: Path, slug: str, theme: str, name: str) -> None:
+    qdir.mkdir(parents=True, exist_ok=True)
+    (qdir / f"{slug}.json").write_text(json.dumps({"theme": theme, "name": name}))
+
+
+def _featured(ctx, lang: str = "de") -> dict:
+    req = _FakeRequest(ctx, {"lang": lang})
+    return json.loads(asyncio.run(featured_pack_view(req)).body)
+
+
+def test_featured_pins_in_season_pack(tmp_path: Path, monkeypatch) -> None:  # noqa: ANN001
+    """During the season window the seasonal pack is pinned over the
+    day-rotation logic — even though analytics would pick another pack."""
+    _freeze_today(monkeypatch, 2026, 6, 12)  # inside 06-01..07-31
+    _write_pack_file(tmp_path, "wm", "worldcup", "Weltmeisterschaft")
+    _write_pack_file(tmp_path, "geographie", "geography", "Geographie")
+    bank = _FakeBank(
+        tmp_path,
+        {
+            "geographie": {"language": "de", "question_count": 30, "name": "Geographie"},
+            "wm": {
+                "language": "de", "question_count": 20, "name": "Weltmeisterschaft",
+                "season": {"start": "06-01", "end": "07-31", "label": "⚽ WM-Saison"},
+            },
+        },
+        {"geographie": [], "wm": []},
+    )
+    # Analytics strongly favours geographie — the seasonal pin must override it.
+    analytics = SimpleNamespace(
+        compute_metrics=lambda _p: {
+            "category_stats": [{"category": "geographie", "games_played": 999}]
+        }
+    )
+    ctx = SimpleNamespace(game=SimpleNamespace(_question_bank=bank),
+                          analytics=analytics, question_stats=None, runtime=_FakeRuntime())
+    out = _featured(ctx)
+    assert out["value"] == "wm"
+    assert out["logic"] == "seasonal"
+    assert out["is_seasonal"] is True
+    assert out["season_label"] == "⚽ WM-Saison"
+    assert "⚽ WM-Saison" in out["meta"]
+
+
+def test_featured_outside_season_is_unchanged(tmp_path: Path, monkeypatch) -> None:  # noqa: ANN001
+    """Outside every window the rotation behaves exactly as before — the
+    seasonal pack does NOT surface and is_seasonal is False."""
+    _freeze_today(monkeypatch, 2026, 2, 1)  # outside 06-01..07-31; even-ish day
+    _write_pack_file(tmp_path, "geographie", "geography", "Geographie")
+    bank = _FakeBank(
+        tmp_path,
+        {
+            "geographie": {"language": "de", "question_count": 30, "name": "Geographie"},
+            "wm": {
+                "language": "de", "question_count": 20, "name": "Weltmeisterschaft",
+                "season": {"start": "06-01", "end": "07-31", "label": "⚽ WM-Saison"},
+            },
+        },
+        {"geographie": [], "wm": []},
+    )
+    ctx = SimpleNamespace(game=SimpleNamespace(_question_bank=bank),
+                          analytics=None, question_stats=None, runtime=_FakeRuntime())
+    out = _featured(ctx)
+    assert out["logic"] != "seasonal"
+    assert out["is_seasonal"] is False
+    assert out["season_label"] == ""
+    assert out["value"] == "geographie"  # falls back to default as before
+
+
+def test_featured_wrap_around_window_pins(tmp_path: Path, monkeypatch) -> None:  # noqa: ANN001
+    """A wrap-around window pins on a date after the new year."""
+    _freeze_today(monkeypatch, 2027, 1, 3)  # inside 12-20..01-06
+    _write_pack_file(tmp_path, "xmas", "worldcup", "Festtage")
+    bank = _FakeBank(
+        tmp_path,
+        {
+            "xmas": {
+                "language": "de", "question_count": 12, "name": "Festtage",
+                "season": {"start": "12-20", "end": "01-06", "label": "🎄 Festtage"},
+            },
+        },
+        {"xmas": []},
+    )
+    ctx = SimpleNamespace(game=SimpleNamespace(_question_bank=bank),
+                          analytics=None, question_stats=None, runtime=_FakeRuntime())
+    out = _featured(ctx)
+    assert out["value"] == "xmas"
+    assert out["is_seasonal"] is True
+
+
+def test_pack_versions_view_annotates_in_season(tmp_path: Path, monkeypatch) -> None:  # noqa: ANN001
+    """The picker endpoint flags in-season packs for badging."""
+    _freeze_today(monkeypatch, 2026, 6, 12)
+    bank = _FakeBank(
+        tmp_path,
+        {
+            "geographie": {"language": "de", "question_count": 30, "name": "Geographie"},
+            "wm": {
+                "language": "de", "question_count": 20, "name": "Weltmeisterschaft",
+                "season": {"start": "06-01", "end": "07-31", "label": "⚽ WM-Saison"},
+            },
+        },
+        {"geographie": [], "wm": []},
+    )
+    ctx = SimpleNamespace(game=SimpleNamespace(_question_bank=bank), runtime=_FakeRuntime())
+    req = _FakeRequest(ctx, {})
+    out = json.loads(asyncio.run(pack_versions_view(req)).body)
+    assert out["wm"]["is_seasonal"] is True
+    assert out["wm"]["season_label"] == "⚽ WM-Saison"
+    assert out["geographie"]["is_seasonal"] is False
+    assert out["geographie"]["season_label"] == ""
+
+
+def test_pack_versions_view_annotation_does_not_leak(tmp_path: Path, monkeypatch) -> None:  # noqa: ANN001
+    """Per-request season flags must not mutate the bank's cached metadata."""
+    _freeze_today(monkeypatch, 2026, 6, 12)
+    raw = {
+        "wm": {
+            "language": "de", "question_count": 20, "name": "Weltmeisterschaft",
+            "season": {"start": "06-01", "end": "07-31", "label": "⚽ WM-Saison"},
+        },
+    }
+    bank = _FakeBank(tmp_path, raw, {"wm": []})
+    ctx = SimpleNamespace(game=SimpleNamespace(_question_bank=bank), runtime=_FakeRuntime())
+    asyncio.run(pack_versions_view(_FakeRequest(ctx, {})))
+    assert "is_seasonal" not in raw["wm"]  # source metadata untouched


### PR DESCRIPTION
Implements #276 — date-tagged packs that surface automatically during their season.

## Season metadata
A pack may carry an optional, **recurring** `season` window. Both bounds are
inclusive and the window is year-agnostic (it surfaces every year):

```json
"season": {"start": "12-01", "end": "12-26", "label": "🎄 Weihnachten"}
```

Wrap-around windows that span the new year are supported:

```json
"season": {"start": "12-20", "end": "01-06", "label": "🎄 Festtage"}
```

Parsing/validation lives in the new `game/seasons.py`. Anything malformed
(bad type, month/day out of range, missing bound, non-`MM-DD` shape) is logged
and dropped, so a bad pack just behaves as non-seasonal — packs **without** a
`season` field are fully back-compatible.

## Surfacing rule
- During an active window the Featured Spotlight rotation **pins** the seasonal
  pack, taking priority over the existing most-played / most-difficult
  day-rotation.
- When several windows overlap, the pick is deterministic: **soonest-ending
  first** (a tight holiday window beats a broad one), then alphabetical by slug.
- **Outside every window, behaviour is exactly as today** — the day-rotation and
  fallback are untouched.

`featured_pack_view` now returns `is_seasonal` + `season_label`, and the
spotlight subtitle shows the season label while in-season.

## Picker badge
`pack_versions_view` (`/api/quizify/packs`) annotates each pack with
`is_seasonal` / `season_label` for *today* (server-side date math, copied
per-request so the cached metadata is never mutated). `admin.js` fetches it and
injects a small `.pack-card-season-badge` onto the matching pack card. CSS added
in `www/css/src/02-shared.css` and `styles.css` rebuilt via
`scripts/build_css.py` (a non-intrusive accent pill that flows in the card's
normal column, so it never overlaps the active-✓ corner or clips at mobile
widths). No bundle rebuild needed — `admin.js` is loaded directly, not bundled.

## Demonstration
The **World Cup / Weltmeisterschaft** packs ship a June–July window as the first
seasonal packs.

## How dates are tested
No test touches the real clock:
- The pure helpers (`is_in_season`, `pick_active_season`) take a `date`
  argument directly.
- The views call `datetime.date.today()` via a local `import datetime`; tests
  monkeypatch `datetime.date` with a fixed-`today` subclass.

21 new tests cover: parse/validation, normal + wrap-around windows, multi-active
deterministic pick, loader back-compat (no `season` → unchanged; malformed →
dropped but pack loads), featured-rotation pinning (incl. overriding analytics)
and outside-window no-op, and the picker annotation (plus a no-leak check).
Suite: **477 passed, 2 skipped** (456 baseline + 21; the 2 HA-harness tests skip
on Python 3.9, as expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)