### PR TITLE
fix(dashboard): render answer text on TV cast instead of [object Object]

### DIFF
--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -1212,7 +1212,13 @@
             // Render answers
             var labels = ['A', 'B', 'C', 'D'];
             currentAnswers = msg.answers || [];
-            els.answersGrid.innerHTML = currentAnswers.map(function(text, i) {
+            els.answersGrid.innerHTML = currentAnswers.map(function(answer, i) {
+                // Answer payloads arrive in two shapes: the `question_started`
+                // (admin/cast) message sends objects `{text, correct}`, while the
+                // `game_state` snapshot sends plain strings. Normalize to the
+                // displayable string so the cast/TV view never renders the raw
+                // object as "[object Object]" (issue #283).
+                var text = (answer && typeof answer === 'object') ? answer.text : answer;
                 // Distribution markup is included up-front but kept hidden via
                 // the .revealed class on the parent (issue #151). Embedding it
                 // at question-render time avoids a DOM thrash at reveal — only


### PR DESCRIPTION
## Problem

When casting to a TV, every answer on the dashboard rendered as `[object Object]` instead of the actual answer text (issue #283).

## Root cause

The cast/TV dashboard (`dashboard.html`) reuses the admin `question_started` message, whose `answers` field is a list of objects `{text, correct}` (see `server/serializers.py::serialize_question_for_admin`). The dashboard's `handleQuestionStarted` mapped each entry directly into `escapeHtml(...)`, stringifying the object to `[object Object]`.

Note the dashboard has a second feed path (`game_state` / `QUESTION_ACTIVE`) where `answers` is a list of plain strings (`game/state.py`), so the fix must handle both shapes.

## Fix

Normalize each answer to its displayable string before rendering: use `.text` when the entry is an object, otherwise use it as-is. The string-shaped `game_state` path is unaffected.

## Testing

- `python3 -m pytest tests/ -q` → 456 passed, 2 skipped.
- `dashboard.html` is a standalone served asset (not part of `build_bundle.py`), so no bundle rebuild needed.

Closes #283