### PR TITLE
fix: project per-player snapshots on get_state/resume + keep pause clock sane (#286 #287 #295 #297)

### DIFF
--- a/custom_components/quizify/game/phase_controller.py
+++ b/custom_components/quizify/game/phase_controller.py
@@ -109,6 +109,14 @@ class PhaseController:
         self.paused_from: GamePhase | None = None
         self.paused_remaining: dict[str, float] = {}
         self.pause_reason: str | None = None
+        # Per-player elapsed at pause + the monotonic instant we paused, so
+        # resume() can preserve both the frozen remaining AND the elapsed
+        # (speed bonus) and advance the round wall-clock by the pause duration
+        # (#295). round_start_time alone is wall-clock and would otherwise keep
+        # running through the pause, desyncing it from the frozen per-player
+        # timers (a late joiner post-resume would get a ~0.5s timer, etc.).
+        self.paused_elapsed: dict[str, float] = {}
+        self.paused_at: float | None = None
 
     # ------------------------------------------------------------------
     # Timer mechanics
@@ -255,12 +263,19 @@ class PhaseController:
             return False
         self.paused_from = GamePhase.QUESTION_ACTIVE
         self.pause_reason = reason
-        # Snapshot remaining time per player and freeze timers in place.
-        # On resume we'll create fresh timers with the saved remaining.
+        # Snapshot remaining AND elapsed time per player and freeze timers in
+        # place. On resume we rebuild timers that preserve BOTH (so the speed
+        # bonus, which scores off elapsed, isn't inflated — #295/#254).
         self.paused_remaining = {}
+        self.paused_elapsed = {}
         for name, timer in self.timers.items():
             self.paused_remaining[name] = max(0.0, timer.get_remaining())
+            self.paused_elapsed[name] = max(0.0, timer.get_elapsed())
         self.timers.clear()
+        # Remember when we paused so resume() can shift the round wall-clock by
+        # the exact pause duration, keeping round_start_time in lock-step with
+        # the frozen per-player remaining (#295).
+        self.paused_at = time.monotonic()
         self.phase = GamePhase.PAUSED
         _LOGGER.info("Game paused (reason=%s)", reason)
         return True
@@ -269,16 +284,32 @@ class PhaseController:
         """Resume a paused game. Returns True if resume happened."""
         if self.phase != GamePhase.PAUSED:
             return False
-        # Restore timers with the remaining time they had at pause.
-        # Late-joiners during PAUSED won't be in paused_remaining and
-        # get a fresh full-round timer here.
+        # Advance the round wall-clock by the pause duration FIRST, so
+        # round_start_time stays in lock-step with the frozen per-player
+        # remaining (#295). Without this shift a long pause leaves
+        # round_start_time far in the past: time_remaining_for_snapshot() and
+        # round_wall_clock_expired() read stale, and a player joining
+        # post-resume gets add_late_joiner_timer ≈ 0.5s (instantly expired).
+        if self.paused_at is not None and self.round_start_time is not None:
+            self.round_start_time += time.monotonic() - self.paused_at
+        # Restore timers with the remaining time AND elapsed they had at pause
+        # (QuestionTimer.resumed preserves both, so the speed bonus measured
+        # from get_elapsed() isn't inflated — #295/#254). Late-joiners during
+        # PAUSED won't be in the snapshots and get a fresh full-round timer.
         full = self.round_duration
         for name in self._players_fn():
-            remaining = self.paused_remaining.get(name, full)
-            timer = QuestionTimer(remaining)
-            timer.start()
+            if name in self.paused_remaining:
+                timer = QuestionTimer.resumed(
+                    remaining=self.paused_remaining[name],
+                    elapsed=self.paused_elapsed.get(name, 0.0),
+                )
+            else:
+                timer = QuestionTimer(full)
+                timer.start()
             self.timers[name] = timer
         self.paused_remaining = {}
+        self.paused_elapsed = {}
+        self.paused_at = None
         self.pause_reason = None
         self.phase = self.paused_from or GamePhase.QUESTION_ACTIVE
         self.paused_from = None

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -1292,32 +1292,27 @@ class QuizifyGameState:
         return self._current_question
 
     def get_leaderboard(self) -> list[dict[str, Any]]:
-        """Return sorted leaderboard data.
+        """Return sorted leaderboard data — wire-identical to the live broadcast.
 
-        NB: ``is_admin`` is required so the client can determine whether
-        the current viewer is the admin (and thus should see the
-        "Start New Game" / "Next Round" buttons). It was missing from
-        this serializer in earlier versions and produced a chronic
-        admin-lockout in the FINALE state — when a game-state snapshot
-        was sent on reconnect the leaderboard had no admin marker, so
-        the player-end client gated the controls off. See v1.1.4 notes.
+        Delegates to :func:`serialize_leaderboard` (the same helper the live
+        ``game_state`` / ``round_summary`` broadcasts use) so the snapshot
+        leaderboard carries the FULL client contract — ``submitted``,
+        ``best_streak``, ``rounds_played``, ``powerups_used``, ``round_score``,
+        ``correct`` — not just rank/name/score/streak (#297). Without those
+        keys a reconnect-after-submit never re-locked the answer buttons
+        (player-core.js reads ``leaderboard[].submitted``) and a FINALE
+        reconnect showed 0 for BESTE SERIE / GESPIELTE RUNDEN / POWER-UPS.
+
+        ``is_admin`` is likewise required so the reconnect client can show the
+        admin "Start New Game" / "Next Round" controls; ``serialize_leaderboard``
+        emits it. (Earlier hand-rolled versions of this method dropped fields
+        and caused a chronic FINALE admin-lockout — see v1.1.4 notes.)
         """
-        players = sorted(
-            self._player_registry.players.values(),
-            key=lambda p: p.score,
-            reverse=True,
-        )
-        return [
-            {
-                "rank": i + 1,
-                "name": p.name,
-                "score": p.score,
-                "streak": p.streak,
-                "connected": p.connected,
-                "is_admin": p.is_admin,
-            }
-            for i, p in enumerate(players)
-        ]
+        # Local import keeps the game-layer free of a module-level dependency
+        # on the server layer (serializers only TYPE_CHECKING-imports game).
+        from ..server.serializers import serialize_leaderboard
+
+        return serialize_leaderboard(self.get_players())
 
     def get_round_summary(self) -> RoundSummary | None:
         """Return the last round summary."""

--- a/custom_components/quizify/game/timer.py
+++ b/custom_components/quizify/game/timer.py
@@ -76,6 +76,30 @@ class QuestionTimer:
             pause_credit = min(self._pause_remaining, max(0.0, elapsed_pause))
         return max(0.0, now - self._start_time - pause_credit)
 
+    @classmethod
+    def resumed(cls, remaining: float, elapsed: float) -> "QuestionTimer":
+        """Build a running timer that reports a known *remaining* AND *elapsed*.
+
+        Used by the pause/resume path (#295). A naive ``QuestionTimer(remaining)``
+        re-``start()``ed at resume time would report ``get_elapsed() ≈ 0`` —
+        inflating the speed bonus, because scoring credits speed off elapsed.
+        This reconstructs the internal clock so that, immediately after resume:
+
+        * ``get_remaining()`` == *remaining* (the time frozen at pause), and
+        * ``get_elapsed()``  == *elapsed* (the time already spent pre-pause),
+
+        and both then advance normally as wall-clock runs. With no bonus/pause
+        credit, ``get_remaining() = _duration - (now - _start_time)`` and
+        ``get_elapsed() = now - _start_time``; setting ``_start_time = now -
+        elapsed`` and ``_duration = remaining + elapsed`` satisfies both.
+        """
+        timer = cls(duration=max(0.0, remaining) + max(0.0, elapsed))
+        timer._start_time = time.monotonic() - max(0.0, elapsed)
+        timer._bonus_time = 0.0
+        timer._pause_remaining = 0.0
+        timer._pause_started_at = None
+        return timer
+
     def reset(self, duration: float | None = None) -> None:
         """Reset the timer, optionally with a new duration."""
         if duration is not None:

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -327,6 +327,17 @@ class QuizifyWebSocketHandler:
 
         async def _get_state(ws: web.WebSocketResponse) -> None:
             state_msg = game_state.get_state_snapshot()
+            # Project into the requesting PLAYER's frame (#286): the raw
+            # snapshot carries canonical answer order, but ``submit_answer``
+            # maps the tapped index through the player's OWN shuffle — sending
+            # canonical order here mis-scores ~2/3 of taps after a mid-round
+            # reconnect (the client auto-sends get_state on every join). Pure
+            # admin/dashboard sockets (no player session) keep canonical order.
+            player = game_state.get_player_by_ws(ws)
+            if player is not None:
+                state_msg = self._round_messages.project_snapshot_for_player(
+                    game_state, snapshot=state_msg, player=player
+                )
             state_msg["type"] = "game_state"
             await self._conn.send(ws, state_msg)
 
@@ -638,6 +649,13 @@ class QuizifyWebSocketHandler:
         ):
             if game_state.resume():
                 self._start_timer_tick(game_state)
+                # Broadcast the resumed state to EVERY player (#287). Without
+                # this, the other players stay frozen on the "Host disconnected"
+                # paused-view (player-core.js only leaves it on a game_state
+                # message) while their timers tick down → scored as timeouts.
+                # Per-player PROJECTED — same mechanism as the manual-resume
+                # fix (#286) so answer buttons keep the right shuffle order.
+                await self._broadcast_state_projected(game_state)
                 _LOGGER.info("Auto-resumed after admin reconnect")
 
         # Generate a fresh token and revoke old one
@@ -1070,9 +1088,11 @@ class QuizifyWebSocketHandler:
         """Resume from PAUSED → restart timer ticks and broadcast state."""
         if not game_state.resume():
             return
-        state = game_state.get_state_snapshot()
-        state["type"] = "game_state"
-        await self._conn.broadcast(state)
+        # Fan out per-player PROJECTED snapshots (#286): the raw snapshot
+        # carries canonical answer order, so a plain broadcast here mis-scored
+        # ~2/3 of taps after resume because the players re-render their answer
+        # buttons from it while submit_answer maps through their own shuffle.
+        await self._broadcast_state_projected(game_state)
         # Restart the per-player tick loop.
         self._start_timer_tick(game_state)
 
@@ -1440,6 +1460,58 @@ class QuizifyWebSocketHandler:
             "type": "lightning_recap",
             "recap": lr.build_recap(),
         })
+
+    async def _broadcast_state_projected(
+        self,
+        game_state: QuizifyGameState,
+        *,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        """Fan out a ``game_state`` snapshot, projected per recipient.
+
+        Each connected PLAYER gets the snapshot projected into their own frame
+        (own shuffled answer order, own timer, flat reveal) via
+        ``project_snapshot_for_player`` — the same mechanism the join/reconnect
+        path uses (#253). Sending the raw canonical snapshot to players would
+        mis-score ~2/3 of their taps because ``submit_answer`` maps the tapped
+        index through the player's OWN shuffle (#286). Pure admin/dashboard
+        sockets (no player session) get the canonical snapshot untouched.
+
+        ``extra`` merges extra top-level keys (e.g. ``pause_reason``) into every
+        message. Used by the resume path (#286 #287) so a resumed game reaches
+        every screen with correctly-ordered answer buttons.
+        """
+        base = game_state.get_state_snapshot()
+
+        # Per-player projected sends.
+        player_ws: set[Any] = set()
+        sends = []
+        for player in game_state.get_players():
+            if player.ws is None or not player.connected:
+                continue
+            player_ws.add(player.ws)
+            msg = self._round_messages.project_snapshot_for_player(
+                game_state, snapshot=base, player=player
+            )
+            msg["type"] = "game_state"
+            if extra:
+                msg.update(extra)
+            sends.append(self._conn.send(player.ws, msg))
+
+        # Raw snapshot for pure admin/dashboard sockets — but skip any socket
+        # that is also a player (admin-as-player already got its projected
+        # copy above, and must NOT see canonical order mid-question).
+        raw = dict(base)
+        raw["type"] = "game_state"
+        if extra:
+            raw.update(extra)
+        for ws, _is_admin in self._conn.iter_admin_and_dashboard_ws():
+            if ws.closed or ws in player_ws:
+                continue
+            sends.append(self._conn.send(ws, raw))
+
+        if sends:
+            await asyncio.gather(*sends)
 
     # ------------------------------------------------------------------
     # Question flow

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -237,8 +237,12 @@
                     // Apply as CSS custom property on root for global use
                     document.documentElement.style.setProperty('--my-player-color', msg.color);
                 }
-                // Request full state so we switch to the correct view immediately
-                send('get_state', {});
+                // No get_state needed: the server already pushes a per-player
+                // PROJECTED game_state snapshot immediately after joined /
+                // reconnected (own shuffled answer order, own timer, flat
+                // reveal — #253). A redundant get_state would just re-deliver
+                // the same projected snapshot (#286). The handleGameState case
+                // below switches us to the correct view from that push.
                 break;
 
             case 'reconnect_failed':

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -3879,8 +3879,12 @@
                     // Apply as CSS custom property on root for global use
                     document.documentElement.style.setProperty('--my-player-color', msg.color);
                 }
-                // Request full state so we switch to the correct view immediately
-                send('get_state', {});
+                // No get_state needed: the server already pushes a per-player
+                // PROJECTED game_state snapshot immediately after joined /
+                // reconnected (own shuffled answer order, own timer, flat
+                // reveal — #253). A redundant get_state would just re-deliver
+                // the same projected snapshot (#286). The handleGameState case
+                // below switches us to the correct view from that push.
                 break;
 
             case 'reconnect_failed':

--- a/tests/test_pause_resume_reconnect_snapshot_286.py
+++ b/tests/test_pause_resume_reconnect_snapshot_286.py
@@ -1,0 +1,394 @@
+"""Regression tests for the P0 pause/resume/reconnect/snapshot cluster.
+
+Four issues shared ONE root cause: state reaching a PLAYER in CANONICAL answer
+order while ``submit_answer`` maps the tapped index through that player's OWN
+per-player shuffle (#253). The #253 fix projected only the join/reconnect
+snapshot; three other paths still leaked canonical order or never broadcast at
+all:
+
+* #286 — ``get_state`` reply and manual resume sent the raw (unprojected)
+  snapshot to players, mis-scoring ~2/3 of taps after a mid-round reconnect /
+  resume.
+* #287 — auto-resume after an admin reconnect resumed the game but never
+  broadcast it, leaving the other players frozen on the "Host disconnected"
+  paused-view while their timers ran out (scored as timeouts).
+* #295 — pause/resume froze per-player timers but not the round wall-clock
+  (``round_start_time``) nor the per-player elapsed, so a late joiner post-resume
+  got an instantly-expired timer and the speed bonus was inflated.
+* #297 — the snapshot leaderboard omitted client-contract fields
+  (``submitted`` / ``best_streak`` / ``rounds_played`` / ``powerups_used`` /
+  ``round_score``), so a reconnect-after-submit never re-locked and FINALE
+  reconnect showed 0 stats.
+
+These tests exercise the real ``QuizifyGameState`` + ``RoundMessageBuilder`` +
+``QuizifyWebSocketHandler`` so they catch drift between the snapshot, the
+shuffle store, the timers and the submit path.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+from custom_components.quizify.server.connection import (  # noqa: E402
+    ConnectionManager,
+)
+from custom_components.quizify.server.round_message_builder import (  # noqa: E402
+    RoundMessageBuilder,
+)
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    ws.close = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    runtime = _FakeRuntime(tmp_path)
+    return QuizifyGameState(runtime=runtime, entry_id="test")
+
+
+@pytest.fixture
+def builder() -> RoundMessageBuilder:
+    return RoundMessageBuilder()
+
+
+def _handler(
+    game: QuizifyGameState, tmp_path: Path
+) -> tuple[QuizifyWebSocketHandler, dict]:
+    """Build a handler whose per-socket sends are recorded by ws-id.
+
+    Returns ``(handler, sends)`` where ``sends[id(ws)]`` is the list of message
+    dicts delivered to that socket. ``broadcast`` is recorded too (last call).
+    """
+    runtime = _FakeRuntime(tmp_path)
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    h._conn = ConnectionManager(runtime, lambda: game)
+    h._get_game_state = lambda: game  # type: ignore[assignment]
+
+    sends: dict = {"by_ws": {}, "broadcasts": []}
+
+    async def _send(ws, message: dict) -> None:
+        sends["by_ws"].setdefault(id(ws), []).append(message)
+
+    async def _broadcast(message: dict) -> None:
+        sends["broadcasts"].append(message)
+
+    h._conn.send = _send  # type: ignore[assignment]
+    h._conn.broadcast = _broadcast  # type: ignore[assignment]
+    return h, sends
+
+
+def _start_round(game: QuizifyGameState) -> None:
+    """Drive into QUESTION_ACTIVE with canonical + per-player shuffles, the way
+    ``_start_next_question`` does. Alice/Bob get FIXED distinct non-identity
+    shuffles so the canonical-vs-player contrast holds deterministically."""
+    game.add_player("Alice", _ws())
+    game.add_player("Bob", _ws())
+    game.start_game(language="de", num_rounds=3, difficulty="easy")
+    question = game.start_next_question()
+    assert question is not None
+    base = list(range(len(question.answers)))
+    canonical = base[1:] + base[:1]
+    alice = base[2:] + base[:2]
+    bob = base[3:] + base[:3] if len(base) > 3 else base[1:] + base[:1]
+    game.set_round_shuffle(canonical, [question.answers[i].text for i in canonical])
+    game.set_player_shuffle("Alice", alice)
+    game.set_player_shuffle("Bob", bob)
+
+
+# ---------------------------------------------------------------------------
+# #286 (a) — get_state reply for a player returns projected answers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_state_reply_projects_for_player(
+    game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """The ``get_state`` reply to a PLAYER socket must carry the player's OWN
+    shuffled answer order — identical to what the join/reconnect push sends —
+    so the tapped index scores the visible answer. Canonical order would
+    mis-score ~2/3 of taps after every mid-round reconnect."""
+    h, sends = _handler(game, tmp_path)
+    _start_round(game)
+    alice = game.get_player("Alice")
+    alice_ws = alice.ws
+    h._conn.add_connection(alice_ws, is_admin=False, is_dashboard=False)
+
+    await h._handle_message(alice_ws, {"type": "get_state"}, is_admin=False)
+
+    msgs = sends["by_ws"][id(alice_ws)]
+    state_msgs = [m for m in msgs if m.get("type") == "game_state"]
+    assert state_msgs, "get_state produced no game_state reply"
+    visible = state_msgs[-1]["question"]["answers"]
+
+    question = game.get_current_question()
+    shuffle = game.get_player_shuffle("Alice")  # what submit_answer uses
+    assert len(visible) == len(question.answers)
+    for i, text in enumerate(visible):
+        assert text == question.answers[shuffle[i]].text
+
+    # The reply must match the canonical-projection a join would have produced.
+    join_projected = RoundMessageBuilder().project_snapshot_for_player(
+        game, snapshot=game.get_state_snapshot(), player=alice
+    )
+    assert visible == join_projected["question"]["answers"]
+
+    # End-to-end: tapping the visible position of the correct answer scores it.
+    correct_text = next(a.text for a in question.answers if a.correct)
+    tapped = visible.index(correct_text)
+    original_index = shuffle[tapped]
+    result = game.submit_answer("Alice", original_index)
+    assert not isinstance(result, str)
+    assert result.correct is True
+
+
+@pytest.mark.asyncio
+async def test_get_state_reply_stays_canonical_for_admin_dashboard(
+    game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """A pure admin/dashboard socket (no player session) still gets the
+    canonical snapshot — projection only applies to player sockets."""
+    h, sends = _handler(game, tmp_path)
+    _start_round(game)
+    dash_ws = _ws()
+    h._conn.add_connection(dash_ws, is_admin=False, is_dashboard=True)
+
+    await h._handle_message(dash_ws, {"type": "get_state"}, is_admin=False)
+
+    msgs = sends["by_ws"][id(dash_ws)]
+    state_msgs = [m for m in msgs if m.get("type") == "game_state"]
+    assert state_msgs
+    visible = state_msgs[-1]["question"]["answers"]
+    canonical = game.get_state_snapshot()["question"]["answers"]
+    assert visible == canonical
+
+
+# ---------------------------------------------------------------------------
+# #286 (b) — manual resume fans out projected per-player state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_manual_resume_broadcasts_projected_and_submit_scores(
+    game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """After ``resume_game`` each player must receive a game_state whose answers
+    are in THEIR shuffle order, and a submit through that order scores
+    correctly (the bug scored the wrong answer ~2/3 of the time)."""
+    h, sends = _handler(game, tmp_path)
+    _start_round(game)
+    alice = game.get_player("Alice")
+    bob = game.get_player("Bob")
+    h._conn.add_connection(alice.ws, is_admin=False, is_dashboard=False)
+    h._conn.add_connection(bob.ws, is_admin=False, is_dashboard=False)
+
+    assert game.pause() is True
+    assert game.phase == GamePhase.PAUSED
+
+    # No-op the tick task so the handler doesn't spin up a real timer loop.
+    h._start_timer_tick = lambda gs: None  # type: ignore[assignment]
+    await h._handle_resume_game(alice.ws, game)
+    assert game.phase == GamePhase.QUESTION_ACTIVE
+
+    question = game.get_current_question()
+    for player in (alice, bob):
+        msgs = sends["by_ws"].get(id(player.ws), [])
+        state_msgs = [m for m in msgs if m.get("type") == "game_state"]
+        assert state_msgs, f"{player.name} got no resumed game_state"
+        visible = state_msgs[-1]["question"]["answers"]
+        shuffle = game.get_player_shuffle(player.name)
+        for i, text in enumerate(visible):
+            assert text == question.answers[shuffle[i]].text
+
+        # Tap the visible position of the correct answer → scores correct.
+        correct_text = next(a.text for a in question.answers if a.correct)
+        tapped = visible.index(correct_text)
+        result = game.submit_answer(player.name, shuffle[tapped])
+        assert not isinstance(result, str)
+        assert result.correct is True
+
+
+# ---------------------------------------------------------------------------
+# #287 — auto-resume after admin reconnect broadcasts to everyone
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_reconnect_auto_resume_broadcasts_to_players(
+    game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """When the admin reconnects and we auto-resume the game WE paused
+    (admin_disconnected), every OTHER player must receive a resumed game_state
+    so they leave the paused-view — otherwise their timers run out unseen."""
+    h, sends = _handler(game, tmp_path)
+    _start_round(game)
+    alice = game.get_player("Alice")  # plain player still on paused-view
+    # Make Alice an admin too? No — keep Alice as the stuck player. Host = admin.
+    game.add_player("Host", _ws())
+    host = game.get_player("Host")
+    host.is_admin = True
+    h._conn.add_connection(alice.ws, is_admin=False, is_dashboard=False)
+
+    # Issue a session token for Host so reconnect resolves it.
+    token = h._conn.create_session_token("Host")
+
+    # WE pause because the admin disconnected.
+    assert game.pause(reason="admin_disconnected") is True
+    assert game.phase == GamePhase.PAUSED
+
+    h._start_timer_tick = lambda gs: None  # type: ignore[assignment]
+    new_admin_ws = _ws()
+    await h._handle_reconnect(
+        new_admin_ws, {"session_token": token}, game
+    )
+
+    # Game resumed...
+    assert game.phase == GamePhase.QUESTION_ACTIVE
+    # ...and the stuck player got a resumed game_state (leaves paused-view).
+    alice_states = [
+        m
+        for m in sends["by_ws"].get(id(alice.ws), [])
+        if m.get("type") == "game_state"
+        and m.get("phase") == GamePhase.QUESTION_ACTIVE.value
+    ]
+    assert alice_states, "stuck player never received the resumed state (#287)"
+    # And it carries Alice's own shuffle order (projected).
+    question = game.get_current_question()
+    shuffle = game.get_player_shuffle("Alice")
+    visible = alice_states[-1]["question"]["answers"]
+    for i, text in enumerate(visible):
+        assert text == question.answers[shuffle[i]].text
+
+
+# ---------------------------------------------------------------------------
+# #295 — pause/resume keeps the round wall-clock and elapsed sane
+# ---------------------------------------------------------------------------
+
+
+def test_resume_shifts_round_start_time_so_late_joiner_timer_is_sane(
+    game: QuizifyGameState,
+) -> None:
+    """After a long pause, ``round_start_time`` must be advanced by the pause
+    duration so a player joining post-resume gets a full-ish late-joiner timer
+    — not the instantly-expired ~0.5s timer the un-shifted wall-clock gave."""
+    _start_round(game)
+    pc = game._phase_controller
+    pc.round_duration = 30.0
+    # Backdate the round start so only ~1s has nominally elapsed.
+    pc.round_start_time = time.monotonic() - 1.0
+
+    assert game.pause() is True
+    # Simulate a long pause by backdating paused_at by 20s.
+    pc.paused_at = time.monotonic() - 20.0
+    before_start = pc.round_start_time
+    assert game.resume() is True
+
+    # round_start_time advanced by ~the pause duration (20s), not left stale.
+    assert pc.round_start_time - before_start >= 19.0
+
+    # A late joiner now gets a sane (multi-second) timer, not ~0.5s.
+    game.add_player("Zoe", _ws())
+    pc.add_late_joiner_timer("Zoe")
+    zoe_timer = game.get_player_timer("Zoe")
+    assert zoe_timer is not None
+    assert zoe_timer.get_remaining() > 5.0
+
+    # And the wall-clock snapshot time isn't already expired.
+    assert pc.time_remaining_for_snapshot() > 5.0
+    assert pc.round_wall_clock_expired() is False
+
+
+def test_resume_preserves_per_player_elapsed_so_speed_bonus_not_inflated(
+    game: QuizifyGameState,
+) -> None:
+    """Resume must preserve each player's pre-pause elapsed so the speed bonus
+    (scored off elapsed) isn't inflated. A naive fresh timer at resume would
+    report elapsed ≈ 0 → maximum speed bonus for a player who actually spent
+    most of the round before the pause."""
+    _start_round(game)
+    alice_timer = game.get_player_timer("Alice")
+    assert alice_timer is not None
+    # Backdate Alice's timer so ~10s has elapsed before the pause.
+    alice_timer._start_time = time.monotonic() - 10.0
+    pre_pause_elapsed = alice_timer.get_elapsed()
+    assert pre_pause_elapsed >= 9.5
+
+    assert game.pause() is True
+    frozen_remaining = game._phase_controller.paused_remaining["Alice"]
+    # Simulate the pause lasting 15s.
+    game._phase_controller.paused_at = time.monotonic() - 15.0
+    assert game.resume() is True
+
+    resumed_timer = game.get_player_timer("Alice")
+    assert resumed_timer is not None
+    # Elapsed is preserved (NOT reset to ~0): the speed bonus stays honest.
+    assert resumed_timer.get_elapsed() >= pre_pause_elapsed - 0.5
+    # And remaining is still the value frozen at pause, unaffected by the 15s
+    # the game spent paused (a naive fresh full-round timer would jump back up).
+    assert abs(resumed_timer.get_remaining() - frozen_remaining) <= 0.5
+
+
+# ---------------------------------------------------------------------------
+# #297 — snapshot leaderboard carries the full client contract
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_leaderboard_carries_client_contract_fields(
+    game: QuizifyGameState,
+) -> None:
+    """``get_state_snapshot`` leaderboard must be wire-identical to the live
+    ``serialize_leaderboard`` broadcast — carrying ``submitted``, ``best_streak``,
+    ``rounds_played``, ``powerups_used``, ``round_score`` — so reconnect-after-
+    submit re-locks and FINALE reconnect shows real stats."""
+    _start_round(game)
+    question = game.get_current_question()
+    correct_idx = next(i for i, a in enumerate(question.answers) if a.correct)
+    game.submit_answer("Alice", correct_idx)
+
+    leaderboard = game.get_state_snapshot()["leaderboard"]
+    assert leaderboard
+    required = {
+        "submitted",
+        "best_streak",
+        "rounds_played",
+        "powerups_used",
+        "round_score",
+        "is_admin",
+    }
+    for entry in leaderboard:
+        missing = required - set(entry)
+        assert not missing, f"leaderboard entry missing {missing}: {entry}"
+
+    alice_entry = next(e for e in leaderboard if e["name"] == "Alice")
+    # Alice submitted this round → the client re-locks her buttons off this.
+    assert alice_entry["submitted"] is True
+
+    # Wire-identical to the live serializer used by the broadcasts.
+    from custom_components.quizify.server.serializers import serialize_leaderboard
+
+    assert leaderboard == serialize_leaderboard(game.get_players())


### PR DESCRIPTION
## Shared root cause

These four P0 issues share one root cause: game state reaches a **player** in the **canonical** (unshuffled) answer order, while `submit_answer` maps the tapped index through that player's **own** per-player shuffle (the #253 anti-cheat shuffle). The #253 fix projected only the join/reconnect snapshot via `project_snapshot_for_player`. Three other paths still sent canonical order to players — or never broadcast at all — so a player who re-renders answer buttons from that state mis-scores roughly two-thirds of their taps.

## What each fix does

### #286 (CRITICAL) — Unprojected snapshot mis-scores taps
- **get_state reply**: resolve the requesting player via `get_player_by_ws` and project the snapshot into their frame; pure admin/dashboard sockets keep canonical order.
- **manual resume**: new `_broadcast_state_projected` helper fans out per-player **projected** snapshots and sends the raw snapshot only to admin/dashboard sockets, mirroring the per-player loop in `_start_next_question`.
- **client**: dropped the now-redundant `get_state` the player client sent after `joined`/`reconnected` — the server already pushes a projected snapshot on join/reconnect. Rebuilt `player.bundle.js` from source so it stays byte-identical.
- The projected snapshot leaderboard now carries `submitted`, so the client re-locks answer buttons after reconnect.

### #287 (CRITICAL) — Auto-resume after admin reconnect never broadcasts
The admin auto-resume inside `_handle_reconnect` resumed the game and restarted the tick but never broadcast the resumed state. Other players stayed frozen on the "Host disconnected" paused-view while their timers ran out and were scored as timeouts. Now it broadcasts the resumed state per-player projected, using the same `_broadcast_state_projected` helper as the #286 resume fix.

### #295 (MEDIUM) — Pause does not shift the round wall-clock
`pause`/`resume` froze the per-player timers but not the round wall-clock `round_start_time` nor the per-player elapsed. After a long pause a player joining post-resume got an instantly-expired late-joiner timer, `time_remaining_for_snapshot` / `round_wall_clock_expired` read stale, and the speed bonus was inflated because a fresh resume timer reported near-zero elapsed. Now `pause` records `paused_at` plus per-player elapsed, and `resume` advances `round_start_time` by the pause duration and rebuilds each timer via `QuestionTimer.resumed(remaining, elapsed)` so both the frozen remaining and the pre-pause elapsed are preserved.

### #297 (MEDIUM) — Snapshot leaderboard missing client-contract fields
`get_leaderboard` now delegates to `serialize_leaderboard(get_players())`, making the snapshot leaderboard wire-identical to the live broadcasts. It carries `submitted`, `best_streak`, `rounds_played`, `powerups_used`, `round_score` and the other contract fields, so reconnect-after-submit re-locks and a FINALE reconnect shows real stats instead of zeros.

## Tests
New regression suite `tests/test_pause_resume_reconnect_snapshot_286.py` covering all four paths:
- get_state reply projects for players and stays canonical for admin/dashboard
- manual resume and admin-reconnect auto-resume fan out projected state, and a submit afterwards scores correctly
- pause then resume keeps `round_start_time` sane so a late joiner gets a sane timer, and preserves per-player elapsed so the speed bonus is not inflated
- snapshot leaderboard carries the full client contract and is wire-identical to `serialize_leaderboard`

Full suite: **484 passed, 2 skipped** (477 baseline plus 7 new). No `manifest.json` bump, no tag.

Closes #286
Closes #287
Closes #295
Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)
