### PR TITLE
fix: three P1 quick-wins (steal inversion, SW scope, admin reconnect)

### DIFF
--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -1182,11 +1182,18 @@ class QuizifyGameState:
             source_player = self._player_registry.get_player(player_id)
             if not target_player or not source_player:
                 return ERR_INVALID_ACTION
-            stolen = target_player.round_score // 2
+            # Clamp the target's round_score at 0 before halving: on the final
+            # round a wrong answer with a wager can drive round_score negative,
+            # and a negative // 2 would invert the steal (target gains, source
+            # loses). Treat a non-positive target round_score as nothing to
+            # steal (#289).
+            stolen = max(0, target_player.round_score) // 2
             target_player.round_score = max(0, target_player.round_score - stolen)
             target_player.score = max(0, target_player.score - stolen)
             source_player.round_score += stolen
-            source_player.score += stolen
+            # Clamp the source total at 0 so a steal can never leave a player
+            # with a permanently negative score (#289).
+            source_player.score = max(0, source_player.score + stolen)
             effect.stolen_points = stolen
 
         _LOGGER.info(

--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -247,8 +247,14 @@ async def sw_view(request: web.Request) -> web.Response:
     body = await ctx.runtime.run_in_executor(sw_path.read_text, "utf-8")
     body = _apply_version(body, version)
     body = body.replace(_ASSET_VER_TOKEN, await _get_asset_version_async(ctx, version))
+    # The SW is served from /quizify/static/sw.js but must control /quizify/*
+    # (the actual pages). A worker can only claim a scope above its own path
+    # if the response carries Service-Worker-Allowed for that wider scope —
+    # without it the browser rejects the {scope: '/quizify/'} registration
+    # and the worker controls nothing (#291).
+    headers = {**_NO_CACHE_HEADERS, "Service-Worker-Allowed": "/quizify/"}
     return web.Response(
-        text=body, content_type="application/javascript", headers=_NO_CACHE_HEADERS
+        text=body, content_type="application/javascript", headers=headers
     )
 
 

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -9,7 +9,12 @@
     // ---- State ----
     let ws = null;
     let reconnectAttempts = 0;
-    const MAX_RECONNECT = 5;
+    // Mirror the player-side reconnect policy (player-utils.js): exponential
+    // backoff capped at 30s and a high attempt budget, not the old 5-attempt /
+    // ~15s budget. An HA restart takes 1-5 min, so the old budget left the
+    // host's admin tablet permanently dead with no recovery (#290).
+    const MAX_RECONNECT = 10;
+    const MAX_RECONNECT_DELAY_MS = 30000;
     let _redirecting = false;
     // When the admin joined themselves as a player via "Als Spieler
     // beitreten", we keep them on the admin page during LOBBY. This
@@ -829,10 +834,17 @@
         ws.onclose = function () {
             ws = null;
             if (reconnectAttempts < MAX_RECONNECT) {
-                reconnectAttempts++;
                 updateConnectionStatus('reconnecting');
-                setTimeout(connect, 1000 * reconnectAttempts);
+                // Exponential backoff, capped at 30s (mirrors player-utils.js
+                // getReconnectDelay). 1s, 2s, 4s, 8s, 16s, 30s, 30s, … keeps
+                // retrying across the full 1-5 min of an HA restart (#290).
+                var delay = Math.min(1000 * Math.pow(2, reconnectAttempts), MAX_RECONNECT_DELAY_MS);
+                reconnectAttempts++;
+                setTimeout(connect, delay);
             } else {
+                // Reached the attempt cap, but recovery is still possible — the
+                // visibilitychange listener and the manual retry affordance in
+                // updateConnectionStatus reset attempts and reconnect (#290).
                 updateConnectionStatus('disconnected');
             }
         };
@@ -1699,8 +1711,35 @@
         var glow = { connected: 'rgba(127,168,151,0.45)', reconnecting: 'rgba(232,196,127,0.45)', disconnected: 'rgba(214,106,106,0.45)' };
         var color = colors[status] || '#6E6A5C';
         var glowColor = glow[status] || 'rgba(110,106,92,0.25)';
-        indicator.innerHTML = '<span style="width:10px;height:10px;border-radius:50%;display:inline-block;background:' +
+        var dot = '<span style="width:10px;height:10px;border-radius:50%;display:inline-block;flex:none;background:' +
             color + ';box-shadow:0 0 10px ' + glowColor + ';"></span>';
+        // Visible label instead of a bare dot the host can't interpret: while
+        // reconnecting/disconnected, show the i18n connection text (and, when
+        // disconnected, a tappable retry affordance) so the host knows the
+        // tablet is trying to recover and can force it (#290). The existing
+        // connection.* keys are reused (no new i18n strings).
+        if (status === 'connected') {
+            indicator.style.cursor = '';
+            indicator.onclick = null;
+            indicator.innerHTML = dot;
+            return;
+        }
+        if (status === 'disconnected') {
+            indicator.style.cursor = 'pointer';
+            indicator.setAttribute('role', 'button');
+            indicator.onclick = function () {
+                // Manual recovery: reset the budget and reconnect immediately.
+                reconnectAttempts = 0;
+                updateConnectionStatus('reconnecting');
+                connect();
+            };
+            indicator.innerHTML = dot + '<span>' + _t('connection.retryConnection') + '</span>';
+            return;
+        }
+        // reconnecting (or any other transient state)
+        indicator.style.cursor = '';
+        indicator.onclick = null;
+        indicator.innerHTML = dot + '<span>' + _t('connection.reconnecting') + '</span>';
     }
 
     // ---- Init ----
@@ -1727,6 +1766,20 @@
 
     connect();
     updateConnectionStatus('reconnecting');
+
+    // Reconnect when the host brings the admin tablet back to the foreground.
+    // Mirrors the player view (player-core.js): the OS may have frozen/closed
+    // the socket while the tab was hidden (e.g. during an HA restart), and the
+    // attempt budget may already be exhausted — reset it and reconnect so the
+    // host doesn't return to a permanently dead tab (#290).
+    document.addEventListener('visibilitychange', function () {
+        if (document.visibilityState !== 'visible') return;
+        if (!ws || ws.readyState === WebSocket.CLOSING || ws.readyState === WebSocket.CLOSED) {
+            reconnectAttempts = 0;
+            updateConnectionStatus('reconnecting');
+            connect();
+        }
+    });
 
     // ---- Question pack update check ----
     checkPackUpdates();

--- a/custom_components/quizify/www/js/sw-update.js
+++ b/custom_components/quizify/www/js/sw-update.js
@@ -68,7 +68,13 @@
     // cache for up to 24h on the SW script; an HTTP-cached sw.js carries the
     // OLD CACHE_VERSION, so the old cache never gets invalidated and a new
     // release can't reset the client. Belt-and-braces for the same invariant.
-    navigator.serviceWorker.register('/quizify/static/sw.js', { updateViaCache: 'none' })
+    // scope: '/quizify/' — the SW lives at /quizify/static/sw.js, so the
+    // default scope would be /quizify/static/ and the worker would control
+    // nothing (the pages live at /quizify/*). Registering with the wider
+    // scope makes the fetch handler and the #215 idle auto-reload actually
+    // fire. Requires the server to send Service-Worker-Allowed: /quizify/
+    // on sw.js (see sw_view) so the wider scope is permitted (#291).
+    navigator.serviceWorker.register('/quizify/static/sw.js', { scope: '/quizify/', updateViaCache: 'none' })
         .then(function (reg) {
             // Deterministic update check on every page load — don't rely on
             // the browser's own (possibly throttled, up-to-24h) navigation

--- a/tests/test_concurrency_167.py
+++ b/tests/test_concurrency_167.py
@@ -173,6 +173,63 @@ class TestStealPowerup:
         assert real_get("Bob").round_score == 10
         assert real_get("Alice").round_score == 0
 
+    def test_steal_against_negative_round_score_transfers_nothing(
+        self, game: QuizifyGameState
+    ) -> None:
+        """Regression for #289: on the final round a wrong answer with a wager
+        drives round_score negative. STEAL halved that negative value, which
+        inverted the steal — the target gained points, the source lost them,
+        and (with no 0-clamp) the source total went permanently negative. A
+        negative target round_score must now yield 0 transferred and leave
+        neither player's total below zero."""
+        _start_question(game, ["Alice", "Bob"])
+        bob = game.get_player("Bob")
+        bob.submitted = True  # STEAL only targets submitted players (#254)
+        bob.round_score = -40  # wrong final-round wager
+        bob.score = 10
+        alice = game.get_player("Alice")
+        alice.round_score = 0
+        alice.score = 0
+        game._powerup_manager._inventory["Alice"] = PowerUpType.STEAL
+
+        effect = game.use_powerup("Alice", target_id="Bob")
+
+        assert not isinstance(effect, str), f"unexpected error: {effect}"
+        # Nothing is stolen from a non-positive round score (max(0, -40)//2 == 0).
+        assert effect.stolen_points == 0
+        # The steal did not invert: Bob's total is unchanged (no points flow to
+        # Alice), and Alice gains nothing.
+        assert game.get_player("Bob").score == 10
+        assert game.get_player("Alice").round_score == 0
+        assert game.get_player("Alice").score == 0
+        # Neither total goes below zero.
+        assert game.get_player("Alice").score >= 0
+        assert game.get_player("Bob").score >= 0
+
+    def test_steal_clamps_negative_source_total_at_zero(
+        self, game: QuizifyGameState
+    ) -> None:
+        """Regression for #289: the source total must be clamped at 0 after a
+        steal. If the source already sits negative (its own wrong final-round
+        wager) and the target has nothing to give, the steal must not leave the
+        source permanently negative."""
+        _start_question(game, ["Alice", "Bob"])
+        bob = game.get_player("Bob")
+        bob.submitted = True  # STEAL only targets submitted players (#254)
+        bob.round_score = -10  # nothing to steal
+        bob.score = 5
+        alice = game.get_player("Alice")
+        alice.round_score = -20  # Alice's own wrong wager
+        alice.score = -20
+        game._powerup_manager._inventory["Alice"] = PowerUpType.STEAL
+
+        effect = game.use_powerup("Alice", target_id="Bob")
+
+        assert not isinstance(effect, str), f"unexpected error: {effect}"
+        assert effect.stolen_points == 0
+        # Source total clamped at 0, never left negative.
+        assert game.get_player("Alice").score == 0
+
 
 # ---------------------------------------------------------------------------
 # #4 — reaction-bonus counters reset between games (the real residual)

--- a/tests/test_version_cachebuster.py
+++ b/tests/test_version_cachebuster.py
@@ -261,6 +261,16 @@ class TestServiceWorkerSubstitution:
         # Precache URLs carry the substituted buster.
         assert "?v=9.9.9-test-" in resp.text
 
+    async def test_sw_served_with_service_worker_allowed_header(self) -> None:
+        """Regression for #291: the SW lives at /quizify/static/sw.js but must
+        control /quizify/* (where the pages live). The browser only permits a
+        registration scope wider than the worker's own path if the response
+        carries Service-Worker-Allowed for that scope. Without this header the
+        {scope: '/quizify/'} registration is rejected and the worker controls
+        nothing (dead fetch handler, no idle auto-reload)."""
+        resp = await sw_view(_fake_request("9.9.9-test"))
+        assert resp.headers.get("Service-Worker-Allowed") == "/quizify/"
+
     async def test_sw_precache_bypasses_http_cache(self) -> None:
         """Install-time precache must go to the server, not the browser HTTP
         cache. HA serves /quizify/static/* with a 31-day max-age, so a plain
@@ -311,6 +321,14 @@ class TestServiceWorkerSource:
         cache for up to 24h, which kept the old CACHE_VERSION alive."""
         src = (self._WWW / "js" / "sw-update.js").read_text(encoding="utf-8")
         assert "updateViaCache: 'none'" in src
+
+    def test_sw_registered_with_quizify_scope(self) -> None:
+        """The SW must register with scope '/quizify/' (#291) — the default
+        scope is the worker's own dir (/quizify/static/), which controls none
+        of the actual pages. Pairs with the Service-Worker-Allowed header on
+        sw_view."""
+        src = (self._WWW / "js" / "sw-update.js").read_text(encoding="utf-8")
+        assert "scope: '/quizify/'" in src
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Three independent P1 quick-win fixes in one branch.

## #289 — STEAL against a negative-wager round inverted the steal

On the final round a wrong answer with a wager drives round_score negative. STEAL halved that negative value, which inverted the transfer: the target gained points and the source lost them, and the source total had no zero-clamp so it could go permanently negative.

Fix: clamp the target round_score at 0 before halving, and clamp the source total at 0 after applying. A non-positive target round_score now transfers 0 and no total drops below zero.

Regression tests added for both the inverted-steal case and the negative source-total clamp.

Closes #289

## #291 — Service worker registered at the wrong scope and was inert

The SW lives at /quizify/static/sw.js, so registering with no scope defaulted to /quizify/static/. The pages live at /quizify/*, so the worker controlled nothing: the fetch handler was dead and the issue #215 idle auto-reload never fired.

Fix: register with scope set to /quizify/, and have sw_view send the Service-Worker-Allowed header for /quizify/ so the browser permits the wider scope.

Test added asserting sw_view returns that header, plus a static guard on the registration scope.

Note: the controllerchange-driven idle reload now becomes reachable. It should be confirmed with a live/mobile check after deploy.

Closes #291

## #290 — Admin tab gave up reconnecting after about 15s

The admin reconnect budget was 5 attempts with linear backoff, about 15s total. An HA restart takes 1 to 5 minutes, so the host admin tablet ended up permanently dead with no recovery.

Fix: mirror the existing player-side reconnect behavior for consistency. Exponential backoff capped at 30s with a higher attempt budget, a visibilitychange listener that resets the attempt counter and reconnects when the tab becomes visible, and a visible reconnecting/retry affordance instead of a bare colored dot. Reuses the existing connection.* i18n keys, so no new strings.

admin.js is loaded directly from admin.html, not bundled, so no generated artifact rebuild is required.

Closes #290

## Tests

Full suite green: 488 passed, 2 skipped from the worktree. Baseline on main was 484 passed, 2 skipped; this PR adds 4 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
