### PR TITLE
fix(player): show power-up button every round + host-gone reset escape hatch (#288, #299)

### DIFF
--- a/custom_components/quizify/www/css/src/07-player.css
+++ b/custom_components/quizify/www/css/src/07-player.css
@@ -2976,3 +2976,17 @@ body.is-admin .reaction-bar {
     height: 52px;
     border-radius: 16px;
 }
+/* ==========================================
+   #299 Host-gone reset affordance
+   Non-admin escape hatch shown on paused/reveal after the host has been
+   gone ~60s. Reuses .btn .btn-primary .btn-glow styling — just spacing.
+   ========================================== */
+#paused-reset-btn {
+    margin-top: var(--space-lg);
+}
+
+#reveal-reset-controls {
+    display: flex;
+    justify-content: center;
+    margin-top: var(--space-md);
+}

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -5952,7 +5952,22 @@ body.is-admin .reaction-bar {
     width: 52px;
     height: 52px;
     border-radius: 16px;
-}/* ==========================================
+}
+/* ==========================================
+   #299 Host-gone reset affordance
+   Non-admin escape hatch shown on paused/reveal after the host has been
+   gone ~60s. Reuses .btn .btn-primary .btn-glow styling — just spacing.
+   ========================================== */
+#paused-reset-btn {
+    margin-top: var(--space-lg);
+}
+
+#reveal-reset-controls {
+    display: flex;
+    justify-content: center;
+    margin-top: var(--space-md);
+}
+/* ==========================================
    Responsive
    ========================================== */
 

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -232,6 +232,14 @@
                     pu.saveSession(msg.session_token, state.playerName);
                 }
                 if (msg.is_admin) state.isAdmin = true;
+                // #288: restore the assigned power-up on (re)join. The server
+                // sends the current power-up in `msg.powerup`; without this a
+                // reconnecting player whose power-up was assigned earlier never
+                // sees the button (it was wiped at the previous reveal).
+                if (msg.powerup !== undefined) {
+                    myPowerUp = msg.powerup;
+                    if (game && game.renderPowerUp) game.renderPowerUp(myPowerUp);
+                }
                 if (msg.color) {
                     state.playerColor = msg.color;
                     // Apply as CSS custom property on root for global use
@@ -301,7 +309,13 @@
                 break;
 
             case 'powerup_assigned':
+                // #288: render immediately. powerup_assigned arrives AFTER
+                // question_started, so handleQuestionStarted's renderPowerUp
+                // ran while myPowerUp was still null — only the final round
+                // (its flourish delays the render) ever showed the button.
+                // Set + render here so the button appears in every round.
                 myPowerUp = msg.powerup_type;
+                game.renderPowerUp(myPowerUp);
                 break;
 
             case 'powerup_applied':
@@ -422,6 +436,14 @@
 
         if (msg.players) lobby.handlePlayerJoined(msg);
 
+        // #299: drop the host-gone reset escape hatch whenever we leave the
+        // paused/reveal views (e.g. the host came back and resumed). The
+        // PAUSED and REVEAL cases below re-arm it if still warranted.
+        if (msg.phase !== 'PAUSED') disarmResetAffordance('paused-reset-btn');
+        if (msg.phase !== 'ANSWER_REVEAL' && msg.phase !== 'REVEAL') {
+            disarmResetAffordance('reveal-reset-btn', 'reveal-reset-controls');
+        }
+
         switch (msg.phase) {
             case 'LOBBY':
                 if (!state.playerName) {
@@ -465,6 +487,10 @@
             case 'REVEAL':
                 pu.showView('reveal-view');
                 reveal.updateRevealView(msg);
+                // #299: if the host has vanished, a reveal nobody can advance
+                // is a dead-end → arm the non-admin reset escape hatch.
+                maybeArmRevealReset(msg);
+                disarmResetAffordance('paused-reset-btn');
                 break;
 
             case 'FINALE':
@@ -737,6 +763,94 @@
         var hintKey = isDisconnect ? 'admin.pausedHostHint' : 'admin.pausedHint';
         if (titleEl) titleEl.textContent = t(titleKey);
         if (messageEl) messageEl.textContent = t(hintKey);
+
+        // #299: host-permanently-gone escape hatch. When the admin device
+        // dies for good, the server lets ANY client reset after 60s (#207),
+        // but until now no non-admin view exposed a button → the game was a
+        // dead-end. Arm a 60s timer on an admin_disconnected pause that
+        // reveals the reset button; a non-admin then has a way out. Admins
+        // already have their own resume/end bar, so skip it for them.
+        if (isDisconnect && !state.isAdmin) {
+            armResetAffordance('paused-reset-btn');
+        } else {
+            disarmResetAffordance('paused-reset-btn');
+        }
+    }
+
+    // ============================================
+    // Host-permanently-gone reset affordance (#299)
+    // ============================================
+
+    // ~60s — mirrors the server's #207 grace window before it authorizes a
+    // reset_game from any client.
+    var RESET_AFFORDANCE_DELAY_MS = 60000;
+    var _resetAffordanceTimers = {};
+
+    // wrapperId (optional) is an extra container revealed alongside the
+    // button — used by the reveal view so its bordered slot stays hidden
+    // until the timer actually fires.
+    function armResetAffordance(btnId, wrapperId) {
+        // Already armed/shown for this view — don't restart the clock (a
+        // repeated PAUSED/REVEAL push shouldn't reset the wait).
+        if (_resetAffordanceTimers[btnId]) return;
+        var btn = document.getElementById(btnId);
+        if (btn && !btn.classList.contains('hidden')) return;
+        _resetAffordanceTimers[btnId] = setTimeout(function () {
+            _resetAffordanceTimers[btnId] = null;
+            var b = document.getElementById(btnId);
+            if (b) {
+                b.disabled = false;
+                b.classList.remove('hidden');
+            }
+            if (wrapperId) {
+                var w = document.getElementById(wrapperId);
+                if (w) w.classList.remove('hidden');
+            }
+        }, RESET_AFFORDANCE_DELAY_MS);
+    }
+
+    function disarmResetAffordance(btnId, wrapperId) {
+        if (_resetAffordanceTimers[btnId]) {
+            clearTimeout(_resetAffordanceTimers[btnId]);
+            _resetAffordanceTimers[btnId] = null;
+        }
+        var btn = document.getElementById(btnId);
+        if (btn) btn.classList.add('hidden');
+        if (wrapperId) {
+            var w = document.getElementById(wrapperId);
+            if (w) w.classList.add('hidden');
+        }
+    }
+
+    // Decide whether the reveal view should arm its reset affordance. The
+    // reveal payload carries the full player list; "no connected admin"
+    // means the host can no longer advance the round → arm the escape hatch.
+    function maybeArmRevealReset(data) {
+        if (state.isAdmin) { disarmResetAffordance('reveal-reset-btn', 'reveal-reset-controls'); return; }
+        var players = (data && data.players) || [];
+        var adminConnected = players.some(function (p) {
+            return p && p.is_admin && p.connected !== false;
+        });
+        if (adminConnected) {
+            disarmResetAffordance('reveal-reset-btn', 'reveal-reset-controls');
+        } else {
+            // The wrapper (#reveal-reset-controls) is kept hidden until the
+            // timer fires — see armResetAffordance's wrapperId reveal — so a
+            // host-gone reveal doesn't show an empty bordered slot for 60s.
+            armResetAffordance('reveal-reset-btn', 'reveal-reset-controls');
+        }
+    }
+
+    function setupResetAffordance() {
+        ['paused-reset-btn', 'reveal-reset-btn'].forEach(function (id) {
+            var btn = document.getElementById(id);
+            if (btn) {
+                btn.addEventListener('click', function () {
+                    btn.disabled = true;
+                    send('reset_game', {});
+                });
+            }
+        });
     }
 
     // ============================================
@@ -1013,6 +1127,7 @@
         setupAdminControls();
         setupReactionBar();
         setupSoundToggle();
+        setupResetAffordance();
         pu.setupCollapsibles();
         if (lightning) { lightning.setSend(send); lightning.init(); }
 

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -3874,6 +3874,14 @@
                     pu.saveSession(msg.session_token, state.playerName);
                 }
                 if (msg.is_admin) state.isAdmin = true;
+                // #288: restore the assigned power-up on (re)join. The server
+                // sends the current power-up in `msg.powerup`; without this a
+                // reconnecting player whose power-up was assigned earlier never
+                // sees the button (it was wiped at the previous reveal).
+                if (msg.powerup !== undefined) {
+                    myPowerUp = msg.powerup;
+                    if (game && game.renderPowerUp) game.renderPowerUp(myPowerUp);
+                }
                 if (msg.color) {
                     state.playerColor = msg.color;
                     // Apply as CSS custom property on root for global use
@@ -3943,7 +3951,13 @@
                 break;
 
             case 'powerup_assigned':
+                // #288: render immediately. powerup_assigned arrives AFTER
+                // question_started, so handleQuestionStarted's renderPowerUp
+                // ran while myPowerUp was still null — only the final round
+                // (its flourish delays the render) ever showed the button.
+                // Set + render here so the button appears in every round.
                 myPowerUp = msg.powerup_type;
+                game.renderPowerUp(myPowerUp);
                 break;
 
             case 'powerup_applied':
@@ -4064,6 +4078,14 @@
 
         if (msg.players) lobby.handlePlayerJoined(msg);
 
+        // #299: drop the host-gone reset escape hatch whenever we leave the
+        // paused/reveal views (e.g. the host came back and resumed). The
+        // PAUSED and REVEAL cases below re-arm it if still warranted.
+        if (msg.phase !== 'PAUSED') disarmResetAffordance('paused-reset-btn');
+        if (msg.phase !== 'ANSWER_REVEAL' && msg.phase !== 'REVEAL') {
+            disarmResetAffordance('reveal-reset-btn', 'reveal-reset-controls');
+        }
+
         switch (msg.phase) {
             case 'LOBBY':
                 if (!state.playerName) {
@@ -4107,6 +4129,10 @@
             case 'REVEAL':
                 pu.showView('reveal-view');
                 reveal.updateRevealView(msg);
+                // #299: if the host has vanished, a reveal nobody can advance
+                // is a dead-end → arm the non-admin reset escape hatch.
+                maybeArmRevealReset(msg);
+                disarmResetAffordance('paused-reset-btn');
                 break;
 
             case 'FINALE':
@@ -4379,6 +4405,94 @@
         var hintKey = isDisconnect ? 'admin.pausedHostHint' : 'admin.pausedHint';
         if (titleEl) titleEl.textContent = t(titleKey);
         if (messageEl) messageEl.textContent = t(hintKey);
+
+        // #299: host-permanently-gone escape hatch. When the admin device
+        // dies for good, the server lets ANY client reset after 60s (#207),
+        // but until now no non-admin view exposed a button → the game was a
+        // dead-end. Arm a 60s timer on an admin_disconnected pause that
+        // reveals the reset button; a non-admin then has a way out. Admins
+        // already have their own resume/end bar, so skip it for them.
+        if (isDisconnect && !state.isAdmin) {
+            armResetAffordance('paused-reset-btn');
+        } else {
+            disarmResetAffordance('paused-reset-btn');
+        }
+    }
+
+    // ============================================
+    // Host-permanently-gone reset affordance (#299)
+    // ============================================
+
+    // ~60s — mirrors the server's #207 grace window before it authorizes a
+    // reset_game from any client.
+    var RESET_AFFORDANCE_DELAY_MS = 60000;
+    var _resetAffordanceTimers = {};
+
+    // wrapperId (optional) is an extra container revealed alongside the
+    // button — used by the reveal view so its bordered slot stays hidden
+    // until the timer actually fires.
+    function armResetAffordance(btnId, wrapperId) {
+        // Already armed/shown for this view — don't restart the clock (a
+        // repeated PAUSED/REVEAL push shouldn't reset the wait).
+        if (_resetAffordanceTimers[btnId]) return;
+        var btn = document.getElementById(btnId);
+        if (btn && !btn.classList.contains('hidden')) return;
+        _resetAffordanceTimers[btnId] = setTimeout(function () {
+            _resetAffordanceTimers[btnId] = null;
+            var b = document.getElementById(btnId);
+            if (b) {
+                b.disabled = false;
+                b.classList.remove('hidden');
+            }
+            if (wrapperId) {
+                var w = document.getElementById(wrapperId);
+                if (w) w.classList.remove('hidden');
+            }
+        }, RESET_AFFORDANCE_DELAY_MS);
+    }
+
+    function disarmResetAffordance(btnId, wrapperId) {
+        if (_resetAffordanceTimers[btnId]) {
+            clearTimeout(_resetAffordanceTimers[btnId]);
+            _resetAffordanceTimers[btnId] = null;
+        }
+        var btn = document.getElementById(btnId);
+        if (btn) btn.classList.add('hidden');
+        if (wrapperId) {
+            var w = document.getElementById(wrapperId);
+            if (w) w.classList.add('hidden');
+        }
+    }
+
+    // Decide whether the reveal view should arm its reset affordance. The
+    // reveal payload carries the full player list; "no connected admin"
+    // means the host can no longer advance the round → arm the escape hatch.
+    function maybeArmRevealReset(data) {
+        if (state.isAdmin) { disarmResetAffordance('reveal-reset-btn', 'reveal-reset-controls'); return; }
+        var players = (data && data.players) || [];
+        var adminConnected = players.some(function (p) {
+            return p && p.is_admin && p.connected !== false;
+        });
+        if (adminConnected) {
+            disarmResetAffordance('reveal-reset-btn', 'reveal-reset-controls');
+        } else {
+            // The wrapper (#reveal-reset-controls) is kept hidden until the
+            // timer fires — see armResetAffordance's wrapperId reveal — so a
+            // host-gone reveal doesn't show an empty bordered slot for 60s.
+            armResetAffordance('reveal-reset-btn', 'reveal-reset-controls');
+        }
+    }
+
+    function setupResetAffordance() {
+        ['paused-reset-btn', 'reveal-reset-btn'].forEach(function (id) {
+            var btn = document.getElementById(id);
+            if (btn) {
+                btn.addEventListener('click', function () {
+                    btn.disabled = true;
+                    send('reset_game', {});
+                });
+            }
+        });
     }
 
     // ============================================
@@ -4655,6 +4769,7 @@
         setupAdminControls();
         setupReactionBar();
         setupSoundToggle();
+        setupResetAffordance();
         pu.setupCollapsibles();
         if (lightning) { lightning.setSend(send); lightning.init(); }
 

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -369,6 +369,15 @@
                     </button>
                 </div>
 
+                <!-- #299: non-admin escape hatch on the reveal. If the host
+                     device dies for good, a reveal nobody can advance is a
+                     dead-end. Hidden by default; revealed by player-core after
+                     ~60s with no connected admin so any client can reset the
+                     stuck game (server authorizes this per #207). -->
+                <div id="reveal-reset-controls" class="pl-result-section hidden">
+                    <button id="reveal-reset-btn" class="btn btn-primary btn-glow" type="button" data-i18n="admin.resetGame">Reset game</button>
+                </div>
+
                 <!-- Hidden helpers — legacy renderers (analytics, leaderboard,
                      all-answers) may still try to write into these IDs during
                      the transition. Keeping them as sr-only nodes prevents
@@ -397,6 +406,12 @@
                 <div class="paused-spinner">
                     <div class="spinner"></div>
                 </div>
+                <!-- #299: host-permanently-gone escape hatch. Hidden by
+                     default; revealed by player-core after ~60s of an
+                     admin_disconnected pause so any client can reset the
+                     stuck game (server authorizes this per #207). Mirrors
+                     the standard player primary button styling. -->
+                <button id="paused-reset-btn" class="btn btn-primary btn-glow hidden" type="button" data-i18n="admin.resetGame">Reset game</button>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary

Two frontend-only player-view bug fixes. All changes are confined to `www/`.

Closes #288
Closes #299

### #288 — Power-up button never appears in rounds 1..N-1
The server sends `powerup_assigned` **after** `question_started`, so the `renderPowerUp` call inside `handleQuestionStarted` ran while `myPowerUp` was still `null` (it gets wiped at the previous reveal). Only the final round ever showed the button, because its dramatic-flourish countdown delays the render past the `powerup_assigned` arrival.

**Fix** (`www/js/player-core.js`):
- `case 'powerup_assigned'` now calls `game.renderPowerUp(msg.powerup_type)` in addition to setting `myPowerUp`.
- `joined` / `reconnected` handler now restores **and** renders `myPowerUp` from the `powerup` field the server already includes in those payloads (`server/websocket.py` joined/reconnected sends, fields confirmed). This fixes reconnecting players who were assigned a power-up earlier.

Verified the render flow against `renderPowerUp` in `player-game.js` (toggles `#powerup-btn` visibility + label).

### #299 — Host-permanently-gone dead-end has no client affordance
After the admin device dies for good, players sit on the paused-view spinner (or an unadvanceable reveal) forever. The server already authorizes **any** client to send `reset_game` ~60s after the admin is gone (#207), but no non-admin view exposed a button → recovery was unreachable without dev tools.

**Fix**:
- `www/player.html`: added a hidden `#paused-reset-btn` to the paused view and a hidden `#reveal-reset-controls` / `#reveal-reset-btn` block to the reveal view. Both reuse the standard player primary-button styling (`btn btn-primary btn-glow`).
- `www/js/player-core.js`: on an `admin_disconnected` pause (non-admin), and on a reveal where no player is both `is_admin` and `connected`, a ~60s timer arms and then reveals the button. Clicking it sends `{type:'reset_game'}` via the existing `send` helper. The affordance is disarmed (and re-hidden) on any phase transition away from paused/reveal (e.g. the host reconnects and resumes), so a returning host cleanly removes it. Admins are skipped — they already have their own resume/end controls.
- `www/css/src/07-player.css`: minimal spacing/centering only (no novel visual design).

**i18n:** reused the existing `admin.resetGame` key ("Spiel zurücksetzen" / "Reset game"), present in both `de.json` and `en.json`. **No new keys added.**

## Build artifacts
- `player-core.js` is a bundle source → **`www/js/player.bundle.js` rebuilt** via `scripts/build_bundle.py`.
- New CSS in `css/src/07-player.css` → **`www/css/styles.css` rebuilt** via `scripts/build_css.py`.
- `player.html` is not bundled (loaded directly).

## Testing
- Python suite: **504 passed** (unaffected — these are JS/HTML/CSS-only changes).
- `node --check` clean on `player-core.js` and the rebuilt bundle; i18n JSON validates.

⚠️ **Needs a live/mobile verify (browser-harness, 390x844) after deploy** per the project's pre-release rule — the power-up assign/render ordering and the host-gone reset flow are runtime/WebSocket behaviors not exercisable by unit tests. Suggested checks: (1) power-up button visible in an early round for the assigned player and after a reconnect; (2) kill the admin device mid-game, confirm the reset button appears on paused **and** reveal after ~60s and successfully resets; (3) confirm the button disappears if the host reconnects/resumes before 60s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
