### PR TITLE
fix: backend bug-fix batch (#298 #302 #303 #307 #309 #310 #293; partial #305 #308 #311)

### DIFF
--- a/custom_components/quizify/game/questions.py
+++ b/custom_components/quizify/game/questions.py
@@ -215,6 +215,12 @@ class QuestionBank:
             "name": category_name,
             "language": pack_language,
             "question_count": len(questions),
+            # Store the pack's theme at load time (#309) so the featured-pack
+            # view can map it to a spotlight icon without re-reading + re-parsing
+            # the pack JSON per request — and, crucially, so it resolves for
+            # community packs too (their on-disk path differs from the slug, so
+            # the old per-request re-read always missed them → 🎲 default icon).
+            "theme": raw.get("theme", "") if isinstance(raw.get("theme"), str) else "",
         }
         # Optional recurring seasonal window (#276). Parsed + validated here so
         # a malformed window is dropped at load time; the normalised MM-DD form
@@ -391,6 +397,11 @@ class QuestionBank:
                 "language": pack_language,
                 "question_count": len(questions),
                 "community": True,
+                # Theme stored at load time (#309) — community packs live at
+                # questions/community/<stem>.json under a ``community-`` slug, so
+                # the old views.py path read (questions_dir / f"{slug}.json")
+                # never found them and they always fell back to the 🎲 icon.
+                "theme": raw.get("theme", "") if isinstance(raw.get("theme"), str) else "",
             }
             community_season = _normalize_season(raw.get("season"))
             if community_season is not None:

--- a/custom_components/quizify/game/scoring_engine.py
+++ b/custom_components/quizify/game/scoring_engine.py
@@ -106,7 +106,15 @@ class ScoringEngine:
             double_points_active=double_points_active,
         )
 
-        # Calculate breakdown for client display.
+        # Calculate breakdown for client display. The client renders the
+        # components additively (base + speed + streak, then "× difficulty"),
+        # so the three integer parts must reconstruct ``points`` exactly —
+        # otherwise the breakdown visibly fails to add up to the awarded score
+        # (#308: "off by 1-2"). The bug was independent int() truncation:
+        # ``points`` truncates the full float once, while speed_bonus and
+        # streak_bonus each truncated separately, leaving a 1-2pt remainder
+        # unaccounted for. Fix: derive streak_bonus as the exact remainder so
+        # base + speed_bonus + streak_bonus == points (pre-milestone).
         speed_bonus = 0
         streak_bonus = 0
         diff_mult = DIFFICULTY_MULTIPLIERS.get(difficulty, 1.0)
@@ -117,8 +125,16 @@ class ScoringEngine:
                 else 0.0
             )
             speed_bonus = int(MAX_SPEED_BONUS * time_fraction)
-            streak_mult = get_streak_multiplier(streak)
-            streak_bonus = int((BASE_POINTS + speed_bonus) * diff_mult * (streak_mult - 1.0))
+            # ``points`` is the authoritative awarded score (the milestone spike
+            # is added separately below and surfaced as ``milestone_bonus``).
+            # Back streak_bonus out of it so base + speed + streak == points,
+            # making the breakdown sum exactly.
+            streak_bonus = points - BASE_POINTS - speed_bonus
+            if streak_bonus < 0:
+                # Defensive: a 0-streak hard-difficulty edge could in principle
+                # leave the speed truncation slightly above points. Never show a
+                # negative bonus; clamp and let speed absorb the difference.
+                streak_bonus = 0
 
         # Wager override (Jeopardy-style final round). On the final round, if
         # the player submitted a wager (0-100% of their pre-round score), it
@@ -129,16 +145,23 @@ class ScoringEngine:
         if is_final_round and wager is not None:
             bank = max(0, score_before_wager)
             wager_pts = int(bank * wager / 100)
-            wager_used = wager_pts
-            if correct:
-                points = wager_pts
-            else:
-                # Lose the wager — but never go below zero so a player can't be
-                # priced out of an existing rematch flow.
-                points = -min(wager_pts, bank)
-            # Clear bonuses since the wager overrides them.
-            speed_bonus = 0
-            streak_bonus = 0
+            # #308: a 0-point bank (or a 0% wager) means there's nothing to bet.
+            # The old code still REPLACED the normal scoring with wager_pts=0,
+            # so a 0-score player who happened to "wager" got 0 even for a
+            # correct answer — punished for wagering. Skip the override entirely
+            # when wager_pts == 0 and let the normal speed/streak/difficulty
+            # scoring stand (and the milestone bonus below still applies).
+            if wager_pts > 0:
+                wager_used = wager_pts
+                if correct:
+                    points = wager_pts
+                else:
+                    # Lose the wager — but never go below zero so a player can't
+                    # be priced out of an existing rematch flow.
+                    points = -min(wager_pts, bank)
+                # Clear bonuses since the wager overrides them.
+                speed_bonus = 0
+                streak_bonus = 0
 
         # Streak milestone bonus — discrete spike awarded the round the streak
         # EXACTLY equals a milestone value (3, 5, 10, 15, 20, 25). Wager rounds

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -748,13 +748,18 @@ class QuizifyGameState:
         self.phase = GamePhase.ANSWER_REVEAL
 
         # Feed the group-level difficulty calibrator (#40). Signal = the share
-        # of *participating* players (connected, i.e. present for this round)
-        # who answered correctly. Then advance the target for the next round.
-        # No-op when not in "auto" mode. Rounds with zero participants carry no
-        # signal (the calibrator ignores total<=0).
+        # of *participating* players who answered correctly. Then advance the
+        # target for the next round. No-op when not in "auto" mode. Rounds with
+        # zero participants carry no signal (the calibrator ignores total<=0).
+        #
+        # #302: base the signal on players who actually SUBMITTED, not merely
+        # connected. Counting every connected-but-idle tab (late joiners, AFK
+        # phones) as wrong dragged the difficulty easier — the opposite of the
+        # intended adaptation, and inconsistent with question_stats.record_round
+        # below, which deliberately excludes timeouts.
         if self._calibrator is not None:
             participants = [
-                p for p in self._player_registry.players.values() if p.connected
+                p for p in self._player_registry.players.values() if p.submitted
             ]
             total = len(participants)
             correct = sum(

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -440,9 +440,12 @@ class QuizifyGameState:
             language=self.language,
         )
 
-        # Verify questions are available
+        # Verify questions are available. Raise with the dedicated
+        # ERR_NO_QUESTIONS_REMAINING code (#308) so the handler can surface the
+        # right error — an empty pack is NOT "game already started". The human
+        # message stays as the exception detail for logs.
         if not self._question_bank._queue:
-            raise ValueError("No questions available for the selected category/difficulty")
+            raise ValueError(ERR_NO_QUESTIONS_REMAINING)
 
         # Drop players who are no longer connected before resetting
         # scores. Players who disconnected during the previous game

--- a/custom_components/quizify/server/connection.py
+++ b/custom_components/quizify/server/connection.py
@@ -19,6 +19,19 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+
+def _log_task_exception(task: "asyncio.Task") -> None:
+    """Done-callback surfacing a fire-and-forget task's exception (#307).
+
+    Without it, an exception in an ensure_future'd background task (token
+    persist, admin-timeout, player-removal) is swallowed or only warns at GC
+    time. Reuses the analytics.py logging-done-callback pattern.
+    """
+    if task.cancelled():
+        return
+    if (exc := task.exception()) is not None:
+        _LOGGER.error("Unhandled exception in background task: %s", exc)
+
 # Filename for the persisted admin session token. Tokens older than
 # _PLAYER_TOKEN_TTL are treated as expired — prevents cross-game token reuse
 # on long-lived hosts.
@@ -37,6 +50,13 @@ class ConnectionManager:
 
     ADMIN_SESSION_GRACE = 120
     PLAYER_SESSION_GRACE = 60
+
+    # Per-send wall-clock cap for a single fan-out send (#307). A half-dead
+    # phone (TCP zero-window, wifi sleep) can otherwise pin drain() up to the
+    # 30s heartbeat; without a cap a single such client stalls the whole
+    # broadcast()/per-player gather and the calling handler room-wide. 2s is
+    # comfortably above a healthy send yet bounds the worst case.
+    _SEND_TIMEOUT = 2.0
 
     def __init__(
         self,
@@ -146,7 +166,8 @@ class ConnectionManager:
             self._admin_session_token = str(uuid.uuid4())
             # Fire-and-forget persist; missing the write isn't fatal, the
             # token just won't survive the next restart.
-            asyncio.ensure_future(self._async_save_admin_token())
+            _persist = asyncio.ensure_future(self._async_save_admin_token())
+            _persist.add_done_callback(_log_task_exception)
         return self._admin_session_token
 
     def validate_admin_token(self, token: str) -> bool:
@@ -212,6 +233,7 @@ class ConnectionManager:
             await self._async_save_admin_token()
 
         self._admin_disconnect_task = asyncio.ensure_future(admin_timeout())
+        self._admin_disconnect_task.add_done_callback(_log_task_exception)
 
     # ------------------------------------------------------------------
     # Player session tokens (with TTL)
@@ -280,9 +302,30 @@ class ConnectionManager:
     def schedule_player_removal(
         self, name: str, timeout: float, remove_fn
     ) -> None:
-        """Schedule *remove_fn(name, timeout)* and track the task."""
+        """Schedule *remove_fn(name, timeout)* and track the task.
+
+        #310: entries used to be popped only on reconnect, so one completed
+        done-Task per distinct removed player name accumulated forever on a
+        long-lived host (the single never-shrinking structure in the codebase).
+        A done-callback now pops the entry once the task finishes (guarded so a
+        re-scheduled task for the same name isn't clobbered). Re-scheduling for
+        a name with a still-pending task cancels the old one first, so the
+        registry never silently leaks a task it can no longer reach.
+        """
+        existing = self._pending_removals.get(name)
+        if existing is not None and not existing.done():
+            existing.cancel()
         task = asyncio.ensure_future(remove_fn(name, timeout))
         self._pending_removals[name] = task
+
+        def _cleanup(t: asyncio.Task) -> None:
+            # Only drop the entry if it's still THIS task (a reconnect may have
+            # already replaced it via cancel_pending_removal / reschedule).
+            if self._pending_removals.get(name) is t:
+                self._pending_removals.pop(name, None)
+            _log_task_exception(t)
+
+        task.add_done_callback(_cleanup)
 
     def cancel_pending_removal(self, name: str) -> None:
         """Cancel a pending removal task for *name* (e.g. on reconnect)."""
@@ -346,9 +389,13 @@ class ConnectionManager:
 
         The public single-socket send primitive. Errors are intentionally
         swallowed (and logged) so one dead/slow client can't break a fan-out.
+        A per-send timeout (#307) bounds a half-dead client so the per-player
+        gather fan-outs (timer ticks, question sends) can't stall room-wide.
         """
         try:
-            await ws.send_json(message)
+            await asyncio.wait_for(ws.send_json(message), timeout=self._SEND_TIMEOUT)
+        except asyncio.TimeoutError:
+            _LOGGER.warning("Timed out sending to WebSocket (slow/dead client)")
         except Exception as err:  # noqa: BLE001
             _LOGGER.warning("Failed to send to WebSocket: %s", err)
 
@@ -361,9 +408,14 @@ class ConnectionManager:
 
         Used by the broadcast helpers so the same fan-out message is
         serialized once (json.dumps) rather than re-encoded per client (#258).
+        Wrapped in a per-send timeout (#307) so one stalled socket can't pin
+        the whole fan-out; a TimeoutError is swallowed like any other send
+        error so the broadcast still reaches the healthy clients.
         """
         try:
-            await ws.send_str(payload)
+            await asyncio.wait_for(ws.send_str(payload), timeout=self._SEND_TIMEOUT)
+        except asyncio.TimeoutError:
+            _LOGGER.warning("Timed out sending to WebSocket (slow/dead client)")
         except Exception as err:  # noqa: BLE001
             _LOGGER.warning("Failed to send to WebSocket: %s", err)
 

--- a/custom_components/quizify/server/serializers.py
+++ b/custom_components/quizify/server/serializers.py
@@ -90,15 +90,28 @@ def serialize_question_for_admin(
 
 
 def serialize_leaderboard(players: list[PlayerSession]) -> list[dict[str, Any]]:
-    """Build sorted leaderboard from player list."""
+    """Build sorted leaderboard from player list.
+
+    Ties share a rank (#308): two players on the same score get the same rank
+    and the next rank skips accordingly (standard competition ranking —
+    1,1,3,…), instead of breaking ties arbitrarily by dict/insertion order and
+    showing one of two equal players as strictly ahead.
+    """
     sorted_players = sorted(players, key=lambda p: p.score, reverse=True)
     result = []
+    prev_score: int | None = None
+    rank = 0
     for i, p in enumerate(sorted_players):
+        # Competition ranking: same score → same rank; the next distinct score
+        # jumps to position i+1.
+        if prev_score is None or p.score != prev_score:
+            rank = i + 1
+            prev_score = p.score
         breakdown = p.round_score_breakdown if hasattr(p, "round_score_breakdown") else {}
         # Determine if this player answered correctly this round
         last_result = p.round_history[-1] if p.round_history else None
         result.append({
-            "rank": i + 1,
+            "rank": rank,
             "name": p.name,
             "score": p.score,
             "streak": p.streak,
@@ -149,12 +162,19 @@ def serialize_finale(
     superlatives: list[dict[str, str]] | None = None,
 ) -> dict[str, Any]:
     """Build finale payload with podium and full leaderboard."""
+    # Shared-rank podium (#308): equal scores share a rank, same as the
+    # leaderboard, so two tied finalists aren't shown 1st/2nd arbitrarily.
+    podium_entries = []
+    _prev: int | None = None
+    _rank = 0
+    for i, p in enumerate(podium):
+        if _prev is None or p.score != _prev:
+            _rank = i + 1
+            _prev = p.score
+        podium_entries.append({"rank": _rank, "name": p.name, "score": p.score})
     result = {
         "type": "finale",
-        "podium": [
-            {"rank": i + 1, "name": p.name, "score": p.score}
-            for i, p in enumerate(podium)
-        ],
+        "podium": podium_entries,
         "leaderboard": serialize_leaderboard(all_players),
         "all_players": serialize_leaderboard(all_players),
     }

--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -423,22 +423,15 @@ async def featured_pack_view(request: web.Request) -> web.Response:
     season_label = chosen_season.label if (seasonal_active and chosen_season) else ""
 
     meta = lang_packs[chosen]
-    # Read pack JSON once for theme (icon lookup). Cheap — packs are
-    # already on disk and aiohttp's executor handles the blocking read.
-    pack_path = bank.questions_dir / f"{chosen}.json"
-    try:
-        raw = await ctx.runtime.run_in_executor(
-            pack_path.read_text, "utf-8"
-        )
-        parsed = json.loads(raw)
-        # A pack file is expected to be a JSON object. Valid-but-non-object
-        # JSON (e.g. a list or bare string) would make ``.get`` raise
-        # AttributeError, which isn't an OSError/ValueError — guard the
-        # structure explicitly so a malformed pack degrades to the default
-        # icon instead of 500-ing the admin setup screen (#168).
-        theme = parsed.get("theme", "") if isinstance(parsed, dict) else ""
-    except (OSError, ValueError):
-        theme = ""
+    # Theme is captured into pack metadata at load time (#309), so read it from
+    # there instead of re-opening + re-parsing the pack JSON per request. The
+    # old per-request read used ``questions_dir / f"{chosen}.json"``, which
+    # never resolved community packs (they live at
+    # ``questions/community/<stem>.json`` under a ``community-`` slug) — so a
+    # featured seasonal/most-played community pack always got the 🎲 default
+    # icon instead of its real theme. Reading from metadata fixes that and drops
+    # a blocking file read from the hot path.
+    theme = meta.get("theme", "") or ""
     icon = _THEME_ICONS.get(theme, "🎲")
 
     count = meta.get("question_count", 0)

--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -692,7 +692,14 @@ async def flag_list_view(request: web.Request) -> web.Response:
         return entries
 
     entries = await ctx.runtime.run_in_executor(_read)
-    return web.json_response({"flags": entries})
+    # #305: never return the stored client IP (``remote``) to callers — the
+    # /api/quizify/* routes are added to hass.http.app.router with NO HA auth,
+    # so /flags is readable unauthenticated. The IP is still stored on disk for
+    # operator forensics; it is simply stripped from the response so an
+    # anonymous caller can't enumerate the IPs of everyone who flagged a
+    # question. Strip it defensively per entry (older entries may pre-date this).
+    sanitized = [{k: v for k, v in e.items() if k != "remote"} for e in entries]
+    return web.json_response({"flags": sanitized})
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -995,6 +995,18 @@ class QuizifyWebSocketHandler:
         language = data.get("language", "de")
         timer_duration = data.get("timer_duration")
 
+        # Validate num_rounds the same way as timer_duration (#303): the WS
+        # value reaches start_game raw, and total_rounds drives
+        # ``self.round >= self.total_rounds``. A non-int makes that comparison
+        # raise TypeError every start_next_question (game wedged); 0/negative
+        # jumps straight to FINALE. Coerce to int + clamp to 1..50, fall back
+        # to the default of 10 on anything unparseable.
+        try:
+            num_rounds = int(num_rounds)
+        except (TypeError, ValueError):
+            num_rounds = 10
+        num_rounds = max(1, min(50, num_rounds))
+
         # category may be None (mixed), a string (single), or a list (multi)
         if isinstance(raw_category, list):
             category = None

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -1403,8 +1403,14 @@ class QuizifyWebSocketHandler:
                         return
             except asyncio.CancelledError:
                 pass
+            except Exception:  # noqa: BLE001
+                # #307: an unexpected exception here used to kill the lightning
+                # task silently, hanging the round on the current question with
+                # a frozen clock. Log it so the failure surfaces.
+                _LOGGER.exception("Lightning loop crashed")
 
         self._lightning_task = asyncio.ensure_future(loop())
+        self._lightning_task.add_done_callback(self._log_task_exception)
 
     def _cancel_lightning_loop(self) -> None:
         if self._lightning_task is not None:
@@ -1687,14 +1693,35 @@ class QuizifyWebSocketHandler:
                     game_state.evaluate_round()
             except asyncio.CancelledError:
                 pass
+            except Exception:  # noqa: BLE001
+                # #307: any other exception used to kill the tick task
+                # silently, leaving the game frozen in QUESTION_ACTIVE with a
+                # stuck countdown. Log it loudly so the failure is diagnosable
+                # instead of presenting as a mysterious hang.
+                _LOGGER.exception("Timer tick loop crashed")
 
         self._timer_tick_task = asyncio.ensure_future(tick_loop())
+        self._timer_tick_task.add_done_callback(self._log_task_exception)
 
     def _cancel_timer_tick(self) -> None:
         """Cancel the timer tick task."""
         if self._timer_tick_task is not None:
             self._timer_tick_task.cancel()
             self._timer_tick_task = None
+
+    @staticmethod
+    def _log_task_exception(task: asyncio.Task) -> None:
+        """Done-callback that surfaces a fire-and-forget task's exception (#307).
+
+        ensure_future/create_task tasks whose exception is never retrieved
+        otherwise raise "Task exception was never retrieved" at GC time (or get
+        swallowed entirely). Reuses the analytics.py logging-done-callback
+        pattern so a crashed background loop is at least loud in the log.
+        """
+        if task.cancelled():
+            return
+        if (exc := task.exception()) is not None:
+            _LOGGER.error("Unhandled exception in background task: %s", exc)
 
     # ------------------------------------------------------------------
     # Round summary broadcast

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -388,7 +388,7 @@ class QuizifyWebSocketHandler:
                 True,
             ),
             "admin_skip": (
-                lambda ws: self._handle_next_question(ws, game_state),
+                lambda ws: self._handle_admin_skip(ws, game_state),
                 True,
             ),
             "end_game": (lambda ws: self._handle_end_game(ws, game_state), True),
@@ -1076,7 +1076,41 @@ class QuizifyWebSocketHandler:
             await self._conn.send_error(ws, ERR_INVALID_ACTION, "Cannot advance now")
             return
 
+        # #298: a stray next_round/next_question in a *real* lobby (stale admin
+        # tab, double-fire) must NOT advance — start_game doesn't change phase,
+        # so an un-started game sits in LOBBY with game_id is None. Advancing
+        # from there either ends an empty queue (FINALE with an empty podium,
+        # round=0) or starts a round with no game_id and scores never reset.
+        # The legitimate internal start→first-question path goes through
+        # _start_next_question directly (see _handle_start_game), so gating the
+        # public handler here doesn't break it.
+        if game_state.phase == GamePhase.LOBBY and game_state.game_id is None:
+            await self._conn.send_error(ws, ERR_INVALID_ACTION, "Cannot advance now")
+            return
+
         await self._start_next_question(game_state)
+
+    async def _handle_admin_skip(
+        self, ws: web.WebSocketResponse, game_state: QuizifyGameState
+    ) -> None:
+        """Handle admin skip — abandon the live question right now (#311).
+
+        ``admin_skip`` used to route to ``_handle_next_question``, which only
+        accepts LOBBY/ANSWER_REVEAL, so mid-question it was a dead no-op: a
+        broken/offensive question forced the room to wait out the timer (pause
+        can't advance either). The fix: during QUESTION_ACTIVE, evaluate the
+        round immediately — locking in whatever answers are already in and
+        transitioning to ANSWER_REVEAL — so the admin can then advance past it.
+        Outside QUESTION_ACTIVE it behaves like the normal advance.
+        """
+        if game_state.phase == GamePhase.QUESTION_ACTIVE:
+            # Stop the countdown and evaluate now. evaluate_round()'s
+            # state-machine event (_fire_broadcast("round_evaluated")) drives
+            # the summary broadcast, same as the timer-expiry auto-evaluate.
+            self._cancel_timer_tick()
+            game_state.evaluate_round()
+            return
+        await self._handle_next_question(ws, game_state)
 
     # ------------------------------------------------------------------
     # Admin: end game

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -244,9 +244,16 @@ class QuizifyWebSocketHandler:
                 elif msg.type == WSMsgType.ERROR:
                     _LOGGER.error("WebSocket error: %s", ws.exception())
         finally:
+            # #293: capture the admin-connection flag BEFORE remove_connection
+            # discards this ws from _admin_connections. The disconnect handler
+            # needs it to decide whether to start the admin-session grace
+            # timeout; reading is_admin_connection(ws) AFTER removal always
+            # returned False, so schedule_admin_timeout never fired (and
+            # cancel_admin_disconnect was equally dead).
+            was_admin = self._conn.is_admin_connection(ws)
             self._conn.remove_connection(ws)
             self._forget_rate_limit(ws)
-            await self._handle_disconnect(ws)
+            await self._handle_disconnect(ws, was_admin=was_admin)
             _LOGGER.debug("WebSocket disconnected, total: %d", len(self._conn.connections))
 
         return ws
@@ -1710,8 +1717,16 @@ class QuizifyWebSocketHandler:
     # Disconnect handling
     # ------------------------------------------------------------------
 
-    async def _handle_disconnect(self, ws: web.WebSocketResponse) -> None:
-        """Handle WebSocket disconnection."""
+    async def _handle_disconnect(
+        self, ws: web.WebSocketResponse, was_admin: bool | None = None
+    ) -> None:
+        """Handle WebSocket disconnection.
+
+        ``was_admin`` is the admin-connection flag captured by ``handle()``
+        BEFORE ``remove_connection`` (#293). When omitted (legacy/test callers),
+        fall back to querying the connection manager — only correct if the ws
+        hasn't been removed yet.
+        """
         game_state = self._get_game_state()
         if not game_state:
             return
@@ -1719,7 +1734,12 @@ class QuizifyWebSocketHandler:
         # Handle admin disconnect — keep game alive for grace period.
         # Strictly gated on real admin connection (was: OR clause allowed
         # dashboard disconnects to trigger the timeout, see #2 in review).
-        if self._conn.is_admin_connection(ws):
+        is_admin_ws = (
+            was_admin
+            if was_admin is not None
+            else self._conn.is_admin_connection(ws)
+        )
+        if is_admin_ws:
             if not self._conn.has_admin_connections():
                 _LOGGER.info(
                     "Admin disconnected, keeping game alive for %ds",

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -18,6 +18,7 @@ from custom_components.quizify.const import (
     ERR_INVALID_ACTION,
     ERR_NAME_INVALID,
     ERR_NAME_TAKEN,
+    ERR_NO_QUESTIONS_REMAINING,
     ERR_NOT_IN_GAME,
     ERR_ROUND_EXPIRED,
     LOBBY_DISCONNECT_GRACE_PERIOD,
@@ -1036,7 +1037,16 @@ class QuizifyWebSocketHandler:
                 timer_duration=timer_value,
             )
         except ValueError as err:
-            await self._conn.send_error(ws, ERR_GAME_ALREADY_STARTED, str(err))
+            # start_game raises two distinct ValueErrors: a wrong-phase
+            # "already started" and an empty-pack "no questions". Surface the
+            # right code instead of always reporting ALREADY_STARTED (#308):
+            # an empty/missing pack is a NO_QUESTIONS_REMAINING condition.
+            code = (
+                ERR_NO_QUESTIONS_REMAINING
+                if str(err) == ERR_NO_QUESTIONS_REMAINING
+                else ERR_GAME_ALREADY_STARTED
+            )
+            await self._conn.send_error(ws, code, str(err))
             return
 
         # Grace period before round 1's timer starts.
@@ -1363,6 +1373,15 @@ class QuizifyWebSocketHandler:
         """Admin ends the lightning round early → jump to the recap."""
         self._cancel_lightning_loop()
         if game_state.phase == GamePhase.LIGHTNING:
+            # Score the in-flight question's answers before tearing the round
+            # down (#308). Without lr.advance(), "End lightning" discarded every
+            # answer already tapped on the current question — the recap omitted
+            # them and players who'd answered correctly got no credit. advance()
+            # scores the current question (and arms the next, which we don't
+            # broadcast since we're finishing anyway).
+            lr = game_state.lightning
+            if lr is not None:
+                lr.advance()
             game_state.finish_lightning_round()
             await self._broadcast_lightning_recap(game_state)
 

--- a/tests/test_backend_bugs_batch.py
+++ b/tests/test_backend_bugs_batch.py
@@ -1,0 +1,280 @@
+"""Regression tests for the 2026-06-11 backend bug-fix batch.
+
+Covers the handler/state-level fixes:
+
+* #298 — next_round/next_question rejected in a *real* (un-started) lobby.
+* #303 — num_rounds from the WS coerced + clamped to 1..50 (fallback 10).
+* #308 — empty-pack start reports NO_QUESTIONS_REMAINING (not ALREADY_STARTED);
+         admin "End lightning" scores the in-flight question's answers.
+* #311 — admin_skip evaluates the round during QUESTION_ACTIVE.
+
+These exercise the same handler entry points the WS dispatch calls, with the
+ConnectionManager broadcast/send stubbed, mirroring test_start_game_fresh.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.const import (  # noqa: E402
+    ERR_GAME_ALREADY_STARTED,
+    ERR_INVALID_ACTION,
+    ERR_NO_QUESTIONS_REMAINING,
+)
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    def create_task(self, coro):
+        return asyncio.ensure_future(coro)
+
+    async def run_in_executor(self, func, *args):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func, *args)
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+@pytest.fixture
+def handler(game: QuizifyGameState, monkeypatch) -> QuizifyWebSocketHandler:
+    runtime = _FakeRuntime(game._runtime.data_dir)  # type: ignore[attr-defined]
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    h._conn = ConnectionManager(runtime, lambda: game)
+    h._conn.broadcast = AsyncMock()
+    h._conn.broadcast_to_admins_and_dashboards = AsyncMock()
+    h._conn.send = AsyncMock()
+    h._conn.send_error = AsyncMock()
+    # Skip the admin-redirect grace sleep + neutralise the real-time tick loop.
+    monkeypatch.setattr(
+        "custom_components.quizify.server.websocket.asyncio.sleep", AsyncMock()
+    )
+    monkeypatch.setattr(h, "_start_timer_tick", lambda *a, **k: None)
+    return h
+
+
+# ---------------------------------------------------------------------------
+# #298 — next_round / next_question in a real lobby
+# ---------------------------------------------------------------------------
+
+
+class TestNextQuestionLobbyGate:
+    @pytest.mark.asyncio
+    async def test_next_question_rejected_in_unstarted_lobby(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        """A stray next_round in a real lobby (game never started → game_id is
+        None) must be rejected, not advance into a ghost round / empty FINALE."""
+        admin = _ws()
+        game.add_player("Markus", admin)
+        game.get_player("Markus").is_admin = True
+        assert game.phase == GamePhase.LOBBY
+        assert game.game_id is None
+
+        await handler._handle_next_question(admin, game)
+
+        handler._conn.send_error.assert_awaited()
+        code = handler._conn.send_error.await_args.args[1]
+        assert code == ERR_INVALID_ACTION
+        # No round started, still a clean lobby.
+        assert game.phase == GamePhase.LOBBY
+        assert game.round == 0
+
+    @pytest.mark.asyncio
+    async def test_internal_start_first_question_still_works(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        """The start→first-question path (start_game has set game_id) is not
+        gated — the game must still advance to round 1."""
+        admin = _ws()
+        game.add_player("Markus", admin)
+        game.get_player("Markus").is_admin = True
+
+        await handler._handle_start_game(
+            admin,
+            {"category": "geographie", "num_rounds": 5, "language": "de",
+             "timer_duration": 30},
+            game,
+        )
+        assert game.game_id is not None
+        assert game.phase == GamePhase.QUESTION_ACTIVE
+        assert game.round == 1
+
+
+# ---------------------------------------------------------------------------
+# #303 — num_rounds validation
+# ---------------------------------------------------------------------------
+
+
+class TestNumRoundsValidation:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("7", 7),       # numeric string coerced
+            (0, 1),         # clamp low
+            (-5, 1),        # clamp negative
+            (999, 50),      # clamp high
+            ("garbage", 10),  # unparseable → default
+            (None, 10),     # None → default
+        ],
+    )
+    async def test_num_rounds_clamped(
+        self,
+        handler: QuizifyWebSocketHandler,
+        game: QuizifyGameState,
+        raw,
+        expected: int,
+    ) -> None:
+        admin = _ws()
+        game.add_player("Markus", admin)
+        game.get_player("Markus").is_admin = True
+
+        await handler._handle_start_game(
+            admin,
+            {"category": "geographie", "num_rounds": raw, "language": "de",
+             "timer_duration": 30},
+            game,
+        )
+        assert game.total_rounds == expected
+        assert isinstance(game.total_rounds, int)
+
+
+# ---------------------------------------------------------------------------
+# #308 — empty-pack start error code
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyPackErrorCode:
+    @pytest.mark.asyncio
+    async def test_empty_pack_reports_no_questions_remaining(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        """Starting with a category that yields no questions must surface
+        NO_QUESTIONS_REMAINING — not the misleading GAME_ALREADY_STARTED."""
+        admin = _ws()
+        game.add_player("Markus", admin)
+        game.get_player("Markus").is_admin = True
+
+        await handler._handle_start_game(
+            admin,
+            {"category": "this-pack-does-not-exist", "num_rounds": 5,
+             "language": "de", "timer_duration": 30},
+            game,
+        )
+        handler._conn.send_error.assert_awaited()
+        code = handler._conn.send_error.await_args.args[1]
+        assert code == ERR_NO_QUESTIONS_REMAINING
+        assert code != ERR_GAME_ALREADY_STARTED
+
+
+# ---------------------------------------------------------------------------
+# #311 — admin_skip during QUESTION_ACTIVE
+# ---------------------------------------------------------------------------
+
+
+class TestAdminSkip:
+    @pytest.mark.asyncio
+    async def test_admin_skip_evaluates_live_question(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        """admin_skip mid-question must evaluate the round immediately
+        (→ ANSWER_REVEAL), instead of being a dead no-op (#311)."""
+        admin = _ws()
+        game.add_player("Markus", admin)
+        game.get_player("Markus").is_admin = True
+        game.start_game(category="geographie", num_rounds=5, language="de")
+        game.start_next_question()
+        assert game.phase == GamePhase.QUESTION_ACTIVE
+
+        await handler._handle_admin_skip(admin, game)
+
+        assert game.phase == GamePhase.ANSWER_REVEAL
+        # Not reported as an invalid action.
+        handler._conn.send_error.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_admin_skip_in_reveal_advances(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        """In ANSWER_REVEAL admin_skip behaves like a normal advance."""
+        admin = _ws()
+        game.add_player("Markus", admin)
+        game.get_player("Markus").is_admin = True
+        game.start_game(category="geographie", num_rounds=5, language="de")
+        game.start_next_question()
+        game.evaluate_round()
+        assert game.phase == GamePhase.ANSWER_REVEAL
+
+        await handler._handle_admin_skip(admin, game)
+        # Advanced into the next question.
+        assert game.phase == GamePhase.QUESTION_ACTIVE
+        assert game.round == 2
+
+
+# ---------------------------------------------------------------------------
+# #308 — admin "End lightning" scores the in-flight question
+# ---------------------------------------------------------------------------
+
+
+class TestEndLightningScoresInFlight:
+    @pytest.mark.asyncio
+    async def test_end_lightning_scores_current_answers(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        """When the admin ends the lightning round early, an already-tapped
+        correct answer on the in-flight question must still be scored (#308)
+        — previously lr.advance() was missing so those answers were discarded.
+        """
+        handler._broadcast_lightning_recap = AsyncMock()  # type: ignore[attr-defined]
+
+        player_ws = _ws()
+        game.add_player("A", player_ws)
+        assert game.start_lightning_round() is True
+        assert game.begin_lightning_questions() is True
+        lr = game.lightning
+        assert lr is not None
+
+        # Player A answers the in-flight question correctly.
+        q = lr.current_question
+        assert q is not None
+        correct_orig = next(i for i, a in enumerate(q.answers) if a.correct)
+        order = lr._shuffles["A"]
+        shuffled_idx = order.index(correct_orig)
+        assert lr.record_answer("A", shuffled_idx) is True
+        # Not yet scored — scoring happens on advance().
+        assert lr.scores["A"] == 0
+
+        await handler._handle_end_lightning(player_ws, game)
+
+        assert game.phase == GamePhase.LIGHTNING_RECAP
+        # The in-flight correct answer was scored before teardown.
+        assert lr.scores["A"] > 0
+        handler._broadcast_lightning_recap.assert_awaited()

--- a/tests/test_backend_correctness_batch.py
+++ b/tests/test_backend_correctness_batch.py
@@ -1,0 +1,371 @@
+"""Regression tests for the 2026-06-11 backend correctness/security batch.
+
+* #302 — auto-difficulty calibrator counts only SUBMITTERS, not idle tabs.
+* #308 — wager-with-0-bank no longer suppresses normal scoring;
+         score-breakdown components sum to the awarded points;
+         podium / leaderboard ties share a rank.
+* #309 — featured-pack theme is read from pack metadata (resolves community
+         packs whose on-disk path differs from their slug).
+* #305 — /flags response never leaks stored client IPs.
+* #310 — _pending_removals self-cleans on task completion + cancels on
+         re-schedule (no unbounded growth).
+* #307 — per-send timeout bounds a stalled WebSocket send.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.const import DIFFICULTY_AUTO  # noqa: E402
+from custom_components.quizify.game.scoring import calculate_round_score  # noqa: E402
+from custom_components.quizify.game.scoring_engine import ScoringEngine  # noqa: E402
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+from custom_components.quizify.game.types import Difficulty  # noqa: E402
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    serialize_finale,
+    serialize_leaderboard,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    def create_task(self, coro):
+        return asyncio.ensure_future(coro)
+
+    async def run_in_executor(self, func, *args):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func, *args)
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+def _correct_index(game: QuizifyGameState) -> int:
+    q = game._current_question
+    assert q is not None
+    return next(i for i, a in enumerate(q.answers) if a.correct)
+
+
+# ---------------------------------------------------------------------------
+# #302 — calibrator counts only submitters
+# ---------------------------------------------------------------------------
+
+
+class TestCalibratorSubmittersOnly:
+    def test_idle_tab_does_not_drag_difficulty(self, game: QuizifyGameState) -> None:
+        """In auto mode, a connected-but-idle player must NOT be counted as a
+        wrong answer — only players who actually submitted feed the signal."""
+        a, b = _ws(), _ws()
+        game.add_player("Answerer", a)
+        game.add_player("Idle", b)  # connected, never submits
+
+        game.start_game(difficulty=DIFFICULTY_AUTO, num_rounds=3, language="de")
+        assert game._calibrator is not None
+        captured: list[tuple[int, int]] = []
+        orig = game._calibrator.record_round
+
+        def _spy(correct: int, total: int) -> None:
+            captured.append((correct, total))
+            orig(correct=correct, total=total)
+
+        game._calibrator.record_round = _spy  # type: ignore[method-assign]
+
+        game.start_next_question()
+        # Only "Answerer" submits (correctly).
+        assert game.submit_answer("Answerer", _correct_index(game)).__class__  # sanity
+        game.evaluate_round()
+
+        assert captured, "calibrator.record_round was not called"
+        correct, total = captured[-1]
+        # total reflects the 1 submitter, NOT the 2 connected players.
+        assert total == 1
+        assert correct == 1
+
+    def test_zero_submitters_carries_no_signal(self, game: QuizifyGameState) -> None:
+        """A round where nobody submits → total 0 → calibrator ignores it."""
+        a = _ws()
+        game.add_player("A", a)
+        game.start_game(difficulty=DIFFICULTY_AUTO, num_rounds=3, language="de")
+        captured: list[tuple[int, int]] = []
+        assert game._calibrator is not None
+        game._calibrator.record_round = lambda correct, total: captured.append(  # type: ignore[method-assign]
+            (correct, total)
+        )
+
+        game.start_next_question()
+        game.evaluate_round()  # nobody submitted
+
+        assert captured[-1] == (0, 0)
+
+
+# ---------------------------------------------------------------------------
+# #308 — wager-with-0-bank no longer suppresses scoring
+# ---------------------------------------------------------------------------
+
+
+class TestWagerZeroBank:
+    def test_zero_bank_wager_does_not_suppress_normal_score(self) -> None:
+        engine = ScoringEngine()
+        # A 0-score player on the final round who "wagers" 100% (bank 0).
+        comp = engine.score_submission(
+            correct=True,
+            elapsed=0.0,
+            round_duration=30.0,
+            difficulty=Difficulty.MEDIUM,
+            streak=1,
+            double_points_active=False,
+            is_final_round=True,
+            wager=100,
+            score_before_wager=0,
+        )
+        # Normal scoring stands (the wager override is skipped at wager_pts==0).
+        expected = calculate_round_score(
+            correct=True,
+            elapsed=0.0,
+            time_limit=30.0,
+            difficulty=Difficulty.MEDIUM,
+            streak=1,
+        )
+        assert expected > 0
+        assert comp.points == expected
+        assert comp.wager_used is None
+
+    def test_nonzero_bank_wager_still_overrides(self) -> None:
+        engine = ScoringEngine()
+        comp = engine.score_submission(
+            correct=True,
+            elapsed=0.0,
+            round_duration=30.0,
+            difficulty=Difficulty.MEDIUM,
+            streak=1,
+            double_points_active=False,
+            is_final_round=True,
+            wager=50,
+            score_before_wager=200,
+        )
+        # 50% of 200 = 100; override replaces normal scoring.
+        assert comp.wager_used == 100
+        assert comp.points == 100
+
+
+# ---------------------------------------------------------------------------
+# #308 — score-breakdown sums to the awarded points
+# ---------------------------------------------------------------------------
+
+
+class TestBreakdownSums:
+    @pytest.mark.parametrize("difficulty", list(Difficulty))
+    @pytest.mark.parametrize("elapsed", [0.0, 3.7, 12.4, 29.9])
+    @pytest.mark.parametrize("streak", [0, 1, 3, 5, 9])
+    def test_base_plus_bonuses_equal_points(
+        self, difficulty: Difficulty, elapsed: float, streak: int
+    ) -> None:
+        engine = ScoringEngine()
+        comp = engine.score_submission(
+            correct=True,
+            elapsed=elapsed,
+            round_duration=30.0,
+            difficulty=difficulty,
+            streak=streak,
+            double_points_active=False,
+            is_final_round=False,
+            wager=None,
+            score_before_wager=0,
+        )
+        # base(10) + speed_bonus + streak_bonus must equal points minus the
+        # discrete milestone spike (which is surfaced separately).
+        base = 10
+        reconstructed = base + comp.speed_bonus + comp.streak_bonus + comp.milestone_bonus
+        assert reconstructed == comp.points
+        assert comp.speed_bonus >= 0
+        assert comp.streak_bonus >= 0
+
+
+# ---------------------------------------------------------------------------
+# #308 — podium / leaderboard ties share a rank
+# ---------------------------------------------------------------------------
+
+
+class _FakePlayer:
+    def __init__(self, name: str, score: int) -> None:
+        self.name = name
+        self.score = score
+        self.streak = 0
+        self.round_score = 0
+        self.round_history: list = []
+        self.round_score_breakdown: dict = {}
+        self.color = "#000"
+        self.is_admin = False
+        self.submitted = False
+        self.max_streak = 0
+        self.powerups_used = 0
+
+
+class TestTiesShareRank:
+    def test_leaderboard_ties_share_rank(self) -> None:
+        players = [
+            _FakePlayer("A", 100),
+            _FakePlayer("B", 100),
+            _FakePlayer("C", 50),
+        ]
+        lb = serialize_leaderboard(players)
+        ranks = {row["name"]: row["rank"] for row in lb}
+        assert ranks["A"] == 1
+        assert ranks["B"] == 1  # tied, same rank
+        assert ranks["C"] == 3  # rank 2 skipped (competition ranking)
+
+    def test_podium_ties_share_rank(self) -> None:
+        podium = [
+            _FakePlayer("A", 100),
+            _FakePlayer("B", 100),
+            _FakePlayer("C", 80),
+        ]
+        out = serialize_finale(podium, podium)
+        pranks = {e["name"]: e["rank"] for e in out["podium"]}
+        assert pranks["A"] == 1
+        assert pranks["B"] == 1
+        assert pranks["C"] == 3
+
+
+# ---------------------------------------------------------------------------
+# #309 — featured-pack theme stored in pack metadata at load time
+# ---------------------------------------------------------------------------
+
+
+class TestPackThemeMetadata:
+    def test_builtin_pack_metadata_carries_theme(self) -> None:
+        from custom_components.quizify.game.questions import QuestionBank
+
+        qb = QuestionBank()
+        qb.load_all_categories()
+        versions = qb.get_pack_versions()
+        assert versions, "no packs loaded"
+        # Every loaded pack exposes a (possibly empty) string theme in metadata.
+        for slug, meta in versions.items():
+            assert "theme" in meta, f"{slug} missing theme in metadata"
+            assert isinstance(meta["theme"], str)
+        # At least one built-in pack has a non-empty theme.
+        assert any(meta["theme"] for meta in versions.values())
+
+    def test_community_pack_theme_resolves_from_metadata(self, tmp_path: Path) -> None:
+        """A community pack (under questions/community/<stem>.json, ``community-``
+        slug) must surface its theme via metadata — the path the old views.py
+        file-read missed (#309)."""
+        import json as _json
+
+        from custom_components.quizify.game.questions import (
+            COMMUNITY_SUBDIR,
+            QuestionBank,
+        )
+
+        qb = QuestionBank(questions_dir=tmp_path)
+        community = tmp_path / COMMUNITY_SUBDIR
+        community.mkdir(parents=True)
+        (community / "mypack.json").write_text(
+            _json.dumps(
+                {
+                    "name": "My Pack",
+                    "language": "de",
+                    "theme": "geography",
+                    "questions": [
+                        {
+                            "id": "q1",
+                            "question": "Hauptstadt von Frankreich?",
+                            "answers": [
+                                {"text": "Paris", "correct": True},
+                                {"text": "Rom", "correct": False},
+                                {"text": "Madrid", "correct": False},
+                            ],
+                            "difficulty": "easy",
+                        }
+                    ],
+                }
+            )
+        )
+        qb.load_community_packs()
+        versions = qb.get_pack_versions()
+        slug = next(s for s in versions if s.startswith("community-"))
+        assert versions[slug]["theme"] == "geography"
+
+
+# ---------------------------------------------------------------------------
+# #305 — /flags never returns stored client IPs
+# ---------------------------------------------------------------------------
+
+
+class _ExecRuntime:
+    """Runtime whose run_in_executor runs the func inline (sync) in-thread."""
+
+    def __init__(self, data_dir: Path) -> None:
+        self.data_dir = data_dir
+
+    async def run_in_executor(self, func, *args):
+        return func(*args)
+
+
+class _FlagRequest:
+    def __init__(self, ctx) -> None:  # noqa: ANN001
+        from custom_components.quizify.server.context import APP_CTX_KEY
+
+        self.app = {APP_CTX_KEY: ctx}
+
+
+class TestFlagListNoIpLeak:
+    @pytest.mark.asyncio
+    async def test_remote_ip_stripped_from_response(self, tmp_path: Path) -> None:
+        import json as _json
+        from types import SimpleNamespace
+
+        from custom_components.quizify.server.views import (
+            _FLAG_FILE,
+            flag_list_view,
+        )
+
+        # Write a flag entry that includes a stored client IP (as flag_view does).
+        flag_path = tmp_path / _FLAG_FILE
+        flag_path.write_text(
+            _json.dumps(
+                {
+                    "ts": 1,
+                    "question_id": "q1",
+                    "reason": "bad",
+                    "player_name": "Foo",
+                    "remote": "203.0.113.42",
+                }
+            )
+            + "\n"
+        )
+
+        ctx = SimpleNamespace(runtime=_ExecRuntime(tmp_path))
+        resp = await flag_list_view(_FlagRequest(ctx))  # type: ignore[arg-type]
+        payload = _json.loads(resp.body)
+
+        assert payload["flags"], "no flags returned"
+        for entry in payload["flags"]:
+            assert "remote" not in entry, "client IP leaked to unauth caller"
+        # The non-sensitive fields are still present.
+        assert payload["flags"][0]["question_id"] == "q1"
+        assert payload["flags"][0]["reason"] == "bad"

--- a/tests/test_connection_layer_batch.py
+++ b/tests/test_connection_layer_batch.py
@@ -1,0 +1,150 @@
+"""Regression tests for the connection-layer fixes in the 2026-06-11 batch.
+
+* #310 — _pending_removals self-cleans when a removal task finishes, and an
+         existing pending task is cancelled before being overwritten (no
+         unbounded growth, no orphaned task).
+* #307 — a stalled WebSocket send is bounded by a per-send timeout so it can't
+         pin the whole broadcast fan-out.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+@pytest.fixture
+def conn(tmp_path: Path) -> ConnectionManager:
+    return ConnectionManager(_FakeRuntime(tmp_path), lambda: None)
+
+
+# ---------------------------------------------------------------------------
+# #310 — _pending_removals bounded
+# ---------------------------------------------------------------------------
+
+
+class TestPendingRemovalsBounded:
+    @pytest.mark.asyncio
+    async def test_completed_task_pops_itself(self, conn: ConnectionManager) -> None:
+        """A removal task that runs to completion must drop its own registry
+        entry — otherwise one done-Task per removed player accumulates forever.
+        """
+        async def _noop(name: str, timeout: float) -> None:
+            return None
+
+        conn.schedule_player_removal("Alice", 0.0, _noop)
+        assert "Alice" in conn._pending_removals
+        # Let the task complete; the done-callback then pops the entry.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert "Alice" not in conn._pending_removals
+
+    @pytest.mark.asyncio
+    async def test_reschedule_cancels_previous_task(
+        self, conn: ConnectionManager
+    ) -> None:
+        """Re-scheduling a removal for the same name must cancel the prior
+        still-pending task instead of silently dropping it (orphan leak)."""
+        started: list[str] = []
+
+        async def _slow(name: str, timeout: float) -> None:
+            started.append(name)
+            await asyncio.sleep(60)
+
+        conn.schedule_player_removal("Bob", 60.0, _slow)
+        first = conn._pending_removals["Bob"]
+        conn.schedule_player_removal("Bob", 60.0, _slow)
+        second = conn._pending_removals["Bob"]
+
+        await asyncio.sleep(0)
+        assert first is not second
+        assert first.cancelled() or first.done()
+        assert not second.done()
+        second.cancel()
+
+    @pytest.mark.asyncio
+    async def test_cancel_pending_removal_still_works(
+        self, conn: ConnectionManager
+    ) -> None:
+        """The reconnect cancel path is unaffected by the done-callback."""
+        async def _slow(name: str, timeout: float) -> None:
+            await asyncio.sleep(60)
+
+        conn.schedule_player_removal("Carol", 60.0, _slow)
+        assert "Carol" in conn._pending_removals
+        conn.cancel_pending_removal("Carol")
+        assert "Carol" not in conn._pending_removals
+
+
+# ---------------------------------------------------------------------------
+# #307 — per-send timeout
+# ---------------------------------------------------------------------------
+
+
+class TestSendTimeout:
+    @pytest.mark.asyncio
+    async def test_broadcast_str_send_times_out_and_is_swallowed(
+        self, conn: ConnectionManager, monkeypatch
+    ) -> None:
+        """A WebSocket whose send_str hangs must be bounded by the per-send
+        timeout and swallowed, not pin the broadcast (#307)."""
+        # Shrink the timeout so the test is fast.
+        monkeypatch.setattr(ConnectionManager, "_SEND_TIMEOUT", 0.05)
+
+        stalled = MagicMock()
+        stalled.closed = False
+
+        async def _hang(_payload):
+            await asyncio.sleep(60)
+
+        stalled.send_str = _hang
+
+        # Should return promptly (within the timeout), not after 60s.
+        await asyncio.wait_for(
+            conn._safe_send_str(stalled, "{}"), timeout=1.0
+        )
+
+    @pytest.mark.asyncio
+    async def test_broadcast_continues_past_stalled_client(
+        self, conn: ConnectionManager, monkeypatch
+    ) -> None:
+        """One stalled client must not prevent a healthy client from receiving
+        the broadcast."""
+        monkeypatch.setattr(ConnectionManager, "_SEND_TIMEOUT", 0.05)
+        delivered: list[str] = []
+
+        healthy = MagicMock()
+        healthy.closed = False
+
+        async def _ok(payload):
+            delivered.append(payload)
+
+        healthy.send_str = _ok
+
+        stalled = MagicMock()
+        stalled.closed = False
+
+        async def _hang(_payload):
+            await asyncio.sleep(60)
+
+        stalled.send_str = _hang
+
+        conn.connections.add(healthy)
+        conn.connections.add(stalled)
+
+        await asyncio.wait_for(conn.broadcast({"type": "ping"}), timeout=1.0)
+        assert delivered, "healthy client never received the broadcast"

--- a/tests/test_featured_pack_260.py
+++ b/tests/test_featured_pack_260.py
@@ -55,7 +55,22 @@ class _FakeBank:
         return self._questions_dir
 
     def get_pack_versions(self) -> dict:
-        return dict(self._pack_versions)
+        # Mirror the real QuestionBank (#309): the pack's ``theme`` is captured
+        # into metadata at load time, not re-read from disk per request. If a
+        # test wrote a pack file with a theme, fold it into the metadata here so
+        # the metadata is the single source of truth the view reads.
+        out = {}
+        for slug, meta in self._pack_versions.items():
+            meta = dict(meta)
+            if "theme" not in meta:
+                pack_file = self._questions_dir / f"{slug}.json"
+                if pack_file.exists():
+                    try:
+                        meta["theme"] = json.loads(pack_file.read_text()).get("theme", "")
+                    except (ValueError, OSError):
+                        meta["theme"] = ""
+            out[slug] = meta
+        return out
 
 
 class _FakeAnalytics:

--- a/tests/test_ws_handle_integration_293.py
+++ b/tests/test_ws_handle_integration_293.py
@@ -1,0 +1,253 @@
+"""WS connection-layer integration tests (issue #293).
+
+The whole ``QuizifyWebSocketHandler.handle()`` entry point — admin auth matrix,
+disconnect cleanup, and the admin-disconnect grace — had zero coverage (49%).
+These drive the *real* handler over a live aiohttp ``TestClient`` WebSocket so
+the auth grant rules and the disconnect path (including the #293 fix that
+captures the admin flag BEFORE remove_connection) are exercised end to end.
+
+Plus a reconnect happy-path test at the handler level: a valid session token
+re-attaches the player and the server replies ``reconnected`` with a rotated
+token.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server import WS_PATH  # noqa: E402
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    def create_task(self, coro):
+        return asyncio.ensure_future(coro)
+
+    async def run_in_executor(self, func, *args):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func, *args)
+
+
+def _ws_mock() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+@pytest.fixture
+def handler(game: QuizifyGameState) -> QuizifyWebSocketHandler:
+    runtime = _FakeRuntime(game._runtime.data_dir)  # type: ignore[attr-defined]
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    h._conn = ConnectionManager(runtime, lambda: game)
+    return h
+
+
+async def _make_client(handler: QuizifyWebSocketHandler) -> TestClient:
+    app = web.Application()
+    app.router.add_get(WS_PATH, handler.handle)
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    return client
+
+
+async def _connect(client: TestClient, query: str = ""):
+    """Open a WS and yield to the loop so the server's handle() has run far
+    enough to register the connection (add_connection) before we assert on it."""
+    ws = await client.ws_connect(WS_PATH + query)
+    # The client's ws_connect returns at handshake time; the server's
+    # add_connection runs a tick later. Let the server task progress.
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if client.app.router:  # always truthy; just yields control
+            if len(_handler_of(client)._conn.connections) >= 1:
+                break
+    return ws
+
+
+def _handler_of(client: TestClient) -> QuizifyWebSocketHandler:
+    # The route handler is the bound handle() method; recover its instance.
+    for route in client.app.router.routes():
+        h = route.handler
+        if hasattr(h, "__self__"):
+            return h.__self__  # type: ignore[return-value]
+    raise AssertionError("handler not found on app")
+
+
+# ---------------------------------------------------------------------------
+# #293 — admin auth matrix over the live handle()
+# ---------------------------------------------------------------------------
+
+
+class TestAdminAuthMatrix:
+    @pytest.mark.asyncio
+    async def test_fresh_install_bootstrap_grants_admin(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """First-ever ?role=admin connect on a fresh install bootstraps admin
+        and a token is persisted."""
+        client = await _make_client(handler)
+        try:
+            ws = await _connect(client, "?role=admin")
+            # Bootstrap must have granted admin and persisted a token.
+            assert handler._conn._admin_session_token is not None
+            assert len(handler._conn._admin_connections) == 1
+            await ws.close()
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_valid_token_grants_admin(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """A connect carrying the persisted token is granted admin (reconnect
+        path)."""
+        # Seed a known token.
+        token = handler._conn.get_or_create_admin_token()
+        client = await _make_client(handler)
+        try:
+            ws = await _connect(client, f"?role=admin&token={token}")
+            assert len(handler._conn._admin_connections) == 1
+            await ws.close()
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_rejected_to_player(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """A wrong token (after a token already exists) is NOT granted admin —
+        the connection drops to player role only."""
+        handler._conn.get_or_create_admin_token()  # a token now exists
+        client = await _make_client(handler)
+        try:
+            ws = await _connect(client, "?role=admin&token=wrong-token")
+            assert len(handler._conn._admin_connections) == 0
+            await ws.close()
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_no_token_player_only(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """A plain player connect (no role) is never admin."""
+        handler._conn.get_or_create_admin_token()
+        client = await _make_client(handler)
+        try:
+            ws = await _connect(client)
+            assert len(handler._conn._admin_connections) == 0
+            assert len(handler._conn.connections) == 1
+            await ws.close()
+        finally:
+            await client.close()
+
+
+# ---------------------------------------------------------------------------
+# #293 — disconnect cleanup + admin grace actually fires
+# ---------------------------------------------------------------------------
+
+
+class TestDisconnectCleanup:
+    @pytest.mark.asyncio
+    async def test_disconnect_removes_connection(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        client = await _make_client(handler)
+        try:
+            ws = await _connect(client)
+            assert len(handler._conn.connections) == 1
+            await ws.close()
+            # Give the server's finally-block a moment to run.
+            await asyncio.sleep(0.1)
+            assert len(handler._conn.connections) == 0
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_admin_disconnect_schedules_grace_timeout(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """#293 core fix: on the LAST admin disconnect the admin-session grace
+        timeout must actually be scheduled. Before the fix, remove_connection
+        ran first so is_admin_connection() was already False and the timeout
+        never armed."""
+        client = await _make_client(handler)
+        try:
+            ws = await _connect(client, "?role=admin")
+            assert len(handler._conn._admin_connections) == 1
+            await ws.close()
+            await asyncio.sleep(0.1)
+            # The grace task must be pending now (it clears the token after
+            # ADMIN_SESSION_GRACE seconds; we only assert it was armed).
+            assert handler._conn.has_pending_admin_disconnect()
+            # Clean up the pending task so it doesn't leak.
+            handler._conn.cancel_admin_disconnect()
+        finally:
+            await client.close()
+
+
+# ---------------------------------------------------------------------------
+# #293 — reconnect happy path (handler level)
+# ---------------------------------------------------------------------------
+
+
+class TestReconnectHappyPath:
+    @pytest.mark.asyncio
+    async def test_valid_token_reattaches_and_rotates(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        handler._conn.broadcast = AsyncMock()  # type: ignore[method-assign]
+
+        # A player exists and holds a valid session token.
+        old_ws = _ws_mock()
+        game.add_player("Dora", old_ws)
+        token = handler._conn.create_session_token("Dora")
+        # Simulate the player having dropped.
+        game.get_player("Dora").connected = False
+
+        new_ws = _ws_mock()
+        await handler._handle_reconnect(
+            new_ws, {"session_token": token, "name": "Dora"}, game
+        )
+
+        # Player re-attached to the new ws + marked connected.
+        player = game.get_player("Dora")
+        assert player.connected is True
+        assert player.ws is new_ws
+
+        # Server replied `reconnected` with a rotated (different) token.
+        sent = [
+            c.args[0] for c in new_ws.send_json.await_args_list
+            if c.args and isinstance(c.args[0], dict)
+        ]
+        reconnected = next(m for m in sent if m.get("type") == "reconnected")
+        assert reconnected["player_id"] == "Dora"
+        assert reconnected["session_token"] != token
+        # Old token revoked, new token resolves to the player.
+        assert handler._conn.get_player_for_token(token) is None
+        assert (
+            handler._conn.get_player_for_token(reconnected["session_token"]) == "Dora"
+        )


### PR DESCRIPTION
Backend bug-fix batch from the 2026-06-11 Fable comprehensive review. Scope is strictly `server/`, `game/`, `tests/` — no `cf-workers/` or `www/` touched (those run in parallel PRs). Commits are organized by issue.

## Fully fixed (closed by this PR)

Closes #298 — `next_round`/`next_question` were accepted in a real LOBBY (start_game doesn't change phase). A stray advance ended an empty queue → empty-podium FINALE, or started a round with `game_id=None`. Now gated on `game_id is not None` when phase is LOBBY; the internal start→first-question path is unaffected.

Closes #302 — auto-difficulty calibrator counted every connected-but-idle tab as wrong, dragging difficulty easier. Signal now based on `p.submitted` (`total<=0` still carries no signal), consistent with `question_stats.record_round`.

Closes #303 — `num_rounds` from the WS was applied raw (non-int → TypeError every round; 0/negative → instant FINALE). Now `int()` + clamp to 1..50, fallback 10, mirroring the timer validation.

Closes #307 — broadcast fan-out had no per-send timeout (a half-dead phone could pin `drain()` to the 30s heartbeat room-wide): each send is now wrapped in `asyncio.wait_for(..., 2s)`, TimeoutError swallowed like other send errors. The tick and lightning loops caught only `CancelledError` and died silently on anything else (frozen countdown): both now `except Exception: _LOGGER.exception(...)`, and the fire-and-forget background tasks get a logging done-callback (analytics.py pattern).

Closes #309 — featured-pack theme was re-read per request from `questions_dir / f"{chosen}.json"`, which never resolved community packs (they live at `questions/community/<stem>.json` under a `community-` slug) → default 🎲 icon. Theme is now stored in pack metadata at load time (built-in + community) and read from there — fixes the icon and drops a blocking re-parse from the hot path.

Closes #310 — `_pending_removals` retained one done-Task per removed player name forever (the only unbounded structure in the codebase). A `add_done_callback` now pops the entry on completion (guarded against clobbering a re-scheduled task) and an existing task is cancelled before overwriting.

Closes #293 — admin-disconnect grace was dead code: `handle()`'s `finally` ran `remove_connection(ws)` before `_handle_disconnect`, so `is_admin_connection(ws)` was always False → `schedule_admin_timeout` never fired. The admin flag is now captured BEFORE `remove_connection` and passed into `_handle_disconnect`. Also adds the WS-layer tests the reviewer asked for (websocket.py was 49% covered): an aiohttp `TestClient` integration test for `handle()` (admin auth matrix: bootstrap grant / valid-token grant / invalid-token reject / no-token player; disconnect cleanup + grace-timeout arming) and a reconnect happy-path handler test.

## Partially fixed — backend done, www remnant tracked separately (NOT auto-closed)

**#308** — Correctness LOWs batch. Backend items fixed:
- [x] Podium/leaderboard ties share a rank (competition ranking 1,1,3,…) instead of insertion order.
- [x] Score-breakdown ints now sum to the awarded points (`base + speed + streak == points`; streak_bonus derived as the exact remainder instead of independently truncated).
- [x] Wager against a 0-point bank no longer suppresses normal scoring (override skipped when `wager_pts==0`).
- [x] Empty-pack start surfaces `NO_QUESTIONS_REMAINING` instead of `ERR_GAME_ALREADY_STARTED`.
- [x] Admin "End lightning" scores the in-flight question's answers (`lr.advance()` before `finish_lightning_round()`).
- [ ] **Deferred (www):** reveal correct-answer highlight by text match (`www/js/player-reveal.js`) — two identical answer texts highlight the wrong button. Left for a www PR.

**#311** — `admin_skip` dead mid-question.
- [x] Backend: `admin_skip` now evaluates the round immediately during QUESTION_ACTIVE (→ ANSWER_REVEAL).
- [ ] **Deferred (www):** the client skip button is still hidden during question/reveal (`www/js/player-core.js`). Until that's unhidden the new backend path isn't reachable from the default UI. Left for a www PR.

**#305** — Security: player-IP disclosure + Markdown injection.
- [x] Backend: `/api/quizify/flags` no longer returns the stored client IP (`remote` dropped from the response; still stored on disk for forensics).
- [ ] **Deferred (cf-workers):** the worker `esc()` Markdown-injection half is handled by the separate security PR — not touched here.

## Tests

Baseline (main): 488 passed / 2 skipped. After this PR: **581 passed / 2 skipped** (+93 new cases, parametrized). New files:
- `tests/test_backend_bugs_batch.py` — #298, #303, #308 (error code + end-lightning), #311
- `tests/test_backend_correctness_batch.py` — #302, #308 (wager/breakdown/ties), #309, #305
- `tests/test_connection_layer_batch.py` — #307 (send timeout), #310
- `tests/test_ws_handle_integration_293.py` — #293 (aiohttp TestClient auth matrix + disconnect + reconnect)
- `tests/test_featured_pack_260.py` updated for the #309 metadata-theme path.

Labels: bug, code-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
