### PR TITLE
fix(www): un-hide admin skip button (#311) + index-based reveal highlight (#308)

### DIFF
--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -666,7 +666,11 @@
         var pauseBtn = document.getElementById('pause-game-btn');
         var resumeBtn = document.getElementById('resume-game-btn');
         if (nextRoundAdminBtn) nextRoundAdminBtn.classList.add('hidden');
-        if (skipBtn) skipBtn.classList.add('hidden');
+        // QUESTION_ACTIVE → the admin (admin-as-player) can skip a live or
+        // broken question. The backend (#318) now evaluates the round on
+        // admin_skip during QUESTION_ACTIVE, so this path is reachable.
+        // Stays hidden for non-admins and outside an active question.
+        if (skipBtn) skipBtn.classList.toggle('hidden', !state.isAdmin);
         // QUESTION_ACTIVE → Pause is the relevant CTA, Resume hidden.
         if (pauseBtn) pauseBtn.classList.remove('hidden');
         if (resumeBtn) resumeBtn.classList.add('hidden');

--- a/custom_components/quizify/www/js/player-reveal.js
+++ b/custom_components/quizify/www/js/player-reveal.js
@@ -82,10 +82,11 @@
         // Fun fact
         renderFunFact(data.fun_fact);
 
-        // Flash answer buttons correct/wrong. Per-player shuffle means
-        // the server's `correct_answer_index` is in the CANONICAL shuffle
-        // and doesn't match this player's button positions. We match by
-        // text instead.
+        // Flash answer buttons correct/wrong. Per-player shuffle means the
+        // server's `correct_answer_index` is in the CANONICAL shuffle and
+        // doesn't match this player's button positions, so flashAnswerButtons
+        // resolves the correct *button index* locally (see its comment) —
+        // index-based to stay correct even with duplicate answer texts (#308).
         flashAnswerButtons(data.correct_answer, myAnswerEntry);
 
         // New result page: hero + answer strip + standings (with medals)
@@ -686,21 +687,61 @@
 
         var mySubmittedIndex = game && game.getLastSubmittedIndex ? game.getLastSubmittedIndex() : -1;
 
-        // Match by TEXT, not shuffled index. With per-player shuffles
-        // the server's correct_answer_index would be in a different
-        // shuffle than this player's buttons. The button text is the
-        // ground truth that survives any reshuffling.
+        // Highlight the correct answer by INDEX, not by text (#308).
+        //
+        // The old code matched the button whose *text* equalled
+        // correct_answer — but a question with two identical answer texts
+        // would highlight the wrong (first-matching) button. We resolve a
+        // single correct *button index* instead.
+        //
+        // Per-player shuffle subtlety: answer buttons are in THIS player's
+        // own shuffled order. The server's `correct_answer_index` is in the
+        // CANONICAL shuffle (not this player's), and `all_answers[].answer_index`
+        // is the ORIGINAL question index — neither maps to a button position
+        // on the client, and the reveal payload carries no per-player correct
+        // button index. So we use the index information we DO have locally:
+        //
+        //   1. If this player answered CORRECTLY, their own submitted button
+        //      position IS the correct button — exact, immune to duplicate
+        //      texts. (`mySubmittedIndex` is the button position the player
+        //      tapped; `myEntry.correct` confirms it was right.)
+        //   2. Otherwise we fall back to text, but skip the player's own
+        //      wrong button when it shares the correct text (the common
+        //      duplicate-text collision), and on a remaining tie pick the
+        //      first match.
+        //
+        // A fully robust fix (correct even when a non-answering / wrong
+        // player faces duplicate correct-texts) requires the server to send
+        // a per-player correct button index in the reveal payload — that is a
+        // server/ change, out of scope for this www-only PR.
         function _buttonAnswerText(btn) {
             var span = btn.querySelector('.answer-btn-text, .answer-text, span');
             return (span ? span.textContent : btn.textContent || '').trim();
         }
         var correctText = (correctAnswerText || '').trim();
 
+        var correctIndex = -1;
+        if (myEntry && myEntry.correct && mySubmittedIndex >= 0 && mySubmittedIndex < buttons.length) {
+            // (1) We answered right → our tapped button is the correct one.
+            correctIndex = mySubmittedIndex;
+        } else if (correctText) {
+            // (2) Resolve by text, preferring a match that isn't our own
+            //     known-wrong button (resolves the duplicate-text trap for
+            //     the wrong-answerer case); else first match.
+            var firstMatch = -1;
+            for (var bi = 0; bi < buttons.length; bi++) {
+                if (_buttonAnswerText(buttons[bi]) === correctText) {
+                    if (firstMatch === -1) firstMatch = bi;
+                    if (bi !== mySubmittedIndex) { correctIndex = bi; break; }
+                }
+            }
+            if (correctIndex === -1) correctIndex = firstMatch;
+        }
+
         buttons.forEach(function(btn, i) {
-            var btnText = _buttonAnswerText(btn);
             btn.classList.remove('is-selected');
 
-            if (correctText && btnText === correctText) {
+            if (i === correctIndex) {
                 btn.classList.add('correct');
             } else if (i === mySubmittedIndex && (!myEntry || !myEntry.correct)) {
                 btn.classList.add('wrong');
@@ -709,9 +750,9 @@
             }
         });
 
-        if (myEntry && !myEntry.correct && mySubmittedIndex >= 0) {
+        if (myEntry && !myEntry.correct && mySubmittedIndex >= 0 && mySubmittedIndex !== correctIndex) {
             var wrongBtn = buttons[mySubmittedIndex];
-            if (wrongBtn) { wrongBtn.classList.remove('dimmed'); wrongBtn.classList.add('wrong'); }
+            if (wrongBtn) { wrongBtn.classList.remove('dimmed', 'correct'); wrongBtn.classList.add('wrong'); }
         }
     }
 

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -1343,10 +1343,11 @@
         // Fun fact
         renderFunFact(data.fun_fact);
 
-        // Flash answer buttons correct/wrong. Per-player shuffle means
-        // the server's `correct_answer_index` is in the CANONICAL shuffle
-        // and doesn't match this player's button positions. We match by
-        // text instead.
+        // Flash answer buttons correct/wrong. Per-player shuffle means the
+        // server's `correct_answer_index` is in the CANONICAL shuffle and
+        // doesn't match this player's button positions, so flashAnswerButtons
+        // resolves the correct *button index* locally (see its comment) —
+        // index-based to stay correct even with duplicate answer texts (#308).
         flashAnswerButtons(data.correct_answer, myAnswerEntry);
 
         // New result page: hero + answer strip + standings (with medals)
@@ -1947,21 +1948,61 @@
 
         var mySubmittedIndex = game && game.getLastSubmittedIndex ? game.getLastSubmittedIndex() : -1;
 
-        // Match by TEXT, not shuffled index. With per-player shuffles
-        // the server's correct_answer_index would be in a different
-        // shuffle than this player's buttons. The button text is the
-        // ground truth that survives any reshuffling.
+        // Highlight the correct answer by INDEX, not by text (#308).
+        //
+        // The old code matched the button whose *text* equalled
+        // correct_answer — but a question with two identical answer texts
+        // would highlight the wrong (first-matching) button. We resolve a
+        // single correct *button index* instead.
+        //
+        // Per-player shuffle subtlety: answer buttons are in THIS player's
+        // own shuffled order. The server's `correct_answer_index` is in the
+        // CANONICAL shuffle (not this player's), and `all_answers[].answer_index`
+        // is the ORIGINAL question index — neither maps to a button position
+        // on the client, and the reveal payload carries no per-player correct
+        // button index. So we use the index information we DO have locally:
+        //
+        //   1. If this player answered CORRECTLY, their own submitted button
+        //      position IS the correct button — exact, immune to duplicate
+        //      texts. (`mySubmittedIndex` is the button position the player
+        //      tapped; `myEntry.correct` confirms it was right.)
+        //   2. Otherwise we fall back to text, but skip the player's own
+        //      wrong button when it shares the correct text (the common
+        //      duplicate-text collision), and on a remaining tie pick the
+        //      first match.
+        //
+        // A fully robust fix (correct even when a non-answering / wrong
+        // player faces duplicate correct-texts) requires the server to send
+        // a per-player correct button index in the reveal payload — that is a
+        // server/ change, out of scope for this www-only PR.
         function _buttonAnswerText(btn) {
             var span = btn.querySelector('.answer-btn-text, .answer-text, span');
             return (span ? span.textContent : btn.textContent || '').trim();
         }
         var correctText = (correctAnswerText || '').trim();
 
+        var correctIndex = -1;
+        if (myEntry && myEntry.correct && mySubmittedIndex >= 0 && mySubmittedIndex < buttons.length) {
+            // (1) We answered right → our tapped button is the correct one.
+            correctIndex = mySubmittedIndex;
+        } else if (correctText) {
+            // (2) Resolve by text, preferring a match that isn't our own
+            //     known-wrong button (resolves the duplicate-text trap for
+            //     the wrong-answerer case); else first match.
+            var firstMatch = -1;
+            for (var bi = 0; bi < buttons.length; bi++) {
+                if (_buttonAnswerText(buttons[bi]) === correctText) {
+                    if (firstMatch === -1) firstMatch = bi;
+                    if (bi !== mySubmittedIndex) { correctIndex = bi; break; }
+                }
+            }
+            if (correctIndex === -1) correctIndex = firstMatch;
+        }
+
         buttons.forEach(function(btn, i) {
-            var btnText = _buttonAnswerText(btn);
             btn.classList.remove('is-selected');
 
-            if (correctText && btnText === correctText) {
+            if (i === correctIndex) {
                 btn.classList.add('correct');
             } else if (i === mySubmittedIndex && (!myEntry || !myEntry.correct)) {
                 btn.classList.add('wrong');
@@ -1970,9 +2011,9 @@
             }
         });
 
-        if (myEntry && !myEntry.correct && mySubmittedIndex >= 0) {
+        if (myEntry && !myEntry.correct && mySubmittedIndex >= 0 && mySubmittedIndex !== correctIndex) {
             var wrongBtn = buttons[mySubmittedIndex];
-            if (wrongBtn) { wrongBtn.classList.remove('dimmed'); wrongBtn.classList.add('wrong'); }
+            if (wrongBtn) { wrongBtn.classList.remove('dimmed', 'correct'); wrongBtn.classList.add('wrong'); }
         }
     }
 
@@ -4308,7 +4349,11 @@
         var pauseBtn = document.getElementById('pause-game-btn');
         var resumeBtn = document.getElementById('resume-game-btn');
         if (nextRoundAdminBtn) nextRoundAdminBtn.classList.add('hidden');
-        if (skipBtn) skipBtn.classList.add('hidden');
+        // QUESTION_ACTIVE → the admin (admin-as-player) can skip a live or
+        // broken question. The backend (#318) now evaluates the round on
+        // admin_skip during QUESTION_ACTIVE, so this path is reachable.
+        // Stays hidden for non-admins and outside an active question.
+        if (skipBtn) skipBtn.classList.toggle('hidden', !state.isAdmin);
         // QUESTION_ACTIVE → Pause is the relevant CTA, Resume hidden.
         if (pauseBtn) pauseBtn.classList.remove('hidden');
         if (resumeBtn) resumeBtn.classList.add('hidden');


### PR DESCRIPTION
## www remnants of the #318 backend batch

Two issues had their backend halves merged in #318 but left www-side remnants. This PR implements those www halves. **www/ only — no server/ files touched.**

### #311 — un-hide the admin skip button (fully fixed → Closes #311)
The backend (#318) made `admin_skip` evaluate the round during `QUESTION_ACTIVE`, so a host can now skip a live or broken question. But the client `skip-question-btn` was still force-hidden in `handleQuestionStarted` (`player-core.js`), so the path was unreachable.

**Change:** the skip button is now visible for the **admin (admin-as-player)** during `QUESTION_ACTIVE`, and stays hidden for non-admins and at reveal (`classList.toggle('hidden', !state.isAdmin)`).

Everything else already existed and is reused as-is — no new design invented:
- HTML button `#skip-question-btn` with `data-i18n="admin.skip"`.
- i18n key `admin.skip` present in **both** locales (`de.json` "Überspringen", `en.json` "Skip") — no i18n addition needed (only these two locale files exist).
- Click wiring already sends the exact message the backend routes:

```js
send('admin_skip', {});   // → {type: "admin_skip"}
```

`_handle_admin_skip(ws, game_state)` takes no extra params, so the empty `{}` payload is correct.

### #308 — reveal highlighted the correct answer by TEXT match (partial → references #308, does NOT close)
`flashAnswerButtons` in `player-reveal.js` matched the correct button by **answer text**. A question with two identical answer texts highlighted the wrong (first-matching) button.

**Change:** highlight by **INDEX** instead of text.

**Per-player-shuffle subtlety (the reason this can't be 100% client-side):** answer buttons are in *this player's own* shuffled order. The reveal payload exposes:
- `correct_answer_index` — in the **canonical** shuffle (not this player's).
- `all_answers[].answer_index` — the **original** question-JSON index.

Neither maps to a button position on the client, and there is **no per-player correct button index** in the payload. So the client uses the index information it *does* have locally:

1. If the player **answered correctly**, their own tapped button position (`getLastSubmittedIndex()`, confirmed by `myEntry.correct`) **is** the correct button — exact and immune to duplicate texts.
2. Otherwise resolve by text but **skip the player's own known-wrong button** on a duplicate-text tie (resolves the common wrong-answerer collision); fall back to first match.

**Remaining server work (why #308 stays open):** the fully robust case — a wrong/non-answering player facing a question with duplicate correct-texts — still can't be disambiguated client-side. The proper fix is for the server to emit a **per-player correct button index** in the reveal payload (e.g. project the correct answer through each player's shuffle in `round_message_builder.build_round_summary` / `serializers.serialize_round_summary`). That's a `server/` change and out of scope for this www-only PR. This PR is the best client-only mitigation; #308 should stay open for the server-side index.

## Build / test
- Bundle **rebuilt** via `scripts/build_bundle.py` (`player.bundle.js` regenerated, byte-identical to sources).
- No CSS change — reuses existing `.correct` / `.wrong` / `.dimmed` classes, so no `build_css.py` run.
- `node --check` clean on `player-core.js`, `player-reveal.js`, and the rebuilt `player.bundle.js`.
- Python suite: **591 passed**; 6 `test_ws_handle_integration_293.py` failures are pre-existing `pytest-socket` `SocketBlockedError`s (verified identical on pristine `main` HEAD with the changes stashed) and are unrelated to this www-only change.

## ⚠️ Needs live/mobile verify after deploy
A browser-harness check at **390x844 (iPhone)** is needed after deploy:
- #311: skip button shows for admin mid-question, fits the admin control bar without clipping, and actually skips a live question.
- #308: with a crafted duplicate-correct-text question, the right button highlights for both a correct answerer and a wrong answerer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
