### PR TITLE
fix(server): emit per-player correct button index for reveal (#308)

### DIFF
--- a/custom_components/quizify/server/round_message_builder.py
+++ b/custom_components/quizify/server/round_message_builder.py
@@ -274,6 +274,30 @@ class RoundMessageBuilder:
         # with per-player shuffles, a shuffled index is meaningless to
         # any other player. The client uses answer_text for display and
         # correct_answer_text for highlighting their own button.
+        #
+        # correct_button_index (#308): the index of the correct answer in
+        # THIS player's OWN shuffled button order. Per-player shuffles (the
+        # #253/#286 projection) mean neither the canonical
+        # ``correct_answer_index`` nor the original ``answer_index`` map to a
+        # player's button positions — and a player who answered wrong or
+        # didn't answer cannot resolve the correct button locally when two
+        # answers share the same text (the duplicate-text trap from #308).
+        # We compute it server-side: a player's shuffle is
+        # ``button_pos -> original_index``, so the correct button is the
+        # position where ``shuffle[pos] == correct_original_idx``. ``-1`` when
+        # unresolvable (no shuffle / no correct answer found); the reveal
+        # client then falls back to its #319 index/text heuristic.
+        def _correct_button_index(player_name: str) -> int:
+            if correct_original_idx < 0:
+                return -1
+            shuffle = game_state.get_player_shuffle(player_name)
+            if not shuffle:
+                return -1
+            try:
+                return shuffle.index(correct_original_idx)
+            except ValueError:
+                return -1
+
         all_answers = []
         for player in game_state.get_players():
             if player.submitted and player.current_answer is not None:
@@ -290,6 +314,7 @@ class RoundMessageBuilder:
                     "answer_index": submitted_orig,  # original index, not shuffled
                     "answer_text": answer_text,
                     "correct": is_correct,
+                    "correct_button_index": _correct_button_index(player.name),
                     "points_earned": player.round_score,
                     "speed_bonus": breakdown.get("speed_bonus", 0),
                     "streak_bonus": breakdown.get("streak_bonus", 0),
@@ -303,6 +328,7 @@ class RoundMessageBuilder:
                     "answer_index": None,
                     "answer_text": "—",
                     "correct": False,
+                    "correct_button_index": _correct_button_index(player.name),
                     "points_earned": 0,
                     "no_answer": True,
                 })

--- a/custom_components/quizify/www/js/player-reveal.js
+++ b/custom_components/quizify/www/js/player-reveal.js
@@ -84,9 +84,11 @@
 
         // Flash answer buttons correct/wrong. Per-player shuffle means the
         // server's `correct_answer_index` is in the CANONICAL shuffle and
-        // doesn't match this player's button positions, so flashAnswerButtons
-        // resolves the correct *button index* locally (see its comment) —
-        // index-based to stay correct even with duplicate answer texts (#308).
+        // doesn't match this player's button positions. flashAnswerButtons
+        // prefers the per-player `correct_button_index` the server now ships
+        // in this player's all_answers entry (#308 follow-up), falling back to
+        // a local index/text heuristic — correct even with duplicate answer
+        // texts (#308).
         flashAnswerButtons(data.correct_answer, myAnswerEntry);
 
         // New result page: hero + answer strip + standings (with medals)
@@ -698,9 +700,15 @@
         // own shuffled order. The server's `correct_answer_index` is in the
         // CANONICAL shuffle (not this player's), and `all_answers[].answer_index`
         // is the ORIGINAL question index — neither maps to a button position
-        // on the client, and the reveal payload carries no per-player correct
-        // button index. So we use the index information we DO have locally:
+        // on the client. We resolve the correct button index in priority order:
         //
+        //   0. PREFERRED — `myEntry.correct_button_index`: the server now
+        //      computes the correct answer's position in THIS player's own
+        //      shuffled order (#308 follow-up) and ships it in the player's
+        //      `all_answers` entry on both the live reveal broadcast and the
+        //      reconnect snapshot. This is exact even when the player answered
+        //      wrong / didn't answer AND two answers share the same text.
+        //      Absent (older server) → fall through to the local heuristic.
         //   1. If this player answered CORRECTLY, their own submitted button
         //      position IS the correct button — exact, immune to duplicate
         //      texts. (`mySubmittedIndex` is the button position the player
@@ -709,11 +717,6 @@
         //      wrong button when it shares the correct text (the common
         //      duplicate-text collision), and on a remaining tie pick the
         //      first match.
-        //
-        // A fully robust fix (correct even when a non-answering / wrong
-        // player faces duplicate correct-texts) requires the server to send
-        // a per-player correct button index in the reveal payload — that is a
-        // server/ change, out of scope for this www-only PR.
         function _buttonAnswerText(btn) {
             var span = btn.querySelector('.answer-btn-text, .answer-text, span');
             return (span ? span.textContent : btn.textContent || '').trim();
@@ -721,7 +724,12 @@
         var correctText = (correctAnswerText || '').trim();
 
         var correctIndex = -1;
-        if (myEntry && myEntry.correct && mySubmittedIndex >= 0 && mySubmittedIndex < buttons.length) {
+        var serverBtnIdx = (myEntry && typeof myEntry.correct_button_index === 'number')
+            ? myEntry.correct_button_index : -1;
+        if (serverBtnIdx >= 0 && serverBtnIdx < buttons.length) {
+            // (0) Server told us the exact correct button in our own order.
+            correctIndex = serverBtnIdx;
+        } else if (myEntry && myEntry.correct && mySubmittedIndex >= 0 && mySubmittedIndex < buttons.length) {
             // (1) We answered right → our tapped button is the correct one.
             correctIndex = mySubmittedIndex;
         } else if (correctText) {

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -1345,9 +1345,11 @@
 
         // Flash answer buttons correct/wrong. Per-player shuffle means the
         // server's `correct_answer_index` is in the CANONICAL shuffle and
-        // doesn't match this player's button positions, so flashAnswerButtons
-        // resolves the correct *button index* locally (see its comment) —
-        // index-based to stay correct even with duplicate answer texts (#308).
+        // doesn't match this player's button positions. flashAnswerButtons
+        // prefers the per-player `correct_button_index` the server now ships
+        // in this player's all_answers entry (#308 follow-up), falling back to
+        // a local index/text heuristic — correct even with duplicate answer
+        // texts (#308).
         flashAnswerButtons(data.correct_answer, myAnswerEntry);
 
         // New result page: hero + answer strip + standings (with medals)
@@ -1959,9 +1961,15 @@
         // own shuffled order. The server's `correct_answer_index` is in the
         // CANONICAL shuffle (not this player's), and `all_answers[].answer_index`
         // is the ORIGINAL question index — neither maps to a button position
-        // on the client, and the reveal payload carries no per-player correct
-        // button index. So we use the index information we DO have locally:
+        // on the client. We resolve the correct button index in priority order:
         //
+        //   0. PREFERRED — `myEntry.correct_button_index`: the server now
+        //      computes the correct answer's position in THIS player's own
+        //      shuffled order (#308 follow-up) and ships it in the player's
+        //      `all_answers` entry on both the live reveal broadcast and the
+        //      reconnect snapshot. This is exact even when the player answered
+        //      wrong / didn't answer AND two answers share the same text.
+        //      Absent (older server) → fall through to the local heuristic.
         //   1. If this player answered CORRECTLY, their own submitted button
         //      position IS the correct button — exact, immune to duplicate
         //      texts. (`mySubmittedIndex` is the button position the player
@@ -1970,11 +1978,6 @@
         //      wrong button when it shares the correct text (the common
         //      duplicate-text collision), and on a remaining tie pick the
         //      first match.
-        //
-        // A fully robust fix (correct even when a non-answering / wrong
-        // player faces duplicate correct-texts) requires the server to send
-        // a per-player correct button index in the reveal payload — that is a
-        // server/ change, out of scope for this www-only PR.
         function _buttonAnswerText(btn) {
             var span = btn.querySelector('.answer-btn-text, .answer-text, span');
             return (span ? span.textContent : btn.textContent || '').trim();
@@ -1982,7 +1985,12 @@
         var correctText = (correctAnswerText || '').trim();
 
         var correctIndex = -1;
-        if (myEntry && myEntry.correct && mySubmittedIndex >= 0 && mySubmittedIndex < buttons.length) {
+        var serverBtnIdx = (myEntry && typeof myEntry.correct_button_index === 'number')
+            ? myEntry.correct_button_index : -1;
+        if (serverBtnIdx >= 0 && serverBtnIdx < buttons.length) {
+            // (0) Server told us the exact correct button in our own order.
+            correctIndex = serverBtnIdx;
+        } else if (myEntry && myEntry.correct && mySubmittedIndex >= 0 && mySubmittedIndex < buttons.length) {
             // (1) We answered right → our tapped button is the correct one.
             correctIndex = mySubmittedIndex;
         } else if (correctText) {

--- a/tests/test_round_summary_correct_button_index_308.py
+++ b/tests/test_round_summary_correct_button_index_308.py
@@ -1,0 +1,199 @@
+"""Regression test for the per-player correct button index (#308).
+
+Background: answers are shuffled PER PLAYER (the #253/#286 projection), so a
+player who answered WRONG or didn't answer cannot tell which button is the
+real correct one when two answers share the same text — the client has no
+per-player mapping from the canonical/original correct index to its own
+button positions.
+
+The server now ships ``correct_button_index`` in each player's
+``all_answers`` entry of the round-summary payload: the index of the correct
+answer in THAT player's own shuffled button order. The reveal client prefers
+it (falling back to its local #319 heuristic when absent).
+
+This test pins that the field:
+  * points at the button position holding the correct answer in each
+    player's own shuffle, AND
+  * differs across two players whose shuffles place the correct answer at
+    different button positions, AND
+  * is correct even when the question has two identical correct-text answers
+    (the duplicate-text trap) for a wrong / non-answering player.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.player import PlayerSession  # noqa: E402
+from custom_components.quizify.game.questions import Answer, Question  # noqa: E402
+from custom_components.quizify.game.state import RoundSummary  # noqa: E402
+from custom_components.quizify.server.round_message_builder import (  # noqa: E402
+    RoundMessageBuilder,
+)
+
+
+def _dup_text_question() -> Question:
+    """A question whose correct answer text ("Paris") is duplicated by a
+    non-correct decoy at original index 1 — the duplicate-text trap.
+
+    Only original index 0 is flagged ``correct``; index 1 is a wrong answer
+    that merely shares the text, which is exactly the case the text-match
+    highlight got wrong before #308.
+    """
+    return Question(
+        id="dup1",
+        question="Capital of France?",
+        answers=[
+            Answer(text="Paris", correct=True),   # orig idx 0 — the real one
+            Answer(text="Paris", correct=False),  # orig idx 1 — decoy, same text
+            Answer(text="Berlin", correct=False),
+            Answer(text="Rome", correct=False),
+        ],
+        difficulty="easy",
+        fun_fact="Paris has been the capital since 508 AD.",
+        category="Geography",
+    )
+
+
+class _FakeGameState:
+    """Minimal stand-in exposing only what RoundMessageBuilder touches."""
+
+    def __init__(
+        self,
+        *,
+        question: Question,
+        players: list[PlayerSession],
+        player_shuffles: dict[str, list[int]],
+        shuffle_map: list[int],
+        round_summary: RoundSummary,
+        round_num: int = 3,
+        total_rounds: int = 10,
+    ) -> None:
+        self._question = question
+        self._players = players
+        self.round = round_num
+        self.total_rounds = total_rounds
+        self.round_duration = 20.0
+        self._player_shuffles = player_shuffles
+        self.shuffle_map = shuffle_map
+        self.shuffled_answers = [question.answers[i].text for i in shuffle_map]
+        self._round_summary = round_summary
+
+    def get_players(self) -> list[PlayerSession]:
+        return list(self._players)
+
+    def get_player_shuffle(self, player_name: str) -> list[int]:
+        return self._player_shuffles.get(player_name) or self.shuffle_map
+
+    def get_round_summary(self) -> RoundSummary | None:
+        return self._round_summary
+
+
+def _summary(q: Question) -> RoundSummary:
+    return RoundSummary(question=q, correct_answer=q.answers[0], fun_fact=q.fun_fact)
+
+
+def _build(players, player_shuffles):
+    q = _dup_text_question()
+    gs = _FakeGameState(
+        question=q,
+        players=players,
+        # canonical shuffle is irrelevant to per-player correct_button_index
+        shuffle_map=[3, 2, 1, 0],
+        player_shuffles=player_shuffles,
+        round_summary=_summary(q),
+    )
+    msg = RoundMessageBuilder().build_round_summary(gs)
+    assert msg is not None
+    return {a["player_name"]: a for a in msg["all_answers"]}
+
+
+class TestCorrectButtonIndex308:
+    def test_wrong_answerer_with_duplicate_text_gets_real_correct_button(self):
+        """Wrong answerer: their button order puts the REAL correct answer
+        (orig 0) at button position 2 and the same-text decoy (orig 1) at
+        position 0. correct_button_index must point at 2 — the real one —
+        not at the decoy a text-match would have grabbed first.
+        """
+        # Alice's shuffle: button_pos -> original_index
+        # pos0->1(decoy "Paris"), pos1->3, pos2->0(real "Paris"), pos3->2
+        alice = PlayerSession(name="Alice", ws=None, score=10)
+        alice.submitted = True
+        alice.current_answer = 2  # answered orig idx 2 ("Berlin") — WRONG
+        alice.round_score = 0
+        alice.round_score_breakdown = {}
+        alice.streak = 0
+
+        answers = _build([alice], {"Alice": [1, 3, 0, 2]})
+        assert answers["Alice"]["correct"] is False
+        # real correct (orig 0) sits at Alice's button position 2
+        assert answers["Alice"]["correct_button_index"] == 2
+
+    def test_non_answerer_gets_correct_button_index(self):
+        """A player who didn't answer still gets a correct_button_index in
+        their own shuffle (the case the client cannot resolve at all)."""
+        bob = PlayerSession(name="Bob", ws=None)
+        bob.submitted = False
+        # Bob's shuffle: pos0->0(real "Paris"), pos1->2, pos2->1(decoy), pos3->3
+        answers = _build([bob], {"Bob": [0, 2, 1, 3]})
+        assert answers["Bob"]["no_answer"] is True
+        # real correct (orig 0) sits at Bob's button position 0
+        assert answers["Bob"]["correct_button_index"] == 0
+
+    def test_differs_across_players_with_different_shuffles(self):
+        """Two players with different shuffles get different button indices
+        for the same correct answer — proving it's per-player, not canonical.
+        """
+        alice = PlayerSession(name="Alice", ws=None)
+        alice.submitted = True
+        alice.current_answer = 2  # WRONG
+        alice.round_score = 0
+        alice.round_score_breakdown = {}
+        alice.streak = 0
+        bob = PlayerSession(name="Bob", ws=None)
+        bob.submitted = False
+
+        answers = _build(
+            [alice, bob],
+            {
+                # real correct orig 0 at Alice pos 2, at Bob pos 0
+                "Alice": [1, 3, 0, 2],
+                "Bob": [0, 2, 1, 3],
+            },
+        )
+        assert answers["Alice"]["correct_button_index"] == 2
+        assert answers["Bob"]["correct_button_index"] == 0
+        assert (
+            answers["Alice"]["correct_button_index"]
+            != answers["Bob"]["correct_button_index"]
+        )
+
+    def test_correct_answerer_button_index_matches_their_tap(self):
+        """A correct answerer's correct_button_index equals the button they
+        tapped (self-consistency with the #319 fallback)."""
+        # Carol's shuffle: pos0->2, pos1->0(real "Paris"), pos2->1, pos3->3
+        carol = PlayerSession(name="Carol", ws=None)
+        carol.submitted = True
+        carol.current_answer = 0  # answered orig 0 ("Paris") — CORRECT
+        carol.round_score = 50
+        carol.round_score_breakdown = {"speed_bonus": 5}
+        carol.streak = 1
+
+        answers = _build([carol], {"Carol": [2, 0, 1, 3]})
+        assert answers["Carol"]["correct"] is True
+        # real correct (orig 0) sits at Carol's button position 1
+        assert answers["Carol"]["correct_button_index"] == 1
+
+    def test_minus_one_when_player_has_no_shuffle(self):
+        """No per-player shuffle stored → falls back to canonical via
+        get_player_shuffle; field still resolves against that order rather
+        than crashing. (Here canonical [3,2,1,0] puts orig 0 at pos 3.)"""
+        dave = PlayerSession(name="Dave", ws=None)
+        dave.submitted = False
+        answers = _build([dave], {})  # no shuffle for Dave
+        # get_player_shuffle falls back to canonical [3,2,1,0] → orig0 at pos3
+        assert answers["Dave"]["correct_button_index"] == 3


### PR DESCRIPTION
## Summary

Server-side follow-up that fully closes the reveal-highlight correctness LOW in #308.

#319 made the reveal highlight index-based on the client, but for a player who answered **WRONG** or **didn't answer** AND the question has two identical correct-text answers, the client cannot tell which duplicate-text button is the real correct one. With per-player shuffles (the #253/#286 projection), neither `correct_answer_index` (canonical-shuffle space) nor `all_answers[].answer_index` (original question index) maps to *this* player's button positions.

## The fix

The server now emits a per-player **`correct_button_index`** — the index of the correct answer in **that player's own shuffled button order** — inside each player's `all_answers` entry of the round-summary payload.

It is computed from the player's shuffle map (`button_pos -> original_index`) and the canonical correct original index:

```python
correct_button_index = game_state.get_player_shuffle(player.name).index(correct_original_idx)
```

`-1` when unresolvable (no shuffle / no correct answer found).

This is added in `build_round_summary`, which feeds **both**:
- the live `_broadcast_round_summary` path, and
- the reconnect snapshot projection (`project_snapshot_for_player`, `ANSWER_REVEAL` branch, which merges `build_round_summary`'s flat output)

…so a reconnect during reveal also gets the field, consistent with how #286 made the snapshot paths projected.

The reveal client (`player-reveal.js` → rebuilt into `player.bundle.js`) now **prefers** `myEntry.correct_button_index` when present and **falls back** to the existing #319 index/text heuristic when absent (back-compat with an older server).

## Tests

New regression test `tests/test_round_summary_correct_button_index_308.py`: a question with two identical correct-text answers ("Paris" at both original index 0 [correct] and 1 [decoy]); asserts `correct_button_index` points at the **real** correct button per player and **differs** across two players with different shuffles (wrong-answerer, non-answerer, correct-answerer, and no-shuffle-fallback cases).

Full suite green except the 6 `tests/test_ws_handle_integration_293.py` cases, which fail **identically on pristine `origin/main`** locally due to `pytest-socket` (`SocketBlockedError`) — a known local-env issue that passes in CI via the socket-enable conftest hook. Not a regression from this PR.

## Deploy notes

- This is a **Python change** → needs a **full HA restart** on deploy (not just a config-entry reload — modules stay in `sys.modules`). The `www/` bundle change takes effect immediately via the cache-buster.
- **Live/mobile verify needed after deploy**: a question with duplicate correct-text answers, where a player who answered wrong / didn't answer sees the *correct* duplicate-text button highlighted (not the decoy).

## Scope

Minimal and back-compatible. No unrelated payload shapes changed. No manifest bump, no tag. The other correctness LOWs listed in #308 (podium ties, score-breakdown sums, wager-0-bank, error codes, end-lightning) are **out of scope** for this PR.

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)
