### PR TITLE
test: cover sensor.py, __init__.py, seasons edge cases, worker-contract (#313)

### DIFF
--- a/cf-workers/contract-check.mjs
+++ b/cf-workers/contract-check.mjs
@@ -7,7 +7,9 @@
 //   1. the shared fixture pack (tests/fixtures/community_pack.json) is ACCEPTED
 //      (validatePack returns null), exactly as the integration's
 //      server/pack_submission.py::validate_pack accepts it; and
-//   2. an obviously malformed pack is REJECTED (returns an error string).
+//   2. every malformation in the shared catalog
+//      (tests/fixtures/community_pack_malformations.json) is REJECTED (returns
+//      an error string), in lockstep with the Python validator (#313).
 //
 // Run: node cf-workers/contract-check.mjs
 // Exits 0 on success, non-zero with a message on any failure. Invoked from
@@ -24,10 +26,43 @@ const workerSrc = readFileSync(join(here, 'quizify-api.js'), 'utf8');
 const fixture = JSON.parse(
   readFileSync(join(repoRoot, 'tests', 'fixtures', 'community_pack.json'), 'utf8'),
 );
+const malformations = JSON.parse(
+  readFileSync(
+    join(repoRoot, 'tests', 'fixtures', 'community_pack_malformations.json'),
+    'utf8',
+  ),
+).malformations;
 
 function fail(msg) {
   console.error(`contract-check FAILED: ${msg}`);
   process.exit(1);
+}
+
+// Apply one shared malformation to a deep copy of the canonical pack. MUST stay
+// in lockstep with `_apply_malformation` in tests/test_worker_contract_256.py —
+// the same `kind` codes mutate the pack identically on both sides (#256/#313).
+function applyMalformation(pack, spec) {
+  const p = JSON.parse(JSON.stringify(pack));
+  switch (spec.kind) {
+    case 'truncate_first_answers':
+      p.questions[0].answers = p.questions[0].answers.slice(0, spec.n);
+      break;
+    case 'delete_field':
+      delete p[spec.field];
+      break;
+    case 'mark_second_answer_correct':
+      p.questions[0].answers[1].correct = true;
+      break;
+    case 'duplicate_first_id':
+      p.questions[1].id = p.questions[0].id;
+      break;
+    case 'blank_first_question_text':
+      p.questions[0].question = '   ';
+      break;
+    default:
+      fail(`unknown malformation kind: ${spec.kind}`);
+  }
+  return p;
 }
 
 // Pull the four schema constants out of the worker source so this check can't
@@ -61,14 +96,23 @@ if (okErr !== null) {
   fail(`worker rejected the canonical fixture pack: ${okErr}`);
 }
 
-// 2. A malformed pack must be rejected. Drop the third answer so the question
-//    no longer has exactly ANSWERS_PER_QUESTION answers.
-const malformed = JSON.parse(JSON.stringify(fixture));
-malformed.questions[0].answers = malformed.questions[0].answers.slice(0, 2);
-const badErr = validatePack(malformed);
-if (badErr === null) {
-  fail('worker accepted a malformed pack (only 2 answers) — schema too loose');
+// 2. EVERY malformation in the shared catalog must be rejected. The same
+//    catalog is replayed on the Python side (test_worker_contract_256.py), so a
+//    divergence on either side fails CI (#313).
+if (!Array.isArray(malformations) || malformations.length < 3) {
+  fail('shared malformation catalog is missing or too small');
+}
+for (const spec of malformations) {
+  const malformed = applyMalformation(fixture, spec);
+  const badErr = validatePack(malformed);
+  if (badErr === null) {
+    fail(
+      `worker ACCEPTED a malformed pack ('${spec.id}': ${spec.reason}) — schema too loose`,
+    );
+  }
 }
 
-console.log('contract-check OK: worker validatePack accepts the fixture and rejects malformed input');
+console.log(
+  `contract-check OK: worker validatePack accepts the fixture and rejects all ${malformations.length} catalogued malformations`,
+);
 process.exit(0);

--- a/tests/fixtures/community_pack_malformations.json
+++ b/tests/fixtures/community_pack_malformations.json
@@ -1,0 +1,32 @@
+{
+  "_comment": "Shared malformation catalog for the worker<->integration pack-validator contract (#256/#313). Each entry names a single mutation applied to the canonical community_pack.json fixture; BOTH validators (Python validate_pack and the worker's validatePack) MUST reject the mutated pack. The 'kind' is applied identically by tests/test_worker_contract_256.py and cf-workers/contract-check.mjs via _apply_malformation / applyMalformation. Keep the two implementations in lockstep.",
+  "malformations": [
+    {
+      "id": "too-few-answers",
+      "kind": "truncate_first_answers",
+      "n": 2,
+      "reason": "first question left with only 2 answers (!= ANSWERS_PER_QUESTION)"
+    },
+    {
+      "id": "missing-name",
+      "kind": "delete_field",
+      "field": "name",
+      "reason": "top-level required 'name' removed"
+    },
+    {
+      "id": "two-correct",
+      "kind": "mark_second_answer_correct",
+      "reason": "first question has two answers flagged correct (must be exactly 1)"
+    },
+    {
+      "id": "duplicate-id",
+      "kind": "duplicate_first_id",
+      "reason": "second question reuses the first question's id"
+    },
+    {
+      "id": "empty-question-text",
+      "kind": "blank_first_question_text",
+      "reason": "first question text blanked (required non-empty string)"
+    }
+  ]
+}

--- a/tests/test_featured_real_stats_313.py
+++ b/tests/test_featured_real_stats_313.py
@@ -1,0 +1,253 @@
+"""Featured-pack rotation against *real* stats services (issue #313).
+
+``test_seasonal_packs_276.py`` exercises ``featured_pack_view`` only with
+``SimpleNamespace`` stubs for analytics/question_stats. This file wires the
+real :class:`QuizifyAnalytics` and :class:`QuestionStatsService` (backed by a
+tmp data dir) through the view so the most-played and most-difficult rotation
+legs are pinned end to end — a regression in ``compute_metrics`` /
+``aggregate_for_questions`` or the view's consumption of them now fails here.
+
+The view picks its rotation leg from ``datetime.now().tm_yday`` parity and its
+season check from ``date.today()``; both are injected via a fixed-date
+``datetime`` module shim so the test is clock-independent and never seasonal.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as _real_dt
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.analytics import QuizifyAnalytics  # noqa: E402
+from custom_components.quizify.game.questions import (  # noqa: E402
+    Answer,
+    Question,
+)
+from custom_components.quizify.question_stats import (  # noqa: E402
+    QuestionStatsService,
+)
+from custom_components.quizify.runtime import StandaloneRuntime  # noqa: E402
+from custom_components.quizify.server.context import APP_CTX_KEY  # noqa: E402
+from custom_components.quizify.server.views import (  # noqa: E402
+    featured_pack_view,
+)
+
+
+class _Bank:
+    """Minimal QuestionBank stand-in exposing only what the view reads."""
+
+    def __init__(self, pack_versions: dict, categories: dict, qdir: Path) -> None:
+        self._pv = pack_versions
+        self._cats = categories
+        self._qdir = qdir
+
+    @property
+    def categories(self) -> dict:
+        return dict(self._cats)
+
+    @property
+    def questions_dir(self) -> Path:
+        return self._qdir
+
+    def get_pack_versions(self) -> dict:
+        return {k: dict(v) for k, v in self._pv.items()}
+
+    def load_all_categories(self) -> dict:
+        return dict(self._cats)
+
+
+class _Request:
+    def __init__(self, ctx, query: dict) -> None:
+        self.app = {APP_CTX_KEY: ctx}
+        self.query = query
+
+
+def _freeze_datetime(monkeypatch, year: int, month: int, day: int) -> None:
+    """Pin BOTH ``datetime.date.today()`` (season check) and
+    ``datetime.datetime.now()`` (day-rotation parity) to a fixed date.
+
+    The view does ``import datetime as _dt`` locally, so patching the real
+    module's ``date``/``datetime`` attributes with fixed subclasses flows the
+    injected date through. ``tm_yday`` parity of the fixed date decides the
+    rotation leg.
+    """
+    fixed_date = _real_dt.date(year, month, day)
+    fixed_dt = _real_dt.datetime(year, month, day, 12, 0, 0)
+
+    class _FixedDate(_real_dt.date):
+        @classmethod
+        def today(cls):
+            return fixed_date
+
+    class _FixedDateTime(_real_dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_dt
+
+    monkeypatch.setattr(_real_dt, "date", _FixedDate)
+    monkeypatch.setattr(_real_dt, "datetime", _FixedDateTime)
+
+
+def _yday_with_parity(even: bool) -> tuple[int, int, int]:
+    """Return a (year, month, day) far from any season window whose day-of-year
+    parity matches ``even`` (even → most-played, odd → most-difficult)."""
+    # Feb is outside the seasonal packs used here. Feb 1 = yday 32 (odd),
+    # Feb 2 = yday 33 (even-day-of-month but yday 33 odd)... compute directly.
+    base = _real_dt.date(2026, 2, 1)
+    for delta in range(0, 20):
+        d = base + _real_dt.timedelta(days=delta)
+        if (d.timetuple().tm_yday % 2 == 0) == even:
+            return (d.year, d.month, d.day)
+    raise AssertionError("no matching date found")  # pragma: no cover
+
+
+def _make_ctx(bank, analytics, question_stats):
+    return SimpleNamespace(
+        game=SimpleNamespace(_question_bank=bank),
+        analytics=analytics,
+        question_stats=question_stats,
+        runtime=SimpleNamespace(
+            run_in_executor=lambda func, *a: _Immediate(func(*a)),
+        ),
+    )
+
+
+class _Immediate:
+    """Awaitable wrapper so the view's ``await runtime.run_in_executor`` works
+    synchronously in-test."""
+
+    def __init__(self, value):
+        self._value = value
+
+    def __await__(self):
+        async def _coro():
+            return self._value
+
+        return _coro().__await__()
+
+
+def _featured(ctx, lang: str = "de") -> dict:
+    return json.loads(asyncio.run(featured_pack_view(_Request(ctx, {"lang": lang}))).body)
+
+
+def _pack_files(qdir: Path, slugs: list[str]) -> None:
+    qdir.mkdir(parents=True, exist_ok=True)
+    for slug in slugs:
+        (qdir / f"{slug}.json").write_text(
+            json.dumps({"theme": slug, "name": slug.title()})
+        )
+
+
+def _pv(slug: str, count: int = 20) -> dict:
+    return {"language": "de", "question_count": count, "name": slug.title()}
+
+
+# ---------------------------------------------------------------------------
+# most-played — real QuizifyAnalytics
+# ---------------------------------------------------------------------------
+
+
+def test_featured_most_played_real_analytics(tmp_path: Path, monkeypatch) -> None:
+    """An even day-of-year picks the most-played leg; a real analytics store
+    seeded with games for 'geschichte' must surface it over the default."""
+    y, m, d = _yday_with_parity(even=True)
+    _freeze_datetime(monkeypatch, y, m, d)
+
+    qdir = tmp_path / "questions"
+    _pack_files(qdir, ["geographie", "geschichte"])
+    bank = _Bank({"geographie": _pv("geographie"), "geschichte": _pv("geschichte")},
+                 {"geographie": [], "geschichte": []}, qdir)
+
+    runtime = StandaloneRuntime(tmp_path / "data")
+    analytics = QuizifyAnalytics(runtime)
+    asyncio.run(analytics.load())
+    # Seed two real completed games on 'geschichte' (>= _FEATURED_MIN_PLAYS).
+    for i in range(2):
+        asyncio.run(analytics.record_game(
+            game_id=f"g{i}", category="geschichte", difficulty="medium",
+            num_rounds=10, players={"Alice": 50 + i, "Bob": 30},
+            duration_seconds=300,
+        ))
+
+    ctx = _make_ctx(bank, analytics, None)
+    out = _featured(ctx)
+    assert out["logic"] == "most-played"
+    assert out["value"] == "geschichte"
+
+
+def test_featured_most_played_below_threshold_falls_back(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """With NO recorded games the most-played leg finds nothing above the
+    threshold and the view falls back to the default pack."""
+    y, m, d = _yday_with_parity(even=True)
+    _freeze_datetime(monkeypatch, y, m, d)
+
+    qdir = tmp_path / "questions"
+    _pack_files(qdir, ["geographie", "geschichte"])
+    bank = _Bank({"geographie": _pv("geographie"), "geschichte": _pv("geschichte")},
+                 {"geographie": [], "geschichte": []}, qdir)
+
+    runtime = StandaloneRuntime(tmp_path / "data")
+    analytics = QuizifyAnalytics(runtime)
+    asyncio.run(analytics.load())  # empty store
+
+    ctx = _make_ctx(bank, analytics, None)
+    out = _featured(ctx)
+    assert out["logic"] == "default"
+    assert out["value"] == "geographie"  # _FEATURED_DEFAULT_DE
+
+
+# ---------------------------------------------------------------------------
+# most-difficult — real QuestionStatsService
+# ---------------------------------------------------------------------------
+
+
+def _q(qid: str) -> Question:
+    return Question(
+        id=qid, question="?",
+        answers=[Answer(text="a", correct=True), Answer(text="b", correct=False),
+                 Answer(text="c", correct=False)],
+    )
+
+
+def test_featured_most_difficult_real_stats(tmp_path: Path, monkeypatch) -> None:
+    """An odd day-of-year picks the most-difficult leg; a real
+    QuestionStatsService where 'hard' has the lowest correct-rate (and enough
+    shown samples) must surface it."""
+    y, m, d = _yday_with_parity(even=False)
+    _freeze_datetime(monkeypatch, y, m, d)
+
+    qdir = tmp_path / "questions"
+    _pack_files(qdir, ["easy", "hard"])
+    easy_qs = [_q("e1"), _q("e2")]
+    hard_qs = [_q("h1"), _q("h2")]
+    bank = _Bank(
+        {"easy": _pv("easy"), "hard": _pv("hard")},
+        {"easy": easy_qs, "hard": hard_qs},
+        qdir,
+    )
+
+    runtime = StandaloneRuntime(tmp_path / "data")
+    stats = QuestionStatsService(runtime)
+    asyncio.run(stats.load())
+    # Easy pack: mostly correct. Hard pack: mostly wrong. >= _FEATURED_MIN_SHOWN
+    # (10) submissions aggregated per pack.
+    for q in easy_qs:
+        stats.record_round(q.id, [(True, 1.0)] * 6)   # 12 shown, 12 correct
+    for q in hard_qs:
+        stats.record_round(q.id, [(True, 1.0), (False, 1.0), (False, 1.0),
+                                  (False, 1.0), (False, 1.0), (False, 1.0)])  # 12 shown, 2 correct
+
+    ctx = _make_ctx(bank, None, stats)
+    out = _featured(ctx)
+    assert out["logic"] == "most-difficult"
+    assert out["value"] == "hard"

--- a/tests/test_init_313.py
+++ b/tests/test_init_313.py
@@ -1,0 +1,171 @@
+"""Tests for the Quizify integration entry lifecycle (issue #313).
+
+Covers ``custom_components.quizify.__init__`` — ``async_setup_entry``,
+``async_unload_entry`` and the ``reset_admin_session`` service — which sat at
+~7% coverage because no test drove the HA entry lifecycle end to end.
+
+These exercise the real wiring against the ``pytest-homeassistant-custom-
+component`` ``hass`` fixture (the harness #271 added): the HTTP app, the
+frontend panel registry, the static-path registrar and the service registry
+are all real, so a regression in the mounting logic surfaces here.
+
+Needs the real ``homeassistant`` package + the harness. Skipped (not errored)
+when those aren't installed locally; CI installs them.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("homeassistant")
+pytest.importorskip("pytest_homeassistant_custom_component")
+
+from homeassistant.core import HomeAssistant  # noqa: E402
+from homeassistant.setup import async_setup_component  # noqa: E402
+from pytest_homeassistant_custom_component.common import (  # noqa: E402
+    MockConfigEntry,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.const import DOMAIN  # noqa: E402
+
+pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+
+@pytest.fixture(autouse=True)
+def _stub_frontend_panel():
+    """Patch the two frontend panel helpers the integration calls.
+
+    The *frontend* component can't be set up under the test harness (the
+    prebuilt ``hass_frontend`` wheel isn't installed), and __init__ imports
+    ``async_register_built_in_panel`` / ``async_remove_panel`` inside its setup
+    and unload functions. Patch them at the source module so the in-function
+    imports resolve to stubs that track panel registration realistically (the
+    real ``async_remove_panel`` raises ``KeyError`` for an unknown panel — the
+    unload code swallows it, so we mirror that here).
+    """
+    panels: dict = {}
+
+    def _register_panel(_hass, *, frontend_url_path, **_kw):
+        panels[frontend_url_path] = True
+
+    def _remove_panel(_hass, path):
+        if path not in panels:
+            raise KeyError(path)
+        del panels[path]
+
+    with (
+        patch(
+            "homeassistant.components.frontend.async_register_built_in_panel",
+            side_effect=_register_panel,
+        ),
+        patch(
+            "homeassistant.components.frontend.async_remove_panel",
+            side_effect=_remove_panel,
+        ),
+    ):
+        yield panels
+
+
+@pytest.fixture
+async def http_hass(hass: HomeAssistant) -> HomeAssistant:
+    """A hass with the HTTP component set up.
+
+    ``async_setup_entry`` mounts routes on ``hass.http.app`` and registers
+    static paths, which need the HTTP component present. Everything else
+    (routes, static paths, services, platform forwarding) stays real.
+    """
+    assert await async_setup_component(hass, "http", {"http": {}})
+    await hass.async_block_till_done()
+    return hass
+
+
+async def _setup(hass: HomeAssistant) -> MockConfigEntry:
+    """Set the entry up through the real config-entries state machine.
+
+    Going through ``hass.config_entries.async_setup`` (rather than calling
+    ``async_setup_entry`` directly) puts the entry in the right state so the
+    platform-forwarding call inside our setup is allowed, exercising the full
+    real path including ``async_forward_entry_setups``.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id) is True
+    await hass.async_block_till_done()
+    return entry
+
+
+async def test_setup_entry_wires_domain_data(http_hass: HomeAssistant) -> None:
+    """A successful setup populates hass.data[DOMAIN] with the core objects
+    and registers the reset_admin_session service."""
+    hass = http_hass
+    entry = await _setup(hass)
+
+    data = hass.data[DOMAIN]
+    assert data["entry_id"] == entry.entry_id
+    for key in ("game", "ws_handler", "analytics", "ctx"):
+        assert data.get(key) is not None, f"missing {key} in hass.data"
+    # Optional-integration plumbing is attached even when unconfigured.
+    for key in ("party_lights", "tts_announcer", "lobby_music"):
+        assert key in data
+
+    assert hass.services.has_service(DOMAIN, "reset_admin_session")
+
+
+async def test_setup_entry_forwards_sensor_platforms(
+    http_hass: HomeAssistant,
+) -> None:
+    """The entry forwards to the sensor + binary_sensor platforms, so the
+    Quizify game-state entities actually materialise."""
+    hass = http_hass
+    await _setup(hass)
+
+    states = hass.states.async_all()
+    entity_ids = {s.entity_id for s in states}
+    # The five sensors + one binary_sensor from the platforms.
+    assert "binary_sensor.quizify_game_active" in entity_ids
+    assert any(e.startswith("sensor.quizify_") for e in entity_ids)
+
+
+async def test_reset_admin_session_service_clears_token(
+    http_hass: HomeAssistant,
+) -> None:
+    """Calling the reset_admin_session service clears the persisted admin
+    token via the ws handler's connection manager."""
+    hass = http_hass
+    await _setup(hass)
+
+    ws_handler = hass.data[DOMAIN]["ws_handler"]
+    # Bootstrap a token so there is something to clear.
+    token = ws_handler.conn.get_or_create_admin_token()
+    assert ws_handler.conn.validate_admin_token(token) is True
+
+    await hass.services.async_call(
+        DOMAIN, "reset_admin_session", {}, blocking=True
+    )
+    # After the reset the old token no longer validates (in-memory cleared).
+    assert ws_handler.conn.validate_admin_token(token) is False
+
+
+async def test_unload_entry_tears_down(http_hass: HomeAssistant) -> None:
+    """Unloading removes hass.data[DOMAIN] and the sidebar panel, and unloads
+    the platform entities (so the Quizify game entities disappear)."""
+    hass = http_hass
+    entry = await _setup(hass)
+    assert DOMAIN in hass.data
+
+    assert await hass.config_entries.async_unload(entry.entry_id) is True
+    await hass.async_block_till_done()
+
+    assert DOMAIN not in hass.data
+    # The platforms were unloaded, so the game-active entity is no longer
+    # available (HA marks unloaded platform entities "unavailable").
+    state = hass.states.get("binary_sensor.quizify_game_active")
+    assert state is None or state.state == "unavailable"

--- a/tests/test_seasons_edge_313.py
+++ b/tests/test_seasons_edge_313.py
@@ -1,0 +1,109 @@
+"""Seasons edge-case coverage (issue #313).
+
+``test_seasonal_packs_276.py`` covers the happy paths of the seasons helper.
+This file pins the three uncovered edges the #313 review called out:
+
+1. ``parse_season`` ValueError path — a ``"MM-XY"`` window whose day part is
+   non-numeric ("12-XY") goes through ``int(parts[1])`` and must be caught and
+   dropped, not raised.
+2. ``_days_until_end`` Feb-29 fallback — when a tie-break window ends on
+   Feb 29 and the comparison year is NOT a leap year, the helper must fall
+   back to Mar 1 (both for the same-year and the roll-to-next-year branch)
+   instead of raising ``ValueError`` from ``date(year, 2, 29)``.
+3. ``_days_until_end`` pre-new-year (December) branch — a wrap-around window
+   whose end has already passed *this* calendar year must roll its end date
+   to next year so the day-count stays positive and ordering is correct.
+
+All dates are injected; nothing touches the real clock.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import date
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.seasons import (  # noqa: E402
+    Season,
+    _days_until_end,
+    parse_season,
+    pick_active_season,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. parse_season — int() ValueError path
+# ---------------------------------------------------------------------------
+
+
+def test_parse_season_non_numeric_day_is_dropped() -> None:
+    """A non-numeric day part ("12-XY") hits ``int()`` → ValueError, which
+    parse_season swallows and returns None (treated as non-seasonal)."""
+    assert parse_season({"start": "12-XY", "end": "12-26", "label": "L"}) is None
+
+
+def test_parse_season_non_numeric_month_is_dropped() -> None:
+    assert parse_season({"start": "XY-01", "end": "12-26", "label": "L"}) is None
+
+
+def test_parse_season_non_numeric_end_is_dropped() -> None:
+    """The same ValueError guard protects the ``end`` field, not just start."""
+    assert parse_season({"start": "12-01", "end": "12-Z", "label": "L"}) is None
+
+
+# ---------------------------------------------------------------------------
+# 2. _days_until_end — Feb-29 fallback in a non-leap year
+# ---------------------------------------------------------------------------
+
+
+def test_days_until_end_feb29_non_leap_same_year() -> None:
+    """2026 is not a leap year, so ``date(2026, 2, 29)`` would raise. The
+    helper must fall back to Mar 1 for ordering."""
+    season = Season(start=(2, 15), end=(2, 29), label="Leap")
+    today = date(2026, 2, 20)
+    # End falls back to Mar 1 (2026-03-01); 9 days from Feb 20.
+    assert _days_until_end(season, today) == (date(2026, 3, 1) - today).days
+
+
+def test_days_until_end_feb29_non_leap_rolls_to_next_year() -> None:
+    """When the (fallback) end date is already in the past this year, the
+    helper rolls to next year — and that branch also catches the Feb-29
+    ValueError, falling back to Mar 1 of ``year + 1``."""
+    season = Season(start=(2, 15), end=(2, 29), label="Leap")
+    today = date(2026, 6, 1)  # past Feb/Mar already → roll to 2027
+    # 2027 is also non-leap, so the next-year branch falls back to Mar 1 2027.
+    assert _days_until_end(season, today) == (date(2027, 3, 1) - today).days
+
+
+def test_days_until_end_feb29_leap_year_uses_real_date() -> None:
+    """In a leap year the real Feb-29 date is used (no fallback)."""
+    season = Season(start=(2, 15), end=(2, 29), label="Leap")
+    today = date(2028, 2, 20)  # 2028 is a leap year
+    assert _days_until_end(season, today) == (date(2028, 2, 29) - today).days
+
+
+# ---------------------------------------------------------------------------
+# 3. _days_until_end — pre-new-year (December) roll-forward branch
+# ---------------------------------------------------------------------------
+
+
+def test_days_until_end_rolls_past_end_to_next_year() -> None:
+    """A window whose end month/day already passed this year must count
+    forward to next year's occurrence (positive day count)."""
+    season = Season(start=(12, 20), end=(1, 6), label="Festtage")
+    today = date(2026, 12, 28)  # end (Jan 6) is in the future → 2027-01-06
+    assert _days_until_end(season, today) == (date(2027, 1, 6) - today).days
+
+
+def test_pick_active_season_wraparound_pre_newyear_ordering() -> None:
+    """End-to-end through ``pick_active_season``: on Dec 28 a tight wrap-around
+    window (ends Jan 6) beats a broad one (ends Mar 31). Exercises the
+    December roll-forward leg of ``_days_until_end`` for both candidates."""
+    seasons_map = {
+        "festtage": Season(start=(12, 20), end=(1, 6), label="Festtage"),
+        "winter": Season(start=(12, 1), end=(3, 31), label="Winter"),
+    }
+    assert pick_active_season(seasons_map, date(2026, 12, 28)) == "festtage"

--- a/tests/test_sensor_313.py
+++ b/tests/test_sensor_313.py
@@ -1,0 +1,297 @@
+"""Tests for the Quizify sensor platform (issue #313).
+
+Mirrors ``test_binary_sensor_271.py`` for the five ``sensor.quizify_*``
+entities that were left untested when binary_sensor got #271. Covers each
+sensor's ``native_value`` + ``extra_state_attributes``, the
+QUESTION_ACTIVE answer-leak guard on the question sensor, the push-based
+state-callback wiring, and ``async_setup_entry`` adding all five entities.
+
+Needs the real ``homeassistant`` package (``SensorEntity`` base) plus the
+``pytest-homeassistant-custom-component`` harness for the ``hass`` fixture.
+Skipped (not errored) when those aren't installed locally; CI installs them.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("homeassistant")
+pytest.importorskip("pytest_homeassistant_custom_component")
+
+from homeassistant.core import HomeAssistant  # noqa: E402
+from pytest_homeassistant_custom_component.common import (  # noqa: E402
+    MockConfigEntry,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.const import DOMAIN  # noqa: E402
+from custom_components.quizify.game.player import PlayerSession  # noqa: E402
+from custom_components.quizify.game.questions import (  # noqa: E402
+    Answer,
+    Question,
+)
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+from custom_components.quizify.sensor import (  # noqa: E402
+    QuizifyCurrentQuestionSensor,
+    QuizifyCurrentRoundSensor,
+    QuizifyLeaderSensor,
+    QuizifyPlayerCountSensor,
+    QuizifyTopScoreSensor,
+    async_setup_entry,
+)
+
+pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+
+def _make_state(*, phase: GamePhase = GamePhase.LOBBY) -> QuizifyGameState:
+    """A real GameState pinned to a given phase, no players."""
+    state = QuizifyGameState()
+    # ``phase`` is a property delegating to the phase controller; set through it.
+    state.phase = phase
+    return state
+
+
+def _add_player(
+    state: QuizifyGameState,
+    name: str,
+    *,
+    score: int = 0,
+    streak: int = 0,
+    connected: bool = True,
+) -> PlayerSession:
+    """Insert a PlayerSession directly into the registry (no real WebSocket).
+
+    ``is_active`` reads ``ws.closed``; a MagicMock with ``closed`` set lets us
+    control the connected/active distinction without a live socket.
+    """
+    ws = MagicMock()
+    ws.closed = not connected
+    player = PlayerSession(name=name, ws=ws)
+    player.score = score
+    player.streak = streak
+    player.connected = connected
+    state._player_registry.players[name] = player
+    return player
+
+
+# ---------------------------------------------------------------------------
+# Current round sensor
+# ---------------------------------------------------------------------------
+
+
+def test_current_round_value_and_attrs() -> None:
+    state = _make_state(phase=GamePhase.QUESTION_ACTIVE)
+    state.round = 4
+    state.total_rounds = 9
+    state.category = "geographie"
+    state.difficulty = "medium"
+    sensor = QuizifyCurrentRoundSensor(state, "entry-1")
+
+    assert sensor.native_value == 4
+    attrs = sensor.extra_state_attributes
+    assert attrs["total_rounds"] == 9
+    assert attrs["phase"] == GamePhase.QUESTION_ACTIVE.value
+    assert attrs["category"] == "geographie"
+    assert attrs["difficulty"] == "medium"
+
+
+def test_current_round_default_zero() -> None:
+    """No game running → round 0."""
+    sensor = QuizifyCurrentRoundSensor(_make_state(), "e")
+    assert sensor.native_value == 0
+
+
+# ---------------------------------------------------------------------------
+# Leader + top-score sensors
+# ---------------------------------------------------------------------------
+
+
+def test_leader_none_when_no_players() -> None:
+    state = _make_state()
+    leader = QuizifyLeaderSensor(state, "e")
+    top = QuizifyTopScoreSensor(state, "e")
+    assert leader.native_value is None
+    assert leader.extra_state_attributes == {"score": 0, "streak": 0}
+    assert top.native_value == 0
+
+
+def test_leader_is_highest_scorer() -> None:
+    state = _make_state()
+    _add_player(state, "Alice", score=30, streak=2)
+    _add_player(state, "Bob", score=70, streak=5)  # leader
+    leader = QuizifyLeaderSensor(state, "e")
+    top = QuizifyTopScoreSensor(state, "e")
+
+    assert leader.native_value == "Bob"
+    attrs = leader.extra_state_attributes
+    assert attrs["score"] == 70
+    assert attrs["streak"] == 5
+    assert top.native_value == 70
+
+
+# ---------------------------------------------------------------------------
+# Player count sensor
+# ---------------------------------------------------------------------------
+
+
+def test_player_count_value_and_connected_split() -> None:
+    state = _make_state()
+    _add_player(state, "Alice", connected=True)
+    _add_player(state, "Bob", connected=True)
+    _add_player(state, "Ghost", connected=False)  # disconnected within grace
+    sensor = QuizifyPlayerCountSensor(state, "e")
+
+    assert sensor.native_value == 3  # all players, incl. disconnected
+    attrs = sensor.extra_state_attributes
+    assert set(attrs["players"]) == {"Alice", "Bob", "Ghost"}
+    # ``connected`` lists only genuinely active sockets (is_active).
+    assert set(attrs["connected"]) == {"Alice", "Bob"}
+
+
+# ---------------------------------------------------------------------------
+# Current question sensor (answer-leak guard)
+# ---------------------------------------------------------------------------
+
+
+def _question() -> Question:
+    return Question(
+        id="q1",
+        question="Capital of France?",
+        answers=[
+            Answer(text="Paris", correct=True),
+            Answer(text="Lyon", correct=False),
+            Answer(text="Nice", correct=False),
+        ],
+    )
+
+
+def test_question_sensor_hidden_during_active() -> None:
+    """During QUESTION_ACTIVE the sensor returns None and nulls the correct
+    answer so a live question's solution can't leak onto a dashboard."""
+    state = _make_state(phase=GamePhase.QUESTION_ACTIVE)
+    state._current_question = _question()
+    sensor = QuizifyCurrentQuestionSensor(state, "e")
+
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes == {"correct_answer": None}
+
+
+def test_question_sensor_reveals_and_caches() -> None:
+    """On ANSWER_REVEAL the sensor surfaces the text + correct answer and
+    caches them so they persist into the following idle phase."""
+    state = _make_state(phase=GamePhase.ANSWER_REVEAL)
+    state._current_question = _question()
+    sensor = QuizifyCurrentQuestionSensor(state, "e")
+
+    assert sensor.native_value == "Capital of France?"
+    assert sensor.extra_state_attributes == {"correct_answer": "Paris"}
+
+    # Move to a non-active idle phase: the cached text/answer persists.
+    state.phase = GamePhase.LOBBY
+    state._current_question = None
+    assert sensor.native_value == "Capital of France?"
+    assert sensor.extra_state_attributes == {"correct_answer": "Paris"}
+
+    # A new live question hides everything again.
+    state.phase = GamePhase.QUESTION_ACTIVE
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes == {"correct_answer": None}
+
+
+def test_question_sensor_starts_empty() -> None:
+    state = _make_state(phase=GamePhase.LOBBY)
+    sensor = QuizifyCurrentQuestionSensor(state, "e")
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes == {"correct_answer": None}
+
+
+# ---------------------------------------------------------------------------
+# Shared base: unique_id, static attrs, push callback wiring
+# ---------------------------------------------------------------------------
+
+
+def test_unique_ids_derive_from_entry_and_key() -> None:
+    state = _make_state()
+    assert (
+        QuizifyCurrentRoundSensor(state, "entry-x").unique_id
+        == "entry-x_current_round"
+    )
+    assert QuizifyLeaderSensor(state, "entry-x").unique_id == "entry-x_leader"
+    assert (
+        QuizifyTopScoreSensor(state, "entry-x").unique_id == "entry-x_top_score"
+    )
+    assert (
+        QuizifyPlayerCountSensor(state, "entry-x").unique_id
+        == "entry-x_player_count"
+    )
+    assert (
+        QuizifyCurrentQuestionSensor(state, "entry-x").unique_id
+        == "entry-x_current_question"
+    )
+
+
+def test_static_attrs() -> None:
+    sensor = QuizifyCurrentRoundSensor(_make_state(), "e")
+    assert sensor._attr_has_entity_name is True
+    assert sensor._attr_should_poll is False
+
+
+async def test_state_callback_writes_ha_state() -> None:
+    """Each sensor registers a callback that fires async_write_ha_state and
+    unregisters cleanly on removal."""
+    state = _make_state()
+    sensor = QuizifyLeaderSensor(state, "e")
+    sensor.async_write_ha_state = MagicMock()
+
+    await sensor.async_added_to_hass()
+    state._notify_state_callbacks()
+    assert sensor.async_write_ha_state.called
+
+    sensor.async_write_ha_state.reset_mock()
+    await sensor.async_will_remove_from_hass()
+    state._notify_state_callbacks()
+    assert not sensor.async_write_ha_state.called
+
+
+# ---------------------------------------------------------------------------
+# async_setup_entry
+# ---------------------------------------------------------------------------
+
+
+async def test_async_setup_entry_adds_all_five(hass: HomeAssistant) -> None:
+    """``async_setup_entry`` reads the game state from hass.data and adds the
+    five Quizify sensor entities with entry-scoped unique ids."""
+    game_state = _make_state()
+    hass.data[DOMAIN] = {"game": game_state}
+
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN)
+    entry.add_to_hass(hass)
+
+    added: list = []
+
+    def _add(entities, update_before_add: bool = False) -> None:
+        added.extend(entities)
+
+    await async_setup_entry(hass, entry, _add)
+
+    assert len(added) == 5
+    types = {type(e) for e in added}
+    assert types == {
+        QuizifyCurrentRoundSensor,
+        QuizifyLeaderSensor,
+        QuizifyTopScoreSensor,
+        QuizifyPlayerCountSensor,
+        QuizifyCurrentQuestionSensor,
+    }
+    for entity in added:
+        assert entity.unique_id.startswith(entry.entry_id)

--- a/tests/test_worker_contract_256.py
+++ b/tests/test_worker_contract_256.py
@@ -20,7 +20,9 @@ If either schema drifts, one of these fails CI.
 
 from __future__ import annotations
 
+import copy
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -39,12 +41,63 @@ from custom_components.quizify.server.pack_submission import (  # noqa: E402
 )
 
 _FIXTURE = _REPO_ROOT / "tests" / "fixtures" / "community_pack.json"
+_MALFORMATIONS = _REPO_ROOT / "tests" / "fixtures" / "community_pack_malformations.json"
 _WORKER = _REPO_ROOT / "cf-workers" / "quizify-api.js"
 _CONTRACT_CHECK = _REPO_ROOT / "cf-workers" / "contract-check.mjs"
+
+# When ``QUIZIFY_REQUIRE_NODE=1`` is set (CI runs node), a missing ``node`` is a
+# hard FAILURE instead of a silent skip (#313). Locally — where node may be
+# absent — the tests still skip. Set it in CI to guarantee the cross-language
+# contract is actually exercised and can't rot behind a perpetual skip.
+_REQUIRE_NODE = os.environ.get("QUIZIFY_REQUIRE_NODE") == "1"
+
+
+def _require_node() -> None:
+    """Skip (local) or fail (CI, ``QUIZIFY_REQUIRE_NODE=1``) when node is absent.
+
+    Turning the old silent ``skipif`` into a CI failure closes the #313 gap
+    where a CI image without node would have quietly green-lit a drifted worker
+    schema by never running the cross-language check at all.
+    """
+    if shutil.which("node") is not None:
+        return
+    msg = "node not available — the worker contract check cannot run"
+    if _REQUIRE_NODE:
+        pytest.fail(f"{msg} (QUIZIFY_REQUIRE_NODE=1 requires it)")
+    pytest.skip(msg)
 
 
 def _load_fixture() -> dict:
     return json.loads(_FIXTURE.read_text(encoding="utf-8"))
+
+
+def _load_malformations() -> list[dict]:
+    data = json.loads(_MALFORMATIONS.read_text(encoding="utf-8"))
+    return data["malformations"]
+
+
+def _apply_malformation(pack: dict, spec: dict) -> dict:
+    """Apply one shared malformation to a *copy* of the canonical pack.
+
+    Mirrors ``applyMalformation`` in ``cf-workers/contract-check.mjs`` exactly —
+    the same ``kind`` codes must mutate the pack identically on both sides so a
+    given malformation pins the same rejection in both validators.
+    """
+    p = copy.deepcopy(pack)
+    kind = spec["kind"]
+    if kind == "truncate_first_answers":
+        p["questions"][0]["answers"] = p["questions"][0]["answers"][: spec["n"]]
+    elif kind == "delete_field":
+        p.pop(spec["field"], None)
+    elif kind == "mark_second_answer_correct":
+        p["questions"][0]["answers"][1]["correct"] = True
+    elif kind == "duplicate_first_id":
+        p["questions"][1]["id"] = p["questions"][0]["id"]
+    elif kind == "blank_first_question_text":
+        p["questions"][0]["question"] = "   "
+    else:  # pragma: no cover - guards against an unhandled new kind
+        raise ValueError(f"unknown malformation kind: {kind}")
+    return p
 
 
 def test_fixture_exists() -> None:
@@ -91,10 +144,33 @@ def test_python_validator_rejects_malformed_fixture() -> None:
     assert errors
 
 
-@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
+@pytest.mark.parametrize(
+    "spec", _load_malformations(), ids=lambda s: s["id"]
+)
+def test_python_validator_rejects_each_shared_malformation(spec: dict) -> None:
+    """Every malformation in the shared catalog must be rejected by the Python
+    validator. The same catalog is replayed against the worker's validatePack
+    (see ``contract-check.mjs``), so a divergence on either side fails CI —
+    broadening the contract beyond the single original malformation (#313)."""
+    pack = _apply_malformation(_load_fixture(), spec)
+    ok, errors = validate_pack(pack)
+    assert not ok, f"Python validate_pack wrongly accepted '{spec['id']}'"
+    assert errors
+
+
+def test_malformation_catalog_is_non_trivial() -> None:
+    """Guard the shared catalog itself: it must carry several malformations so
+    a careless edit can't quietly shrink the contract back to one case."""
+    specs = _load_malformations()
+    assert len(specs) >= 3
+    assert len({s["id"] for s in specs}) == len(specs)  # unique ids
+
+
 def test_worker_source_parses() -> None:
     """`node --check` proves the worker source still parses — a syntax error
-    would otherwise only surface at deploy time."""
+    would otherwise only surface at deploy time. Hard-fails (not skips) under
+    ``QUIZIFY_REQUIRE_NODE=1`` so CI can't silently bypass it (#313)."""
+    _require_node()
     result = subprocess.run(
         ["node", "--check", str(_WORKER)],
         capture_output=True,
@@ -103,11 +179,14 @@ def test_worker_source_parses() -> None:
     assert result.returncode == 0, f"node --check failed:\n{result.stderr}"
 
 
-@pytest.mark.skipif(shutil.which("node") is None, reason="node not available")
 def test_worker_validator_matches_contract() -> None:
     """Run the JS contract check: the worker's validatePack must accept the
-    shared fixture and reject a malformed pack. This is the cross-language pin —
-    if the worker schema drifts from the fixture, this fails CI."""
+    shared fixture and reject *every* malformation in the shared catalog. This
+    is the cross-language pin — if the worker schema drifts from the fixture or
+    stops rejecting any catalogued malformation, this fails CI.
+
+    Hard-fails (not skips) under ``QUIZIFY_REQUIRE_NODE=1`` (#313)."""
+    _require_node()
     result = subprocess.run(
         ["node", str(_CONTRACT_CHECK)],
         capture_output=True,


### PR DESCRIPTION
Closes #313

Test-coverage debt batch from the 2026-06-11 comprehensive review. **Test-only** — no production code behavior changes (the only non-test file touched is `cf-workers/contract-check.mjs`, which is the test harness, not the deployed worker).

## What's covered

### `sensor.py` (had no dedicated test file)
New `tests/test_sensor_313.py` mirrors `test_binary_sensor_271.py` for all five `sensor.quizify_*` entities:
- `native_value` + `extra_state_attributes` for current-round, leader, top-score, player-count, current-question
- the `QUESTION_ACTIVE` answer-leak guard on the question sensor (hidden during a live question, revealed + cached on `ANSWER_REVEAL`)
- the push-based state-callback register/unregister wiring
- `async_setup_entry` adds all five entities with entry-scoped unique ids

### `__init__.py` (setup/unload/reset-service untested)
New `tests/test_init_313.py` drives `async_setup_entry` / `async_unload_entry` / the `reset_admin_session` service **end to end through the real config-entries state machine** on the `pytest-homeassistant-custom-component` `hass` fixture (the harness #271 added). The HTTP component is real (routes + static paths mount for real); the two frontend panel helpers are stubbed because the prebuilt `hass_frontend` wheel isn't installed in the test harness. Asserts domain-data wiring, platform forwarding (the sensor/binary_sensor entities materialise), the reset service clearing the admin token, and teardown.

### `seasons.py` edge cases (#282)
New `tests/test_seasons_edge_313.py` pins the three edges the review named:
- `parse_season("12-XY")` — the `int()` `ValueError` path is swallowed → `None`
- `_days_until_end` Feb-29-in-non-leap-year fallback to Mar 1 (both the same-year and the roll-to-next-year branch)
- `_days_until_end` December pre-new-year wrap-around roll-forward leg

### Featured rotation against real services (was stub-only)
New `tests/test_featured_real_stats_313.py` wires real `QuizifyAnalytics` + `QuestionStatsService` (backed by a tmp data dir) through `featured_pack_view` for both the most-played and most-difficult rotation legs, plus the below-threshold fallback — replacing the `SimpleNamespace` stubs.

### Worker-contract node-skip (#256)
`tests/test_worker_contract_256.py` + `cf-workers/contract-check.mjs`:
- The silent node skip becomes a **CI failure** under `QUIZIFY_REQUIRE_NODE=1` (local runs without node still skip), so a CI image lacking node can no longer green-light a drifted worker schema by never running the cross-language check.
- A **shared malformation catalog** (`tests/fixtures/community_pack_malformations.json`) is replayed identically by both the Python `validate_pack` and the worker's `validatePack` (lockstep `_apply_malformation` / `applyMalformation`), broadening the contract from one malformation to five: too-few-answers, missing-name, two-correct, duplicate-id, empty-question-text.

## Coverage (full suite, term-missing)
| module | before | after |
|--------|--------|-------|
| `sensor.py` | 92% | **100%** |
| `game/seasons.py` | 89% | **100%** |
| `__init__.py` | 70% | **75%** |

(The issue's headline `sensor.py 0%` / `__init__.py 7%` reflect per-module-isolation measurement; the full-suite baseline already had incidental coverage. The substantive gap — no dedicated sensor test file, no setup/unload/reset exercise, the named seasons edges — is what this closes. The remaining `__init__.py` lines 219-263 are the options-flow re-attach `_update_listener`, outside this issue's targets.)

## Test plan
- `pytest tests/` — **638 passed** (33 new), up from 605.
- `QUIZIFY_REQUIRE_NODE=1 pytest tests/test_worker_contract_256.py` — 12 passed (env-gated node tests run, not skip).
- `node cf-workers/contract-check.mjs` — accepts the fixture, rejects all 5 catalogued malformations.
- Pre-existing `test_ws_handle_integration_293.py` failures locally are a sandbox TCP-bind limitation (aiohttp test server binds a real port); they're independent of this change and pass in CI.

## Deferred
None of the four named targets were deferred. The options-flow `_update_listener` reattach path in `__init__.py` (lines 219-263) is left untested as it's beyond the issue's named setup/unload/reset scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)