### PR TITLE
ci: enforce QUIZIFY_REQUIRE_NODE=1 in CI (#328)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,15 @@ jobs:
         with:
           python-version: "3.13"
 
+      # Node is required for the worker ⇄ integration contract check
+      # (cf-workers/contract-check.mjs + `node --check`). ubuntu-latest ships
+      # node by default, but pinning it makes the gate deterministic so the
+      # QUIZIFY_REQUIRE_NODE=1 hard-fail below can never be undermined by a
+      # runner image that happens to drop node (#328).
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
@@ -27,6 +36,11 @@ jobs:
           pip install -r requirements_test.txt
 
       - name: Run tests
+        # Enforce the worker-contract gate: a missing node here is a hard
+        # FAILURE, not a silent skip, so the cross-language check can't rot
+        # behind a perpetual skip (#313, #328).
+        env:
+          QUIZIFY_REQUIRE_NODE: "1"
         run: pytest tests/ -v
 
       - name: Byte-compile component (catches syntax errors)


### PR DESCRIPTION
## What

Wires the worker-contract gate into the `pytest` CI job so the cross-language
worker ⇄ integration check can never silently skip on a runner without node.

The worker-contract test (`tests/test_worker_contract_256.py`) invokes `node`
(via `cf-workers/contract-check.mjs` and `node --check`) to prove the
Cloudflare worker's `validatePack` schema stays in sync with the Python
`validate_pack`. When node is absent the test **skips** by default; under
`QUIZIFY_REQUIRE_NODE=1` it **hard-fails** instead (#313). Until now that env
gate was not wired into the workflow, so a future runner image that dropped
node could have quietly green-lit a drifted worker schema.

## Changes (`.github/workflows/test.yml` only, +14 lines)

- Set `QUIZIFY_REQUIRE_NODE: "1"` on the "Run tests" step — turns a missing
  node into a CI failure instead of a silent skip.
- Add `actions/setup-node@v4` (node 20) before the test step. `ubuntu-latest`
  ships node by default, but pinning it makes the gate **deterministic**: the
  hard-fail can no longer be undermined by a runner image that happens to drop
  node, and the node version is reproducible.

## Testing

Locally with node present and the gate on:

- `QUIZIFY_REQUIRE_NODE=1 pytest tests/ -k worker -v` → 22 passed, 4 skipped
  (the two node-invoking tests `test_worker_source_parses` and
  `test_worker_validator_matches_contract` run and pass — no skip).
- `QUIZIFY_REQUIRE_NODE=1 pytest tests/ -q` → 620 passed, 4 skipped.

No user-facing change; CI-only.

Refs #328 (one box of the #328 tech-debt checklist; does not close it).