### PR TITLE
style: enable ruff E501 + B/SIM/UP/C4 families (#328)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,9 @@ docs/
 .playwright-mcp/
 
 # ---- Config & tooling ----
-pyproject.toml
+# pyproject.toml IS tracked: it holds the ruff lint-gate config the CI
+# `ruff check` job relies on (issues #306/#328). Without it committed the
+# gate would silently fall back to ruff's defaults.
 package.json
 package-lock.json
 requirements.txt

--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -182,7 +182,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     options = entry.options or {}
     # Lobby music plays server-side on the configured media_player while the
     # game waits in the lobby. Empty/unset → the playback service stays inert.
-    game_state.lobby_music_url = (options.get(CONF_LOBBY_MUSIC_URL) or "").strip() or None
+    game_state.lobby_music_url = (
+        (options.get(CONF_LOBBY_MUSIC_URL) or "").strip() or None
+    )
     party_lights = QuizifyPartyLights(
         hass=hass,
         entity_ids=list(options.get(CONF_PARTY_LIGHT_ENTITIES) or []),
@@ -215,9 +217,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Re-attach on options change so toggling lights/TTS in the UI takes
     # effect without an HA restart.
-    async def _update_listener(_hass: HomeAssistant, updated_entry: ConfigEntry) -> None:
+    async def _update_listener(
+        _hass: HomeAssistant, updated_entry: ConfigEntry
+    ) -> None:
         opts = updated_entry.options or {}
-        game_state.lobby_music_url = (opts.get(CONF_LOBBY_MUSIC_URL) or "").strip() or None
+        game_state.lobby_music_url = (
+            (opts.get(CONF_LOBBY_MUSIC_URL) or "").strip() or None
+        )
         # Toggle the community-pack submit feature live (#180) — no HA restart.
         ctx.community_submit_url = (
             opts.get(CONF_COMMUNITY_SUBMIT_URL) or ""

--- a/custom_components/quizify/analytics.py
+++ b/custom_components/quizify/analytics.py
@@ -11,7 +11,7 @@ import json
 import logging
 import os
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, TypedDict
 
 if TYPE_CHECKING:
@@ -352,12 +352,18 @@ class QuizifyAnalytics:
             if cat not in cat_stats:
                 cat_stats[cat] = {"games": 0, "total_score": 0, "total_players": 0}
             cat_stats[cat]["games"] += 1
-            cat_stats[cat]["total_score"] += game.get("average_score", 0) * game["player_count"]
+            cat_stats[cat]["total_score"] += (
+                game.get("average_score", 0) * game["player_count"]
+            )
             cat_stats[cat]["total_players"] += game["player_count"]
 
         category_list = []
         for cat, stats in cat_stats.items():
-            avg_score = stats["total_score"] / stats["total_players"] if stats["total_players"] > 0 else 0
+            avg_score = (
+                stats["total_score"] / stats["total_players"]
+                if stats["total_players"] > 0
+                else 0
+            )
             category_list.append({
                 "category": cat,
                 "games_played": stats["games"],
@@ -378,14 +384,18 @@ class QuizifyAnalytics:
             "recent_games": [
                 {
                     "game_id": g["game_id"],
-                    "date": datetime.fromtimestamp(g["ended_at"], tz=timezone.utc).strftime("%Y-%m-%d %H:%M"),
+                    "date": datetime.fromtimestamp(
+                        g["ended_at"], tz=UTC
+                    ).strftime("%Y-%m-%d %H:%M"),
                     "category": g.get("category", "mixed"),
                     "player_count": g["player_count"],
                     "rounds_played": g["rounds_played"],
                     "winner": g.get("winner", ""),
                     "duration": g.get("duration_seconds", 0),
                 }
-                for g in sorted(current_games, key=lambda g: g["ended_at"], reverse=True)[:20]
+                for g in sorted(
+                    current_games, key=lambda g: g["ended_at"], reverse=True
+                )[:20]
             ],
             "generated_at": now,
         }
@@ -396,7 +406,7 @@ class QuizifyAnalytics:
         """Aggregate game counts for chart visualization."""
         from datetime import timedelta  # noqa: PLC0415
 
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
 
         if period == "7d":
             days = 7
@@ -404,12 +414,13 @@ class QuizifyAnalytics:
                 (now - timedelta(days=i)).strftime("%Y-%m-%d"): 0 for i in range(days)
             }
             for game in games:
-                dt = datetime.fromtimestamp(game["ended_at"], tz=timezone.utc)
+                dt = datetime.fromtimestamp(game["ended_at"], tz=UTC)
                 key = dt.strftime("%Y-%m-%d")
                 if key in buckets:
                     buckets[key] += 1
             labels = [
-                (now - timedelta(days=i)).strftime("%a") for i in range(days - 1, -1, -1)
+                (now - timedelta(days=i)).strftime("%a")
+                for i in range(days - 1, -1, -1)
             ]
             values = [
                 buckets[(now - timedelta(days=i)).strftime("%Y-%m-%d")]
@@ -422,7 +433,7 @@ class QuizifyAnalytics:
                 week_start = now - timedelta(days=now.weekday() + 7 * i)
                 week_buckets[week_start.strftime("%Y-%m-%d")] = 0
             for game in games:
-                dt = datetime.fromtimestamp(game["ended_at"], tz=timezone.utc)
+                dt = datetime.fromtimestamp(game["ended_at"], tz=UTC)
                 week_start = dt - timedelta(days=dt.weekday())
                 key = week_start.strftime("%Y-%m-%d")
                 if key in week_buckets:
@@ -433,7 +444,7 @@ class QuizifyAnalytics:
         else:
             month_buckets: dict[str, int] = {}
             for game in games:
-                dt = datetime.fromtimestamp(game["ended_at"], tz=timezone.utc)
+                dt = datetime.fromtimestamp(game["ended_at"], tz=UTC)
                 key = dt.strftime("%Y-%m")
                 month_buckets[key] = month_buckets.get(key, 0) + 1
             sorted_keys = sorted(month_buckets.keys())[-12:]

--- a/custom_components/quizify/game/lightning.py
+++ b/custom_components/quizify/game/lightning.py
@@ -113,7 +113,7 @@ class LightningRound:
         self._question_start: float | None = None
 
         # scores keyed by player name; recap rows in question order.
-        self.scores: dict[str, int] = {name: 0 for name in self._players}
+        self.scores: dict[str, int] = dict.fromkeys(self._players, 0)
         self._recaps: list[LightningQuestionRecap] = []
 
         # Per-question answer matrix: index -> {player_name -> LightningAnswer}.

--- a/custom_components/quizify/game/phase_controller.py
+++ b/custom_components/quizify/game/phase_controller.py
@@ -61,7 +61,7 @@ class TickResolution:
     dashboard_remaining: float = 0.0
 
 
-class GamePhase(str, Enum):
+class GamePhase(str, Enum):  # noqa: UP042 — StrEnum changes str()/serialization
     """Game phase states."""
 
     LOBBY = "LOBBY"

--- a/custom_components/quizify/game/player.py
+++ b/custom_components/quizify/game/player.py
@@ -53,17 +53,20 @@ class PlayerSession:
     submitted: bool = False
     current_answer: int | None = None
     submission_time: float | None = None
-    last_answer_correct: bool = False  # cached at submit_answer time, read in _do_evaluate_round
+    # cached at submit_answer time, read in _do_evaluate_round
+    last_answer_correct: bool = False
     # Elapsed seconds between round start and this player's submission.
     # Captured in submit_answer so per-question stats can record honest
     # times without re-deriving from speed_bonus arithmetic.
     last_elapsed: float = 0.0
     round_score: int = 0
-    round_score_breakdown: dict = field(default_factory=dict)  # speed_bonus, streak_bonus, diff_mult
+    # speed_bonus, streak_bonus, diff_mult
+    round_score_breakdown: dict = field(default_factory=dict)
     round_history: list[str] = field(default_factory=list)
 
     # Superlative tracking
-    answer_times: list[float] = field(default_factory=list)  # elapsed per correct answer
+    # elapsed per correct answer
+    answer_times: list[float] = field(default_factory=list)
     round_scores: list[int] = field(default_factory=list)  # score per round
     max_streak: int = 0
     freezes_used: int = 0

--- a/custom_components/quizify/game/player_registry.py
+++ b/custom_components/quizify/game/player_registry.py
@@ -104,7 +104,9 @@ class PlayerRegistry:
                         return False, ERR_NAME_TAKEN
                     existing_player.ws = ws
                     existing_player.connected = True
-                    _LOGGER.info("Player reconnected by name (lobby): %s", existing_name)
+                    _LOGGER.info(
+                        "Player reconnected by name (lobby): %s", existing_name
+                    )
                     return True, None
                 # Stale connected flag — the browser reloaded but
                 # _handle_disconnect hasn't fired yet, so the slot still looks
@@ -113,7 +115,8 @@ class PlayerRegistry:
                 # ghost session lingers (Beatify #646).
                 if existing_player.ws is None or existing_player.ws.closed:
                     _LOGGER.info(
-                        "Player %s: stale connected flag, old WS closed — allowing rejoin",
+                        "Player %s: stale connected flag, old WS closed — "
+                        "allowing rejoin",
                         existing_name,
                     )
                     existing_player.ws = ws
@@ -132,11 +135,20 @@ class PlayerRegistry:
         # Assign a unique color from the palette (cycle if more than palette size)
         used_colors = {p.color for p in self.players.values()}
         available = [c for c in PLAYER_COLORS if c not in used_colors]
-        color = available[0] if available else PLAYER_COLORS[len(self.players) % len(PLAYER_COLORS)]
+        color = (
+            available[0]
+            if available
+            else PLAYER_COLORS[len(self.players) % len(PLAYER_COLORS)]
+        )
 
         # Add new player
         player = PlayerSession(
-            name=name, ws=ws, score=initial_score, streak=0, joined_late=joined_late, color=color
+            name=name,
+            ws=ws,
+            score=initial_score,
+            streak=0,
+            joined_late=joined_late,
+            color=color,
         )
         self.players[name] = player
         self._sessions[player.session_id] = name

--- a/custom_components/quizify/game/powerups.py
+++ b/custom_components/quizify/game/powerups.py
@@ -10,7 +10,7 @@ FREEZE_DURATION = 5.0  # seconds
 TIME_BOOST_DURATION = 5.0  # seconds
 
 
-class PowerUpType(str, Enum):
+class PowerUpType(str, Enum):  # noqa: UP042 — StrEnum changes str()/serialization
     """Available quiz power-up types."""
 
     JOKER = "joker"  # removes one wrong answer
@@ -37,7 +37,8 @@ class PowerUpManager:
     def __init__(self) -> None:
         """Initialize empty power-up state."""
         self._inventory: dict[str, PowerUpType] = {}  # player_id → held power-up
-        self._double_points_active: dict[str, bool] = {}  # player_id → active this round
+        # player_id → active this round
+        self._double_points_active: dict[str, bool] = {}
 
     def reset(self) -> None:
         """Clear all power-up state."""

--- a/custom_components/quizify/game/questions.py
+++ b/custom_components/quizify/game/questions.py
@@ -144,7 +144,10 @@ def _parse_question(data: dict, category_name: str) -> Question | None:
         )
         return None
 
-    answers = [Answer(text=a["text"], correct=bool(a.get("correct", False))) for a in answers_raw]
+    answers = [
+        Answer(text=a["text"], correct=bool(a.get("correct", False)))
+        for a in answers_raw
+    ]
 
     return Question(
         id=data["id"],
@@ -168,7 +171,8 @@ class QuestionBank:
         self._queue: list[Question] = []
         self._queue_index: int = 0
         self._loaded: bool = False
-        # Question history: maps question_id -> unix timestamp last shown (or 0 if never)
+        # Question history: maps question_id -> unix timestamp last shown
+        # (or 0 if never)
         self._history: dict[str, float] = {}
         self._history_path: Path | None = None
         # Questions shown in the current game (to record at end)
@@ -235,7 +239,12 @@ class QuestionBank:
         if season_meta is not None:
             meta["season"] = season_meta
         self._pack_versions[category] = meta
-        _LOGGER.debug("Loaded %d questions for category '%s' (v%s)", len(questions), category, pack_version)
+        _LOGGER.debug(
+            "Loaded %d questions for category '%s' (v%s)",
+            len(questions),
+            category,
+            pack_version,
+        )
         return questions
 
     def load_all_categories(self) -> dict[str, list[Question]]:
@@ -340,7 +349,8 @@ class QuestionBank:
             questions_data = raw.get("questions")
             if not isinstance(questions_data, list) or not questions_data:
                 _LOGGER.warning(
-                    "Skipping community pack '%s': 'questions' must be a non-empty list",
+                    "Skipping community pack '%s': 'questions' must be a "
+                    "non-empty list",
                     file_path.name,
                 )
                 continue
@@ -406,7 +416,11 @@ class QuestionBank:
                 # questions/community/<stem>.json under a ``community-`` slug, so
                 # the old views.py path read (questions_dir / f"{slug}.json")
                 # never found them and they always fell back to the 🎲 icon.
-                "theme": raw.get("theme", "") if isinstance(raw.get("theme"), str) else "",
+                "theme": (
+                    raw.get("theme", "")
+                    if isinstance(raw.get("theme"), str)
+                    else ""
+                ),
             }
             community_season = _normalize_season(raw.get("season"))
             if community_season is not None:
@@ -427,7 +441,7 @@ class QuestionBank:
         return list(self._categories.keys())
 
     def get_pack_versions(self) -> dict[str, dict]:
-        """Return metadata (version, name, language, question_count) for each loaded pack."""
+        """Return metadata (version, name, language, question_count) per pack."""
         return dict(self._pack_versions)
 
     def get_next_question(
@@ -519,7 +533,7 @@ class QuestionBank:
     def get_question_count(
         self, category: str, difficulty: str | None = None
     ) -> int:
-        """Return the number of questions for a category, optionally filtered by difficulty."""
+        """Return the question count for a category, optionally by difficulty."""
         questions = self._categories.get(category, [])
         if difficulty is not None:
             return sum(1 for q in questions if q.difficulty == difficulty)

--- a/custom_components/quizify/game/scoring_engine.py
+++ b/custom_components/quizify/game/scoring_engine.py
@@ -161,7 +161,7 @@ class ScoringEngine:
             # scoring stand (and the milestone bonus below still applies).
             if wager_pts > 0:
                 wager_used = wager_pts
-                if correct:
+                if correct:  # noqa: SIM108 — keep the loss-branch comment readable
                     points = wager_pts
                 else:
                     # Lose the wager — but never go below zero so a player can't

--- a/custom_components/quizify/game/seasons.py
+++ b/custom_components/quizify/game/seasons.py
@@ -81,7 +81,9 @@ def parse_season(raw: object) -> Season | None:
     if raw is None:
         return None
     if not isinstance(raw, dict):
-        _LOGGER.warning("Ignoring 'season': expected an object, got %s", type(raw).__name__)
+        _LOGGER.warning(
+            "Ignoring 'season': expected an object, got %s", type(raw).__name__
+        )
         return None
 
     start = _parse_md(raw.get("start"))
@@ -97,7 +99,9 @@ def parse_season(raw: object) -> Season | None:
     label_raw = raw.get("label", "")
     label = label_raw.strip() if isinstance(label_raw, str) else ""
     if not label:
-        _LOGGER.warning("Season window %s–%s has no label; using a generic one", start, end)
+        _LOGGER.warning(
+            "Season window %s–%s has no label; using a generic one", start, end
+        )
         label = "Seasonal"
     label = label[:_MAX_LABEL_LEN]
 

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import random
 import secrets
@@ -155,7 +156,9 @@ class QuizifyGameState:
         self._last_settings: dict[str, Any] | None = None
 
         # Broadcast callback — set by websocket layer
-        self._broadcast_callback: Callable[[dict[str, Any]], Awaitable[None]] | None = None
+        self._broadcast_callback: (
+            Callable[[dict[str, Any]], Awaitable[None]] | None
+        ) = None
 
         # State-change observers (HA sensor entities subscribe here so they
         # can push updates without polling). Pure callbacks, no async.
@@ -189,9 +192,12 @@ class QuizifyGameState:
         # doesn't know a player. `player_shuffles` is per-player so two
         # phones sitting next to each other see A/B/C in different
         # orders — anti-cheat against couch-neighbour collusion.
-        self.shuffle_map: list[int] = []        # canonical: shuffled_pos -> original_index
-        self.shuffled_answers: list[str] = []   # canonical answers in shuffled order
-        self.player_shuffles: dict[str, list[int]] = {}  # name -> shuffled_pos -> original_index
+        # canonical: shuffled_pos -> original_index
+        self.shuffle_map: list[int] = []
+        # canonical answers in shuffled order
+        self.shuffled_answers: list[str] = []
+        # name -> shuffled_pos -> original_index
+        self.player_shuffles: dict[str, list[int]] = {}
 
     # ------------------------------------------------------------------
     # Phase / timing delegation (issue #188)
@@ -260,7 +266,7 @@ class QuizifyGameState:
         self._phase_controller.pause_reason = value
 
     @property
-    def last_settings(self) -> "dict[str, Any] | None":
+    def last_settings(self) -> dict[str, Any] | None:
         """Settings of the most recent start_game, or None if never started.
 
         Used by the one-tap rematch path to restart with the previous game's
@@ -305,10 +311,8 @@ class QuizifyGameState:
 
     def unregister_state_callback(self, cb: Callable[[], None]) -> None:
         """Unsubscribe a previously-registered observer."""
-        try:
+        with contextlib.suppress(ValueError):
             self._state_callbacks.remove(cb)
-        except ValueError:
-            pass
 
     def _notify_state_callbacks(self) -> None:
         """Fire all registered state observers. Keeps the broadcast pipeline
@@ -566,7 +570,9 @@ class QuizifyGameState:
         if connected:
             lucky_player = random.choice(connected)
             powerup = self._powerup_manager.assign_random_powerup(lucky_player.name)
-            _LOGGER.debug("Power-up %s assigned to %s", powerup.value, lucky_player.name)
+            _LOGGER.debug(
+                "Power-up %s assigned to %s", powerup.value, lucky_player.name
+            )
 
         self._phase_controller.enter_question_active()
         self._round_summary = None
@@ -1004,7 +1010,9 @@ class QuizifyGameState:
                     num_rounds=self.round,
                     players=players,
                     duration_seconds=duration,
-                    started_at=int(self._game_start_time) if self._game_start_time else None,
+                    started_at=(
+                        int(self._game_start_time) if self._game_start_time else None
+                    ),
                     player_details=player_details,
                 )
             except Exception:  # noqa: BLE001
@@ -1081,7 +1089,11 @@ class QuizifyGameState:
             player_names,
             language=language or self.language,
             category=category if category is not None else self.category,
-            categories=categories if categories is not None else getattr(self, "categories", None),
+            categories=(
+                categories
+                if categories is not None
+                else getattr(self, "categories", None)
+            ),
             difficulty=difficulty,
         )
         if not lr.start():
@@ -1128,7 +1140,9 @@ class QuizifyGameState:
     # Power-ups
     # ------------------------------------------------------------------
 
-    def use_powerup(self, player_id: str, target_id: str | None = None) -> PowerUpEffect | str:
+    def use_powerup(
+        self, player_id: str, target_id: str | None = None
+    ) -> PowerUpEffect | str:
         """Use the player's held power-up.
 
         Returns PowerUpEffect on success, or error code string.
@@ -1164,7 +1178,12 @@ class QuizifyGameState:
             target_player = (
                 self._player_registry.get_player(target_id) if target_id else None
             )
-            if not target_id or target_id == player_id or not target_player or not target_player.is_active:
+            if (
+                not target_id
+                or target_id == player_id
+                or not target_player
+                or not target_player.is_active
+            ):
                 # FREEZE: skip already-submitted players so the pause is actually
                 # useful (freezing a locked-in opponent burns the power-up).
                 # STEAL: the opposite — only a SUBMITTED target has a round_score
@@ -1187,7 +1206,11 @@ class QuizifyGameState:
             target_check = self._player_registry.get_player(target_id)
             if held == PowerUpType.FREEZE and target_check and target_check.submitted:
                 return ERR_INVALID_ACTION
-            if held == PowerUpType.STEAL and target_check and not target_check.submitted:
+            if (
+                held == PowerUpType.STEAL
+                and target_check
+                and not target_check.submitted
+            ):
                 return ERR_INVALID_ACTION
 
         # Determine wrong answer indices for joker
@@ -1265,7 +1288,9 @@ class QuizifyGameState:
     # State access
     # ------------------------------------------------------------------
 
-    def set_round_shuffle(self, shuffle_map: list[int], shuffled_answers: list[str]) -> None:
+    def set_round_shuffle(
+        self, shuffle_map: list[int], shuffled_answers: list[str]
+    ) -> None:
         """Store the canonical shuffle mapping for the current round."""
         self.shuffle_map = shuffle_map
         self.shuffled_answers = shuffled_answers
@@ -1454,7 +1479,11 @@ class QuizifyGameState:
                 {"name": p.name, "score": p.score, "rank": i + 1}
                 for i, p in enumerate(podium)
             ]
-            awards = self._finale_superlatives if self._finale_superlatives is not None else compute_superlatives(self.get_players())
+            awards = (
+                self._finale_superlatives
+                if self._finale_superlatives is not None
+                else compute_superlatives(self.get_players())
+            )
             if awards:
                 snapshot["superlatives"] = [s.to_dict() for s in awards]
 

--- a/custom_components/quizify/game/timer.py
+++ b/custom_components/quizify/game/timer.py
@@ -93,7 +93,7 @@ class QuestionTimer:
         return max(0.0, time.monotonic() - self._start_time)
 
     @classmethod
-    def resumed(cls, remaining: float, elapsed: float) -> "QuestionTimer":
+    def resumed(cls, remaining: float, elapsed: float) -> QuestionTimer:
         """Build a running timer that reports a known *remaining* AND *elapsed*.
 
         Used by the pause/resume path (#295). A naive ``QuestionTimer(remaining)``

--- a/custom_components/quizify/game/types.py
+++ b/custom_components/quizify/game/types.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from enum import Enum
 
 
-class Difficulty(str, Enum):
+class Difficulty(str, Enum):  # noqa: UP042 — StrEnum changes str()/serialization
     """Question difficulty levels."""
 
     EASY = "easy"

--- a/custom_components/quizify/ha_service.py
+++ b/custom_components/quizify/ha_service.py
@@ -23,7 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def fire_and_forget_service(
-    hass: "HomeAssistant | None",
+    hass: HomeAssistant | None,
     domain: str,
     service: str,
     data: dict[str, object],

--- a/custom_components/quizify/lights.py
+++ b/custom_components/quizify/lights.py
@@ -62,7 +62,7 @@ class QuizifyPartyLights:
 
     def __init__(
         self,
-        hass: "HomeAssistant | None",
+        hass: HomeAssistant | None,
         entity_ids: list[str],
         game_state: QuizifyGameState,
     ) -> None:
@@ -109,7 +109,11 @@ class QuizifyPartyLights:
         # party glow doesn't linger after a session ends. Done by special-
         # casing LOBBY when the round just rolled back to 0 (i.e. came
         # from FINALE/reset, not a fresh boot).
-        if phase == GamePhase.LOBBY and self._game.round == 0 and self._game.game_id is None:
+        if (
+            phase == GamePhase.LOBBY
+            and self._game.round == 0
+            and self._game.game_id is None
+        ):
             self._call("light", "turn_off", {
                 "entity_id": self._entity_ids,
                 "transition": 1.5,

--- a/custom_components/quizify/lobby_music.py
+++ b/custom_components/quizify/lobby_music.py
@@ -36,7 +36,7 @@ class QuizifyLobbyMusic:
 
     def __init__(
         self,
-        hass: "HomeAssistant | None",
+        hass: HomeAssistant | None,
         media_player_entity_id: str | None,
         game_state: QuizifyGameState,
     ) -> None:

--- a/custom_components/quizify/question_stats.py
+++ b/custom_components/quizify/question_stats.py
@@ -152,7 +152,9 @@ class QuestionStatsService:
 
     def get_easiest(self, limit: int = 25, min_shown: int = 3) -> list[dict[str, Any]]:
         """Inverse of get_hardest — highest correct rate."""
-        hardest = self.get_hardest(limit=len(self._data["questions"]), min_shown=min_shown)
+        hardest = self.get_hardest(
+            limit=len(self._data["questions"]), min_shown=min_shown
+        )
         hardest.sort(key=lambda x: x["correct_rate"], reverse=True)
         return hardest[:limit]
 

--- a/custom_components/quizify/runtime.py
+++ b/custom_components/quizify/runtime.py
@@ -15,8 +15,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Awaitable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Awaitable, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant

--- a/custom_components/quizify/server/__init__.py
+++ b/custom_components/quizify/server/__init__.py
@@ -36,7 +36,7 @@ WS_PATH = "/api/quizify/ws"
 
 def build_aiohttp_app(
     ctx: AppContext,
-    ws_handler: "QuizifyWebSocketHandler",
+    ws_handler: QuizifyWebSocketHandler,
 ) -> web.Application:
     """Build a fully-wired aiohttp Application for standalone mode.
 

--- a/custom_components/quizify/server/connection.py
+++ b/custom_components/quizify/server/connection.py
@@ -7,7 +7,8 @@ import json
 import logging
 import time
 import uuid
-from typing import TYPE_CHECKING, Awaitable, Callable
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
 
 from aiohttp import web
 
@@ -20,7 +21,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-def _log_task_exception(task: "asyncio.Task") -> None:
+def _log_task_exception(task: asyncio.Task) -> None:
     """Done-callback surfacing a fire-and-forget task's exception (#307).
 
     Without it, an exception in an ensure_future'd background task (token
@@ -116,7 +117,7 @@ class ConnectionManager:
 
     def iter_admin_and_dashboard_ws(
         self,
-    ) -> "list[tuple[web.WebSocketResponse, bool]]":
+    ) -> list[tuple[web.WebSocketResponse, bool]]:
         """Yield (ws, is_admin) for every admin and dashboard connection.
 
         Lets callers fan out to admin + TV-dashboard spectator sockets
@@ -397,7 +398,7 @@ class ConnectionManager:
         """
         try:
             await asyncio.wait_for(ws.send_json(message), timeout=self._SEND_TIMEOUT)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             _LOGGER.warning("Timed out sending to WebSocket (slow/dead client)")
         except Exception as err:  # noqa: BLE001
             _LOGGER.warning("Failed to send to WebSocket: %s", err)
@@ -417,7 +418,7 @@ class ConnectionManager:
         """
         try:
             await asyncio.wait_for(ws.send_str(payload), timeout=self._SEND_TIMEOUT)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             _LOGGER.warning("Timed out sending to WebSocket (slow/dead client)")
         except Exception as err:  # noqa: BLE001
             _LOGGER.warning("Failed to send to WebSocket: %s", err)

--- a/custom_components/quizify/server/pack_submission.py
+++ b/custom_components/quizify/server/pack_submission.py
@@ -31,7 +31,7 @@ import json
 import logging
 import re
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 import aiohttp
@@ -149,7 +149,9 @@ def validate_pack(pack: object) -> tuple[bool, list[str]]:
         else:
             seen_ids.add(qid)
         if not isinstance(q.get("question"), str) or not q.get("question", "").strip():
-            errors.append(f"{prefix}: 'question' is required and must be a non-empty string.")
+            errors.append(
+                f"{prefix}: 'question' is required and must be a non-empty string."
+            )
         answers = q.get("answers")
         if not isinstance(answers, list) or len(answers) != SUBMIT_ANSWERS_PER_QUESTION:
             errors.append(
@@ -167,7 +169,8 @@ def validate_pack(pack: object) -> tuple[bool, list[str]]:
                 correct_count += 1
         if correct_count != 1:
             errors.append(
-                f"{prefix}: exactly 1 answer must be marked correct (got {correct_count})."
+                f"{prefix}: exactly 1 answer must be marked correct "
+                f"(got {correct_count})."
             )
 
     return (not errors), errors[:10]
@@ -203,7 +206,7 @@ class PackSubmissionStore:
 
     _ISSUE_NUMBER_RE = re.compile(r"/issues/(\d+)(?:[#?].*)?$")
 
-    def __init__(self, ctx: "AppContext") -> None:
+    def __init__(self, ctx: AppContext) -> None:
         self._ctx = ctx
         self._path = ctx.runtime.data_dir / SUBMIT_RECORDS_FILE
         # Shared across all stores pointing at the same file (this class is
@@ -244,8 +247,8 @@ class PackSubmissionStore:
         except ValueError:
             return True
         if last.tzinfo is None:
-            last = last.replace(tzinfo=timezone.utc)
-        elapsed = (datetime.now(timezone.utc) - last).total_seconds()
+            last = last.replace(tzinfo=UTC)
+        elapsed = (datetime.now(UTC) - last).total_seconds()
         return elapsed >= SUBMIT_POLL_INTERVAL_SECONDS
 
     @staticmethod
@@ -280,7 +283,9 @@ class PackSubmissionStore:
                 issue = await resp.json()
             return issue.get("state", ""), issue.get("state_reason") or ""
         except (aiohttp.ClientError, ValueError) as err:
-            _LOGGER.debug("Pack-submission poll: issue %s failed: %s", issue_number, err)
+            _LOGGER.debug(
+                "Pack-submission poll: issue %s failed: %s", issue_number, err
+            )
             return None
 
     async def reconcile(self, data: dict) -> dict:
@@ -290,7 +295,7 @@ class PackSubmissionStore:
         pending or GitHub unreachable — so a failure backs off for the full
         interval instead of retrying on every admin-tab open.
         """
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(UTC).isoformat()
         data["last_poll"] = now
 
         submissions = data.get("submissions", [])
@@ -355,7 +360,7 @@ class PackSubmissionStore:
 # ---------------------------------------------------------------------------
 
 
-def _get_ctx(request: web.Request) -> "AppContext":
+def _get_ctx(request: web.Request) -> AppContext:
     return request.app[APP_CTX_KEY]
 
 
@@ -401,7 +406,10 @@ async def submit_pack_view(request: web.Request) -> web.Response:
     submit_url = (ctx.community_submit_url or "").strip()
     if not submit_url:
         return web.json_response(
-            {"code": ERR_SUBMIT_DISABLED, "message": "Pack submission is not configured."},
+            {
+                "code": ERR_SUBMIT_DISABLED,
+                "message": "Pack submission is not configured.",
+            },
             status=403,
         )
 
@@ -422,7 +430,10 @@ async def submit_pack_view(request: web.Request) -> web.Response:
     client_ip = request.remote or "unknown"
     if not _check_rate_limit(client_ip):
         return web.json_response(
-            {"code": ERR_SUBMIT_RATE_LIMITED, "message": "Too many submissions, slow down."},
+            {
+                "code": ERR_SUBMIT_RATE_LIMITED,
+                "message": "Too many submissions, slow down.",
+            },
             status=429,
         )
 
@@ -440,7 +451,10 @@ async def submit_pack_view(request: web.Request) -> web.Response:
         encoded = json.dumps(pack).encode("utf-8")
     except (TypeError, ValueError):
         return web.json_response(
-            {"code": ERR_SUBMIT_INVALID_FORMAT, "message": "Pack is not serializable JSON."},
+            {
+                "code": ERR_SUBMIT_INVALID_FORMAT,
+                "message": "Pack is not serializable JSON.",
+            },
             status=400,
         )
     if len(encoded) > SUBMIT_MAX_PACK_BYTES:
@@ -475,32 +489,41 @@ async def submit_pack_view(request: web.Request) -> web.Response:
     timeout = aiohttp.ClientTimeout(total=SUBMIT_POLL_TIMEOUT_SECONDS)
     worker_payload: dict[str, Any]
     try:
-        async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.post(
+        async with (
+            aiohttp.ClientSession(timeout=timeout) as session,
+            session.post(
                 submit_url, json={"pack": pack}, headers=submit_headers
-            ) as resp:
-                try:
-                    worker_payload = await resp.json(content_type=None)
-                except (ValueError, aiohttp.ClientError):
-                    worker_payload = {}
-                if resp.status >= 400:
-                    code = worker_payload.get("code") if isinstance(worker_payload, dict) else None
-                    message = (
-                        worker_payload.get("message")
-                        if isinstance(worker_payload, dict)
-                        else None
-                    )
-                    return web.json_response(
-                        {
-                            "code": code or ERR_SUBMIT_GITHUB_ERROR,
-                            "message": message or f"Worker returned HTTP {resp.status}.",
-                        },
-                        status=resp.status if resp.status in (400, 429) else 502,
-                    )
+            ) as resp,
+        ):
+            try:
+                worker_payload = await resp.json(content_type=None)
+            except (ValueError, aiohttp.ClientError):
+                worker_payload = {}
+            if resp.status >= 400:
+                code = (
+                    worker_payload.get("code")
+                    if isinstance(worker_payload, dict)
+                    else None
+                )
+                message = (
+                    worker_payload.get("message")
+                    if isinstance(worker_payload, dict)
+                    else None
+                )
+                return web.json_response(
+                    {
+                        "code": code or ERR_SUBMIT_GITHUB_ERROR,
+                        "message": message or f"Worker returned HTTP {resp.status}.",
+                    },
+                    status=resp.status if resp.status in (400, 429) else 502,
+                )
     except aiohttp.ClientError as err:
         _LOGGER.warning("Pack submission proxy failed: %s", err)
         return web.json_response(
-            {"code": ERR_SUBMIT_GITHUB_ERROR, "message": f"Could not reach the worker: {err}"},
+            {
+                "code": ERR_SUBMIT_GITHUB_ERROR,
+                "message": f"Could not reach the worker: {err}",
+            },
             status=502,
         )
 
@@ -515,11 +538,13 @@ async def submit_pack_view(request: web.Request) -> web.Response:
         "id": f"{int(time.time() * 1000)}",
         "name": str(pack.get("name", "")) if isinstance(pack, dict) else "",
         "language": str(pack.get("language", "")) if isinstance(pack, dict) else "",
-        "question_count": len(pack.get("questions", [])) if isinstance(pack, dict) else 0,
+        "question_count": (
+            len(pack.get("questions", [])) if isinstance(pack, dict) else 0
+        ),
         "issue_number": issue_number,
         "issue_url": issue_url,
         "status": SUBMIT_STATUS_PENDING,
-        "created": datetime.now(timezone.utc).isoformat(),
+        "created": datetime.now(UTC).isoformat(),
         "last_checked": None,
     }
     await PackSubmissionStore(ctx).add(record)

--- a/custom_components/quizify/server/protocol.py
+++ b/custom_components/quizify/server/protocol.py
@@ -239,11 +239,6 @@ CLIENT_MESSAGE_TYPES: frozenset[str] = frozenset({
     "start_lightning_questions",
     "lightning_answer",
     "end_lightning",
-    # Pre-existing handlers (unreleased features wired in the WS layer).
-    # Listed here so the protocol-coverage test passes; remove once the
-    # features either ship or get pulled out of the dispatch.
-    "submit_wager",
-    "reaction",
 })
 
 
@@ -271,7 +266,8 @@ TYPESCRIPT_DECLARATIONS = """
 //   | { type: 'round_summary'; correct_answer_index: number; correct_answer: string;
 //       question_id: string; fun_fact: string; leaderboard: LeaderboardEntry[];
 //       players: Player[]; round: number; total_rounds: number; last_round: boolean;
-//       all_answers: AnswerEntry[]; answer_distribution: DistEntry[]; question_text: string; }
+//       all_answers: AnswerEntry[]; answer_distribution: DistEntry[];
+//       question_text: string; }
 //   | { type: 'finale'; podium: PodiumEntry[]; leaderboard: LeaderboardEntry[];
 //       all_players: LeaderboardEntry[]; superlatives: Superlative[]; }
 //   | { type: 'game_state'; phase: GamePhase; round: number; total_rounds: number;

--- a/custom_components/quizify/server/round_message_builder.py
+++ b/custom_components/quizify/server/round_message_builder.py
@@ -307,7 +307,11 @@ class RoundMessageBuilder:
                     if 0 <= submitted_orig < len(summary.question.answers)
                     else "?"
                 )
-                is_correct = summary.question.answers[submitted_orig].correct if submitted_orig < len(summary.question.answers) else False
+                is_correct = (
+                    summary.question.answers[submitted_orig].correct
+                    if submitted_orig < len(summary.question.answers)
+                    else False
+                )
                 breakdown = player.round_score_breakdown
                 all_answers.append({
                     "player_name": player.name,
@@ -318,7 +322,9 @@ class RoundMessageBuilder:
                     "points_earned": player.round_score,
                     "speed_bonus": breakdown.get("speed_bonus", 0),
                     "streak_bonus": breakdown.get("streak_bonus", 0),
-                    "difficulty_multiplier": breakdown.get("difficulty_multiplier", 1.0),
+                    "difficulty_multiplier": breakdown.get(
+                        "difficulty_multiplier", 1.0
+                    ),
                     "double_points": breakdown.get("double_points", False),
                     "streak": player.streak,
                 })

--- a/custom_components/quizify/server/serializers.py
+++ b/custom_components/quizify/server/serializers.py
@@ -25,7 +25,8 @@ def build_game_status_response(
     return {
         "exists": True,
         "phase": game_state.phase.value,
-        "can_join": game_state.phase.value in ("LOBBY", "QUESTION_ACTIVE", "ANSWER_REVEAL"),
+        "can_join": game_state.phase.value
+        in ("LOBBY", "QUESTION_ACTIVE", "ANSWER_REVEAL"),
     }
 
 
@@ -107,7 +108,9 @@ def serialize_leaderboard(players: list[PlayerSession]) -> list[dict[str, Any]]:
         if prev_score is None or p.score != prev_score:
             rank = i + 1
             prev_score = p.score
-        breakdown = p.round_score_breakdown if hasattr(p, "round_score_breakdown") else {}
+        breakdown = (
+            p.round_score_breakdown if hasattr(p, "round_score_breakdown") else {}
+        )
         # Determine if this player answered correctly this round
         last_result = p.round_history[-1] if p.round_history else None
         result.append({
@@ -208,7 +211,9 @@ def serialize_round_summary(
     the same payload to avoid a dashboard-only round_summary fork.
     """
     # Compute answer distribution from all_answers
-    answer_distribution = _compute_answer_distribution(all_answers or [], num_answer_options)
+    answer_distribution = _compute_answer_distribution(
+        all_answers or [], num_answer_options
+    )
 
     return {
         "type": "round_summary",

--- a/custom_components/quizify/server/token_store.py
+++ b/custom_components/quizify/server/token_store.py
@@ -11,6 +11,7 @@ locations), and that's fine — admin bootstraps once per host.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -61,10 +62,8 @@ class TokenStore:
         """Delete the storage file (idempotent)."""
         async with self._lock:
             def _rm() -> None:
-                try:
+                with contextlib.suppress(FileNotFoundError):
                     self._path.unlink()
-                except FileNotFoundError:
-                    pass
 
             try:
                 await self._runtime.run_in_executor(_rm)

--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -87,7 +87,7 @@ _ASSET_FP_CACHE: tuple[int, str] | None = None  # (monotonic_ns, fingerprint)
 _MANIFEST_CACHE: tuple[int, str] | None = None
 
 
-def _get_ctx(request: web.Request) -> "AppContext":
+def _get_ctx(request: web.Request) -> AppContext:
     """Pull the AppContext stashed on the aiohttp application."""
     return request.app[APP_CTX_KEY]
 
@@ -192,7 +192,7 @@ def _get_asset_version(version: str) -> str:
     return f"{version}-{fingerprint}"
 
 
-async def _get_asset_version_async(ctx: "AppContext", version: str) -> str:
+async def _get_asset_version_async(ctx: AppContext, version: str) -> str:
     """Async cache-buster value, never blocking the event loop (#213).
 
     Fast path (cache fresh): no filesystem access, returns inline. Slow path
@@ -564,10 +564,12 @@ async def pack_update_check_view(request: web.Request) -> web.Response:
     upstream: dict | None = None
     try:
         timeout = aiohttp.ClientTimeout(total=5)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.get(_PACK_VERSIONS_URL) as resp:
-                if resp.status == 200:
-                    upstream = await resp.json(content_type=None)
+        async with (
+            aiohttp.ClientSession(timeout=timeout) as session,
+            session.get(_PACK_VERSIONS_URL) as resp,
+        ):
+            if resp.status == 200:
+                upstream = await resp.json(content_type=None)
     except Exception as exc:  # noqa: BLE001
         _LOGGER.warning("Pack update check failed: %s", exc)
 

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import math
 import random
@@ -92,7 +93,7 @@ class QuizifyWebSocketHandler:
     def __init__(
         self,
         runtime: Runtime,
-        game_state_provider: "Callable[[], QuizifyGameState | None]",
+        game_state_provider: Callable[[], QuizifyGameState | None],
     ) -> None:
         """Initialize handler."""
         self._runtime = runtime
@@ -277,7 +278,9 @@ class QuizifyWebSocketHandler:
             self._conn.remove_connection(ws)
             self._forget_rate_limit(ws)
             await self._handle_disconnect(ws, was_admin=was_admin)
-            _LOGGER.debug("WebSocket disconnected, total: %d", len(self._conn.connections))
+            _LOGGER.debug(
+                "WebSocket disconnected, total: %d", len(self._conn.connections)
+            )
 
         return ws
 
@@ -676,17 +679,17 @@ class QuizifyWebSocketHandler:
             player.is_admin
             and game_state.phase == GamePhase.PAUSED
             and game_state.get_pause_reason() == "admin_disconnected"
+            and game_state.resume()
         ):
-            if game_state.resume():
-                self._start_timer_tick(game_state)
-                # Broadcast the resumed state to EVERY player (#287). Without
-                # this, the other players stay frozen on the "Host disconnected"
-                # paused-view (player-core.js only leaves it on a game_state
-                # message) while their timers tick down → scored as timeouts.
-                # Per-player PROJECTED — same mechanism as the manual-resume
-                # fix (#286) so answer buttons keep the right shuffle order.
-                await self._broadcast_state_projected(game_state)
-                _LOGGER.info("Auto-resumed after admin reconnect")
+            self._start_timer_tick(game_state)
+            # Broadcast the resumed state to EVERY player (#287). Without
+            # this, the other players stay frozen on the "Host disconnected"
+            # paused-view (player-core.js only leaves it on a game_state
+            # message) while their timers tick down → scored as timeouts.
+            # Per-player PROJECTED — same mechanism as the manual-resume
+            # fix (#286) so answer buttons keep the right shuffle order.
+            await self._broadcast_state_projected(game_state)
+            _LOGGER.info("Auto-resumed after admin reconnect")
 
         # Generate a fresh token and revoke old one
         new_token = self._conn.rotate_session_token(token, name)
@@ -745,7 +748,9 @@ class QuizifyWebSocketHandler:
         if 0 <= shuffled_index < len(player_shuffle):
             original_index = player_shuffle[shuffled_index]
         else:
-            await self._conn.send_error(ws, ERR_INVALID_ACTION, "Answer index out of range")
+            await self._conn.send_error(
+                ws, ERR_INVALID_ACTION, "Answer index out of range"
+            )
             return
 
         result = game_state.submit_answer(player.name, original_index)
@@ -990,7 +995,10 @@ class QuizifyWebSocketHandler:
             }
 
             # For joker, send the removed answer to the using player only
-            if result.type == PowerUpType.JOKER and result.joker_remove_index is not None:
+            if (
+                result.type == PowerUpType.JOKER
+                and result.joker_remove_index is not None
+            ):
                 # Map the canonical original index to THIS player's shuffled
                 # position. The buttons are rendered in the per-player shuffle
                 # order, so mapping through the canonical shuffle_map would
@@ -1312,10 +1320,9 @@ class QuizifyWebSocketHandler:
         # connections actually die. Real clients have already received the
         # reset above and will reconnect into the fresh lobby on their own.
         for pws in stale_wses:
-            try:
+            # Best-effort cleanup — a socket that's already gone is fine.
+            with contextlib.suppress(Exception):
                 await pws.close()
-            except Exception:  # noqa: BLE001 — best-effort cleanup
-                pass
 
     # ------------------------------------------------------------------
     # Admin: kick player
@@ -1358,7 +1365,9 @@ class QuizifyWebSocketHandler:
 
         if target_ws is not None and not target_ws.closed:
             try:
-                await target_ws.send_json({"type": "kicked", "reason": "removed_by_admin"})
+                await target_ws.send_json(
+                    {"type": "kicked", "reason": "removed_by_admin"}
+                )
                 await target_ws.close()
             except Exception as err:  # noqa: BLE001
                 _LOGGER.debug("Closing kicked player WS raised: %s", err)
@@ -1683,7 +1692,9 @@ class QuizifyWebSocketHandler:
         # Canonical shuffle — used by admin/dashboard and as a fallback.
         indices = list(range(len(question.answers)))
         random.shuffle(indices)
-        game_state.set_round_shuffle(indices, [question.answers[i].text for i in indices])
+        game_state.set_round_shuffle(
+            indices, [question.answers[i].text for i in indices]
+        )
 
         # Per-player shuffles: each phone sees A/B/C in its own order
         # (anti-cheat — couch neighbours can't shout "B!"). The
@@ -1904,13 +1915,12 @@ class QuizifyWebSocketHandler:
             if was_admin is not None
             else self._conn.is_admin_connection(ws)
         )
-        if is_admin_ws:
-            if not self._conn.has_admin_connections():
-                _LOGGER.info(
-                    "Admin disconnected, keeping game alive for %ds",
-                    self._conn.ADMIN_SESSION_GRACE,
-                )
-                self._conn.schedule_admin_timeout()
+        if is_admin_ws and not self._conn.has_admin_connections():
+            _LOGGER.info(
+                "Admin disconnected, keeping game alive for %ds",
+                self._conn.ADMIN_SESSION_GRACE,
+            )
+            self._conn.schedule_admin_timeout()
 
         player = game_state.get_player_by_ws(ws)
         if not player:
@@ -1970,7 +1980,9 @@ class QuizifyWebSocketHandler:
                         "type": "player_left",
                         "players": serialize_player_list(remaining),
                     })
-                    _LOGGER.info("Removed disconnected player after grace period: %s", name)
+                    _LOGGER.info(
+                        "Removed disconnected player after grace period: %s", name
+                    )
 
         self._conn.schedule_player_removal(player.name, grace, remove_after_timeout)
 

--- a/custom_components/quizify/tts.py
+++ b/custom_components/quizify/tts.py
@@ -41,7 +41,7 @@ class QuizifyTTSAnnouncer:
 
     def __init__(
         self,
-        hass: "HomeAssistant | None",
+        hass: HomeAssistant | None,
         tts_entity_id: str | None,
         media_player_entity_id: str | None,
         game_state: QuizifyGameState,
@@ -117,7 +117,10 @@ class QuizifyTTSAnnouncer:
         if phase == GamePhase.FINALE:
             leader = self._game.leader
             if leader is not None:
-                self._speak(f"Game over. The winner is {leader.name} with {leader.score} points!")
+                self._speak(
+                    f"Game over. The winner is {leader.name} "
+                    f"with {leader.score} points!"
+                )
             else:
                 self._speak("Game over.")
             return
@@ -140,8 +143,15 @@ class QuizifyTTSAnnouncer:
         if not self.is_configured:
             return
         now = time.monotonic()
-        if self._last_spoken_at is not None and now - self._last_spoken_at < TTS_MIN_INTERVAL:
-            _LOGGER.debug("TTS throttled (%.1fs since last): %s", now - self._last_spoken_at, message)
+        if (
+            self._last_spoken_at is not None
+            and now - self._last_spoken_at < TTS_MIN_INTERVAL
+        ):
+            _LOGGER.debug(
+                "TTS throttled (%.1fs since last): %s",
+                now - self._last_spoken_at,
+                message,
+            )
             return
         self._last_spoken_at = now
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,28 @@
+# Ruff configuration for the Quizify Home Assistant custom integration.
+#
+# The CI lint gate (.github/workflows/test.yml, issue #306) runs
+# `ruff check custom_components/`. This file is the single source of truth for
+# the ruleset it enforces.
+#
+# Ruleset history:
+#   - Initial gate (#306): E4/E7/E9 + F + I — the safe, high-signal core.
+#   - #328: added E501 (line-length) plus B (flake8-bugbear), SIM
+#     (flake8-simplify), UP (pyupgrade) and C4 (flake8-comprehensions) after
+#     fixing every existing violation, so the gate now enforces them too.
+[tool.ruff]
+line-length = 88
+target-version = "py313"
+
+[tool.ruff.lint]
+select = [
+    "E4",   # pycodestyle — import errors
+    "E7",   # pycodestyle — statement errors
+    "E9",   # pycodestyle — runtime/syntax errors
+    "E501", # pycodestyle — line too long
+    "F",    # pyflakes
+    "I",    # isort — import ordering
+    "B",    # flake8-bugbear
+    "SIM",  # flake8-simplify
+    "UP",   # pyupgrade
+    "C4",   # flake8-comprehensions
+]


### PR DESCRIPTION
## What

Implements the deferred ruff tech-debt item from #328: fix all violations in the previously-deferred style families, then add them to the ruff `select` so the CI lint gate enforces them.

While doing this I found the documented ruff config (`pyproject.toml`) was **gitignored**, so the `ruff check` gate (#306) was silently running with ruff's defaults (not even `I`). This PR commits the config so the gate actually enforces the intended ruleset: `E4/E7/E9 + F + I` (core) plus the new `E501 + B + SIM + UP + C4`.

## Fixes by family

| Family | Count | What |
|---|---|---|
| E501 line-too-long | ~62 | Manual wraps (call args, ternaries, boolean chains, long log/f-strings, dict literals, inline comments moved above). 1 TS-mirror docstring line split. No `# noqa` needed. |
| UP037 quoted-annotation | 14 | Autofix — safe, every module has `from __future__ import annotations`. |
| UP035 deprecated-import | 2 | `Awaitable`/`Callable` → `collections.abc`; imports re-sorted. |
| UP017 datetime.UTC | 11 | `timezone.utc` → `UTC`; dropped now-unused `timezone` import. |
| UP041 aliased-errors | 2 | `asyncio.TimeoutError` → builtin `TimeoutError` (identical on 3.11+). |
| C420 dict-comprehension | 1 | → `dict.fromkeys`. |
| B033 duplicate set value | 2 | Removed redundant `submit_wager`/`reaction` (already in the same frozenset). |
| SIM105 | 3 | `try/except/pass` → `contextlib.suppress`. |
| SIM117 | 2 | Nested `async with` → single parenthesized `with`. |
| SIM102 | 2 | Nested `if` → combined `and` (short-circuit preserves the side-effectful `resume()` guard). |

## `# noqa` exceptions (behavior-risky, left as-is per #328 guidance)

- **UP042 ×3** (`game/phase_controller.py`, `game/powerups.py`, `game/types.py`): `class X(str, Enum)` → `StrEnum` changes `str()`/format/serialization semantics, and these enums travel over the WS protocol. Kept with `# noqa: UP042`.
- **SIM108 ×1** (`game/scoring_engine.py`): the `if/else` carries an inline explanatory comment a ternary would drop. Kept with `# noqa: SIM108`.

No hunks had to be reverted — all autofixes were verified behavior-preserving.

## Verification

- `ruff check custom_components/` → **green** (exit 0), reading the committed config.
- Full suite: **649 passed**, identical to a clean `origin/main` checkout. The 6 failing `test_ws_handle_integration_293.py` cases are a known local-only `pytest-socket` sandbox artifact — they fail the same way on origin/main and are unrelated to this change.
- Generated artifacts (`player.bundle.js` / `styles.css`) rebuild with **zero drift** (ruff only touches Python).

No behavior change; the gate now enforces these families.

Refs #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)