### PR TITLE
chore: add mypy type-check gate (#328)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,33 @@ jobs:
       - name: Ruff lint
         run: ruff check custom_components/
 
+  mypy:
+    # Static type-check gate (issue #328). Pragmatic, NOT --strict: the
+    # [tool.mypy] config in pyproject.toml catches real type errors (wrong
+    # types, Optional-init mistakes) while scoping ignore_missing_imports to
+    # the HA/aiohttp stack so framework typing gaps don't red the gate.
+    # Home Assistant is installed so its config-entry / metaclass typing
+    # (e.g. ConfigFlow's `domain=` __init_subclass__ kwarg) resolves — without
+    # it mypy can't see the framework base classes and flags a false positive.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install mypy + runtime/framework deps
+        run: |
+          python -m pip install --upgrade pip
+          # HA (+ its transitive aiohttp/voluptuous) so framework imports
+          # resolve; capped < 2026.3 to stay on the 3.13-compatible line, same
+          # constraint the test job uses. mypy pinned for a deterministic gate.
+          pip install "homeassistant<2026.3" "mypy==1.13.0"
+
+      - name: mypy type-check
+        run: mypy
+
   drift:
     # Generated-artifact-drift guard (issue #306). player.bundle.js / styles.css
     # are committed but generated from www/js/ and www/css/src/ modules. The

--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -105,14 +105,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Community-pack submission stays inert until this worker URL is set
         # (#180). Empty/unset → the in-app submit UI hides itself.
         community_submit_url=(
-            (entry.options or {}).get(CONF_COMMUNITY_SUBMIT_URL) or ""
+            entry.options.get(CONF_COMMUNITY_SUBMIT_URL) or ""
         ).strip()
         or None,
         # Shared secret sent as X-Quizify-Secret to the worker (#256). Empty →
         # header omitted (back-compatible); set it alongside the worker's
         # SHARED_SECRET to close the open-proxy hole.
         community_submit_secret=(
-            (entry.options or {}).get(CONF_COMMUNITY_SUBMIT_SECRET) or ""
+            entry.options.get(CONF_COMMUNITY_SUBMIT_SECRET) or ""
         ).strip()
         or None,
     )
@@ -178,8 +178,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Wire optional HA integrations from the options flow. Both attach via
     # game state callbacks (Phase 1 plumbing) and stay silent if their
-    # respective entities aren't configured.
-    options = entry.options or {}
+    # respective entities aren't configured. (entry.options is always a
+    # MappingProxyType — never None — so no `or {}` fallback is needed.)
+    options = entry.options
     # Lobby music plays server-side on the configured media_player while the
     # game waits in the lobby. Empty/unset → the playback service stays inert.
     game_state.lobby_music_url = (
@@ -220,7 +221,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def _update_listener(
         _hass: HomeAssistant, updated_entry: ConfigEntry
     ) -> None:
-        opts = updated_entry.options or {}
+        opts = updated_entry.options  # always a MappingProxyType, never None
         game_state.lobby_music_url = (
             (opts.get(CONF_LOBBY_MUSIC_URL) or "").strip() or None
         )

--- a/custom_components/quizify/game/player_registry.py
+++ b/custom_components/quizify/game/player_registry.py
@@ -17,6 +17,8 @@ from ..const import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from aiohttp import web
 
 from .player import PLAYER_COLORS, PlayerSession
@@ -67,7 +69,7 @@ class PlayerRegistry:
         name: str,
         ws: web.WebSocketResponse,
         phase_value: str,
-        average_score_fn: callable,
+        average_score_fn: Callable[[], int],
     ) -> tuple[bool, str | None]:
         """Add a player to the game.
 

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -8,7 +8,7 @@ import logging
 import random
 import secrets
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -49,7 +49,10 @@ from .types import TIME_LIMITS, Difficulty
 if TYPE_CHECKING:
     from aiohttp import web
 
+    from ..analytics import QuizifyAnalytics
+    from ..question_stats import QuestionStatsService
     from ..runtime import Runtime
+    from .lightning import LightningRound
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -157,7 +160,7 @@ class QuizifyGameState:
 
         # Broadcast callback — set by websocket layer
         self._broadcast_callback: (
-            Callable[[dict[str, Any]], Awaitable[None]] | None
+            Callable[[dict[str, Any]], Coroutine[Any, Any, None]] | None
         ) = None
 
         # State-change observers (HA sensor entities subscribe here so they
@@ -165,9 +168,9 @@ class QuizifyGameState:
         self._state_callbacks: list[Callable[[], None]] = []
 
         # Analytics / stats service (injected from __init__.py)
-        self._stats_service = None
+        self._stats_service: QuizifyAnalytics | None = None
         # Per-question stats sink (optional; standalone tests skip it).
-        self._question_stats = None
+        self._question_stats: QuestionStatsService | None = None
         self._game_start_time: float | None = None
 
         # Cached finale data (computed once in end_game, cleared in reset_to_lobby)
@@ -178,7 +181,7 @@ class QuizifyGameState:
         # Active LightningRound (issue #42), or None when not in a lightning
         # round. Owns its own questions/scores/recap; this class only holds
         # the reference + phase so the WS layer can route to it.
-        self._lightning = None  # type: ignore[assignment]
+        self._lightning: LightningRound | None = None
 
         # True between start_lightning_round() and begin_lightning_questions():
         # the intro splash ("Bolt Burst", issue #201) is on screen and the
@@ -922,9 +925,14 @@ class QuizifyGameState:
 
         # Persist any per-question stats accumulated this game.
         if self._question_stats is not None:
+            # Bind to a local so the narrowed (non-None) type survives into the
+            # nested coroutine closure (mypy can't assume the attribute stays
+            # non-None across the await).
+            question_stats = self._question_stats
+
             async def _save_qs() -> None:
                 try:
-                    await self._question_stats.save_if_dirty()
+                    await question_stats.save_if_dirty()
                 except Exception:  # noqa: BLE001
                     _LOGGER.exception("Failed to save question stats")
 
@@ -988,6 +996,12 @@ class QuizifyGameState:
         if not self._stats_service or not self.game_id:
             return
 
+        # Bind the narrowed (non-None) values to locals so they survive into
+        # the nested coroutine closure below (mypy re-widens self.* across the
+        # await boundary).
+        stats_service = self._stats_service
+        game_id = self.game_id
+
         duration = int(time.time() - (self._game_start_time or time.time()))
         players = {p.name: p.score for p in self.get_players()}
         # Per-player details feed the all-time rollup (best streak, milestone
@@ -1003,8 +1017,8 @@ class QuizifyGameState:
 
         async def _do_record() -> None:
             try:
-                await self._stats_service.record_game(
-                    game_id=self.game_id,
+                await stats_service.record_game(
+                    game_id=game_id,
                     category=self.category,
                     difficulty=self.difficulty,
                     num_rounds=self.round,
@@ -1489,7 +1503,7 @@ class QuizifyGameState:
 
         if self.phase == GamePhase.LIGHTNING and self._lightning is not None:
             lr = self._lightning
-            q = lr.current_question
+            lq = lr.current_question
             snapshot["lightning"] = {
                 "index": lr.index,
                 "num_questions": lr.num_questions,
@@ -1500,14 +1514,14 @@ class QuizifyGameState:
                 # showing and the first question hasn't been broadcast.
                 "splash_pending": self._lightning_splash_pending,
             }
-            if q is not None:
+            if lq is not None:
                 # Canonical (admin/TV) answer order; players get their own
                 # shuffle pushed via the lightning_question event.
                 snapshot["lightning"]["question"] = {
-                    "text": q.question,
-                    "answers": [a.text for a in q.answers],
-                    "category": q.category,
-                    "image_url": q.image_url,
+                    "text": lq.question,
+                    "answers": [a.text for a in lq.answers],
+                    "category": lq.category,
+                    "image_url": lq.image_url,
                 }
 
         if self.phase == GamePhase.LIGHTNING_RECAP and self._lightning is not None:
@@ -1520,7 +1534,7 @@ class QuizifyGameState:
     # ------------------------------------------------------------------
 
     def set_broadcast_callback(
-        self, callback: Callable[[dict[str, Any]], Awaitable[None]]
+        self, callback: Callable[[dict[str, Any]], Coroutine[Any, Any, None]]
     ) -> None:
         """Set the callback used to broadcast state to connected clients."""
         self._broadcast_callback = callback

--- a/custom_components/quizify/question_stats.py
+++ b/custom_components/quizify/question_stats.py
@@ -130,7 +130,7 @@ class QuestionStatsService:
     def get_hardest(self, limit: int = 25, min_shown: int = 3) -> list[dict[str, Any]]:
         """Questions with the LOWEST correct rate, gated by min_shown so a
         one-time miss doesn't dominate the list."""
-        items = []
+        items: list[dict[str, Any]] = []
         for q in self._data["questions"].values():
             if q["shown_count"] < min_shown:
                 continue

--- a/custom_components/quizify/runtime.py
+++ b/custom_components/quizify/runtime.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable
+from collections.abc import Coroutine
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
@@ -37,7 +37,7 @@ class Runtime(Protocol):
         Files live directly under this directory (no extra ``quizify/`` prefix).
         """
 
-    def create_task(self, coro: Awaitable[Any]) -> Any:
+    def create_task(self, coro: Coroutine[Any, Any, Any]) -> Any:
         """Schedule *coro* on the running event loop, fire-and-forget."""
 
     async def run_in_executor(self, func, *args) -> Any:
@@ -60,7 +60,7 @@ class HARuntime:
         """Underlying HA instance, for code paths that genuinely need it."""
         return self._hass
 
-    def create_task(self, coro: Awaitable[Any]) -> Any:
+    def create_task(self, coro: Coroutine[Any, Any, Any]) -> Any:
         return self._hass.async_create_task(coro)
 
     async def run_in_executor(self, func, *args) -> Any:
@@ -78,7 +78,7 @@ class StandaloneRuntime:
     def data_dir(self) -> Path:
         return self._data_dir
 
-    def create_task(self, coro: Awaitable[Any]) -> Any:
+    def create_task(self, coro: Coroutine[Any, Any, Any]) -> Any:
         return asyncio.ensure_future(coro)
 
     async def run_in_executor(self, func, *args) -> Any:

--- a/custom_components/quizify/server/serializers.py
+++ b/custom_components/quizify/server/serializers.py
@@ -261,7 +261,7 @@ def _compute_answer_distribution(
         elif isinstance(idx, int) and 0 <= idx < num_options:
             counts[idx] += 1
 
-    distribution = []
+    distribution: list[dict[str, Any]] = []
     for i, count in enumerate(counts):
         distribution.append({
             "index": i,

--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -29,7 +29,13 @@ from .pack_submission import (
 from .serializers import build_game_status_response
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from .context import AppContext
+
+    # aiohttp request handler shape, matching what `UrlDispatcher.add_route`
+    # accepts. Used to type the ROUTES table precisely instead of `object`.
+    _RouteHandler = Callable[[web.Request], Awaitable[web.StreamResponse]]
 
 
 # GitHub raw URL for pack version manifests
@@ -416,6 +422,13 @@ async def featured_pack_view(request: web.Request) -> web.Response:
     else:
         logic_used = logic
 
+    # Invariant: every branch above resolves `chosen` to a real pack slug — the
+    # `chosen is None` fallback always assigns one, and the seasonal/logic
+    # branches only reach the final `else` when `chosen` is already set. Assert
+    # it so the downstream `seasons.get` / `lang_packs[...]` accesses are typed
+    # as `str` (mypy can't correlate the separate `seasonal_active` flag).
+    assert chosen is not None
+
     # The pinned pack's label (e.g. "🎄 Weihnachten") for the spotlight subtitle
     # and the picker badge. ``season_label`` is the active label or "".
     chosen_season = seasons.get(chosen)
@@ -702,7 +715,7 @@ async def flag_list_view(request: web.Request) -> web.Response:
 
 # Each entry is (method, path, handler). Kept as data so the HA adapter and
 # the standalone server can register the same set without duplication.
-ROUTES: list[tuple[str, str, object]] = [
+ROUTES: list[tuple[str, str, _RouteHandler]] = [
     ("GET", "/quizify/admin", admin_view),
     ("GET", "/quizify/launcher", launcher_view),
     ("GET", "/quizify/player", player_view),

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from ..runtime import Runtime
+    from ..tts import QuizifyTTSAnnouncer
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -114,7 +115,7 @@ class QuizifyWebSocketHandler:
         # Optional TTS announcer. Set by __init__.py / dev_server after
         # construction so the handler doesn't have to know about HA
         # services. Calling announce_milestone on None is the no-op path.
-        self._tts_announcer = None
+        self._tts_announcer: QuizifyTTSAnnouncer | None = None
         # Per-connection message flood guard (#169). Keyed on id(ws); the
         # entry is dropped by _forget_rate_limit() on disconnect so the
         # backing dict is bounded by the number of *live* connections.
@@ -326,7 +327,10 @@ class QuizifyWebSocketHandler:
             return
 
         handlers = self._message_dispatch(data, game_state)
-        entry = handlers.get(msg_type)
+        # msg_type comes from untyped client JSON and may be None (no "type"
+        # field) — dict.get tolerates that and routes it to the unknown-type
+        # branch below, so the arg-type mismatch is intentional.
+        entry = handlers.get(msg_type)  # type: ignore[arg-type]
         if entry is None:
             _LOGGER.warning("Unknown message type: %s", msg_type)
             await self._conn.send_error(ws, ERR_INVALID_ACTION, "Unknown message type")
@@ -507,7 +511,7 @@ class QuizifyWebSocketHandler:
         # Auto-append number if name is taken
         original_name = name
         counter = 2
-        while game_state.get_player(name) and game_state.get_player(name).connected:
+        while (existing := game_state.get_player(name)) and existing.connected:
             name = f"{original_name} {counter}"
             counter += 1
 
@@ -959,7 +963,10 @@ class QuizifyWebSocketHandler:
 
         wager = data.get("wager")
         try:
-            wager_int = int(wager)
+            # wager is untyped client JSON (may be None / non-numeric); the
+            # except below catches TypeError/ValueError from int() — the
+            # arg-type mismatch is the intended defensive path.
+            wager_int = int(wager)  # type: ignore[arg-type]
         except (TypeError, ValueError):
             await self._conn.send_error(ws, ERR_INVALID_ACTION, "Invalid wager")
             return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,46 @@ select = [
     "UP",   # pyupgrade
     "C4",   # flake8-comprehensions
 ]
+
+# mypy configuration for the Quizify Home Assistant custom integration.
+#
+# The CI type-check gate (.github/workflows/test.yml, issue #328) runs
+# `mypy custom_components/quizify`. This is a *pragmatic* baseline gate, not
+# `--strict`: the goal is to catch real type errors (wrong types,
+# Optional-init mistakes) and keep the gate GREEN, rather than drown CI in
+# hundreds of HA-framework / untyped-def warnings that carry no runtime
+# signal. `disallow_untyped_defs` / `strict` are intentionally NOT enabled.
+#
+# `ignore_missing_imports` is scoped per-module to HA + its async/web stack
+# (homeassistant.*, aiohttp.*, voluptuous, …) whose type stubs are absent or
+# incomplete — everything else is still checked normally.
+[tool.mypy]
+python_version = "3.13"
+files = ["custom_components/quizify"]
+# The package uses absolute `custom_components.quizify.*` imports, but there is
+# no `custom_components/__init__.py` (HA loads it as a namespace path). Anchor
+# the module namespace at the repo root so mypy resolves every module under the
+# single `custom_components.quizify.*` name (avoids the "found twice under
+# different module names" clash).
+explicit_package_bases = true
+mypy_path = "."
+namespace_packages = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+no_implicit_optional = true
+# Keep the baseline pragmatic — checking untyped def bodies would surface the
+# strict flood (#328). Annotated code is still fully checked.
+check_untyped_defs = false
+
+# Third-party packages without (complete) type stubs. Scoped per-module so the
+# rest of the tree keeps real import resolution. HA + aiohttp + voluptuous ship
+# either no stubs or partial ones; treating their imports as `Any` here removes
+# framework noise without weakening checks on our own code.
+[[tool.mypy.overrides]]
+module = [
+    "homeassistant.*",
+    "aiohttp.*",
+    "voluptuous.*",
+    "pytest_homeassistant_custom_component.*",
+]
+ignore_missing_imports = true


### PR DESCRIPTION
Enables a **pragmatic, green** mypy type-check gate over `custom_components/quizify` — the last deferred tech-debt box from #328 ([#328](https://github.com/mholzi/quizify/issues/328)). The other three boxes are already done (#329/#330/#331); completing this one resolves the tracking issue.

## Config & strictness (why not `--strict`)
`mypy==1.13.0`, configured in `[tool.mypy]` (pyproject.toml — already tracked since #331). Deliberately **not** `--strict`: a strict run surfaces hundreds of HA-framework / untyped-def warnings that carry no runtime signal and would red the gate forever. The goal is the ~15 real errors #328 flagged, caught and green.

- `python_version = "3.13"`, `files = ["custom_components/quizify"]`
- `explicit_package_bases = true` + `mypy_path = "."` + `namespace_packages = true` — the package uses absolute `custom_components.quizify.*` imports but has no `custom_components/__init__.py` (HA loads it as a namespace path); this anchors every module under one name and avoids the "found twice under different module names" clash.
- `warn_redundant_casts`, `warn_unused_ignores = true`, `no_implicit_optional = true`
- `check_untyped_defs = false` (avoids the strict flood — annotated code is still fully checked); `disallow_untyped_defs` / `strict` intentionally **off**
- per-module `[[tool.mypy.overrides]]` `ignore_missing_imports = true` scoped to `homeassistant.*`, `aiohttp.*`, `voluptuous.*`, `pytest_homeassistant_custom_component.*` (no / partial stubs). The rest of the tree keeps real import resolution.

## Fixed properly (13 — annotations + behaviour-preserving guards, no runtime change)
Type annotations are erased at runtime; the two guards added (`assert`, walrus) preserve existing logic exactly.

- **player_registry** — `average_score_fn: callable` (the builtin, invalid as a type annotation) → `Callable[[], int]`
- **runtime** — `create_task(coro: Awaitable[Any])` → `Coroutine[Any, Any, Any]` (Protocol + both impls) to match HA's `async_create_task`; every caller already passes a coroutine
- **question_stats** / **serializers** — annotated the heterogeneous result lists `list[dict[str, Any]]` so `.sort(key=...)` and mixed-value dicts type-check
- **state** — typed the injected optionals via TYPE_CHECKING imports: `_stats_service: QuizifyAnalytics | None`, `_question_stats: QuestionStatsService | None`, `_lightning: LightningRound | None`, broadcast callback `Coroutine`; bound narrowed optionals to locals before nested coroutine closures (mypy re-widens `self.*` across `await`); renamed a clashing `q` → `lq` in the lightning snapshot branch; removed a now-redundant `# type: ignore[assignment]`
- **views** — typed the `ROUTES` handler element (`object` → aiohttp handler alias `Callable[[Request], Awaitable[StreamResponse]]`); added `assert chosen is not None` documenting a real invariant every branch already satisfies
- **__init__** — dropped the redundant `entry.options or {}` (HA's `ConfigEntry` coerces options to a `MappingProxyType` in its constructor — never `None`) so `dict.get` overloads resolve cleanly
- **websocket** — walrus narrowing for the name-collision loop: `while (existing := game_state.get_player(name)) and existing.connected` (also removes a double lookup)

## Suppressed (2 — scoped inline `# type: ignore[code]`, with reasons)
Both are values from **untyped client JSON** where the defensive runtime path is intentional:

- `websocket.py` `entry = handlers.get(msg_type)  # type: ignore[arg-type]` — `msg_type` may be `None` (no `"type"` field); `dict.get` tolerates it and routes to the unknown-type branch.
- `websocket.py` `wager_int = int(wager)  # type: ignore[arg-type]` — `wager` may be `None`/non-numeric; the surrounding `try/except (TypeError, ValueError)` is the intended path.

No blanket file-level ignores; no per-module `disable_error_code`.

## CI
New `mypy` job in `.github/workflows/test.yml`: installs `homeassistant<2026.3` (same cap as the test job, pulls aiohttp/voluptuous transitively) + `mypy==1.13.0`, runs `mypy`. A real gate (non-zero exit fails CI). HA is installed because without it mypy false-positives in `config_flow.py` (can't see `ConfigFlow`'s `domain=` `__init_subclass__` kwarg).

## Verification
- **mypy**: `Success: no issues found in 39 source files` (exit 0)
- **ruff**: `ruff check custom_components/` → `All checks passed!` (gate not regressed)
- **tests**: full suite **649 passed**. The 6 `test_ws_handle_integration_293.py` `SocketBlockedError` failures are a known local-sandbox artifact — confirmed **identical** on a clean `origin/main` checkout with the same venv (6 failed / 649 passed both sides), **zero new failures introduced**. CI's pytest job has sockets, so it stays green there.
- **no artifact drift**: rebuilt via `build_bundle.py` + `build_css.py` → `player.bundle.js` and `styles.css` unchanged (Python + config only).

No user-facing behaviour change.

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)