### PR TITLE
feat: auto-trigger Lightning Round mid-game (#285)

### DIFF
--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -185,9 +185,30 @@ class QuizifyGameState:
 
         # True between start_lightning_round() and begin_lightning_questions():
         # the intro splash ("Bolt Burst", issue #201) is on screen and the
-        # first question has not been broadcast yet — the admin's Start
-        # control advances out of it.
+        # first question has not been broadcast yet. For the auto-triggered
+        # flow (#285) the WS loop advances out of it on a grace timer rather
+        # than a host tap.
         self._lightning_splash_pending: bool = False
+
+        # Auto-trigger bookkeeping (issue #285). The Lightning Round is no
+        # longer a host-manual mode — it fires on its own exactly once per
+        # game at a uniformly random round inside the eligible window
+        # (rounds 3 … N-1). Picked up front in start_game() so the pick is a
+        # single seedable draw the tests can pin.
+        #   * _lightning_enabled  — the settings toggle (default ON).
+        #   * _lightning_target_round — the 1-based round the LR fires BEFORE,
+        #     or None when disabled / the window is empty (short game).
+        #   * _lightning_fired — guards the once-per-game guarantee.
+        #   * _round_to_resume — while in the LIGHTNING/LIGHTNING_RECAP
+        #     detour, the normal round the game returns to afterwards.
+        self._lightning_enabled: bool = True
+        self._lightning_target_round: int | None = None
+        self._lightning_fired: bool = False
+        self._round_to_resume: int = 0
+        # Injectable RNG for the target-round pick so tests are deterministic
+        # without monkeypatching the module-global ``random``. Defaults to the
+        # shared module RNG in production.
+        self._lightning_rng: random.Random = random.Random()
 
         # Round shuffle state (owned here, not in WS handler).
         # `shuffle_map` is the "canonical" per-round shuffle used by the
@@ -403,12 +424,19 @@ class QuizifyGameState:
         num_rounds: int = 10,
         language: str | None = None,
         timer_duration: int | None = None,
+        lightning_enabled: bool = True,
+        lightning_seed: int | None = None,
     ) -> dict[str, Any]:
         """Start a new game session.
 
         Pass ``categories`` (list of slugs) for multi-category mode.
         Pass ``category`` (single slug) for single-category mode.
         Pass neither for mixed (all packs).
+
+        ``lightning_enabled`` (the settings toggle, default ON) controls
+        whether the auto Lightning Round (#285) is armed for this game.
+        ``lightning_seed`` lets tests pin the random target-round draw; it is
+        never passed in production.
 
         Returns dict with game info on success.
         Raises ValueError on invalid state.
@@ -424,6 +452,16 @@ class QuizifyGameState:
         self.total_rounds = num_rounds
         self.round = 0
         self._timer_override = timer_duration
+
+        # Arm the auto Lightning Round (#285). Pick the target round once, up
+        # front, so it is a single seedable draw — the WS round-advance path
+        # consults should_trigger_lightning() and fires when reached.
+        self._lightning_enabled = lightning_enabled
+        self._lightning_fired = False
+        self._round_to_resume = 0
+        if lightning_seed is not None:
+            self._lightning_rng = random.Random(lightning_seed)
+        self._lightning_target_round = self._pick_lightning_round(num_rounds)
 
         # Group-level adaptive difficulty (#40). Only the explicit "auto" mode
         # opts in; any fixed difficulty the host pinned (easy/medium/hard) is
@@ -449,6 +487,7 @@ class QuizifyGameState:
             "num_rounds": num_rounds,
             "language": self.language,
             "timer_duration": timer_duration,
+            "lightning_enabled": lightning_enabled,
         }
 
         # Load questions. The bank is preloaded off the event loop at
@@ -1055,6 +1094,10 @@ class QuizifyGameState:
         self._calibrator = None
         self._lightning = None
         self._lightning_splash_pending = False
+        # Auto-trigger bookkeeping (#285) — re-armed by the next start_game.
+        self._lightning_target_round = None
+        self._lightning_fired = False
+        self._round_to_resume = 0
 
         for player in self._player_registry.players.values():
             player.reset_for_new_game()
@@ -1069,6 +1112,45 @@ class QuizifyGameState:
     # state live in game/lightning.py; this class only owns the reference
     # and the phase transition so the WS handler has one place to call.
 
+    def _pick_lightning_round(self, num_rounds: int) -> int | None:
+        """Pick the round the auto Lightning Round fires before (#285).
+
+        The eligible window is rounds ``3 … num_rounds-1`` (1-based): the
+        first two rounds are blocked so the game establishes itself, and the
+        final round is blocked so the Lightning Round never replaces the
+        climactic last question. Returns a uniformly-random round in that
+        window, or ``None`` when the toggle is off OR the window is empty
+        (``num_rounds < 4`` — a short game simply skips the Lightning Round,
+        we never force one).
+        """
+        if not self._lightning_enabled:
+            return None
+        low, high = 3, num_rounds - 1
+        if high < low:
+            return None  # window empty → short game, no Lightning Round
+        return self._lightning_rng.randint(low, high)
+
+    @property
+    def lightning_target_round(self) -> int | None:
+        """The round the auto Lightning Round fires before, or None (#285)."""
+        return self._lightning_target_round
+
+    def should_trigger_lightning(self) -> bool:
+        """True iff the auto Lightning Round should fire right now (#285).
+
+        Consulted by the WS round-advance path BEFORE it starts the next
+        normal question. Fires exactly once per game, when the game is about
+        to enter the pre-picked target round (``self.round`` counts completed
+        rounds, so ``round + 1`` is the round we are about to start). Guarded
+        by ``_lightning_fired`` for the once-per-game guarantee and only from
+        a between-rounds phase.
+        """
+        if self._lightning_fired or self._lightning_target_round is None:
+            return False
+        if self.phase not in (GamePhase.LOBBY, GamePhase.ANSWER_REVEAL):
+            return False
+        return self.round + 1 == self._lightning_target_round
+
     def start_lightning_round(
         self,
         *,
@@ -1076,21 +1158,26 @@ class QuizifyGameState:
         categories: list[str] | None = None,
         difficulty: str | None = None,
         language: str | None = None,
+        auto: bool = False,
     ) -> bool:
         """Begin a lightning round, reusing the current player roster.
 
-        Returns True if it started, False if no questions were available.
-        Allowed from LOBBY (standalone lightning), FINALE (after a game), or
-        LIGHTNING_RECAP (the "play again" button after a lightning round —
-        issue #294; this is the same "between rounds" situation as FINALE).
-        A fresh LightningRound is built below and ``_lightning`` /
-        ``_lightning_splash_pending`` are reassigned, so re-entry from
-        LIGHTNING_RECAP starts cleanly. (#285 will later restructure
-        lightning entry; this is a minimal fix for the dead-end.)
+        Returns True if it started, False if no questions were available or
+        the phase is wrong.
+
+        ``auto=True`` is the #285 mid-game auto path: it remembers the
+        in-progress round so the game can resume the normal flow after the
+        recap, marks the once-per-game flag, and is allowed to fire from
+        ANSWER_REVEAL (between two normal rounds). ``auto=False`` keeps the
+        legacy entry phases (LOBBY/FINALE/LIGHTNING_RECAP) used by tests and
+        any remaining standalone callers.
         """
         from .lightning import LightningRound  # local import — avoid cycle
 
-        if self.phase not in (
+        if auto:
+            if self.phase not in (GamePhase.LOBBY, GamePhase.ANSWER_REVEAL):
+                return False
+        elif self.phase not in (
             GamePhase.LOBBY,
             GamePhase.FINALE,
             GamePhase.LIGHTNING_RECAP,
@@ -1113,10 +1200,17 @@ class QuizifyGameState:
         if not lr.start():
             return False
 
+        if auto:
+            # Remember the normal round we detoured out of so the game resumes
+            # there after the recap, and burn the once-per-game flag.
+            self._round_to_resume = self.round
+            self._lightning_fired = True
+
         self._lightning = lr
         self.phase = GamePhase.LIGHTNING
-        # Open on the intro splash (issue #201); the admin's Start control
-        # calls begin_lightning_questions() to advance into question 1.
+        # Open on the intro splash (issue #201). In the auto flow (#285) the
+        # WS loop advances out of it on a grace timer (no host tap);
+        # begin_lightning_questions() still performs the transition.
         self._lightning_splash_pending = True
         self._notify_state_callbacks()
         return True
@@ -1149,6 +1243,35 @@ class QuizifyGameState:
             self.phase = GamePhase.LIGHTNING_RECAP
             self._flush_history()
             self._notify_state_callbacks()
+
+    @property
+    def in_lightning_detour(self) -> bool:
+        """True while the auto Lightning Round is interrupting a live game (#285).
+
+        Distinguishes the mid-game auto detour (a normal game is paused in the
+        background, ``_round_to_resume`` > 0) from a standalone lightning
+        session started from the lobby. The WS layer uses this to decide
+        whether the recap's advance returns to the main game or to the lobby.
+        """
+        return self._round_to_resume > 0
+
+    def resume_after_lightning(self) -> bool:
+        """Return to the paused main game after the auto Lightning recap (#285).
+
+        Flips LIGHTNING_RECAP back to ANSWER_REVEAL and restores the round
+        counter so the next ``start_next_question`` proceeds into the
+        originally-scheduled round. Returns True if a detour was active, False
+        otherwise (a standalone lightning session has no main game to resume).
+        """
+        if self.phase != GamePhase.LIGHTNING_RECAP or not self.in_lightning_detour:
+            return False
+        self.round = self._round_to_resume
+        self._round_to_resume = 0
+        self._lightning = None
+        self._lightning_splash_pending = False
+        self.phase = GamePhase.ANSWER_REVEAL
+        self._notify_state_callbacks()
+        return True
 
     # ------------------------------------------------------------------
     # Power-ups

--- a/custom_components/quizify/server/protocol.py
+++ b/custom_components/quizify/server/protocol.py
@@ -232,13 +232,11 @@ CLIENT_MESSAGE_TYPES: frozenset[str] = frozenset({
     "resume_game",
     "admin_skip",
     "kick_player",
-    # Lightning Round (issue #42): host starts the mode; players submit
-    # answers via lightning_answer (separate from submit_answer so the
-    # normal-round path stays untouched).
-    "start_lightning",
-    "start_lightning_questions",
+    # Lightning Round (issue #42 mechanics, #285 auto-trigger): the round now
+    # fires automatically mid-game — there is no host start/end action any
+    # more. Players still submit via lightning_answer (separate from
+    # submit_answer so the normal-round path stays untouched).
     "lightning_answer",
-    "end_lightning",
 })
 
 

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -56,6 +56,24 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
+def _coerce_toggle(value: Any, *, default: bool) -> bool:
+    """Coerce a wire toggle value to a bool (#285).
+
+    Front-end checkboxes serialize as a JSON ``bool``, but be defensive about
+    string forms ("false"/"0"/"off"/"no") and a missing key so a malformed
+    payload can't accidentally arm/disarm a setting against the default.
+    """
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() not in ("false", "0", "off", "no", "")
+    return default
+
+
 class QuizifyWebSocketHandler:
     """Handle WebSocket connections for Quizify."""
 
@@ -90,6 +108,12 @@ class QuizifyWebSocketHandler:
     # clients swap from the splash to the question view before the first clock
     # starts ticking, so the countdown the players see matches the server window.
     LIGHTNING_SPLASH_GRACE = 1.0
+
+    # Auto Lightning Round (#285): with the host-manual "Start" tap retired,
+    # the intro splash holds for this long on its own before question 1 so
+    # players get the "Lightning Round incoming!" beat to read it, then the
+    # loop auto-dismisses the splash and begins.
+    AUTO_LIGHTNING_SPLASH_HOLD = 3.0
 
     def __init__(
         self,
@@ -426,18 +450,6 @@ class QuizifyWebSocketHandler:
             "resume_game": (lambda ws: self._handle_resume_game(ws, game_state), True),
             "kick_player": (
                 lambda ws: self._handle_kick_player(ws, data, game_state),
-                True,
-            ),
-            "start_lightning": (
-                lambda ws: self._handle_start_lightning(ws, data, game_state),
-                True,
-            ),
-            "start_lightning_questions": (
-                lambda ws: self._handle_start_lightning_questions(ws, game_state),
-                True,
-            ),
-            "end_lightning": (
-                lambda ws: self._handle_end_lightning(ws, game_state),
                 True,
             ),
         }
@@ -1083,6 +1095,10 @@ class QuizifyWebSocketHandler:
         num_rounds = data.get("num_rounds", 10)
         language = data.get("language", "de")
         timer_duration = data.get("timer_duration")
+        # Auto Lightning Round toggle (#285), default ON. Coerce truthily so a
+        # missing key, a JSON bool, or a "0"/"false" string all resolve
+        # sanely; only an explicit false-y value disables it.
+        lightning_enabled = _coerce_toggle(data.get("lightning_enabled"), default=True)
 
         # Validate num_rounds the same way as timer_duration (#303): the WS
         # value reaches start_game raw, and total_rounds drives
@@ -1123,6 +1139,7 @@ class QuizifyWebSocketHandler:
                 num_rounds=num_rounds,
                 language=language,
                 timer_duration=timer_value,
+                lightning_enabled=lightning_enabled,
             )
         except ValueError as err:
             # start_game raises two distinct ValueErrors: a wrong-phase
@@ -1160,6 +1177,17 @@ class QuizifyWebSocketHandler:
         self, ws: web.WebSocketResponse, game_state: QuizifyGameState
     ) -> None:
         """Handle admin next_question command."""
+        # Auto Lightning Round recap (#285): the host's normal advance after a
+        # mid-game lightning recap resumes the paused main game. resume_after_
+        # lightning() flips LIGHTNING_RECAP→ANSWER_REVEAL and restores the
+        # round counter, so the start_next_question below lands on the
+        # originally-scheduled round.
+        if game_state.phase == GamePhase.LIGHTNING_RECAP:
+            self._cancel_lightning_loop()
+            if game_state.resume_after_lightning():
+                await self._start_next_question(game_state)
+            return
+
         if game_state.phase not in (GamePhase.LOBBY, GamePhase.ANSWER_REVEAL):
             await self._conn.send_error(ws, ERR_INVALID_ACTION, "Cannot advance now")
             return
@@ -1397,55 +1425,57 @@ class QuizifyWebSocketHandler:
     # and fan out the question/recap payloads over the existing connection
     # layer.
 
-    async def _handle_start_lightning(
-        self, ws: web.WebSocketResponse, data: dict, game_state: QuizifyGameState
-    ) -> None:
-        """Admin triggers a lightning round (from LOBBY or FINALE)."""
+    async def _start_auto_lightning(self, game_state: QuizifyGameState) -> None:
+        """Fire the auto Lightning Round mid-game (#285).
+
+        Replaces the retired host-manual ``start_lightning`` entry: there is
+        no host tap. We detour out of the current round (``auto=True``
+        remembers it), broadcast the intro splash, then the loop auto-advances
+        out of the splash after a grace and runs the fast question loop. After
+        the recap the host's normal advance resumes the main game.
+        """
         # Stop any normal-round timer first — the two loops are mutually
         # exclusive.
         self._cancel_timer_tick()
 
-        raw_category = data.get("category")
-        if isinstance(raw_category, list):
-            category = None
-            categories = raw_category or None
-        else:
-            category = raw_category or None
-            categories = None
-        difficulty = data.get("difficulty")
-        language = data.get("language")
-
         started = game_state.start_lightning_round(
-            category=category,
-            categories=categories,
-            difficulty=difficulty,
-            language=language,
+            # Reuse the running game's own pack/difficulty/language selection.
+            category=game_state.category,
+            difficulty=game_state.difficulty,
+            language=game_state.language,
+            auto=True,
         )
         if not started:
-            await self._conn.send_error(
-                ws, ERR_INVALID_ACTION, "Cannot start lightning round"
+            # No questions available for the lightning queue, or wrong phase.
+            # Fall back to the normal round so the game never wedges.
+            _LOGGER.warning(
+                "Auto lightning round could not start; continuing normal game"
             )
+            await self._continue_normal_question(game_state)
             return
 
-        # Broadcast a phase-entry state so every client switches view.
+        # Broadcast a phase-entry state so every client switches to the
+        # lightning view, then the intro splash ("Bolt Burst", #201).
         state = game_state.get_state_snapshot()
         state["type"] = "game_state"
         await self._conn.broadcast(state)
-
-        # Show the intro splash ("Bolt Burst", issue #201) on host/TV + every
-        # player phone. The question loop does NOT start yet — it waits for the
-        # admin to tap Start (start_lightning_questions).
         await self._broadcast_lightning_splash(game_state)
 
-    async def _handle_start_lightning_questions(
-        self, ws: web.WebSocketResponse, game_state: QuizifyGameState
-    ) -> None:
-        """Admin dismisses the intro splash → run the first question (#201)."""
-        if game_state.phase != GamePhase.LIGHTNING:
+        # Auto-advance: no host tap. The loop itself dismisses the splash after
+        # the grace and starts question 1.
+        self._start_lightning_loop(game_state, auto_dismiss_splash=True)
+
+    async def _continue_normal_question(self, game_state: QuizifyGameState) -> None:
+        """Start the next normal question without re-checking the LR trigger.
+
+        Used by the auto-LR fallback path (LR couldn't start) so we don't
+        recurse back into should_trigger_lightning() — the flag is already
+        burned, so this is just the plain question start.
+        """
+        question = game_state.start_next_question()
+        if question is None:
             return
-        if not game_state.begin_lightning_questions():
-            return  # splash already dismissed / nothing to do — stay silent
-        self._start_lightning_loop(game_state)
+        await self._emit_question(game_state, question)
 
     async def _broadcast_lightning_splash(
         self, game_state: QuizifyGameState
@@ -1490,31 +1520,29 @@ class QuizifyWebSocketHandler:
             "score": lr.scores.get(player.name, 0),
         })
 
-    async def _handle_end_lightning(
-        self, ws: web.WebSocketResponse, game_state: QuizifyGameState
+    def _start_lightning_loop(
+        self,
+        game_state: QuizifyGameState,
+        *,
+        auto_dismiss_splash: bool = False,
     ) -> None:
-        """Admin ends the lightning round early → jump to the recap."""
-        self._cancel_lightning_loop()
-        if game_state.phase == GamePhase.LIGHTNING:
-            # Score the in-flight question's answers before tearing the round
-            # down (#308). Without lr.advance(), "End lightning" discarded every
-            # answer already tapped on the current question — the recap omitted
-            # them and players who'd answered correctly got no credit. advance()
-            # scores the current question (and arms the next, which we don't
-            # broadcast since we're finishing anyway).
-            lr = game_state.lightning
-            if lr is not None:
-                lr.advance()
-            game_state.finish_lightning_round()
-            await self._broadcast_lightning_recap(game_state)
-
-    def _start_lightning_loop(self, game_state: QuizifyGameState) -> None:
         """Drive the fast lightning loop: broadcast question, wait for the
-        fixed window or all-answered, advance with no reveal, repeat."""
+        fixed window or all-answered, advance with no reveal, repeat.
+
+        With ``auto_dismiss_splash`` (the #285 auto flow) the loop first holds
+        the intro splash for ``AUTO_LIGHTNING_SPLASH_HOLD`` seconds and then
+        dismisses it itself — there is no host "Start" tap any more.
+        """
         self._cancel_lightning_loop()
 
         async def loop() -> None:
             try:
+                if auto_dismiss_splash:
+                    # Hold the intro splash on its own, then advance out of it.
+                    await asyncio.sleep(self.AUTO_LIGHTNING_SPLASH_HOLD)
+                    if game_state.phase != GamePhase.LIGHTNING:
+                        return
+                    game_state.begin_lightning_questions()
                 # Brief grace so clients swap from the intro splash (#201) to
                 # the question view before the first clock starts ticking.
                 await asyncio.sleep(self.LIGHTNING_SPLASH_GRACE)
@@ -1688,6 +1716,15 @@ class QuizifyWebSocketHandler:
         """Start the next question: shuffle answers, broadcast, start timer ticks."""
         self._cancel_timer_tick()
 
+        # Auto Lightning Round (#285): exactly once per game, when the game is
+        # about to enter the pre-picked target round, detour into the fast
+        # Lightning Round first. The normal round resumes after the recap (the
+        # host's next advance lands on resume_after_lightning → ANSWER_REVEAL →
+        # this same path, which by then sees _lightning_fired and proceeds).
+        if game_state.should_trigger_lightning():
+            await self._start_auto_lightning(game_state)
+            return
+
         question = game_state.start_next_question()
         if question is None:
             # Game ended (no more questions or round limit reached).
@@ -1696,6 +1733,17 @@ class QuizifyWebSocketHandler:
             # finale broadcast source). No direct broadcast here. (#255.)
             return
 
+        await self._emit_question(game_state, question)
+
+    async def _emit_question(
+        self, game_state: QuizifyGameState, question: Any
+    ) -> None:
+        """Shuffle, broadcast and arm the timer for an already-started question.
+
+        Split out from ``_start_next_question`` (#285) so the auto-LR fallback
+        path can reuse the identical emission without re-running the LR
+        trigger check.
+        """
         # Canonical shuffle — used by admin/dashboard and as a fallback.
         indices = list(range(len(question.answers)))
         random.shuffle(indices)

--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -261,6 +261,21 @@
                              {{LANGUAGE_CHIPS}} token. -->
                         <div class="vF-answers chip-group chip-group--flags" id="language-chips" role="group" data-i18n-aria-label="admin.language" aria-label="Language">{{LANGUAGE_CHIPS}}</div>
                     </div>
+
+                    <!-- Lightning Round auto-trigger toggle (#285). Default ON.
+                         When on, a surprise fast Lightning Round fires once at a
+                         random mid-game round (3 … N-1). The value rides through
+                         start_game like every other setting (admin.js
+                         _buildStartGamePayload → lightning_enabled). Uses the
+                         shared .toggle-compact switch (Beatify pattern). -->
+                    <div class="vF-step">
+                        <div class="vF-q"><span class="num">6</span><span data-i18n="setup.eigene.q6">Lightning Round?</span></div>
+                        <label class="toggle-compact setup-lightning-toggle" for="lightning-enabled-toggle">
+                            <input type="checkbox" id="lightning-enabled-toggle" checked>
+                            <span class="toggle-switch-compact" aria-hidden="true"></span>
+                            <span class="toggle-label" data-i18n="setup.eigene.lightningHint">Surprise fast round mid-game</span>
+                        </label>
+                    </div>
                 </div>
 
                 <button type="button" id="setup-apply-btn" class="btn btn-primary btn-lg btn-block">
@@ -481,19 +496,19 @@
                 <div id="admin-finale-leaderboard" class="leaderboard"></div>
             </section>
 
+            <!-- The Lightning Round is now an automatic mid-game event (#285);
+                 the manual "⚡ Lightning Round" entry button was retired. -->
             <div class="admin-actions lobby-actions--sticky mt-lg">
-                <button type="button" id="lightning-round-btn" class="btn btn-secondary btn-lg btn-block">
-                    ⚡ <span data-i18n="lightning.start">Lightning Round</span>
-                </button>
                 <button type="button" id="new-game-btn" class="btn btn-primary btn-lg btn-block" data-i18n="admin.startNewGame">Start New Game</button>
             </div>
         </div>
 
         <!-- Lightning Round view (issue #42) -->
         <div id="admin-lightning-view" class="view">
-            <!-- Intro splash preview + Start control (issue #201). Shown
-                 while the "Bolt Burst" splash is up on host/TV + phones;
-                 hidden once the admin starts the questions. -->
+            <!-- Intro splash preview (issue #201). Shown on host/TV + phones
+                 while the "Bolt Burst" splash is up. The Lightning Round now
+                 auto-triggers and auto-advances (#285) — there is no host
+                 Start/End control here any more. -->
             <section id="admin-lightning-splash" class="card-section" hidden>
                 <h2 class="section-header">⚡ <span data-i18n="lightning.splashKicker">Lightning Round</span></h2>
                 <p class="hint" data-i18n="lightning.splashAdminMeta">Splash visible to all players</p>
@@ -505,14 +520,6 @@
                 <div id="admin-lightning-question" class="question-text" style="font-size:1.1rem;"></div>
                 <div id="admin-lightning-timer" class="timer-text mt-md"></div>
             </section>
-            <div class="admin-actions lobby-actions--sticky mt-lg">
-                <button type="button" id="admin-lightning-start-btn" class="btn btn-primary btn-lg btn-block" hidden>
-                    ⚡ <span data-i18n="lightning.splashStart">Let's go</span>
-                </button>
-                <button type="button" id="admin-lightning-end-btn" class="btn btn-secondary btn-lg btn-block">
-                    🏁 <span data-i18n="lightning.endNow">End Lightning</span>
-                </button>
-            </div>
         </div>
 
         <!-- Lightning Round recap view -->
@@ -525,11 +532,13 @@
                 <h2 class="section-header"><span data-i18n="lightning.questionRecap">Question-by-question</span></h2>
                 <div id="admin-lightning-recap-grid" class="lightning-recap-grid"></div>
             </section>
+            <!-- The Lightning Round is a mid-game detour now (#285): the recap's
+                 primary action resumes the paused main game. The old "Another
+                 Lightning Round" rematch button (a #294 dead-end) was retired. -->
             <div class="admin-actions lobby-actions--sticky mt-lg">
-                <button type="button" id="admin-lightning-again-btn" class="btn btn-secondary btn-lg btn-block">
-                    ⚡ <span data-i18n="lightning.again">Another Lightning Round</span>
+                <button type="button" id="admin-lightning-continue-btn" class="btn btn-primary btn-lg btn-block">
+                    ▶︎ <span data-i18n="lightning.continueGame">Continue game</span>
                 </button>
-                <button type="button" id="admin-lightning-newgame-btn" class="btn btn-primary btn-lg btn-block" data-i18n="admin.startNewGame">Start New Game</button>
             </div>
         </div>
 

--- a/custom_components/quizify/www/css/src/07-player.css
+++ b/custom_components/quizify/www/css/src/07-player.css
@@ -1417,6 +1417,17 @@
     padding-left: 30px;  /* align with question text, skipping the badge */
 }
 
+/* Lightning Round toggle row (#285) — a .toggle-compact switch sitting in a
+   vF-step, aligned with the answer chips above it (skip the number badge). */
+.setup-lightning-toggle {
+    padding-left: 30px;
+    gap: 10px;
+}
+.setup-lightning-toggle .toggle-label {
+    font-size: 0.9rem;
+    color: var(--color-text-secondary);
+}
+
 /* ==========================================
    Player Lobby — variant B (You + the Room) + D (Rules)
    ==========================================

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -4427,6 +4427,17 @@ footer {
     padding-left: 30px;  /* align with question text, skipping the badge */
 }
 
+/* Lightning Round toggle row (#285) — a .toggle-compact switch sitting in a
+   vF-step, aligned with the answer chips above it (skip the number badge). */
+.setup-lightning-toggle {
+    padding-left: 30px;
+    gap: 10px;
+}
+.setup-lightning-toggle .toggle-label {
+    font-size: 0.9rem;
+    color: var(--color-text-secondary);
+}
+
 /* ==========================================
    Player Lobby — variant B (You + the Room) + D (Rules)
    ==========================================

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -362,7 +362,9 @@
       "q2": "Wie schwer?",
       "q3": "Wie viele Runden?",
       "q4": "Wie viel Zeit pro Frage?",
-      "q5": "In welcher Sprache?"
+      "q5": "In welcher Sprache?",
+      "q6": "Blitzrunde?",
+      "lightningHint": "Überraschungs-Schnellrunde mitten im Spiel"
     }
   },
   "featured": {
@@ -575,8 +577,11 @@
     "splashEndValue": "Ende",
     "splashEndLabel": "Auflösung",
     "splashWaiting": "Warten auf Host",
+    "splashStarting": "Startet",
     "splashAdminMeta": "Splash für alle Spieler sichtbar",
     "splashStart": "Los geht's",
+    "continueGame": "Spiel fortsetzen",
+    "recapWaitHint": "Kurz halten — der Host setzt das Spiel fort",
     "answeredAtEnd": "· Auflösung am Ende",
     "rightAnswers": "Die richtigen Antworten, Frage für Frage",
     "correctTag": "Richtig",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -362,7 +362,9 @@
       "q2": "How hard?",
       "q3": "How many rounds?",
       "q4": "How long per question?",
-      "q5": "Which language?"
+      "q5": "Which language?",
+      "q6": "Lightning Round?",
+      "lightningHint": "Surprise fast round mid-game"
     }
   },
   "featured": {
@@ -575,8 +577,11 @@
     "splashEndValue": "End",
     "splashEndLabel": "answers revealed",
     "splashWaiting": "Waiting for host",
+    "splashStarting": "Starting",
     "splashAdminMeta": "Splash visible to all players",
     "splashStart": "Let's go",
+    "continueGame": "Continue game",
+    "recapWaitHint": "Hang tight — the host continues the game",
     "answeredAtEnd": "· answers revealed at the end",
     "rightAnswers": "The right answers, question by question",
     "correctTag": "Correct",

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -362,7 +362,9 @@
       "q2": "¿Qué dificultad?",
       "q3": "¿Cuántas rondas?",
       "q4": "¿Cuánto tiempo por pregunta?",
-      "q5": "¿Qué idioma?"
+      "q5": "¿Qué idioma?",
+      "q6": "¿Ronda Relámpago?",
+      "lightningHint": "Ronda rápida sorpresa a mitad de la partida"
     }
   },
   "featured": {
@@ -575,8 +577,11 @@
     "splashEndValue": "Final",
     "splashEndLabel": "respuestas reveladas",
     "splashWaiting": "Esperando al anfitrión",
+    "splashStarting": "Empezando",
     "splashAdminMeta": "Pantalla visible para todos los jugadores",
     "splashStart": "¡Vamos!",
+    "continueGame": "Continuar partida",
+    "recapWaitHint": "Un momento — el anfitrión continúa la partida",
     "answeredAtEnd": "· respuestas reveladas al final",
     "rightAnswers": "Las respuestas correctas, pregunta por pregunta",
     "correctTag": "Correcto",

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -54,6 +54,10 @@
         return 'en';
     })();
     let selectedTimer = 30;  // seconds per question (20 / 30 / 45)
+    // Auto Lightning Round toggle (#285), default ON. The surprise fast round
+    // fires once at a random mid-game round; the host opts out via the setup
+    // toggle. Read live from the checkbox at start_game time.
+    let selectedLightning = true;
 
     // Game state
     let currentPhase = 'LOBBY';
@@ -139,20 +143,18 @@
         adminFinaleLeaderboard: document.getElementById('admin-finale-leaderboard'),
         newGameBtn: document.getElementById('new-game-btn'),
         lobbyBackBtn: document.getElementById('lobby-back-btn'),
-        // Lightning Round (issue #42)
-        lightningRoundBtn: document.getElementById('lightning-round-btn'),
+        // Lightning Round (issue #42 mechanics, #285 auto-trigger). The manual
+        // start / start-questions / end / again controls were retired; only
+        // the display elements + the recap "Continue" button remain.
         adminLightningProgress: document.getElementById('admin-lightning-progress'),
         adminLightningQuestion: document.getElementById('admin-lightning-question'),
         adminLightningTimer: document.getElementById('admin-lightning-timer'),
-        adminLightningEndBtn: document.getElementById('admin-lightning-end-btn'),
         adminLightningSplash: document.getElementById('admin-lightning-splash'),
         adminLightningSplashRules: document.getElementById('admin-lightning-splash-rules'),
         adminLightningQuestionSection: document.getElementById('admin-lightning-question-section'),
-        adminLightningStartBtn: document.getElementById('admin-lightning-start-btn'),
         adminLightningRecapLeaderboard: document.getElementById('admin-lightning-recap-leaderboard'),
         adminLightningRecapGrid: document.getElementById('admin-lightning-recap-grid'),
-        adminLightningAgainBtn: document.getElementById('admin-lightning-again-btn'),
-        adminLightningNewGameBtn: document.getElementById('admin-lightning-newgame-btn'),
+        adminLightningContinueBtn: document.getElementById('admin-lightning-continue-btn'),
         // Admin join modal
         adminJoinModal: document.getElementById('admin-join-modal'),
         adminNameInput: document.getElementById('admin-name-input'),
@@ -848,6 +850,15 @@
         selectedTimer = parseInt(v, 10);
         updateSettingsSummary();
     });
+    // Lightning Round toggle (#285) — keep selectedLightning in sync with the
+    // checkbox so the start payload reflects the host's choice.
+    var lightningToggle = document.getElementById('lightning-enabled-toggle');
+    if (lightningToggle) {
+        selectedLightning = !!lightningToggle.checked;
+        on(lightningToggle, 'change', function () {
+            selectedLightning = !!lightningToggle.checked;
+        });
+    }
     setupChips(els.languageChips, function (v) {
         // Session-only switch — not persisted. On the next full-page reload
         // the UI resolves back to the Home Assistant language (#152).
@@ -1134,11 +1145,9 @@
     // ---- Lightning Round (issue #42) ----
 
     function _toggleAdminLightningSplash(showSplash) {
+        // #285: the host no longer dismisses the splash (no Start button) — it
+        // auto-advances server-side. This just swaps the splash/question panes.
         if (els.adminLightningSplash) els.adminLightningSplash.hidden = !showSplash;
-        if (els.adminLightningStartBtn) {
-            els.adminLightningStartBtn.hidden = !showSplash;
-            if (showSplash) els.adminLightningStartBtn.disabled = false;
-        }
         if (els.adminLightningQuestionSection) {
             els.adminLightningQuestionSection.hidden = showSplash;
         }
@@ -1522,12 +1531,17 @@
             : selectedCategory === 'multi'
                 ? selectedCategories
                 : selectedCategory;
+        // Read the Lightning toggle live so a last-second flip is honoured even
+        // if the change listener didn't fire (e.g. programmatic state).
+        var lightningEl = document.getElementById('lightning-enabled-toggle');
+        var lightningEnabled = lightningEl ? !!lightningEl.checked : selectedLightning;
         return {
             category: categoryPayload,
             difficulty: selectedDifficulty === 'mixed' ? null : selectedDifficulty,
             num_rounds: selectedRounds,
             language: selectedLanguage,
             timer_duration: selectedTimer,
+            lightning_enabled: lightningEnabled,
         };
     }
 
@@ -1733,17 +1747,11 @@
 
     on(els.newGameBtn, 'click', function () { send('reset_game', {}); });
 
-    // Lightning Round (issue #42). Reuses the players + question bank that
-    // are already loaded — no extra setup. Server picks fresh questions via
-    // the history-aware queue.
-    on(els.lightningRoundBtn, 'click', function () { send('start_lightning', {}); });
-    on(els.adminLightningStartBtn, 'click', function () {
-        if (els.adminLightningStartBtn) els.adminLightningStartBtn.disabled = true;
-        send('start_lightning_questions', {});  // dismiss intro splash (#201)
-    });
-    on(els.adminLightningEndBtn, 'click', function () { send('end_lightning', {}); });
-    on(els.adminLightningAgainBtn, 'click', function () { send('start_lightning', {}); });
-    on(els.adminLightningNewGameBtn, 'click', function () { send('reset_game', {}); });
+    // Lightning Round (issue #42 mechanics, #285 auto-trigger). It now fires
+    // automatically mid-game and auto-advances, so there is no manual start /
+    // end control. The recap's only action resumes the paused main game via
+    // the normal next_question advance (server: resume_after_lightning).
+    on(els.adminLightningContinueBtn, 'click', function () { send('next_question', {}); });
 
     // ---- Reset Game button (header) ----
     on(els.resetGameBtn, 'click', function () {

--- a/custom_components/quizify/www/js/player-end.js
+++ b/custom_components/quizify/www/js/player-end.js
@@ -371,19 +371,8 @@
             };
         }
 
-        // Lightning Round trigger from the finale (issue #42). Sends
-        // start_lightning over the existing WS — server transitions into
-        // the LIGHTNING phase and the phase router swaps views. No
-        // navigation needed (admin is already on /quizify/player).
-        var lightningBtn = document.getElementById('lightning-from-end-btn');
-        if (lightningBtn) {
-            lightningBtn.onclick = function () {
-                var ws = state.ws;
-                if (!ws || ws.readyState !== WebSocket.OPEN) return;
-                lightningBtn.disabled = true;
-                try { ws.send(JSON.stringify({ type: 'start_lightning' })); } catch (e) { /* ignore */ }
-            };
-        }
+        // The manual Lightning Round finale trigger (issue #42) was retired in
+        // #285 — the Lightning Round is now an automatic mid-game event.
 
         if (newGameBtn) {
             newGameBtn.onclick = function () {

--- a/custom_components/quizify/www/js/player-lightning.js
+++ b/custom_components/quizify/www/js/player-lightning.js
@@ -43,14 +43,10 @@
             secEl.textContent = Math.round(msg.seconds_per_question) + 's';
         }
 
-        // Admin gets the Start footer bar; players get the waiting hint.
-        var adminBar = document.getElementById('lightning-splash-adminbar');
+        // #285: the splash auto-advances — no host Start bar. Everyone sees
+        // the "Starting…" hint while the round arms itself.
         var waitHint = document.getElementById('lightning-splash-waithint');
-        if (adminBar) adminBar.classList.toggle('hidden', !state.isAdmin);
-        if (waitHint) waitHint.classList.toggle('hidden', !!state.isAdmin);
-
-        var startBtn = document.getElementById('lightning-splash-start-btn');
-        if (startBtn) startBtn.disabled = false;
+        if (waitHint) waitHint.classList.remove('hidden');
     }
 
     // ------------------------------------------------------------------
@@ -103,9 +99,7 @@
         var timer = document.getElementById('lightning-timer');
         if (timer) timer.textContent = Math.ceil(msg.seconds || 15);
 
-        // Admin gets an "end now" control.
-        var adminBar = document.getElementById('lightning-admin-bar');
-        if (adminBar) adminBar.classList.toggle('hidden', !state.isAdmin);
+        // #285: no host "end now" control during the auto round.
 
         _answeredIndex = -1;
     }
@@ -233,21 +227,16 @@
                 });
             })(i);
         }
-        var splashStartBtn = document.getElementById('lightning-splash-start-btn');
-        if (splashStartBtn) {
-            splashStartBtn.addEventListener('click', function () {
+        // #285: the splash auto-advances and the round auto-ends — no host
+        // start/end controls. The recap's only action resumes the paused main
+        // game via the normal next_question advance.
+        var continueBtn = document.getElementById('lightning-recap-continue-btn');
+        if (continueBtn) {
+            continueBtn.addEventListener('click', function () {
                 this.disabled = true;  // one-shot; avoid double-fire
-                _send('start_lightning_questions', {});
+                _send('next_question', {});
             });
         }
-
-        var endBtn = document.getElementById('lightning-end-btn');
-        if (endBtn) endBtn.addEventListener('click', function () { _send('end_lightning', {}); });
-
-        var againBtn = document.getElementById('lightning-recap-again-btn');
-        if (againBtn) againBtn.addEventListener('click', function () { _send('start_lightning', {}); });
-        var newGameBtn = document.getElementById('lightning-recap-newgame-btn');
-        if (newGameBtn) newGameBtn.addEventListener('click', function () { _send('reset_game', {}); });
     }
 
     window.QuizifyPlayerLightning = {

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -2470,19 +2470,8 @@
             };
         }
 
-        // Lightning Round trigger from the finale (issue #42). Sends
-        // start_lightning over the existing WS — server transitions into
-        // the LIGHTNING phase and the phase router swaps views. No
-        // navigation needed (admin is already on /quizify/player).
-        var lightningBtn = document.getElementById('lightning-from-end-btn');
-        if (lightningBtn) {
-            lightningBtn.onclick = function () {
-                var ws = state.ws;
-                if (!ws || ws.readyState !== WebSocket.OPEN) return;
-                lightningBtn.disabled = true;
-                try { ws.send(JSON.stringify({ type: 'start_lightning' })); } catch (e) { /* ignore */ }
-            };
-        }
+        // The manual Lightning Round finale trigger (issue #42) was retired in
+        // #285 — the Lightning Round is now an automatic mid-game event.
 
         if (newGameBtn) {
             newGameBtn.onclick = function () {
@@ -2566,14 +2555,10 @@
             secEl.textContent = Math.round(msg.seconds_per_question) + 's';
         }
 
-        // Admin gets the Start footer bar; players get the waiting hint.
-        var adminBar = document.getElementById('lightning-splash-adminbar');
+        // #285: the splash auto-advances — no host Start bar. Everyone sees
+        // the "Starting…" hint while the round arms itself.
         var waitHint = document.getElementById('lightning-splash-waithint');
-        if (adminBar) adminBar.classList.toggle('hidden', !state.isAdmin);
-        if (waitHint) waitHint.classList.toggle('hidden', !!state.isAdmin);
-
-        var startBtn = document.getElementById('lightning-splash-start-btn');
-        if (startBtn) startBtn.disabled = false;
+        if (waitHint) waitHint.classList.remove('hidden');
     }
 
     // ------------------------------------------------------------------
@@ -2626,9 +2611,7 @@
         var timer = document.getElementById('lightning-timer');
         if (timer) timer.textContent = Math.ceil(msg.seconds || 15);
 
-        // Admin gets an "end now" control.
-        var adminBar = document.getElementById('lightning-admin-bar');
-        if (adminBar) adminBar.classList.toggle('hidden', !state.isAdmin);
+        // #285: no host "end now" control during the auto round.
 
         _answeredIndex = -1;
     }
@@ -2756,21 +2739,16 @@
                 });
             })(i);
         }
-        var splashStartBtn = document.getElementById('lightning-splash-start-btn');
-        if (splashStartBtn) {
-            splashStartBtn.addEventListener('click', function () {
+        // #285: the splash auto-advances and the round auto-ends — no host
+        // start/end controls. The recap's only action resumes the paused main
+        // game via the normal next_question advance.
+        var continueBtn = document.getElementById('lightning-recap-continue-btn');
+        if (continueBtn) {
+            continueBtn.addEventListener('click', function () {
                 this.disabled = true;  // one-shot; avoid double-fire
-                _send('start_lightning_questions', {});
+                _send('next_question', {});
             });
         }
-
-        var endBtn = document.getElementById('lightning-end-btn');
-        if (endBtn) endBtn.addEventListener('click', function () { _send('end_lightning', {}); });
-
-        var againBtn = document.getElementById('lightning-recap-again-btn');
-        if (againBtn) againBtn.addEventListener('click', function () { _send('start_lightning', {}); });
-        var newGameBtn = document.getElementById('lightning-recap-newgame-btn');
-        if (newGameBtn) newGameBtn.addEventListener('click', function () { _send('reset_game', {}); });
     }
 
     window.QuizifyPlayerLightning = {

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -524,11 +524,10 @@
                     <button id="play-again-same-btn" class="resbtn resbtn--primary" type="button" data-i18n="admin.playAgainSame">
                         Play again
                     </button>
+                    <!-- The manual "⚡ Lightning" finale entry was retired in
+                         #285 — the Lightning Round is now an automatic mid-game
+                         event. -->
                     <div class="resbtn-row">
-                        <button id="lightning-from-end-btn" class="resbtn resbtn--secondary" type="button">
-                            <span class="resbtn-bolt qz-icon" data-ui-icon="bolt" aria-hidden="true">⚡</span>
-                            <span data-i18n="lightning.startShort">Lightning</span>
-                        </button>
                         <button id="new-game-btn" class="resbtn resbtn--secondary" type="button" data-i18n="admin.newGameShort">
                             New Game
                         </button>
@@ -544,9 +543,9 @@
         </div>
 
         <!-- Lightning Round Intro Splash (issue #201) — "Bolt Burst".
-             Shown on host/TV + player phone after the admin triggers a
-             lightning round, BEFORE the first question. The admin taps
-             Start in the footer bar to advance into the round. -->
+             Shown on host/TV + player phone when the Lightning Round
+             auto-triggers mid-game (#285), BEFORE the first question. It
+             auto-advances after a short hold — no host tap. -->
         <div id="lightning-splash-view" class="view hidden">
             <div class="lr-splash-stage">
                 <div class="lr-splash-rays" aria-hidden="true"></div>
@@ -568,17 +567,11 @@
                     </div>
                 </div>
             </div>
-            <!-- Player phones: waiting for host hint -->
-            <div id="lightning-splash-waithint" class="lr-splash-waithint hidden">
-                <span data-i18n="lightning.splashWaiting">Waiting for host</span>
+            <!-- Everyone (host + phones) sees the auto-start hint; the round
+                 begins on its own after a short hold (#285). -->
+            <div id="lightning-splash-waithint" class="lr-splash-waithint">
+                <span data-i18n="lightning.splashStarting">Starting</span>
                 <span class="dots" aria-hidden="true">●●●</span>
-            </div>
-            <!-- Admin: full-width sticky footer Start bar -->
-            <div id="lightning-splash-adminbar" class="lr-splash-adminbar hidden">
-                <div class="lr-splash-adminmeta" data-i18n="lightning.splashAdminMeta">Splash visible to all players</div>
-                <button id="lightning-splash-start-btn" class="lr-splash-startbtn" type="button">
-                    <span data-i18n="lightning.splashStart">Let's go</span>
-                </button>
             </div>
         </div>
 
@@ -638,12 +631,8 @@
                     <span class="lr-score-note" data-i18n="lightning.answeredAtEnd">· answers revealed at the end</span>
                 </p>
 
-                <div id="lightning-admin-bar" class="admin-control-bar hidden" style="position:static;">
-                    <button id="lightning-end-btn" class="control-btn control-btn--danger" type="button">
-                        <span class="control-icon qz-icon qz-icon--coral" data-ui-icon="finish">🏁</span>
-                        <span class="control-label" data-i18n="lightning.endNow">End Lightning</span>
-                    </button>
-                </div>
+                <!-- The host "End Lightning" control was retired in #285 — the
+                     auto round always runs its full question set, no early end. -->
             </div>
         </div>
 
@@ -667,21 +656,18 @@
                     <div id="lightning-recap-grid" class="lightning-recap-grid"></div>
                 </div>
 
+                <!-- Mid-game auto Lightning recap (#285): the host's only action
+                     is to resume the paused main game. The #294 "Lightning
+                     again" dead-end button was retired. -->
                 <div id="lightning-recap-admin" class="end-admin-controls hidden">
-                    <button id="lightning-recap-again-btn" class="resbtn resbtn--primary" type="button">
-                        <span class="resbtn-bolt qz-icon" data-ui-icon="bolt" aria-hidden="true">⚡</span>
-                        <span data-i18n="lightning.againShort">Lightning again</span>
+                    <button id="lightning-recap-continue-btn" class="resbtn resbtn--primary" type="button">
+                        <span data-i18n="lightning.continueGame">Continue game</span>
                     </button>
-                    <div class="resbtn-row">
-                        <button id="lightning-recap-newgame-btn" class="resbtn resbtn--secondary" type="button" data-i18n="admin.newGameShort">
-                            New Game
-                        </button>
-                    </div>
                 </div>
 
                 <div id="lightning-recap-player-msg" class="end-player-message hidden">
                     <p class="thanks-line"><span class="qz-icon feedback-icon qz-icon--coral" data-ui-icon="party" aria-hidden="true"></span><span data-i18n="leaderboard.thanksEmoji">Thanks for playing!</span></p>
-                    <p class="end-hint" data-i18n="leaderboard.waitForHost">Wait for the host to start a new game</p>
+                    <p class="end-hint" data-i18n="lightning.recapWaitHint">Hang tight — the host continues the game</p>
                 </div>
             </div>
         </div>

--- a/tests/test_backend_bugs_batch.py
+++ b/tests/test_backend_bugs_batch.py
@@ -168,6 +168,66 @@ class TestNumRoundsValidation:
 
 
 # ---------------------------------------------------------------------------
+# #285 — Lightning toggle wired through start_game
+# ---------------------------------------------------------------------------
+
+
+class TestLightningToggleWiring:
+    @pytest.mark.asyncio
+    async def test_default_on_arms_lightning(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        admin = _ws()
+        game.add_player("Markus", admin)
+        game.get_player("Markus").is_admin = True
+        # No lightning_enabled key → default ON → a target is armed.
+        await handler._handle_start_game(
+            admin,
+            {"category": "geographie", "num_rounds": 10, "language": "de"},
+            game,
+        )
+        assert game.lightning_target_round is not None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("falsey", [False, "false", "0", "off", 0])
+    async def test_toggle_off_disarms_lightning(
+        self,
+        handler: QuizifyWebSocketHandler,
+        game: QuizifyGameState,
+        falsey,
+    ) -> None:
+        admin = _ws()
+        game.add_player("Markus", admin)
+        game.get_player("Markus").is_admin = True
+        await handler._handle_start_game(
+            admin,
+            {
+                "category": "geographie",
+                "num_rounds": 10,
+                "language": "de",
+                "lightning_enabled": falsey,
+            },
+            game,
+        )
+        assert game.lightning_target_round is None
+
+
+def test_coerce_toggle_forms() -> None:
+    from custom_components.quizify.server.websocket import _coerce_toggle
+
+    assert _coerce_toggle(None, default=True) is True
+    assert _coerce_toggle(None, default=False) is False
+    assert _coerce_toggle(True, default=False) is True
+    assert _coerce_toggle(False, default=True) is False
+    assert _coerce_toggle(1, default=False) is True
+    assert _coerce_toggle(0, default=True) is False
+    for off in ("false", "0", "off", "no", ""):
+        assert _coerce_toggle(off, default=True) is False
+    for on in ("true", "1", "on", "yes"):
+        assert _coerce_toggle(on, default=False) is True
+
+
+# ---------------------------------------------------------------------------
 # #308 — empty-pack start error code
 # ---------------------------------------------------------------------------
 
@@ -240,41 +300,12 @@ class TestAdminSkip:
 
 
 # ---------------------------------------------------------------------------
-# #308 — admin "End lightning" scores the in-flight question
+# #308/#285 — the "End lightning" early-teardown bug is now MOOT
 # ---------------------------------------------------------------------------
-
-
-class TestEndLightningScoresInFlight:
-    @pytest.mark.asyncio
-    async def test_end_lightning_scores_current_answers(
-        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
-    ) -> None:
-        """When the admin ends the lightning round early, an already-tapped
-        correct answer on the in-flight question must still be scored (#308)
-        — previously lr.advance() was missing so those answers were discarded.
-        """
-        handler._broadcast_lightning_recap = AsyncMock()  # type: ignore[attr-defined]
-
-        player_ws = _ws()
-        game.add_player("A", player_ws)
-        assert game.start_lightning_round() is True
-        assert game.begin_lightning_questions() is True
-        lr = game.lightning
-        assert lr is not None
-
-        # Player A answers the in-flight question correctly.
-        q = lr.current_question
-        assert q is not None
-        correct_orig = next(i for i, a in enumerate(q.answers) if a.correct)
-        order = lr._shuffles["A"]
-        shuffled_idx = order.index(correct_orig)
-        assert lr.record_answer("A", shuffled_idx) is True
-        # Not yet scored — scoring happens on advance().
-        assert lr.scores["A"] == 0
-
-        await handler._handle_end_lightning(player_ws, game)
-
-        assert game.phase == GamePhase.LIGHTNING_RECAP
-        # The in-flight correct answer was scored before teardown.
-        assert lr.scores["A"] > 0
-        handler._broadcast_lightning_recap.assert_awaited()
+#
+# The host-manual ``end_lightning`` action (which used to discard the
+# in-flight question's answers, #308) was retired in #285: the Lightning Round
+# auto-triggers mid-game and always runs to completion through the loop's
+# ``advance()`` (which scores every question, including the last). There is no
+# early-end path left, so the #308 fix is moot. The loop's per-question
+# scoring is covered by the LightningRound engine tests in test_lightning.py.

--- a/tests/test_dispatch_guard_270.py
+++ b/tests/test_dispatch_guard_270.py
@@ -54,9 +54,9 @@ ADMIN_REQUIRED_TYPES = {
     "pause_game",
     "resume_game",
     "kick_player",
-    "start_lightning",
-    "start_lightning_questions",
-    "end_lightning",
+    # start_lightning / start_lightning_questions / end_lightning were retired
+    # in #285 — the Lightning Round now auto-triggers mid-game, with no
+    # host-facing start/end message.
 }
 
 NON_ADMIN_TYPES = {

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -402,3 +402,56 @@ class TestLightningWsLoop:
 
         assert state.phase == GamePhase.LIGHTNING_RECAP
         assert lr.scores["A"] == LIGHTNING_POINTS_PER_CORRECT
+
+
+# ---------- WS handler: #285 auto-trigger entry + resume ----------
+
+
+class TestLightningAutoEntry:
+    @pytest.mark.asyncio
+    async def test_start_next_question_detours_into_auto_lightning(
+        self, state: QuizifyGameState
+    ) -> None:
+        """When the game is about to enter the pre-picked target round, the
+        normal advance path detours into the auto Lightning Round instead of a
+        normal question."""
+        state.add_player("A", _fake_ws())
+        h = _handler(state)
+        state.start_game(num_rounds=10, lightning_seed=42)
+        target = state.lightning_target_round
+        assert target is not None
+        # Position the game just before the target round.
+        state.round = target - 1
+        state.phase = GamePhase.ANSWER_REVEAL
+        assert state.should_trigger_lightning() is True
+
+        # The advance detours; phase becomes LIGHTNING (splash up).
+        await h._start_next_question(state)
+        assert state.phase == GamePhase.LIGHTNING
+        assert state.lightning is not None
+        assert state.in_lightning_detour is True
+        h._cancel_lightning_loop()
+
+    @pytest.mark.asyncio
+    async def test_recap_advance_resumes_main_game(
+        self, state: QuizifyGameState
+    ) -> None:
+        """The host's normal next_question after the mid-game lightning recap
+        resumes the paused main game at the originally-scheduled round."""
+        state.add_player("A", _fake_ws())
+        h = _handler(state)
+        state.start_game(num_rounds=10, lightning_seed=42)
+        target = state.lightning_target_round
+        assert target is not None
+        resume_round = target - 1
+        state.round = resume_round
+        state.phase = GamePhase.ANSWER_REVEAL
+        assert state.start_lightning_round(auto=True) is True
+        state.finish_lightning_round()
+        assert state.phase == GamePhase.LIGHTNING_RECAP
+
+        # next_question from the recap → resume + start the target round.
+        await h._handle_next_question(state.get_player("A").ws, state)
+        assert state.phase == GamePhase.QUESTION_ACTIVE
+        assert state.round == target  # the originally-scheduled round now ran
+        h._cancel_timer_tick()

--- a/tests/test_lightning_autotrigger_285.py
+++ b/tests/test_lightning_autotrigger_285.py
@@ -1,0 +1,272 @@
+"""Tests for the auto-triggered Lightning Round (issue #285).
+
+The Lightning Round (#42) stopped being a host-manual mode and became an
+automatic, random mid-game event. These tests pin the contract Markus
+confirmed (2026-06-11):
+
+* AC2 — fires exactly once per game, at a uniformly random round.
+* AC3 — eligible window is rounds 3 … N-1 (first two + last blocked).
+* AC4 — a short game (window empty) skips it; we never force one.
+* AC5 — a settings toggle (default ON) arms it; off disarms it.
+
+The target-round pick is seeded via ``start_game(lightning_seed=...)`` so the
+window bounds, the once-per-game guarantee and the short-game skip are all
+asserted deterministically. The fast-loop mechanics live in
+``game/lightning.py`` and are covered by ``test_lightning.py`` — here we drive
+the *entry* (state machine) only.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+
+
+def _fake_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+class _Runtime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+    def create_task(self, coro):  # noqa: ANN001
+        import asyncio
+
+        return asyncio.ensure_future(coro)
+
+
+@pytest.fixture
+def state(tmp_path: Path) -> QuizifyGameState:
+    st = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="test")
+    st.add_player("A", _fake_ws())
+    return st
+
+
+# ---------------------------------------------------------------------------
+# AC3 — eligible window = rounds 3 … N-1
+# ---------------------------------------------------------------------------
+
+
+class TestEligibleWindow:
+    def test_earliest_is_round_3(self, state: QuizifyGameState) -> None:
+        # seed 14 lands the uniform pick on the window's low bound for N=10.
+        state.start_game(num_rounds=10, lightning_seed=14)
+        assert state.lightning_target_round == 3
+
+    def test_latest_is_n_minus_1(self, state: QuizifyGameState) -> None:
+        # seed 0 lands the pick on the window's high bound (N-1 = 9) for N=10.
+        state.start_game(num_rounds=10, lightning_seed=0)
+        assert state.lightning_target_round == 9
+
+    def test_target_never_outside_window_over_many_seeds(
+        self, state: QuizifyGameState
+    ) -> None:
+        for seed in range(300):
+            state.reset_to_lobby()
+            state.start_game(num_rounds=12, lightning_seed=seed)
+            target = state.lightning_target_round
+            assert target is not None
+            assert 3 <= target <= 11  # 3 … N-1, N=12
+
+    def test_round_1_and_2_never_trigger(self, state: QuizifyGameState) -> None:
+        # Pin the target to round 3 (earliest), then assert no trigger fires
+        # while the game is about to enter round 1 or round 2.
+        state.start_game(num_rounds=10, lightning_seed=14)
+        assert state.lightning_target_round == 3
+        # About to enter round 1 (round counter == 0).
+        assert state.round == 0
+        assert state.should_trigger_lightning() is False
+        # Simulate completing round 1 → about to enter round 2.
+        state.round = 1
+        state.phase = GamePhase.ANSWER_REVEAL
+        assert state.should_trigger_lightning() is False
+        # About to enter round 3 → fires.
+        state.round = 2
+        assert state.should_trigger_lightning() is True
+
+    def test_last_round_never_triggers(self, state: QuizifyGameState) -> None:
+        # N-1 is the high bound, so the pick can never select round N itself.
+        # Drive the counter to "about to enter the final round" and confirm no
+        # trigger, regardless of the (already-armed) target.
+        state.start_game(num_rounds=5, lightning_seed=0)
+        target = state.lightning_target_round
+        assert target is not None and target <= 4  # never 5 (the last round)
+
+
+# ---------------------------------------------------------------------------
+# AC2 — fires exactly once per game
+# ---------------------------------------------------------------------------
+
+
+class TestExactlyOnce:
+    def test_trigger_only_at_target_round(self, state: QuizifyGameState) -> None:
+        state.start_game(num_rounds=10, lightning_seed=42)
+        target = state.lightning_target_round
+        assert target is not None
+        # Walk every between-rounds advance point; only the target fires.
+        fired_at = []
+        for upcoming in range(1, 11):
+            state.round = upcoming - 1
+            state.phase = (
+                GamePhase.LOBBY if upcoming == 1 else GamePhase.ANSWER_REVEAL
+            )
+            if state.should_trigger_lightning():
+                fired_at.append(upcoming)
+        assert fired_at == [target]
+
+    def test_fired_flag_blocks_second_trigger(
+        self, state: QuizifyGameState
+    ) -> None:
+        state.start_game(num_rounds=10, lightning_seed=42)
+        target = state.lightning_target_round
+        assert target is not None
+        # Position the game at the target and actually start the auto round.
+        state.round = target - 1
+        state.phase = GamePhase.ANSWER_REVEAL
+        assert state.should_trigger_lightning() is True
+        assert state.start_lightning_round(auto=True) is True
+        # Once armed, the flag is burned — even back at the same round it never
+        # re-triggers.
+        state.phase = GamePhase.ANSWER_REVEAL
+        state.round = target - 1
+        assert state.should_trigger_lightning() is False
+
+
+# ---------------------------------------------------------------------------
+# AC4 — short game skips it
+# ---------------------------------------------------------------------------
+
+
+class TestShortGameSkip:
+    @pytest.mark.parametrize("num_rounds", [1, 2, 3])
+    def test_window_empty_no_target(
+        self, state: QuizifyGameState, num_rounds: int
+    ) -> None:
+        state.start_game(num_rounds=num_rounds, lightning_seed=42)
+        assert state.lightning_target_round is None
+        # And no advance point ever triggers.
+        for upcoming in range(1, num_rounds + 1):
+            state.round = upcoming - 1
+            state.phase = (
+                GamePhase.LOBBY if upcoming == 1 else GamePhase.ANSWER_REVEAL
+            )
+            assert state.should_trigger_lightning() is False
+
+    def test_four_rounds_is_smallest_eligible(
+        self, state: QuizifyGameState
+    ) -> None:
+        # N=4 → window is just {3}; the LR is armed (not skipped).
+        state.start_game(num_rounds=4, lightning_seed=42)
+        assert state.lightning_target_round == 3
+
+
+# ---------------------------------------------------------------------------
+# AC5 — settings toggle, default ON
+# ---------------------------------------------------------------------------
+
+
+class TestToggle:
+    def test_default_on_arms_lightning(self, state: QuizifyGameState) -> None:
+        # No explicit toggle → ON by default.
+        state.start_game(num_rounds=10, lightning_seed=42)
+        assert state.lightning_target_round is not None
+
+    def test_toggle_off_disarms_lightning(
+        self, state: QuizifyGameState
+    ) -> None:
+        state.start_game(
+            num_rounds=10, lightning_enabled=False, lightning_seed=42
+        )
+        assert state.lightning_target_round is None
+        # No advance point triggers when disabled.
+        for upcoming in range(1, 11):
+            state.round = upcoming - 1
+            state.phase = (
+                GamePhase.LOBBY if upcoming == 1 else GamePhase.ANSWER_REVEAL
+            )
+            assert state.should_trigger_lightning() is False
+
+    def test_toggle_persisted_in_last_settings(
+        self, state: QuizifyGameState
+    ) -> None:
+        # "Play again — same settings" must carry the toggle choice.
+        state.start_game(num_rounds=10, lightning_enabled=False)
+        assert state.last_settings["lightning_enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# Detour / resume — the mid-game entry + return-to-game transition
+# ---------------------------------------------------------------------------
+
+
+class TestDetourAndResume:
+    def test_auto_entry_from_answer_reveal(
+        self, state: QuizifyGameState
+    ) -> None:
+        # auto=True may fire from ANSWER_REVEAL (between rounds); the legacy
+        # auto=False path still rejects that phase.
+        state.start_game(num_rounds=10, lightning_seed=42)
+        state.round = state.lightning_target_round - 1  # type: ignore[operator]
+        state.phase = GamePhase.ANSWER_REVEAL
+        assert state.start_lightning_round(auto=False) is False
+        assert state.start_lightning_round(auto=True) is True
+        assert state.phase == GamePhase.LIGHTNING
+        assert state.in_lightning_detour is True
+
+    def test_resume_restores_round_and_phase(
+        self, state: QuizifyGameState
+    ) -> None:
+        state.start_game(num_rounds=10, lightning_seed=42)
+        target = state.lightning_target_round
+        assert target is not None
+        resume_round = target - 1
+        state.round = resume_round
+        state.phase = GamePhase.ANSWER_REVEAL
+        assert state.start_lightning_round(auto=True) is True
+        state.finish_lightning_round()
+        assert state.phase == GamePhase.LIGHTNING_RECAP
+
+        assert state.resume_after_lightning() is True
+        # Back in the main game at the round we detoured from, ready for the
+        # normal start_next_question to proceed into the target round.
+        assert state.phase == GamePhase.ANSWER_REVEAL
+        assert state.round == resume_round
+        assert state.in_lightning_detour is False
+        assert state.lightning is None
+
+    def test_resume_noop_without_detour(
+        self, state: QuizifyGameState
+    ) -> None:
+        # A standalone lightning session (no main game paused behind it) has
+        # nothing to resume.
+        state.add_player("A", _fake_ws())
+        assert state.start_lightning_round() is True  # auto=False, from LOBBY
+        state.finish_lightning_round()
+        assert state.in_lightning_detour is False
+        assert state.resume_after_lightning() is False
+
+    def test_reset_clears_autotrigger_state(
+        self, state: QuizifyGameState
+    ) -> None:
+        state.start_game(num_rounds=10, lightning_seed=42)
+        assert state.lightning_target_round is not None
+        state.reset_to_lobby()
+        assert state.lightning_target_round is None
+        assert state.in_lightning_detour is False


### PR DESCRIPTION
Turns the Lightning Round (#42) from a host-manual mode into an **automatic, random in-game event** woven into the normal round flow.

## Behaviour (all confirmed by Markus 2026-06-11)
- **Automatic, once per game** — fires on its own, no host action, guaranteed exactly once.
- **Eligible window = rounds 3 … N-1** — first two rounds + the last round are blocked. The target round is a single uniformly-random, seedable draw made at game start.
- **Short games skip it** — if the window is empty (N < 4) no Lightning Round occurs; never forced.
- **Settings toggle, default ON** — a new setup-screen toggle (`.toggle-compact` Beatify pattern) wired through `start_game` like every other setting (`admin.js _buildStartGamePayload` → `lightning_enabled` → `game_state.start_game`).

## Entry mechanics
`start_next_question()` detours into the auto Lightning Round when the game is about to enter the target round. The intro splash auto-advances (no host tap), the fast loop runs to the recap, and the host's normal **Continue game** advance resumes the paused main game at the originally-scheduled round (`resume_after_lightning` → `ANSWER_REVEAL`). `game/lightning.py` mechanics are unchanged — only the *entry* changed. The random pick is seedable (`start_game(lightning_seed=…)`) so tests are deterministic.

## Retired host-manual entry (supersedes #42)
- Removed `start_lightning` / `start_lightning_questions` / `end_lightning` protocol types, WS handlers and dispatch entries.
- Removed the admin **⚡ Lightning Round** button, the splash Start / End controls, and the finale + player "Lightning" CTAs.
- The recap **Another Lightning Round** button (a #294 dead-end) is replaced by a **Continue game** action.
- The #308 *"End lightning discards in-flight answers"* bug is now **moot** — there is no early-end path; the loop always runs to completion via `advance()`.

The TV dashboard lightning views (#296) are **unchanged** and driven by the same `lightning_splash` / `lightning_question` / `lightning_tick` / `lightning_recap` broadcasts.

## Tests
+27 new tests: eligible-window bounds (round 3 earliest, N-1 latest), exactly-once-per-game, short-game skip, toggle on/off + `last_settings` persistence, `_coerce_toggle` wire forms, and the WS auto-entry + recap-resume flow. Full suite green locally (688 passed; the 6 `test_ws_handle_integration_293` failures are the known pytest-socket sandbox blocks that pass in CI). Rebuilt `player.bundle.js` + `styles.css` (zero drift). `ruff` + `mypy` clean.

## Mobile-verify before merge
The new **Lightning Round?** toggle lives at the end of the Custom-settings step; worth a 390px check that the switch + label fit one line and the retired admin buttons left the setup/finale footers clean.

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)