### PR TITLE
fix: move blocking manifest.json reads off the event loop (#343)

### DIFF
--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -51,8 +51,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     from .question_stats import QuestionStatsService  # noqa: PLC0415
     from .runtime import HARuntime  # noqa: PLC0415
     from .server import STATIC_URL_PREFIX, WS_PATH, WWW_DIR  # noqa: PLC0415
-    from .server.context import APP_CTX_KEY, AppContext  # noqa: PLC0415
-    from .server.views import register_routes  # noqa: PLC0415
+    from .server.context import (  # noqa: PLC0415
+        APP_CTX_KEY,
+        AppContext,
+        read_manifest_version,
+    )
+    from .server.views import (  # noqa: PLC0415
+        refresh_live_version,
+        register_routes,
+    )
     from .server.websocket import QuizifyWebSocketHandler  # noqa: PLC0415
     from .tts import QuizifyTTSAnnouncer  # noqa: PLC0415
 
@@ -93,12 +100,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Wire broadcast callback so game state can push events to clients.
     game_state.set_broadcast_callback(ws_handler.broadcast_state)
 
+    # Read the manifest version OFF the event loop (#343). HA's loop-watcher
+    # flags read_text() inside the loop; doing it in an executor and passing the
+    # result in explicitly (instead of relying on AppContext's synchronous
+    # default_factory) keeps the loop clean.
+    version = await hass.async_add_executor_job(read_manifest_version)
+
     ctx = AppContext(
         runtime=runtime,
         game=game_state,
         analytics=analytics,
         ws_handler=ws_handler,
         question_stats=question_stats,
+        version=version,
         # HA's configured language drives the admin UI's initial language
         # (Settings → General). hass.config.language is always set on HA.
         ha_language=hass.config.language,
@@ -143,6 +157,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # for the frontend resource version stamp.
     await hass.http.async_register_static_paths(
         [StaticPathConfig(STATIC_URL_PREFIX, str(WWW_DIR), cache_headers=True)]
+    )
+
+    # Keep the live manifest version (the asset cache-buster source) fresh OFF
+    # the event loop (#343). The launcher/HTML serve path reads a pure
+    # in-memory value with zero loop I/O; a background interval re-reads
+    # manifest.json in an executor thread so a direct-rsync deploy (manifest
+    # bumped on disk without an integration reload) still busts the browser
+    # cache without a full HA restart — just without blocking the loop. Run it
+    # once now so the first serve already has the live value, then on an
+    # interval. The mtime cache makes the steady-state tick a single stat().
+    from datetime import timedelta  # noqa: PLC0415
+
+    from homeassistant.helpers.event import (  # noqa: PLC0415
+        async_track_time_interval,
+    )
+
+    await refresh_live_version(runtime)
+
+    async def _refresh_live_version_tick(_now: object) -> None:
+        await refresh_live_version(runtime)
+
+    entry.async_on_unload(
+        async_track_time_interval(
+            hass, _refresh_live_version_tick, timedelta(seconds=30)
+        )
     )
 
     # Register sidebar panel.

--- a/custom_components/quizify/server/context.py
+++ b/custom_components/quizify/server/context.py
@@ -40,9 +40,13 @@ def read_manifest_version() -> str:
     ``/api/quizify/status`` payload). Bumping ``manifest.json`` is all
     a release needs.
 
-    Synchronous on purpose: called once at app startup, before any
-    request handlers run, so there's no event-loop blocking concern.
-    Falls back to ``"unknown"`` only if the file is missing or malformed.
+    BLOCKING (``read_text``) — must NOT be called on the event loop (#343).
+    On the HA path ``async_setup_entry`` runs it via
+    ``hass.async_add_executor_job`` and passes the result into
+    ``AppContext(version=...)`` explicitly; the synchronous ``default_factory``
+    on the dataclass is only a fallback for the standalone dev server and
+    tests, which are not on HA's loop. Falls back to ``"unknown"`` only if the
+    file is missing or malformed.
     """
     try:
         data = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))

--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -32,6 +32,7 @@ from .serializers import build_game_status_response
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
+    from ..runtime import Runtime
     from .context import AppContext
 
     # aiohttp request handler shape, matching what `UrlDispatcher.add_route`
@@ -88,10 +89,59 @@ _ASSET_FP_TTL_NS = 5 * 1_000_000_000  # 5s
 _ASSET_FP_CACHE: tuple[int, str] | None = None  # (monotonic_ns, fingerprint)
 
 # mtime-keyed cache for the live manifest version. Without this the
-# integration would re-parse manifest.json on every request; with it we
+# integration would re-parse manifest.json on every refresh; with it we
 # only re-read when the file actually changed (which means a deploy
 # happened). Tuple of (mtime_ns, version).
 _MANIFEST_CACHE: tuple[int, str] | None = None
+
+# Pure in-memory "live" manifest version served on the HTML request hot path.
+# Refreshed OFF the event loop by ``refresh_live_version`` (a background
+# ``async_track_time_interval`` on the HA path, see __init__.py). The request
+# handler reads this with zero ``os.stat``/``read_text`` on the loop (#343),
+# so HA's loop-watcher no longer flags the launcher serve. ``None`` until the
+# first refresh runs — until then the request path falls back to
+# ``ctx.version`` (the value read off the loop at setup). A direct-rsync deploy
+# (manifest bumped on disk without an integration reload) is still picked up:
+# the background refresh re-reads the file on its next mtime-changed tick, so
+# the asset cache-buster updates without a full HA restart (the v1.1.43
+# mechanism), just without blocking the loop.
+_LIVE_VERSION: str | None = None
+
+
+def _refresh_live_version() -> str | None:
+    """Re-read manifest.json from disk and update the in-memory live version.
+
+    BLOCKING (``os.stat`` + ``read_text``) — must run OFF the event loop (in an
+    executor thread, or in the standalone dev server which has no HA loop, or
+    in tests). Returns the resolved version, or ``None`` if the file is missing
+    or unreadable (the caller then keeps the previous in-memory value / the
+    setup-time fallback). The mtime cache means an unchanged file is a single
+    ``stat`` with no re-parse.
+    """
+    global _MANIFEST_CACHE, _LIVE_VERSION
+    try:
+        mtime_ns = os.stat(_MANIFEST_PATH).st_mtime_ns
+        if _MANIFEST_CACHE is not None and _MANIFEST_CACHE[0] == mtime_ns:
+            _LIVE_VERSION = _MANIFEST_CACHE[1]
+            return _LIVE_VERSION
+        data = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+        version = str(data["version"])
+        _MANIFEST_CACHE = (mtime_ns, version)
+        _LIVE_VERSION = version
+        return version
+    except (OSError, ValueError, KeyError) as exc:
+        _LOGGER.debug("Could not read live version from manifest: %s", exc)
+        return None
+
+
+async def refresh_live_version(runtime: Runtime) -> None:
+    """Refresh the in-memory live manifest version off the event loop.
+
+    Wired as a periodic ``async_track_time_interval`` callback on the HA path
+    (see ``async_setup_entry``) and called once at setup. Runs the blocking
+    re-read in an executor thread so the loop is never blocked (#343).
+    """
+    await runtime.run_in_executor(_refresh_live_version)
 
 
 def _get_ctx(request: web.Request) -> AppContext:
@@ -100,32 +150,17 @@ def _get_ctx(request: web.Request) -> AppContext:
 
 
 def _get_live_version(fallback: str) -> str:
-    """Read the live manifest version, busting the cache when the file changes.
+    """Return the live manifest version — pure in-memory, NO loop I/O (#343).
 
-    Why this exists: ``ctx.version`` is set at integration setup time, so a
-    direct-rsync deploy (manifest.json updated on disk without an HA
-    integration reload) would leave ``ctx.version`` stale. The HTML asset
-    URLs use ``?v={{VERSION}}`` for cache-busting; if VERSION never moves,
-    browsers serve the stale CSS/JS forever after a deploy and the user
-    has to manually clear cache. Re-reading manifest.json on mtime change
-    fixes the cache-bust round-trip end-to-end.
-
-    Falls back to ``fallback`` (typically ``ctx.version``) if the file is
-    missing or unreadable — defensive, since this code path runs on every
-    HTML request.
+    The actual disk read happens in ``_refresh_live_version`` (off the loop:
+    a background interval on the HA path, an executor refresh, or the
+    standalone dev server). This reader just returns the last-refreshed
+    in-memory value, falling back to ``fallback`` (typically ``ctx.version``,
+    the value read off the loop at setup) until the first refresh has run or
+    if the manifest was unreadable. Safe to call on the event loop on every
+    HTML request — that's the whole point of moving the read out of here.
     """
-    global _MANIFEST_CACHE
-    try:
-        mtime_ns = os.stat(_MANIFEST_PATH).st_mtime_ns
-        if _MANIFEST_CACHE is not None and _MANIFEST_CACHE[0] == mtime_ns:
-            return _MANIFEST_CACHE[1]
-        data = json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
-        version = str(data.get("version", fallback))
-        _MANIFEST_CACHE = (mtime_ns, version)
-        return version
-    except (OSError, ValueError, KeyError) as exc:
-        _LOGGER.debug("Could not read live version from manifest: %s", exc)
-        return fallback
+    return _LIVE_VERSION if _LIVE_VERSION is not None else fallback
 
 
 def _compute_asset_fingerprint(www_dir: Path = _WWW_DIR) -> str:

--- a/scripts/dev_server.py
+++ b/scripts/dev_server.py
@@ -43,6 +43,9 @@ from custom_components.quizify.server.context import (  # noqa: E402
     APP_CTX_KEY,
     AppContext,
 )
+from custom_components.quizify.server.views import (  # noqa: E402
+    refresh_live_version,
+)
 from custom_components.quizify.server.websocket import (  # noqa: E402
     QuizifyWebSocketHandler,
 )
@@ -171,6 +174,11 @@ def main(argv: list[str] | None = None) -> int:
             await ctx.question_stats.load()
         await ctx.game.async_load_history()
         await ctx.ws_handler._conn.async_load_admin_token()
+        # Populate the in-memory live manifest version so the HTML serve path
+        # has it without a per-request read (#343). The standalone server has
+        # no background interval, but a single refresh at startup is enough —
+        # the dev server is restarted on every code change anyway.
+        await refresh_live_version(ctx.runtime)
 
     app.on_startup.append(_load_state)
 

--- a/tests/test_performance_169.py
+++ b/tests/test_performance_169.py
@@ -143,6 +143,12 @@ class TestRateLimitBounded:
 
 
 class TestManifestCacheConsistent:
+    """The disk re-read now lives in ``_refresh_live_version`` (run OFF the
+    event loop, #343); ``_get_live_version`` is a pure in-memory reader. These
+    guard that the off-loop refresh still picks up an mtime change (so the
+    cache-buster updates after a direct-rsync deploy without an HA restart) and
+    that the in-memory reader returns the refreshed value with zero I/O."""
+
     def test_repeated_reads_are_consistent(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -150,7 +156,10 @@ class TestManifestCacheConsistent:
         manifest.write_text('{"version": "9.9.9"}', encoding="utf-8")
         monkeypatch.setattr(views, "_MANIFEST_PATH", manifest)
         monkeypatch.setattr(views, "_MANIFEST_CACHE", None)
+        monkeypatch.setattr(views, "_LIVE_VERSION", None)
 
+        assert views._refresh_live_version() == "9.9.9"
+        # The in-memory reader now serves the refreshed value, no disk access.
         first = views._get_live_version("fallback")
         second = views._get_live_version("fallback")
         assert first == second == "9.9.9"
@@ -163,11 +172,14 @@ class TestManifestCacheConsistent:
         os.utime(manifest, ns=(1_000_000_000, 1_000_000_000))
         monkeypatch.setattr(views, "_MANIFEST_PATH", manifest)
         monkeypatch.setattr(views, "_MANIFEST_CACHE", None)
+        monkeypatch.setattr(views, "_LIVE_VERSION", None)
+        views._refresh_live_version()
         assert views._get_live_version("fb") == "1.0.0"
 
         # New content + a distinct mtime → the cache key changes → re-read.
         manifest.write_text('{"version": "2.0.0"}', encoding="utf-8")
         os.utime(manifest, ns=(2_000_000_000, 2_000_000_000))
+        views._refresh_live_version()
         assert views._get_live_version("fb") == "2.0.0"
 
     def test_missing_file_falls_back(
@@ -175,7 +187,43 @@ class TestManifestCacheConsistent:
     ) -> None:
         monkeypatch.setattr(views, "_MANIFEST_PATH", tmp_path / "nope.json")
         monkeypatch.setattr(views, "_MANIFEST_CACHE", None)
+        monkeypatch.setattr(views, "_LIVE_VERSION", None)
+        # Refresh returns None (file unreadable) and leaves the in-memory value
+        # unset, so the reader serves the supplied fallback.
+        assert views._refresh_live_version() is None
         assert views._get_live_version("the-fallback") == "the-fallback"
+
+    @pytest.mark.asyncio
+    async def test_async_refresh_runs_off_loop_and_picks_up_bump(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``refresh_live_version`` must offload the blocking read to the
+        runtime's executor (so the loop stays clean, #343) AND pick up a bumped
+        manifest, proving the no-restart cache-buster still works."""
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text('{"version": "1.0.0"}', encoding="utf-8")
+        os.utime(manifest, ns=(1_000_000_000, 1_000_000_000))
+        monkeypatch.setattr(views, "_MANIFEST_PATH", manifest)
+        monkeypatch.setattr(views, "_MANIFEST_CACHE", None)
+        monkeypatch.setattr(views, "_LIVE_VERSION", None)
+
+        ran_via_executor = {"n": 0}
+
+        async def _run_in_executor(func, *args):
+            ran_via_executor["n"] += 1
+            return func(*args)
+
+        runtime = SimpleNamespace(run_in_executor=_run_in_executor)
+
+        await views.refresh_live_version(runtime)
+        assert ran_via_executor["n"] == 1
+        assert views._get_live_version("fb") == "1.0.0"
+
+        # Simulate a direct-rsync deploy: manifest bumped on disk, no reload.
+        manifest.write_text('{"version": "1.0.1"}', encoding="utf-8")
+        os.utime(manifest, ns=(2_000_000_000, 2_000_000_000))
+        await views.refresh_live_version(runtime)
+        assert views._get_live_version("fb") == "1.0.1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

HA's event-loop watcher flagged Quizify for **blocking file I/O on the event loop** when reading `manifest.json` at two sites (warned on every startup and every launcher serve):

1. `server/context.py` — `read_manifest_version()` via `AppContext.version`'s synchronous `default_factory`, invoked during `async_setup_entry`.
2. `server/views.py` — `_get_live_version()` on the launcher HTML hot path (`os.stat` per request + `read_text` on a cache miss).

## How

**Setup read (context.py / `__init__.py`).** `async_setup_entry` now reads the version off the loop via `hass.async_add_executor_job(read_manifest_version)` and passes it into `AppContext(version=...)` explicitly. The synchronous `default_factory` is kept only as a fallback for the standalone dev server and tests (which aren't on HA's loop). Docstring updated to state it must not run on the loop.

**Request hot path (views.py).** `_get_live_version()` is now a **pure in-memory reader** — zero `os.stat`/`read_text` on the loop. The blocking re-read lives in a new sync helper `_refresh_live_version()` and an async wrapper `refresh_live_version(runtime)` that offloads it to an executor thread. On the HA path a 30s `async_track_time_interval` (set up in `async_setup_entry`, plus one refresh at setup) keeps the in-memory value fresh off the loop. The interval's unsub is registered via `entry.async_on_unload`, so it tears down cleanly on unload. The mtime cache keeps the steady-state tick to a single `stat()`.

## No-restart cache-buster preserved

A direct-rsync deploy (manifest bumped on disk **without** an integration reload) is still picked up: the background refresh re-reads on its next mtime-changed tick, so the asset `?v=` cache-buster updates **without a full HA restart** (the v1.1.43 mechanism) — just without blocking the loop.

**Dev server:** `build_app` keeps the `default_factory` version; the startup hook calls `refresh_live_version()` once to populate the in-memory value (the dev server restarts on every code change, so no interval is needed). Verified `build_app` still constructs the app and serves a version.

## Tests

- The manifest-cache tests in `test_performance_169.py` now target `_refresh_live_version` + the in-memory reader (the disk read moved out of `_get_live_version`).
- Added `test_async_refresh_runs_off_loop_and_picks_up_bump`: asserts `refresh_live_version` offloads via the runtime executor **and** picks up a bumped manifest (proves the no-restart path still works).
- Existing `test_version_cachebuster.py` suite unchanged and green (its `_get_live_version` monkeypatch signature is unchanged).

Local: 699 passed; the only failures are the `test_ws_handle_integration_293` / `test_perf_wasted_work_304` socket tests that can't bind sockets under the local sandbox (pass in CI). ruff + mypy clean. 0 artifact drift (www/ untouched).

## How to confirm the warning is gone

The `[homeassistant.util.loop] Detected blocking call … manifest.json` warning fires on (a) startup (`async_setup_entry`) and (b) the first launcher serve (`_serve_html` → `_get_live_version`). After this change both paths read off the loop / from memory, so neither should appear in the HA log on the next RC deploy verification.

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)