### PR TITLE
fix(lightning): stop auto Lightning Round wiping the shared question queue (#350)

### DIFF
--- a/custom_components/quizify/game/lightning.py
+++ b/custom_components/quizify/game/lightning.py
@@ -130,38 +130,57 @@ class LightningRound:
 
         Returns False if no questions are available (caller should abort).
         """
-        # Reuse the shared QuestionBank queue, restricted to the requested
-        # category/language — the normal game's history-aware least-recently
-        # -shown ordering applies, so a lightning round after a main game
-        # naturally pulls fresh questions.
+        # Build a PRIVATE question pool for the lightning round (#350).
+        #
+        # This used to call ``self._bank.reset(...)`` + ``get_next_question()``,
+        # which rebuilt and consumed the *shared* game queue mid-game. Two
+        # bugs fell out of that: (1) it destroyed the main game's queue
+        # position/ordering, risking re-shown questions on resume, and (2)
+        # when the host picked "auto" difficulty, ``reset`` filtered on
+        # ``q.difficulty == "auto"`` — a difficulty no question carries — so
+        # the queue came back EMPTY and the fallback ended the game right at
+        # the auto-lightning round. We now pull from a private pool and never
+        # touch the bank's ``_queue``/``_queue_index``.
+        #
         # Cache hit — the bank is preloaded off-loop at setup (#258).
         self._bank.load_all_categories()
-        self._bank.reset(
+
+        # "auto" is a group-adaptive *mode*, not a per-question difficulty;
+        # no question has difficulty=="auto". Map it to None so the pool spans
+        # all difficulties instead of coming back empty.
+        difficulty = None if self.difficulty in (None, "auto") else self.difficulty
+
+        # Prefer questions the main game hasn't shown this session — the
+        # history-aware ordering (never-shown first) already does this, but
+        # excluding the shown-this-game set keeps a repeat out of the pool
+        # entirely even in small packs.
+        pool = self._bank.build_pool(
             category=self.category,
             categories=self.categories,
-            difficulty=self.difficulty,
+            difficulty=difficulty,
             language=self.language,
+            exclude_ids=self._bank.shown_this_game_ids(),
         )
+
         # Lightning is fast tap-an-answer (3 options, 15s each). Estimate
         # questions (#275) have no answer grid and the lightning view has no
-        # slider, so an estimate question would render as an empty card.
-        # Exclude them from the lightning pool — keep pulling until we have
-        # enough multiple-choice questions or the queue is exhausted. The
-        # attempt bound guards against an all-estimate pool (e.g. the user
-        # picked only the Schätzfragen/Estimation packs) so this can't spin.
-        max_attempts = self.num_questions * 20
-        attempts = 0
-        while len(self._questions) < self.num_questions and attempts < max_attempts:
-            attempts += 1
-            q = self._bank.get_next_question(
-                category=self.category, difficulty=self.difficulty
-            )
-            if q is None:
+        # slider, so an estimate question would render as an empty card —
+        # skip them. Iterating a finite pool can't spin, so no attempt bound
+        # is needed (an all-estimate pool simply yields no questions).
+        for q in pool:
+            if len(self._questions) >= self.num_questions:
                 break
             if getattr(q, "is_estimate", False):
                 continue
             self._questions.append(q)
             self._bank.record_shown(q.id)
+
+        # Claim the chosen questions out of the main game's pending queue so
+        # they aren't shown again when the normal round flow resumes (#285
+        # mid-game auto-lightning). No-op when the queue is empty (e.g. a
+        # lightning round started from the lobby).
+        if self._questions:
+            self._bank.drop_from_queue({q.id for q in self._questions})
 
         if not self._questions:
             _LOGGER.warning("Lightning round: no questions available")

--- a/custom_components/quizify/game/questions.py
+++ b/custom_components/quizify/game/questions.py
@@ -803,16 +803,24 @@ class QuestionBank:
         self._shown_this_game = []
         await self.save_history_async(runtime)
 
-    def _build_queue(
+    def build_pool(
         self,
         category: str | None = None,
         difficulty: str | None = None,
         language: str | None = None,
         categories: list[str] | None = None,
-    ) -> None:
-        """Build and shuffle the internal question queue.
+        exclude_ids: set[str] | None = None,
+    ) -> list[Question]:
+        """Return a history-ordered question pool **without** mutating state.
+
+        Same filtering + never-shown-first ordering as the internal game
+        queue, but returns the list instead of assigning it to ``_queue``.
+        Used by the lightning round (#350) to build its own private queue so
+        it never disturbs the main game's ``_queue``/``_queue_index``.
 
         Priority: ``categories`` list > single ``category`` > all (mixed).
+        ``exclude_ids`` drops those question ids from the pool (e.g. questions
+        the main game already showed this session).
         """
         if categories:
             pool = [q for slug in categories for q in self._categories.get(slug, [])]
@@ -827,15 +835,51 @@ class QuestionBank:
         if language is not None:
             pool = [q for q in pool if q.language == language]
 
+        if exclude_ids:
+            pool = [q for q in pool if q.id not in exclude_ids]
+
         # Sort by history: never-shown questions first, then oldest-shown first.
         # Within each group, randomise to avoid predictable ordering.
         if self._history:
-            import random as _random
             never_shown = [q for q in pool if q.id not in self._history]
             previously_shown = [q for q in pool if q.id in self._history]
-            _random.shuffle(never_shown)
+            random.shuffle(never_shown)
             previously_shown.sort(key=lambda q: self._history.get(q.id, 0))
-            self._queue = never_shown + previously_shown
-        else:
-            self._queue = self.shuffle_questions(pool)
+            return never_shown + previously_shown
+        return self.shuffle_questions(pool)
+
+    def _build_queue(
+        self,
+        category: str | None = None,
+        difficulty: str | None = None,
+        language: str | None = None,
+        categories: list[str] | None = None,
+    ) -> None:
+        """Build and shuffle the internal question queue."""
+        self._queue = self.build_pool(category, difficulty, language, categories)
         self._queue_index = 0
+
+    def remaining_queue_ids(self) -> set[str]:
+        """Ids of questions still queued but not yet served this game.
+
+        Lets a detour (e.g. the lightning round, #350) see what the main game
+        is about to show without mutating the shared queue.
+        """
+        return {q.id for q in self._queue[self._queue_index:]}
+
+    def shown_this_game_ids(self) -> set[str]:
+        """Ids of questions already shown in the current game session."""
+        return set(self._shown_this_game)
+
+    def drop_from_queue(self, ids: set[str]) -> None:
+        """Remove not-yet-served questions from the pending queue (#350).
+
+        Lets the lightning round claim questions from the shared pool without
+        the main game re-showing them in its remaining rounds. The already
+        served prefix (and thus ``_queue_index``) is left untouched.
+        """
+        if not ids:
+            return
+        served = self._queue[: self._queue_index]
+        remaining = [q for q in self._queue[self._queue_index :] if q.id not in ids]
+        self._queue = served + remaining

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -455,3 +455,84 @@ class TestLightningAutoEntry:
         assert state.phase == GamePhase.QUESTION_ACTIVE
         assert state.round == target  # the originally-scheduled round now ran
         h._cancel_timer_tick()
+
+
+# ---------- Shared-queue preservation + auto difficulty (#350) ----------
+
+
+class TestLightningSharedQueue350:
+    """Regression for #350 (P0).
+
+    The lightning round used to ``reset()`` and consume the *shared* game
+    queue. That (a) filtered on ``difficulty="auto"`` — a mode, not a
+    per-question tag — yielding an EMPTY queue that ended auto-difficulty
+    games right at the lightning round, and (b) destroyed the main game's
+    queue position/ordering. The round now builds a private pool and never
+    disturbs the bank's ``_queue``/``_queue_index``.
+    """
+
+    def test_start_with_auto_difficulty_finds_questions(
+        self, bank: QuestionBank
+    ) -> None:
+        # difficulty="auto" must span all difficulties, not filter on a tag
+        # no question carries (which used to empty the queue).
+        lr = LightningRound(bank, ["A", "B"], language="de", difficulty="auto")
+        assert lr.start() is True
+        assert lr.num_questions > 0
+        assert lr.current_question is not None
+
+    def test_start_preserves_main_game_queue(self, bank: QuestionBank) -> None:
+        # Simulate a main game mid-flight: build the queue and serve 2 rounds.
+        bank.reset(language="de")
+        served_ids = set()
+        for _ in range(2):
+            q = bank.get_next_question()
+            assert q is not None
+            bank.record_shown(q.id)
+            served_ids.add(q.id)
+        index_before = bank._queue_index
+        assert index_before == 2
+
+        lr = LightningRound(bank, ["A"], language="de")
+        assert lr.start() is True
+        lightning_ids = {q.id for q in lr._questions}
+
+        # The already-served prefix (and thus the index) is untouched.
+        assert bank._queue_index == index_before
+        assert {q.id for q in bank._queue[:index_before]} == served_ids
+        # Lightning never re-shows a question the main game already served…
+        assert lightning_ids.isdisjoint(served_ids)
+        # …and its picks are claimed out of the pending queue so the resumed
+        # main game can't show them either.
+        assert lightning_ids.isdisjoint(bank.remaining_queue_ids())
+        # The main game still has fresh questions to serve.
+        nxt = bank.get_next_question()
+        assert nxt is not None
+        assert nxt.id not in lightning_ids
+
+    @pytest.mark.asyncio
+    async def test_auto_lightning_does_not_end_auto_difficulty_game(
+        self, state: QuizifyGameState
+    ) -> None:
+        # Full path: an auto-difficulty game whose auto lightning fires must
+        # enter the lightning phase with real questions — not fall through the
+        # "no questions" fallback that used to end the game.
+        state.add_player("A", _fake_ws())
+        h = _handler(state)
+        state.start_game(num_rounds=10, difficulty="auto", lightning_seed=42)
+        assert state.difficulty == "auto"
+        target = state.lightning_target_round
+        assert target is not None
+
+        state.round = target - 1
+        state.phase = GamePhase.ANSWER_REVEAL
+        await h._start_auto_lightning(state)
+        h._cancel_lightning_loop()
+
+        assert state.phase == GamePhase.LIGHTNING
+        assert state.lightning is not None
+        assert state.lightning.num_questions > 0
+        # The main game's queue survived the detour and can still serve.
+        lightning_ids = {q.id for q in state.lightning._questions}
+        assert lightning_ids.isdisjoint(state._question_bank.remaining_queue_ids())
+        assert state._question_bank.get_next_question() is not None


### PR DESCRIPTION
Fixes #350 (P0).

## Problem
The auto Lightning Round (#285, default ON, fires once per game in rounds 3…N-1) reused the **main** game's `QuestionBank`: `LightningRound.start()` called `bank.reset(...)` + `get_next_question()`, which rebuilt and consumed the **shared** queue mid-game.

- **P0:** When the host picked **`auto`** difficulty, `reset()` filtered on `q.difficulty == "auto"` — a difficulty no question carries — so the queue came back **empty**. The round failed to start and the fallback (`_continue_normal_question` → `start_next_question` on the empty queue → "No more questions available") **ended every auto-difficulty game right at the lightning round.**
- Even for fixed difficulties, resetting the shared queue **destroyed the main game's position/ordering**, risking re-shown questions on resume.

## Fix
`LightningRound.start()` now builds a **private** pool and never touches the bank's `_queue`/`_queue_index`:

- New `QuestionBank.build_pool(...)` — the same history-aware ("never-shown first") ordering as the internal queue, but returned as a list instead of mutating state. `_build_queue()` now delegates to it (no behaviour change for the main game).
- Maps difficulty **`"auto"` → `None`** so the lightning pool spans all difficulties instead of coming back empty.
- Excludes `shown_this_game_ids()` from the pool, then **`drop_from_queue()`** removes the chosen questions from the pending main queue so the resumed game can't repeat them (the served prefix + index are preserved).

## Tests
Adds `TestLightningSharedQueue350` (all green):
- `test_start_with_auto_difficulty_finds_questions` — `difficulty="auto"` now yields a non-empty round.
- `test_start_preserves_main_game_queue` — served prefix + `_queue_index` survive; picks are disjoint from the served set and the pending queue; the main game can still serve.
- `test_auto_lightning_does_not_end_auto_difficulty_game` — the full auto path enters `LIGHTNING` with real questions instead of ending the game.

Local: **768 passed, 5 skipped** (HA-only, run in CI); `ruff` clean; `compileall` ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)