### PR TITLE
fix(security): gate host-only API endpoints on the admin session token (#356)

### DIFF
--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -149,6 +149,33 @@ def _get_ctx(request: web.Request) -> AppContext:
     return request.app[APP_CTX_KEY]
 
 
+def _is_admin_authenticated(request: web.Request) -> bool:
+    """Validate the admin session token on a host-only data request (#356).
+
+    The sensitive read endpoints (flags, all-time, analytics data, tts-entities,
+    question-stats, pack submissions) expose host-only data — player names +
+    free-text flag reasons, per-person play history, HA entity ids. They are
+    registered on ``hass.http.app.router`` with NO HA auth, so without a gate
+    any client that can reach port 8123 (including the internet on a
+    port-forwarded install) can read them. Gate them on the admin session token
+    the admin page already holds, sent as ``?token=`` or the ``X-Quizify-Token``
+    header. Same credential as the admin WebSocket — no new secret, no HA-login
+    requirement, and the unauthenticated player/dashboard flow is untouched.
+    """
+    token = request.query.get("token") or request.headers.get("X-Quizify-Token")
+    if not token:
+        return False
+    conn = getattr(getattr(_get_ctx(request), "ws_handler", None), "conn", None)
+    if conn is None:  # pragma: no cover — ws_handler is always wired in prod
+        return False
+    return conn.validate_admin_token(token)
+
+
+def _unauthorized() -> web.Response:
+    """401 for a request that failed the admin-token gate (#356)."""
+    return web.json_response({"error": "unauthorized"}, status=401)
+
+
 def _get_live_version(fallback: str) -> str:
     """Return the live manifest version — pure in-memory, NO loop I/O (#343).
 
@@ -716,6 +743,8 @@ async def tts_entities_view(request: web.Request) -> web.Response:
     dev server (no hass) both lists are empty — the dropdowns then show the
     graceful "configure in HA" fallback.
     """
+    if not _is_admin_authenticated(request):
+        return _unauthorized()
     ctx = _get_ctx(request)
     # Only the HA runtime exposes ``hass``; the standalone dev server does not.
     hass = getattr(ctx.runtime, "hass", None)
@@ -742,6 +771,8 @@ async def tts_entities_view(request: web.Request) -> web.Response:
 
 async def analytics_data_view(request: web.Request) -> web.Response:
     """Return analytics data as JSON."""
+    if not _is_admin_authenticated(request):
+        return _unauthorized()
     ctx = _get_ctx(request)
     if not ctx.analytics:
         return web.json_response({"total_games": 0})
@@ -759,6 +790,8 @@ async def question_stats_view(request: web.Request) -> web.Response:
       - ``min_shown``: minimum times a question must have been shown
         before it counts, default 3 (filters out noisy one-off misses)
     """
+    if not _is_admin_authenticated(request):
+        return _unauthorized()
     ctx = _get_ctx(request)
     if ctx.question_stats is None:
         return web.json_response({"questions": []})
@@ -788,6 +821,8 @@ async def all_time_leaderboard_view(request: web.Request) -> web.Response:
     games_played, total_score, wins, best_streak, streak_milestones_hit,
     last_played (unix seconds).
     """
+    if not _is_admin_authenticated(request):
+        return _unauthorized()
     ctx = _get_ctx(request)
     if not ctx.analytics:
         return web.json_response({"players": []})
@@ -941,10 +976,13 @@ async def flag_question_view(request: web.Request) -> web.Response:
 async def flag_list_view(request: web.Request) -> web.Response:
     """Return all flagged questions as JSON.
 
-    Used by the analytics dashboard. Not exposed to players — but no auth
-    is enforced here (matches the rest of the API). On HA the auth layer
-    above us handles it; on standalone the home LAN is trusted.
+    Used by the analytics dashboard. Host-only — gated on the admin session
+    token (#356) because the entries carry player names + free-text flag
+    reasons. The stored client IP is additionally stripped from the response
+    (#305).
     """
+    if not _is_admin_authenticated(request):
+        return _unauthorized()
     ctx = _get_ctx(request)
     flag_path = ctx.runtime.data_dir / _FLAG_FILE
 
@@ -979,6 +1017,18 @@ async def flag_list_view(request: web.Request) -> web.Response:
 
 # Each entry is (method, path, handler). Kept as data so the HA adapter and
 # the standalone server can register the same set without duplication.
+async def _gated_submissions_list_view(request: web.Request) -> web.StreamResponse:
+    """Admin-token gate (#356) in front of the imported submissions list.
+
+    The submissions list is a host-review surface (community pack proposals);
+    keep it behind the same admin session token as the other data endpoints
+    without editing the pack_submission module.
+    """
+    if not _is_admin_authenticated(request):
+        return _unauthorized()
+    return await submissions_list_view(request)
+
+
 ROUTES: list[tuple[str, str, _RouteHandler]] = [
     ("GET", "/quizify/admin", admin_view),
     ("GET", "/quizify/launcher", launcher_view),
@@ -1003,7 +1053,7 @@ ROUTES: list[tuple[str, str, _RouteHandler]] = [
     # Community pack submission (#180). Inert until community_submit_url is set:
     # the config endpoint reports enabled:false and POSTs are refused.
     ("GET", "/api/quizify/pack-submit/config", submit_config_view),
-    ("GET", "/api/quizify/pack-submit/submissions", submissions_list_view),
+    ("GET", "/api/quizify/pack-submit/submissions", _gated_submissions_list_view),
     ("POST", "/api/quizify/pack-submit", submit_pack_view),
 ]
 

--- a/custom_components/quizify/www/analytics.html
+++ b/custom_components/quizify/www/analytics.html
@@ -341,10 +341,39 @@
             });
         });
 
+        // #356: the analytics/flags endpoints are admin-token gated. The token
+        // is the admin session token the host holds; read it from this tab's
+        // sessionStorage (set by the admin page) or from a ?token= URL param so
+        // the dashboard keeps working when opened straight from the admin panel.
+        function adminToken() {
+            try {
+                var fromUrl = new URLSearchParams(window.location.search).get('token');
+                return fromUrl
+                    || sessionStorage.getItem('quizify_admin_session_token')
+                    || '';
+            } catch (e) { return ''; }
+        }
+        function withToken(url) {
+            var tok = adminToken();
+            if (!tok) { return url; }
+            return url + (url.indexOf('?') === -1 ? '?' : '&')
+                + 'token=' + encodeURIComponent(tok);
+        }
+
         function loadData() {
-            fetch('/api/quizify/analytics/data?period=' + currentPeriod)
-                .then(function(r) { return r.json(); })
+            fetch(withToken('/api/quizify/analytics/data?period=' + currentPeriod))
+                .then(function(r) {
+                    if (r.status === 401) {
+                        var tAuth = (window.QuizifyI18n && window.QuizifyI18n.t)
+                            || function (k) { return k; };
+                        document.getElementById('loading').textContent =
+                            tAuth('analytics.authRequired');
+                        return null;
+                    }
+                    return r.json();
+                })
                 .then(function(data) {
+                    if (!data) { return; }
                     document.getElementById('loading').style.display = 'none';
 
                     if (data.total_games === 0) {
@@ -449,8 +478,8 @@
         }
 
         function loadFlags() {
-            fetch('/api/quizify/flags')
-                .then(function (r) { return r.json(); })
+            fetch(withToken('/api/quizify/flags'))
+                .then(function (r) { return r.ok ? r.json() : null; })
                 .then(function (data) {
                     var flags = (data && data.flags) || [];
                     if (!flags.length) {

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -463,6 +463,7 @@
     "back": "← Zurück",
     "loading": "Lade Auswertung…",
     "loadFailed": "Auswertung konnte nicht geladen werden.",
+    "authRequired": "Admin-Sitzung erforderlich — öffne die Auswertung über die Admin-Seite.",
     "period7d": "7T",
     "period30d": "30T",
     "period90d": "90T",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -463,6 +463,7 @@
     "back": "← Back",
     "loading": "Loading analytics…",
     "loadFailed": "Failed to load analytics.",
+    "authRequired": "Admin session required — open Analytics from the admin page.",
     "period7d": "7d",
     "period30d": "30d",
     "period90d": "90d",

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -448,6 +448,7 @@
     "back": "← Atrás",
     "loading": "Cargando estadísticas…",
     "loadFailed": "No se pudieron cargar las estadísticas.",
+    "authRequired": "Se requiere sesión de administrador — abre Estadísticas desde la página de administración.",
     "period7d": "7d",
     "period30d": "30d",
     "period90d": "90d",

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -1660,7 +1660,12 @@
     }
 
     function _loadTtsEntities(cfg) {
-        fetch('/api/quizify/tts-entities')
+        // #356: the tts-entities endpoint is admin-token gated. Send the
+        // session token the admin page already holds.
+        var _tok = sessionStorage.getItem('quizify_admin_session_token');
+        var _url = '/api/quizify/tts-entities'
+            + (_tok ? '?token=' + encodeURIComponent(_tok) : '');
+        fetch(_url)
             .then(function (resp) { return resp.ok ? resp.json() : null; })
             .then(function (data) {
                 data = data || {};

--- a/custom_components/quizify/www/js/pack-submit.js
+++ b/custom_components/quizify/www/js/pack-submit.js
@@ -309,7 +309,12 @@ window.QuizifyPackSubmit = (function () {
         var card = el('pack-submit-list-card');
         if (!listEl) { return; }
         try {
-            var resp = await fetch(SUBMISSIONS_URL);
+            // #356: submissions list is admin-token gated; forward the token
+            // the admin page holds.
+            var _tok = sessionStorage.getItem('quizify_admin_session_token');
+            var _url = SUBMISSIONS_URL
+                + (_tok ? '?token=' + encodeURIComponent(_tok) : '');
+            var resp = await fetch(_url);
             if (!resp.ok) { return; }
             var data = await resp.json();
             var subs = (data && data.submissions) || [];

--- a/tests/test_admin_token_gating_356.py
+++ b/tests/test_admin_token_gating_356.py
@@ -1,0 +1,115 @@
+"""Regression tests for issue #356 (P1 security).
+
+The host-only data endpoints (flags, all-time leaderboard, analytics data,
+tts-entities, question-stats, pack submissions) used to be readable by any
+client that could reach port 8123 — they carry player names + free-text flag
+reasons, per-person play history and HA entity ids. They are now gated on the
+admin session token (``?token=`` or the ``X-Quizify-Token`` header); a request
+without a valid token gets 401.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.server import views  # noqa: E402
+from custom_components.quizify.server.context import APP_CTX_KEY  # noqa: E402
+
+_TOKEN = "valid-admin-token"
+
+
+class _Conn:
+    def validate_admin_token(self, token: str) -> bool:
+        return token == _TOKEN
+
+
+class _Runtime:
+    def __init__(self, data_dir: Path) -> None:
+        self.data_dir = data_dir
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+
+class _Req:
+    def __init__(
+        self,
+        ctx,  # noqa: ANN001
+        *,
+        query_token: str | None = None,
+        header_token: str | None = None,
+    ) -> None:
+        self.app = {APP_CTX_KEY: ctx}
+        self.query: dict[str, str] = {}
+        if query_token is not None:
+            self.query["token"] = query_token
+        self.headers: dict[str, str] = {}
+        if header_token is not None:
+            self.headers["X-Quizify-Token"] = header_token
+
+
+def _ctx(tmp_path: Path):
+    return SimpleNamespace(
+        runtime=_Runtime(tmp_path),
+        analytics=None,
+        question_stats=None,
+        ws_handler=SimpleNamespace(conn=_Conn()),
+    )
+
+
+# The five in-file gated handlers that gracefully handle empty deps, so a
+# passing gate lands on a normal (non-401) response.
+_GATED = [
+    views.flag_list_view,
+    views.all_time_leaderboard_view,
+    views.analytics_data_view,
+    views.tts_entities_view,
+    views.question_stats_view,
+]
+
+
+@pytest.mark.parametrize("handler", _GATED)
+def test_no_token_is_401(handler, tmp_path: Path) -> None:
+    resp = asyncio.run(handler(_Req(_ctx(tmp_path))))
+    assert resp.status == 401
+    assert json.loads(resp.body) == {"error": "unauthorized"}
+
+
+@pytest.mark.parametrize("handler", _GATED)
+def test_wrong_token_is_401(handler, tmp_path: Path) -> None:
+    resp = asyncio.run(handler(_Req(_ctx(tmp_path), query_token="nope")))
+    assert resp.status == 401
+
+
+@pytest.mark.parametrize("handler", _GATED)
+def test_valid_query_token_passes(handler, tmp_path: Path) -> None:
+    resp = asyncio.run(handler(_Req(_ctx(tmp_path), query_token=_TOKEN)))
+    assert resp.status != 401
+
+
+@pytest.mark.parametrize("handler", _GATED)
+def test_valid_header_token_passes(handler, tmp_path: Path) -> None:
+    resp = asyncio.run(handler(_Req(_ctx(tmp_path), header_token=_TOKEN)))
+    assert resp.status != 401
+
+
+def test_submissions_wrapper_gates_without_token(tmp_path: Path) -> None:
+    # The wrapper must 401 before delegating to the imported handler.
+    resp = asyncio.run(views._gated_submissions_list_view(_Req(_ctx(tmp_path))))
+    assert resp.status == 401
+
+
+def test_missing_ws_handler_denies(tmp_path: Path) -> None:
+    # Defensive: a ctx without a wired ws_handler must fail closed, not open.
+    ctx = SimpleNamespace(runtime=_Runtime(tmp_path), analytics=None)
+    resp = asyncio.run(views.flag_list_view(_Req(ctx, query_token=_TOKEN)))
+    assert resp.status == 401

--- a/tests/test_backend_correctness_batch.py
+++ b/tests/test_backend_correctness_batch.py
@@ -326,11 +326,22 @@ class _ExecRuntime:
         return func(*args)
 
 
+# #356: /flags is now admin-token gated — carry a token + validating conn.
+_FLAG_TOKEN = "test-admin-token"
+
+
+class _FlagConn:
+    def validate_admin_token(self, token: str) -> bool:
+        return token == _FLAG_TOKEN
+
+
 class _FlagRequest:
-    def __init__(self, ctx) -> None:  # noqa: ANN001
+    def __init__(self, ctx, token: str | None = _FLAG_TOKEN) -> None:  # noqa: ANN001
         from custom_components.quizify.server.context import APP_CTX_KEY
 
         self.app = {APP_CTX_KEY: ctx}
+        self.query = {"token": token} if token else {}
+        self.headers: dict[str, str] = {}
 
 
 class TestFlagListNoIpLeak:
@@ -359,7 +370,10 @@ class TestFlagListNoIpLeak:
             + "\n"
         )
 
-        ctx = SimpleNamespace(runtime=_ExecRuntime(tmp_path))
+        ctx = SimpleNamespace(
+            runtime=_ExecRuntime(tmp_path),
+            ws_handler=SimpleNamespace(conn=_FlagConn()),
+        )
         resp = await flag_list_view(_FlagRequest(ctx))  # type: ignore[arg-type]
         payload = _json.loads(resp.body)
 

--- a/tests/test_tts_entities_view_281.py
+++ b/tests/test_tts_entities_view_281.py
@@ -53,12 +53,26 @@ class _StandaloneRuntime:
     """No ``hass`` attribute — mirrors the dev-server runtime."""
 
 
+# #356: tts-entities is now admin-token gated. Supply a token + a matching
+# ConnectionManager stub so these endpoint tests exercise the real (200) path.
+_TOKEN = "test-admin-token"
+
+
+class _FakeConn:
+    def validate_admin_token(self, token: str) -> bool:
+        return token == _TOKEN
+
+
 class _FakeRequest:
-    def __init__(self, ctx) -> None:  # noqa: ANN001
+    def __init__(self, ctx, token: str | None = _TOKEN) -> None:  # noqa: ANN001
         self.app = {APP_CTX_KEY: ctx}
+        self.query = {"token": token} if token else {}
+        self.headers: dict[str, str] = {}
 
 
 def _call(ctx) -> dict:  # noqa: ANN001
+    if not hasattr(ctx, "ws_handler"):
+        ctx.ws_handler = SimpleNamespace(conn=_FakeConn())
     resp = asyncio.run(tts_entities_view(_FakeRequest(ctx)))  # type: ignore[arg-type]
     return json.loads(resp.body)
 


### PR DESCRIPTION
Fixes #356 (P1 security). **Approach A** (admin-token gating), per Markus.

## Problem
The sensitive read endpoints were on `hass.http.app.router` with **no auth**, so any client that could reach port 8123 (incl. the internet on a port-forwarded/reverse-proxied install) could read host-only data:
- `/api/quizify/flags` — player names + free-text flag reasons
- `/api/quizify/all-time` — per-person play history + `last_played`
- `/api/quizify/analytics/data`
- `/api/quizify/tts-entities` — enumerated HA `tts`/`media_player` entity ids
- `/api/quizify/question-stats`
- `/api/quizify/pack-submit/submissions`

\#305 only stripped IPs from `/flags`; the endpoints themselves stayed open.

## Why not just `requires_auth=True`?
The pages that consume these (analytics.html, admin) are themselves served **without** HA auth (the panel iframe loads `/quizify/launcher` unauthenticated) and fetch with no credential. Forcing HA auth would 401 the analytics dashboard + admin data panels. Approach A reuses the **admin session token** the host already holds — no HA-login requirement, and the unauthenticated player/dashboard flow is untouched.

## Change
- **Backend** — `_is_admin_authenticated(request)` validates `?token=` / `X-Quizify-Token` against `conn.validate_admin_token`. The six data endpoints now `401` without a valid token (fail-closed if `ws_handler` is missing). Left open: `game-status`, `status`, `featured-pack`, `packs`, `packs/updates`, `flag-question` POST, `pack-submit` config + POST, and all HTML/player routes.
- **Frontend** — forwards the token from `sessionStorage['quizify_admin_session_token']`: `admin.js` (tts-entities), `pack-submit.js` (submissions), and `analytics.html` (token from sessionStorage or `?token=`, with an "admin session required" message on 401). New `analytics.authRequired` i18n key (en/de/es).

## Tests
- New `test_admin_token_gating_356.py`: 401 without / with wrong token; 200 with valid query **and** header token across all gated handlers; the submissions wrapper gate; fail-closed when `ws_handler` is absent.
- Updated the two existing endpoint tests (`tts-entities`, `flag-list`) to carry a token.
- **794 passed, 5 skipped**; `ruff` clean on `custom_components/`; artifact-drift green.

## ⚠️ Live-verify pending before merge
Backend + consumers are unit-tested, but the real browser flow isn't yet confirmed. Before merge, verify on a live HA (deploy `.py` → **restart HA**, www assets are cache-busted):
1. Admin TTS engine/speaker dropdowns still populate.
2. Analytics dashboard (opened from admin) still loads stats + flagged questions.
3. An unauthenticated `GET /api/quizify/flags` now returns **401**.

Happy to run this via browser-harness on your go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)