### PR TITLE
fix(security): rate-limit + bound the unauthenticated flag POST (#357)

### DIFF
--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -27,6 +27,7 @@ from .pack_submission import (
     submit_config_view,
     submit_pack_view,
 )
+from .rate_limit import SlidingWindowLimiter
 from .serializers import build_game_status_response
 
 if TYPE_CHECKING:
@@ -921,6 +922,19 @@ async def pack_update_check_view(request: web.Request) -> web.Response:
 _FLAG_FILE = "flagged.jsonl"
 _FLAG_MAX_BYTES = 256 * 1024  # cap at ~256 KB to bound disk use
 _FLAG_REASON_MAX = 200
+# Cap the caller-supplied question_id (#357). Without a bound an anonymous POST
+# could append a ~1 MB entry, and the size-trim runs BEFORE the append so an
+# oversized single line would still persist. Real ids are short slugs.
+_FLAG_QUESTION_ID_MAX = 64
+# Per-IP rate limit on the unauthenticated flag POST (#357). Mirrors the
+# pack-submit guard: generous for a real "flag a few questions" burst, tight
+# enough that the endpoint can't be hammered into unbounded executor disk
+# writes. Empty buckets are evicted by the limiter so the dict stays bounded.
+_FLAG_RATE_LIMIT_REQUESTS = 5
+_FLAG_RATE_LIMIT_WINDOW = 60  # seconds
+_flag_rate_limiter = SlidingWindowLimiter(
+    _FLAG_RATE_LIMIT_REQUESTS, _FLAG_RATE_LIMIT_WINDOW
+)
 
 
 async def flag_question_view(request: web.Request) -> web.Response:
@@ -932,6 +946,12 @@ async def flag_question_view(request: web.Request) -> web.Response:
     for a "raise the maintainer's attention" signal).
     """
     ctx = _get_ctx(request)
+
+    # Per-IP rate limit (#357). Reject early — before the JSON parse and the
+    # executor disk write — so a flood can't pin the loop or grow the file.
+    if not _flag_rate_limiter.check(request.remote or ""):
+        return web.json_response({"error": "rate_limited"}, status=429)
+
     try:
         body = await request.json()
     except (ValueError, TypeError):
@@ -940,6 +960,8 @@ async def flag_question_view(request: web.Request) -> web.Response:
     question_id = (body or {}).get("question_id")
     if not isinstance(question_id, str) or not question_id:
         return web.json_response({"error": "missing_question_id"}, status=400)
+    # Bound the caller-supplied id before it is persisted (#357).
+    question_id = question_id[:_FLAG_QUESTION_ID_MAX]
 
     reason = str((body or {}).get("reason", ""))[:_FLAG_REASON_MAX]
     player_name = str((body or {}).get("player_name", ""))[:50]

--- a/tests/test_flag_rate_limit_357.py
+++ b/tests/test_flag_rate_limit_357.py
@@ -1,0 +1,124 @@
+"""Regression tests for issue #357 (P2 security).
+
+The unauthenticated ``POST /api/quizify/flag-question`` had no rate limit and
+only an is-non-empty check on ``question_id``. A flood could pin the event loop
+on executor disk writes, and a single oversized ``question_id`` could append a
+~1 MB line (the 256 KB size-trim runs *before* the append, so it persisted).
+
+The endpoint now: rate-limits per client IP (5/60s, mirroring pack-submit) and
+caps ``question_id`` to 64 chars before persisting.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.server import views  # noqa: E402
+from custom_components.quizify.server.context import APP_CTX_KEY  # noqa: E402
+
+
+class _Runtime:
+    def __init__(self, data_dir: Path) -> None:
+        self.data_dir = data_dir
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+
+class _Req:
+    def __init__(self, ctx, remote: str, body: dict) -> None:  # noqa: ANN001
+        self.app = {APP_CTX_KEY: ctx}
+        self.remote = remote
+        self._body = body
+
+    async def json(self) -> dict:
+        return self._body
+
+
+def _ctx(tmp_path: Path):
+    return SimpleNamespace(runtime=_Runtime(tmp_path))
+
+
+async def _post(ctx, remote: str, body: dict):  # noqa: ANN001
+    return await views.flag_question_view(_Req(ctx, remote, body))
+
+
+def test_valid_flag_persists(tmp_path: Path) -> None:
+    ip = "203.0.113.1"
+    views._flag_rate_limiter.forget(ip)
+    resp = asyncio.run(_post(_ctx(tmp_path), ip, {"question_id": "geo_037"}))
+    assert resp.status == 200
+    lines = (tmp_path / views._FLAG_FILE).read_text("utf-8").splitlines()
+    assert json.loads(lines[0])["question_id"] == "geo_037"
+
+
+def test_sixth_post_from_same_ip_is_rate_limited(tmp_path: Path) -> None:
+    ip = "203.0.113.2"
+    views._flag_rate_limiter.forget(ip)
+    ctx = _ctx(tmp_path)
+
+    async def run() -> list[int]:
+        out = []
+        for i in range(6):
+            r = await _post(ctx, ip, {"question_id": f"q{i}"})
+            out.append(r.status)
+        return out
+
+    statuses = asyncio.run(run())
+    assert statuses[:5] == [200, 200, 200, 200, 200]
+    assert statuses[5] == 429
+
+
+def test_rate_limit_is_per_ip(tmp_path: Path) -> None:
+    a, b = "203.0.113.3", "203.0.113.4"
+    views._flag_rate_limiter.forget(a)
+    views._flag_rate_limiter.forget(b)
+    ctx = _ctx(tmp_path)
+
+    async def run() -> tuple[int, int]:
+        # Exhaust IP a.
+        for i in range(5):
+            await _post(ctx, a, {"question_id": f"a{i}"})
+        blocked = (await _post(ctx, a, {"question_id": "a5"})).status
+        # A different IP is unaffected.
+        allowed = (await _post(ctx, b, {"question_id": "b0"})).status
+        return blocked, allowed
+
+    blocked, allowed = asyncio.run(run())
+    assert blocked == 429
+    assert allowed == 200
+
+
+def test_question_id_is_capped_at_64_chars(tmp_path: Path) -> None:
+    ip = "203.0.113.5"
+    views._flag_rate_limiter.forget(ip)
+    resp = asyncio.run(
+        _post(_ctx(tmp_path), ip, {"question_id": "x" * 5000})
+    )
+    assert resp.status == 200
+    entry = json.loads((tmp_path / views._FLAG_FILE).read_text("utf-8").splitlines()[0])
+    assert entry["question_id"] == "x" * 64
+
+
+def test_over_limit_does_not_write(tmp_path: Path) -> None:
+    ip = "203.0.113.6"
+    views._flag_rate_limiter.forget(ip)
+    ctx = _ctx(tmp_path)
+
+    async def run() -> None:
+        for i in range(5):
+            await _post(ctx, ip, {"question_id": f"q{i}"})
+        await _post(ctx, ip, {"question_id": "OVERFLOW"})
+
+    asyncio.run(run())
+    body = (tmp_path / views._FLAG_FILE).read_text("utf-8")
+    assert "OVERFLOW" not in body  # the rejected POST wrote nothing


### PR DESCRIPTION
Fixes #357 (P2 security).

## Problem
`POST /api/quizify/flag-question` was unauthenticated with **no rate limit**, and `question_id` was only checked non-empty. So:
- A flood could pin the event loop on executor disk writes (one read-rewrite-trim + append per request).
- A single oversized `question_id` could append a ~1 MB line — and the 256 KB size-trim runs **before** the append, so an oversized single entry still persisted.

## Fix
- Per-IP `SlidingWindowLimiter` (**5 / 60s**, mirroring the pack-submit guard); over-limit requests return **429** and are rejected *before* the JSON parse and the disk write. Empty buckets are evicted by the limiter, so the backing dict stays bounded.
- Cap `question_id` to **64 chars** before persisting.

The `flag-question` POST stays unauthenticated (players flag questions) — this just bounds abuse. The flag *list* is admin-gated separately (#356).

## Tests
`test_flag_rate_limit_357.py`: valid flag persists; 6th POST from one IP is 429; the limit is per-IP; `question_id` truncated to 64; a rejected POST writes nothing. **799 passed, 5 skipped**; ruff clean; backend-only (no UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)