### PR TITLE
fix(security): require the admin token for a crown transfer (#358)

### DIFF
--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -27,6 +27,7 @@ from .pack_submission import (
     submit_config_view,
     submit_pack_view,
 )
+from .rate_limit import SlidingWindowLimiter
 from .serializers import build_game_status_response
 
 if TYPE_CHECKING:
@@ -921,6 +922,19 @@ async def pack_update_check_view(request: web.Request) -> web.Response:
 _FLAG_FILE = "flagged.jsonl"
 _FLAG_MAX_BYTES = 256 * 1024  # cap at ~256 KB to bound disk use
 _FLAG_REASON_MAX = 200
+# Cap the caller-supplied question_id (#357). Without a bound an anonymous POST
+# could append a ~1 MB entry, and the size-trim runs BEFORE the append so an
+# oversized single line would still persist. Real ids are short slugs.
+_FLAG_QUESTION_ID_MAX = 64
+# Per-IP rate limit on the unauthenticated flag POST (#357). Mirrors the
+# pack-submit guard: generous for a real "flag a few questions" burst, tight
+# enough that the endpoint can't be hammered into unbounded executor disk
+# writes. Empty buckets are evicted by the limiter so the dict stays bounded.
+_FLAG_RATE_LIMIT_REQUESTS = 5
+_FLAG_RATE_LIMIT_WINDOW = 60  # seconds
+_flag_rate_limiter = SlidingWindowLimiter(
+    _FLAG_RATE_LIMIT_REQUESTS, _FLAG_RATE_LIMIT_WINDOW
+)
 
 
 async def flag_question_view(request: web.Request) -> web.Response:
@@ -932,6 +946,12 @@ async def flag_question_view(request: web.Request) -> web.Response:
     for a "raise the maintainer's attention" signal).
     """
     ctx = _get_ctx(request)
+
+    # Per-IP rate limit (#357). Reject early — before the JSON parse and the
+    # executor disk write — so a flood can't pin the loop or grow the file.
+    if not _flag_rate_limiter.check(request.remote or ""):
+        return web.json_response({"error": "rate_limited"}, status=429)
+
     try:
         body = await request.json()
     except (ValueError, TypeError):
@@ -940,6 +960,8 @@ async def flag_question_view(request: web.Request) -> web.Response:
     question_id = (body or {}).get("question_id")
     if not isinstance(question_id, str) or not question_id:
         return web.json_response({"error": "missing_question_id"}, status=400)
+    # Bound the caller-supplied id before it is persisted (#357).
+    question_id = question_id[:_FLAG_QUESTION_ID_MAX]
 
     reason = str((body or {}).get("reason", ""))[:_FLAG_REASON_MAX]
     player_name = str((body or {}).get("player_name", ""))[:50]

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -586,15 +586,43 @@ class QuizifyWebSocketHandler:
                     # re-joining host. has_other_admin() no longer blocks on a
                     # disconnected admin, so without this demotion two players
                     # would briefly carry is_admin and break the #208 invariant.
+                    #
+                    # #358: transferring the crown from a stale admin to a
+                    # DIFFERENT name is the takeover vector. During the host's
+                    # reload / wifi blip the real admin is momentarily
+                    # disconnected (so has_other_admin() is False), and any LAN
+                    # client sending `is_admin: true` under a new name would
+                    # otherwise demote the host and seize control mid-game.
+                    # Require proof: a valid admin session token in the join.
+                    # Fail SOFT — no error, just no crown — so we don't
+                    # reintroduce the brittle token state machine DESIGN.md
+                    # warns about; the legit host still recovers via the
+                    # token-based reconnect path, which preserves is_admin on
+                    # their own slot. A first claim (no admin yet) and a
+                    # same-name reclaim stay token-free (the documented Beatify
+                    # trust trade-off).
                     stale_admin = game_state.get_admin()
                     if stale_admin is not None and stale_admin.name != name:
-                        stale_admin.is_admin = False
-                        _LOGGER.info(
-                            "Crown transferred from stale admin %s to %s",
-                            stale_admin.name,
-                            name,
-                        )
-                    player_obj.is_admin = True
+                        claim_token = data.get("admin_token")
+                        if claim_token and self._conn.validate_admin_token(
+                            claim_token
+                        ):
+                            stale_admin.is_admin = False
+                            player_obj.is_admin = True
+                            _LOGGER.info(
+                                "Crown transferred from stale admin %s to %s",
+                                stale_admin.name,
+                                name,
+                            )
+                        else:
+                            _LOGGER.warning(
+                                "Crown transfer denied for %s: no valid admin "
+                                "token; stale admin %s keeps the crown",
+                                name,
+                                stale_admin.name,
+                            )
+                    else:
+                        player_obj.is_admin = True
 
             # If a lightning round is mid-flight, register the late joiner so
             # they can score from the next question on (issue #42).

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -1787,7 +1787,13 @@
         // the server's roster broadcast re-renders the lobby) can't open the
         // modal again and create a duplicate self-join.
         if (els.participateBtn) els.participateBtn.disabled = true;
-        send('join', { name: name, is_admin: true });
+        // #358: carry the admin session token so the server can authorise a
+        // crown transfer from a stale (disconnected) admin slot — without it a
+        // LAN client could seize the crown during a host reload.
+        var _joinMsg = { name: name, is_admin: true };
+        var _adminTok = sessionStorage.getItem('quizify_admin_session_token');
+        if (_adminTok) _joinMsg.admin_token = _adminTok;
+        send('join', _joinMsg);
         closeAdminJoinModal();
     }
 

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -98,7 +98,16 @@
                     if (isAdminSelfJoin) {
                         state.isAdmin = true;
                     }
-                    if (state.isAdmin) joinMsg.is_admin = true;
+                    if (state.isAdmin) {
+                        joinMsg.is_admin = true;
+                        // #358: attach the admin session token (if this tab
+                        // holds one) so the server can authorise a crown
+                        // transfer from a stale admin slot. Optional + fail-soft
+                        // — a missing token just means no auto-crown, never a
+                        // rejected join, so the DESIGN.md trust model stands.
+                        var _at = sessionStorage.getItem('quizify_admin_session_token');
+                        if (_at) joinMsg.admin_token = _at;
+                    }
                     send('join', joinMsg);
                 }
                 // else: waiting for auto-join interval or user to click join
@@ -1014,7 +1023,13 @@
             if (isAdminSelfJoin) {
                 state.isAdmin = true;
             }
-            if (state.isAdmin) joinMsg.is_admin = true;
+            if (state.isAdmin) {
+                joinMsg.is_admin = true;
+                // #358: attach the admin session token (fail-soft) so a crown
+                // transfer from a stale admin slot can be authorised.
+                var _at = sessionStorage.getItem('quizify_admin_session_token');
+                if (_at) joinMsg.admin_token = _at;
+            }
             send('join', joinMsg);
         } else {
             // WS not open at click time (initial connect still pending, or

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -4203,7 +4203,16 @@
                     if (isAdminSelfJoin) {
                         state.isAdmin = true;
                     }
-                    if (state.isAdmin) joinMsg.is_admin = true;
+                    if (state.isAdmin) {
+                        joinMsg.is_admin = true;
+                        // #358: attach the admin session token (if this tab
+                        // holds one) so the server can authorise a crown
+                        // transfer from a stale admin slot. Optional + fail-soft
+                        // — a missing token just means no auto-crown, never a
+                        // rejected join, so the DESIGN.md trust model stands.
+                        var _at = sessionStorage.getItem('quizify_admin_session_token');
+                        if (_at) joinMsg.admin_token = _at;
+                    }
                     send('join', joinMsg);
                 }
                 // else: waiting for auto-join interval or user to click join
@@ -5119,7 +5128,13 @@
             if (isAdminSelfJoin) {
                 state.isAdmin = true;
             }
-            if (state.isAdmin) joinMsg.is_admin = true;
+            if (state.isAdmin) {
+                joinMsg.is_admin = true;
+                // #358: attach the admin session token (fail-soft) so a crown
+                // transfer from a stale admin slot can be authorised.
+                var _at = sessionStorage.getItem('quizify_admin_session_token');
+                if (_at) joinMsg.admin_token = _at;
+            }
             send('join', joinMsg);
         } else {
             // WS not open at click time (initial connect still pending, or

--- a/tests/test_crown_seizure_358.py
+++ b/tests/test_crown_seizure_358.py
@@ -1,0 +1,154 @@
+"""Regression tests for issue #358 (P2 security) — crown seizure.
+
+During the host's reload / wifi blip the real admin is momentarily
+disconnected, so the single-admin guard (``has_other_admin`` counts only
+*connected* admins) doesn't block a claim. The #207 crown-recovery branch then
+demoted the stale admin and crowned the claimer — so any LAN client sending
+``join {is_admin: true}`` under a new name could seize control mid-game.
+
+The crown *transfer* from a stale admin to a different name now requires a
+valid admin session token in the join, and fails SOFT (no error, no crown)
+without one. First claims (no admin yet) and same-name reclaims stay
+token-free (the documented Beatify trust trade-off).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    return ws
+
+
+async def _handler_with_token(game: QuizifyGameState):
+    runtime = _FakeRuntime(game._runtime.data_dir)  # type: ignore[attr-defined]
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    h._conn = ConnectionManager(runtime, lambda: game)
+    h._conn.broadcast = AsyncMock()
+    h._conn.send = AsyncMock()
+    await h._conn.try_bootstrap_admin()
+    return h, h._conn._admin_session_token
+
+
+def _make_game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+def _seat_stale_admin(game: QuizifyGameState, name: str = "Host") -> None:
+    """Seat an admin player, then mark it disconnected (reload/wifi blip)."""
+    game.add_player(name, _ws())
+    admin = game.get_player(name)
+    admin.is_admin = True
+    admin.connected = False
+
+
+class TestCrownSeizure358:
+    @pytest.mark.asyncio
+    async def test_no_token_cannot_seize_from_stale_admin(
+        self, tmp_path: Path
+    ) -> None:
+        game = _make_game(tmp_path)
+        h, _tok = await _handler_with_token(game)
+        _seat_stale_admin(game)
+
+        # Attacker joins under a NEW name claiming admin, WITHOUT a token.
+        await h._handle_join(_ws(), {"name": "Attacker", "is_admin": True}, game)
+
+        assert game.get_player("Attacker") is not None
+        assert game.get_player("Attacker").is_admin is False
+        # The stale host keeps the crown.
+        assert game.get_player("Host").is_admin is True
+
+    @pytest.mark.asyncio
+    async def test_wrong_token_cannot_seize(self, tmp_path: Path) -> None:
+        game = _make_game(tmp_path)
+        h, _tok = await _handler_with_token(game)
+        _seat_stale_admin(game)
+
+        await h._handle_join(
+            _ws(),
+            {"name": "Attacker", "is_admin": True, "admin_token": "bogus"},
+            game,
+        )
+        assert game.get_player("Attacker").is_admin is False
+        assert game.get_player("Host").is_admin is True
+
+    @pytest.mark.asyncio
+    async def test_valid_token_transfers_crown(self, tmp_path: Path) -> None:
+        game = _make_game(tmp_path)
+        h, token = await _handler_with_token(game)
+        _seat_stale_admin(game)
+
+        # The legit host re-joins under a new name WITH the admin token.
+        await h._handle_join(
+            _ws(),
+            {"name": "Host-again", "is_admin": True, "admin_token": token},
+            game,
+        )
+        assert game.get_player("Host-again").is_admin is True
+        assert game.get_player("Host").is_admin is False
+
+    @pytest.mark.asyncio
+    async def test_first_claim_needs_no_token(self, tmp_path: Path) -> None:
+        # No admin exists yet → first claim is granted token-free (Beatify
+        # trust trade-off, unchanged).
+        game = _make_game(tmp_path)
+        h, _tok = await _handler_with_token(game)
+
+        await h._handle_join(_ws(), {"name": "Host", "is_admin": True}, game)
+        assert game.get_player("Host").is_admin is True
+
+    @pytest.mark.asyncio
+    async def test_same_name_reclaim_needs_no_token(self, tmp_path: Path) -> None:
+        # The admin's /admin -> /player redirect re-joining under the SAME name
+        # is idempotent and stays token-free.
+        game = _make_game(tmp_path)
+        h, _tok = await _handler_with_token(game)
+        _seat_stale_admin(game, "Host")
+
+        await h._handle_join(_ws(), {"name": "Host", "is_admin": True}, game)
+        assert game.get_player("Host").is_admin is True
+
+    @pytest.mark.asyncio
+    async def test_connected_admin_still_blocks_claim(
+        self, tmp_path: Path
+    ) -> None:
+        # #208 invariant unchanged: a *connected* admin blocks any other claim,
+        # token or not.
+        game = _make_game(tmp_path)
+        h, token = await _handler_with_token(game)
+        game.add_player("Host", _ws())
+        game.get_player("Host").is_admin = True  # connected admin
+
+        await h._handle_join(
+            _ws(),
+            {"name": "Attacker", "is_admin": True, "admin_token": token},
+            game,
+        )
+        assert game.get_player("Attacker").is_admin is False
+        assert game.get_player("Host").is_admin is True

--- a/tests/test_flag_rate_limit_357.py
+++ b/tests/test_flag_rate_limit_357.py
@@ -1,0 +1,124 @@
+"""Regression tests for issue #357 (P2 security).
+
+The unauthenticated ``POST /api/quizify/flag-question`` had no rate limit and
+only an is-non-empty check on ``question_id``. A flood could pin the event loop
+on executor disk writes, and a single oversized ``question_id`` could append a
+~1 MB line (the 256 KB size-trim runs *before* the append, so it persisted).
+
+The endpoint now: rate-limits per client IP (5/60s, mirroring pack-submit) and
+caps ``question_id`` to 64 chars before persisting.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.server import views  # noqa: E402
+from custom_components.quizify.server.context import APP_CTX_KEY  # noqa: E402
+
+
+class _Runtime:
+    def __init__(self, data_dir: Path) -> None:
+        self.data_dir = data_dir
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+
+class _Req:
+    def __init__(self, ctx, remote: str, body: dict) -> None:  # noqa: ANN001
+        self.app = {APP_CTX_KEY: ctx}
+        self.remote = remote
+        self._body = body
+
+    async def json(self) -> dict:
+        return self._body
+
+
+def _ctx(tmp_path: Path):
+    return SimpleNamespace(runtime=_Runtime(tmp_path))
+
+
+async def _post(ctx, remote: str, body: dict):  # noqa: ANN001
+    return await views.flag_question_view(_Req(ctx, remote, body))
+
+
+def test_valid_flag_persists(tmp_path: Path) -> None:
+    ip = "203.0.113.1"
+    views._flag_rate_limiter.forget(ip)
+    resp = asyncio.run(_post(_ctx(tmp_path), ip, {"question_id": "geo_037"}))
+    assert resp.status == 200
+    lines = (tmp_path / views._FLAG_FILE).read_text("utf-8").splitlines()
+    assert json.loads(lines[0])["question_id"] == "geo_037"
+
+
+def test_sixth_post_from_same_ip_is_rate_limited(tmp_path: Path) -> None:
+    ip = "203.0.113.2"
+    views._flag_rate_limiter.forget(ip)
+    ctx = _ctx(tmp_path)
+
+    async def run() -> list[int]:
+        out = []
+        for i in range(6):
+            r = await _post(ctx, ip, {"question_id": f"q{i}"})
+            out.append(r.status)
+        return out
+
+    statuses = asyncio.run(run())
+    assert statuses[:5] == [200, 200, 200, 200, 200]
+    assert statuses[5] == 429
+
+
+def test_rate_limit_is_per_ip(tmp_path: Path) -> None:
+    a, b = "203.0.113.3", "203.0.113.4"
+    views._flag_rate_limiter.forget(a)
+    views._flag_rate_limiter.forget(b)
+    ctx = _ctx(tmp_path)
+
+    async def run() -> tuple[int, int]:
+        # Exhaust IP a.
+        for i in range(5):
+            await _post(ctx, a, {"question_id": f"a{i}"})
+        blocked = (await _post(ctx, a, {"question_id": "a5"})).status
+        # A different IP is unaffected.
+        allowed = (await _post(ctx, b, {"question_id": "b0"})).status
+        return blocked, allowed
+
+    blocked, allowed = asyncio.run(run())
+    assert blocked == 429
+    assert allowed == 200
+
+
+def test_question_id_is_capped_at_64_chars(tmp_path: Path) -> None:
+    ip = "203.0.113.5"
+    views._flag_rate_limiter.forget(ip)
+    resp = asyncio.run(
+        _post(_ctx(tmp_path), ip, {"question_id": "x" * 5000})
+    )
+    assert resp.status == 200
+    entry = json.loads((tmp_path / views._FLAG_FILE).read_text("utf-8").splitlines()[0])
+    assert entry["question_id"] == "x" * 64
+
+
+def test_over_limit_does_not_write(tmp_path: Path) -> None:
+    ip = "203.0.113.6"
+    views._flag_rate_limiter.forget(ip)
+    ctx = _ctx(tmp_path)
+
+    async def run() -> None:
+        for i in range(5):
+            await _post(ctx, ip, {"question_id": f"q{i}"})
+        await _post(ctx, ip, {"question_id": "OVERFLOW"})
+
+    asyncio.run(run())
+    body = (tmp_path / views._FLAG_FILE).read_text("utf-8")
+    assert "OVERFLOW" not in body  # the rejected POST wrote nothing

--- a/tests/test_reset_game_207.py
+++ b/tests/test_reset_game_207.py
@@ -301,8 +301,16 @@ async def test_host_reclaims_crown_from_stale_slot_on_rejoin(
     """#209 crown-recovery: when the host re-joins under a disambiguated
     name while the stale (disconnected) old admin slot lingers, the host
     must (re)acquire the single admin crown — and the stale slot must be
-    demoted so exactly one admin exists (single-admin invariant #208)."""
+    demoted so exactly one admin exists (single-admin invariant #208).
+
+    #358: a crown transfer to a *different* name now requires the admin
+    session token (which the real host holds and the frontend sends), so the
+    attacker path is closed. The legit host carries it here."""
     h = _auth_handler(game, tmp_path)
+    # Seed the persisted admin token directly (avoids the executor-backed
+    # store); the real host holds this and the frontend now sends it (#358).
+    token = "recovery-token"
+    h._conn._admin_session_token = token
 
     # Old admin slot (the /quizify/admin tab joined-as-player), now stale:
     old_ws = _ws()
@@ -311,11 +319,18 @@ async def test_host_reclaims_crown_from_stale_slot_on_rejoin(
     game.get_player("Host").connected = False  # admin WS closing on redirect
 
     # Host re-joins on a fresh player WS; the lingering "Host" slot forces
-    # the disambiguated "Host 2" name, carrying is_admin: true.
+    # the disambiguated "Host 2" name, carrying is_admin: true + the token.
     new_ws = _ws()
     h._conn.add_connection(new_ws, is_admin=False, is_dashboard=False)
     await h._handle_message(
-        new_ws, {"type": "join", "name": "Host 2", "is_admin": True}, is_admin=False
+        new_ws,
+        {
+            "type": "join",
+            "name": "Host 2",
+            "is_admin": True,
+            "admin_token": token,
+        },
+        is_admin=False,
     )
 
     new_player = game.get_player("Host 2")


### PR DESCRIPTION
Fixes #358 (P2 security) — crown seizure.

## Problem
During the host's reload / wifi blip the real admin is momentarily disconnected, so `has_other_admin()` (which counts only **connected** admins) doesn't block a claim. The #207 crown-recovery branch then demoted the stale admin and crowned the claimer — so any LAN client sending `join {is_admin: true}` under a new name could **seize control mid-game**.

## Fix (fail-soft, token-gated transfer)
- `websocket._handle_join`: transferring the crown from a stale admin to a **different name** now requires a valid admin session token in the join. It **fails soft** — no error, just no crown — without one, so the legit host still recovers via the token-based reconnect path (`is_admin` preserved on their own slot). This deliberately avoids reintroducing the brittle token state machine `DESIGN.md` warns about ("8 betas worth of bugs"). First claims (no admin yet) and same-name reclaims stay token-free (the documented Beatify trust trade-off).
- **Frontend**: `admin.js` (join-as-player) and `player-core.js` (both join sites) now attach the admin session token from `sessionStorage['quizify_admin_session_token']` when claiming `is_admin`, so the legit crown recovery keeps working. `player.bundle.js` rebuilt.

## Tests
- New `test_crown_seizure_358.py`: no-token / wrong-token can't seize; valid token transfers; first-claim + same-name reclaim stay token-free; a connected admin still blocks (unchanged #208).
- Updated the #207 recovery test to carry the token the real host holds.
- **805 passed, 5 skipped**; ruff clean; artifact-drift green.

## ⚠️ Live-verify recommended before merge
This is the historically fragile admin-as-player crown path. Confirm on a live HA (deploy + **HA restart** for the `.py`; www is cache-busted):
1. Host "Join as Player" still gets the crown (👑).
2. The `/admin → /player` redirect at game start keeps the crown.
3. (Optional) a second device sending `is_admin:true` while the host is briefly offline does **not** get the crown.

## Known residual (follow-up)
In LOBBY, name-based rejoin of an **admin's exact name** still inherits `is_admin` without a token (`player_registry.py`) — a narrower variant of the same class, not closed here. Can file a follow-up if you want it closed too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)