### PR TITLE
fix(perf): cache the unauthenticated pack-updates GitHub fetch (#360)

### DIFF
--- a/custom_components/quizify/game/questions.py
+++ b/custom_components/quizify/game/questions.py
@@ -331,6 +331,15 @@ class QuestionBank:
         """Directory the question-pack JSON files are loaded from."""
         return self._questions_dir
 
+    @property
+    def is_loaded(self) -> bool:
+        """Whether :meth:`load_all_categories` has already populated the bank.
+
+        Lets callers skip a redundant (executor-offloaded) reload when the
+        packs are already cached in memory.
+        """
+        return self._loaded
+
     def load_category(self, category: str) -> list[Question]:
         """Load questions for a single category from its JSON file."""
         file_path = self._questions_dir / f"{category}.json"

--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 import aiohttp
 from aiohttp import web
 
+from ..const import SUBMIT_POLL_INTERVAL_SECONDS
 from ..game.seasons import is_in_season, parse_season, pick_active_season
 from .context import APP_CTX_KEY
 from .pack_submission import (
@@ -46,6 +47,15 @@ _PACK_VERSIONS_URL = (
     "https://raw.githubusercontent.com/mholzi/quizify/main/"
     "custom_components/quizify/questions/versions.json"
 )
+
+# In-memory cache for the upstream versions.json (#360). The
+# ``GET /api/quizify/packs/updates`` endpoint is unauthenticated, so without a
+# throttle any client could loop it and make the HA host hammer GitHub's raw
+# endpoint on every request. Mirror pack_submission's hourly reconcile throttle
+# (SUBMIT_POLL_INTERVAL_SECONDS) and reuse the cached copy within the window.
+_UPSTREAM_CACHE_TTL_SECONDS = SUBMIT_POLL_INTERVAL_SECONDS
+# (fetched_at_monotonic, versions_dict_or_None)
+_upstream_versions_cache: tuple[float, dict | None] | None = None
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -867,14 +877,12 @@ async def pack_versions_view(request: web.Request) -> web.Response:
     return web.json_response(annotated)
 
 
-async def pack_update_check_view(request: web.Request) -> web.Response:
-    """Check GitHub for updated question packs."""
-    ctx = _get_ctx(request)
-    await ctx.runtime.run_in_executor(ctx.game.question_bank.load_all_categories)
-    installed = ctx.game.question_bank.get_pack_versions()
+async def _fetch_upstream_versions() -> dict | None:
+    """Fetch versions.json from GitHub (best-effort, 5s timeout).
 
-    # Fetch upstream versions.json from GitHub (best-effort, 5s timeout)
-    upstream: dict | None = None
+    Returns the parsed manifest, or ``None`` on any non-200/error so callers
+    can fall back gracefully.
+    """
     try:
         timeout = aiohttp.ClientTimeout(total=5)
         async with (
@@ -882,9 +890,49 @@ async def pack_update_check_view(request: web.Request) -> web.Response:
             session.get(_PACK_VERSIONS_URL) as resp,
         ):
             if resp.status == 200:
-                upstream = await resp.json(content_type=None)
+                return await resp.json(content_type=None)
     except Exception as exc:  # noqa: BLE001
         _LOGGER.warning("Pack update check failed: %s", exc)
+    return None
+
+
+async def _get_upstream_versions() -> dict | None:
+    """Return the upstream versions.json, refreshing on cache-miss/TTL expiry.
+
+    Repeated calls within ``_UPSTREAM_CACHE_TTL_SECONDS`` reuse the cached copy
+    so the unauthenticated update-check endpoint can't be looped to hammer
+    GitHub (#360). Only successful fetches are cached; a failed fetch returns
+    ``None`` without poisoning the cache, so the next request retries — the same
+    best-effort behaviour as before caching.
+    """
+    global _upstream_versions_cache
+    now = time.monotonic()
+    cache = _upstream_versions_cache
+    if cache is not None and now - cache[0] < _UPSTREAM_CACHE_TTL_SECONDS:
+        return cache[1]
+
+    upstream = await _fetch_upstream_versions()
+    if upstream is not None:
+        _upstream_versions_cache = (now, upstream)
+    return upstream
+
+
+async def pack_update_check_view(request: web.Request) -> web.Response:
+    """Check GitHub for updated question packs.
+
+    The upstream versions.json fetch is cached in-memory (#360) so repeated
+    unauthenticated calls don't make the HA host hammer GitHub. The pack reload
+    is likewise skipped once the bank is already loaded.
+    """
+    ctx = _get_ctx(request)
+    bank = ctx.game.question_bank
+    # Packs are cached in memory after the first load; only pay the executor
+    # hop + disk read when they haven't been loaded yet.
+    if not bank.is_loaded:
+        await ctx.runtime.run_in_executor(bank.load_all_categories)
+    installed = bank.get_pack_versions()
+
+    upstream = await _get_upstream_versions()
 
     updates = []
     if upstream:

--- a/tests/test_pack_updates_cache_360.py
+++ b/tests/test_pack_updates_cache_360.py
@@ -1,0 +1,190 @@
+"""Tests for the cached pack-update-check endpoint (#360).
+
+``pack_update_check_view`` backs ``GET /api/quizify/packs/updates`` — an
+unauthenticated endpoint. Before #360 every request performed an uncached
+aiohttp fetch of GitHub's raw ``versions.json`` plus a full pack re-load in the
+executor, so any client could loop it to make the HA host hammer GitHub and burn
+loop/executor time. The fix caches the upstream manifest in-memory for
+``_UPSTREAM_CACHE_TTL_SECONDS`` and skips the pack reload once the bank is
+already loaded, while keeping the response shape identical and falling back
+gracefully when the fetch fails.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.server import views  # noqa: E402
+from custom_components.quizify.server.context import APP_CTX_KEY  # noqa: E402
+
+
+class _FakeBank:
+    """Minimal QuestionBank double tracking reload calls."""
+
+    def __init__(self, versions: dict, loaded: bool = True) -> None:
+        self._versions = versions
+        self._loaded = loaded
+        self.load_calls = 0
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._loaded
+
+    def load_all_categories(self) -> dict:
+        self.load_calls += 1
+        self._loaded = True
+        return {}
+
+    def get_pack_versions(self) -> dict:
+        return {slug: dict(meta) for slug, meta in self._versions.items()}
+
+
+class _FakeRuntime:
+    def __init__(self) -> None:
+        self.exec_calls = 0
+
+    async def run_in_executor(self, fn, *args):  # noqa: ANN001, ANN002
+        self.exec_calls += 1
+        return fn(*args)
+
+
+class _FakeRequest:
+    def __init__(self, ctx) -> None:  # noqa: ANN001
+        self.app = {APP_CTX_KEY: ctx}
+        self.query: dict[str, str] = {}
+        self.headers: dict[str, str] = {}
+
+
+def _make_ctx(bank: _FakeBank) -> SimpleNamespace:
+    return SimpleNamespace(
+        game=SimpleNamespace(question_bank=bank),
+        runtime=_FakeRuntime(),
+    )
+
+
+def _call(ctx) -> dict:  # noqa: ANN001
+    resp = asyncio.run(views.pack_update_check_view(_FakeRequest(ctx)))  # type: ignore[arg-type]
+    return json.loads(resp.body)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Each test starts (and ends) with an empty upstream cache."""
+    views._upstream_versions_cache = None
+    yield
+    views._upstream_versions_cache = None
+
+
+def _install_fake_fetch(monkeypatch, payload, counter) -> None:  # noqa: ANN001
+    async def _fake_fetch():
+        counter["n"] += 1
+        return payload
+
+    monkeypatch.setattr(views, "_fetch_upstream_versions", _fake_fetch)
+
+
+def test_second_call_within_ttl_does_not_refetch(monkeypatch) -> None:
+    """A repeat call inside the TTL window reuses the cached manifest."""
+    counter = {"n": 0}
+    _install_fake_fetch(monkeypatch, {"animals": "1.2.0"}, counter)
+    bank = _FakeBank({"animals": {"version": "1.0.0", "name": "Animals"}})
+    ctx = _make_ctx(bank)
+
+    first = _call(ctx)
+    second = _call(ctx)
+
+    assert counter["n"] == 1  # only one GitHub fetch for two requests
+    assert first == second
+    # Response shape preserved + update detected.
+    assert first["upstream_available"] is True
+    assert first["upstream"] == {"animals": "1.2.0"}
+    assert first["updates"] == [
+        {
+            "slug": "animals",
+            "name": "Animals",
+            "installed_version": "1.0.0",
+            "upstream_version": "1.2.0",
+        }
+    ]
+    assert first["installed"] == {"animals": {"version": "1.0.0", "name": "Animals"}}
+
+
+def test_ttl_expiry_refetches(monkeypatch) -> None:
+    """Once the cached entry ages past the TTL, the next call refetches."""
+    counter = {"n": 0}
+    _install_fake_fetch(monkeypatch, {"animals": "1.2.0"}, counter)
+    bank = _FakeBank({"animals": {"version": "1.0.0", "name": "Animals"}})
+    ctx = _make_ctx(bank)
+
+    _call(ctx)
+    assert counter["n"] == 1
+
+    # Simulate the clock advancing past the TTL by ageing the cached timestamp.
+    ts, payload = views._upstream_versions_cache
+    views._upstream_versions_cache = (
+        ts - views._UPSTREAM_CACHE_TTL_SECONDS - 1,
+        payload,
+    )
+
+    _call(ctx)
+    assert counter["n"] == 2
+
+
+def test_failed_fetch_falls_back_and_is_not_cached(monkeypatch) -> None:
+    """A failed fetch returns None gracefully and does not poison the cache."""
+    counter = {"n": 0}
+    _install_fake_fetch(monkeypatch, None, counter)
+    bank = _FakeBank({"animals": {"version": "1.0.0", "name": "Animals"}})
+    ctx = _make_ctx(bank)
+
+    out = _call(ctx)
+    assert out["upstream"] is None
+    assert out["upstream_available"] is False
+    assert out["updates"] == []
+    assert out["installed"] == {"animals": {"version": "1.0.0", "name": "Animals"}}
+    # Nothing cached → a subsequent successful fetch is attempted (not skipped).
+    assert views._upstream_versions_cache is None
+
+    _install_fake_fetch(monkeypatch, {"animals": "1.2.0"}, counter)
+    out2 = _call(ctx)
+    assert out2["upstream_available"] is True
+    assert views._upstream_versions_cache is not None
+
+
+def test_already_loaded_bank_skips_executor_reload(monkeypatch) -> None:
+    """When packs are already loaded, the endpoint skips the executor reload."""
+    counter = {"n": 0}
+    _install_fake_fetch(monkeypatch, {"animals": "1.0.0"}, counter)
+    bank = _FakeBank(
+        {"animals": {"version": "1.0.0", "name": "Animals"}}, loaded=True
+    )
+    ctx = _make_ctx(bank)
+
+    _call(ctx)
+
+    assert bank.load_calls == 0
+    assert ctx.runtime.exec_calls == 0
+
+
+def test_unloaded_bank_loads_once_via_executor(monkeypatch) -> None:
+    """A cold bank is loaded through the executor exactly once."""
+    counter = {"n": 0}
+    _install_fake_fetch(monkeypatch, {"animals": "1.0.0"}, counter)
+    bank = _FakeBank(
+        {"animals": {"version": "1.0.0", "name": "Animals"}}, loaded=False
+    )
+    ctx = _make_ctx(bank)
+
+    _call(ctx)
+
+    assert bank.load_calls == 1
+    assert ctx.runtime.exec_calls == 1


### PR DESCRIPTION
Fixes #360

`GET /api/quizify/packs/updates` (`pack_update_check_view`) is unauthenticated and previously performed an **uncached** aiohttp fetch of GitHub's raw `versions.json` on every request, plus a full pack re-load in the executor. Any client could loop it to make the HA host hammer GitHub and burn loop/executor time — in contrast to `pack_submission.py`'s hourly-throttled reconcile.

## Fix
- Cache the upstream `versions.json` in-memory for `SUBMIT_POLL_INTERVAL_SECONDS` (~1h), mirroring the pack-submission reconcile throttle. Repeated calls within the window reuse the cached copy instead of re-fetching.
- Only successful fetches are cached: a failed/non-200 fetch returns `None` and is **not** cached, so behaviour on fetch failure is unchanged (graceful fallback, retry next request).
- Skip the executor pack reload once the bank is already loaded (new `QuestionBank.is_loaded` property); `load_all_categories` already memoised internally, this also avoids the executor hop.
- Response shape (`installed` / `upstream` / `updates` / `upstream_available`) is identical.

## Tests
`tests/test_pack_updates_cache_360.py`: a second call within the TTL does not re-fetch (fake fetch + call-count assertion), TTL expiry re-fetches, failed fetch falls back and is not cached, and the executor reload is skipped when the bank is already loaded.

Full suite: 810 passed, 5 skipped. `ruff check custom_components/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)