### PR TITLE
refactor: replace cross-module private-attribute wiring with setters (#364)

### DIFF
--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -76,8 +76,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await question_stats.load()
 
     game_state = QuizifyGameState(runtime=runtime, entry_id=entry.entry_id)
-    game_state._stats_service = analytics
-    game_state._question_stats = question_stats
+    game_state.set_stats_services(analytics, question_stats)
     # Read persisted question history off the event loop (issue #222).
     await game_state.async_load_history()
 
@@ -241,7 +240,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     tts_announcer.attach()
     # Let the WS handler push milestone announcements directly — the
     # state-callback path only sees phase transitions.
-    ws_handler._tts_announcer = tts_announcer
+    ws_handler.set_tts_announcer(tts_announcer)
 
     # Lobby music shares the TTS media_player entity (no separate field).
     lobby_music = QuizifyLobbyMusic(
@@ -305,7 +304,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         domain_data["lobby_music"] = new_lm
         handler = domain_data.get("ws_handler")
         if handler is not None:
-            handler._tts_announcer = new_tts
+            handler.set_tts_announcer(new_tts)
         _LOGGER.info("Quizify options reloaded")
 
     entry.async_on_unload(entry.add_update_listener(_update_listener))

--- a/custom_components/quizify/game/player.py
+++ b/custom_components/quizify/game/player.py
@@ -143,6 +143,23 @@ class PlayerSession:
         """Record the result of a round ('correct', 'wrong', or 'timeout')."""
         self.round_history.append(result)
 
+    def add_reaction_bonus(self, round_num: int, cap: int) -> bool:
+        """Award a +1 reaction bonus for ``round_num``, respecting ``cap``.
+
+        Encapsulates the inbound reaction-bonus bookkeeping so the WS layer
+        no longer pokes ``_reaction_bonuses_received`` directly. Each player
+        may receive at most ``cap`` bonuses per round; once at the cap the
+        call is a no-op. Returns ``True`` when a bonus was actually granted
+        (score/round_score incremented), ``False`` when the cap blocked it.
+        """
+        received = self._reaction_bonuses_received.get(round_num, 0)
+        if received >= cap:
+            return False
+        self._reaction_bonuses_received[round_num] = received + 1
+        self.score += 1
+        self.round_score += 1
+        return True
+
     def reset_for_new_game(self) -> None:
         """Reset all game-level stats for a new game."""
         self.joined_late = False

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -229,6 +229,21 @@ class QuizifyGameState:
         # name -> shuffled_pos -> original_index
         self.player_shuffles: dict[str, list[int]] = {}
 
+    def set_stats_services(
+        self,
+        stats_service: QuizifyAnalytics | None,
+        question_stats: QuestionStatsService | None,
+    ) -> None:
+        """Inject the analytics + per-question stats sinks.
+
+        Public wiring entry point called from ``__init__.py`` so setup no
+        longer assigns the private ``_stats_service`` / ``_question_stats``
+        attributes across the module boundary (#364). Either may be ``None``
+        (standalone tests / dev server), matching the pre-wired defaults.
+        """
+        self._stats_service = stats_service
+        self._question_stats = question_stats
+
     # ------------------------------------------------------------------
     # Phase / timing delegation (issue #188)
     # ------------------------------------------------------------------

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -947,14 +947,13 @@ class QuizifyWebSocketHandler:
             if not recipient or recipient.name == reactor.name:
                 continue  # can't tip your own hat
             # Per-round inbound counter (separate from `reaction_bonuses_given`
-            # which tracks OUTGOING bonuses). A real PlayerSession field so it
-            # is reset per game in reset_for_new_game() (#167).
-            bonuses_in = recipient._reaction_bonuses_received
-            if bonuses_in.get(round_num, 0) >= self._REACTION_BONUS_CAP_PER_ROUND:
-                continue
-            bonuses_in[round_num] = bonuses_in.get(round_num, 0) + 1
-            recipient.score += 1
-            recipient.round_score += 1
+            # which tracks OUTGOING bonuses). Encapsulated on PlayerSession so
+            # it is reset per game in reset_for_new_game() (#167) and the cap
+            # logic lives with the state it guards (#364).
+            if not recipient.add_reaction_bonus(
+                round_num, self._REACTION_BONUS_CAP_PER_ROUND
+            ):
+                continue  # recipient already at the per-round cap
             bonus_recipients.append(recipient.name)
 
         if bonus_recipients:
@@ -2215,6 +2214,18 @@ class QuizifyWebSocketHandler:
             return True
         admin = game_state.get_admin()
         return admin is None or not admin.connected
+
+    def set_tts_announcer(
+        self, announcer: QuizifyTTSAnnouncer | None
+    ) -> None:
+        """Wire (or rewire) the optional TTS announcer.
+
+        Public entry point used by ``__init__.py`` at setup and on every
+        options reload, so the wiring no longer pokes the private
+        ``_tts_announcer`` attribute across the module boundary (#364).
+        ``None`` clears it, restoring the no-op announcement path.
+        """
+        self._tts_announcer = announcer
 
     def _apply_tts_config(self, tts: dict[str, Any]) -> None:
         """Push a flat TTS-settings dict onto the announcer (#281).

--- a/tests/test_wiring_setters_364.py
+++ b/tests/test_wiring_setters_364.py
@@ -1,0 +1,110 @@
+"""Regression (#364): cross-module wiring must go through public setters
+instead of poking private attributes.
+
+The setup path in ``__init__.py`` previously assigned private attributes
+across module boundaries:
+  * ``game_state._stats_service`` / ``game_state._question_stats``
+  * ``ws_handler._tts_announcer``
+and the reaction handler read/updated ``recipient._reaction_bonuses_received``
+directly. These tests pin the public entry points that replaced them and
+assert ``add_reaction_bonus`` enforces the exact same per-round cap.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.player import PlayerSession  # noqa: E402
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def test_set_stats_services_wires_both_sinks(tmp_path: Path) -> None:
+    state = QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+    # Default (pre-wire) is None on both.
+    assert state._stats_service is None
+    assert state._question_stats is None
+
+    analytics = MagicMock(name="analytics")
+    question_stats = MagicMock(name="question_stats")
+    state.set_stats_services(analytics, question_stats)
+
+    assert state._stats_service is analytics
+    assert state._question_stats is question_stats
+
+    # None clears them again (standalone/dev path).
+    state.set_stats_services(None, None)
+    assert state._stats_service is None
+    assert state._question_stats is None
+
+
+def test_set_tts_announcer_wires_and_clears(tmp_path: Path) -> None:
+    handler = QuizifyWebSocketHandler(
+        runtime=_FakeRuntime(tmp_path),
+        game_state_provider=lambda: None,
+    )
+    assert handler._tts_announcer is None
+
+    announcer = MagicMock(name="announcer")
+    handler.set_tts_announcer(announcer)
+    assert handler._tts_announcer is announcer
+
+    handler.set_tts_announcer(None)
+    assert handler._tts_announcer is None
+
+
+def test_add_reaction_bonus_enforces_cap() -> None:
+    cap = QuizifyWebSocketHandler._REACTION_BONUS_CAP_PER_ROUND
+    player = PlayerSession(name="Alice", ws=None)
+    round_num = 1
+
+    # Up to the cap: each grant awards +1 and returns True.
+    for expected_score in range(1, cap + 1):
+        assert player.add_reaction_bonus(round_num, cap) is True
+        assert player.score == expected_score
+        assert player.round_score == expected_score
+
+    # At the cap: further grants are no-ops returning False.
+    assert player.add_reaction_bonus(round_num, cap) is False
+    assert player.score == cap
+    assert player.round_score == cap
+    assert player._reaction_bonuses_received[round_num] == cap
+
+
+def test_add_reaction_bonus_is_per_round() -> None:
+    cap = 3
+    player = PlayerSession(name="Bob", ws=None)
+
+    # Fill round 1 to the cap.
+    for _ in range(cap):
+        assert player.add_reaction_bonus(1, cap) is True
+    assert player.add_reaction_bonus(1, cap) is False
+
+    # A different round has its own fresh counter.
+    assert player.add_reaction_bonus(2, cap) is True
+    assert player._reaction_bonuses_received == {1: cap, 2: 1}
+    assert player.score == cap + 1
+
+
+def test_reset_for_new_game_clears_received_bonuses() -> None:
+    cap = 3
+    player = PlayerSession(name="Carol", ws=None)
+    player.add_reaction_bonus(1, cap)
+    assert player._reaction_bonuses_received == {1: 1}
+
+    player.reset_for_new_game()
+    assert player._reaction_bonuses_received == {}
+    # After reset the same round is grantable again (the #167 bug this guards).
+    assert player.add_reaction_bonus(1, cap) is True


### PR DESCRIPTION
Fixes #364

Setup and the reaction handler reached across module boundaries into private attributes. This pure refactor routes all such wiring through explicit public methods — behaviour is identical.

## Changes
- **`game/state.py`** — new `QuizifyGameState.set_stats_services(analytics, question_stats)`; `__init__.py` calls it instead of assigning `game_state._stats_service` / `game_state._question_stats`.
- **`server/websocket.py`** — new `QuizifyWebSocketHandler.set_tts_announcer(announcer)`; `__init__.py` calls it at setup and on every options reload instead of poking `ws_handler._tts_announcer`.
- **`game/player.py`** — new `PlayerSession.add_reaction_bonus(round_num, cap)` encapsulating the inbound reaction-bonus read/update; the reveal-reaction handler no longer touches `recipient._reaction_bonuses_received`. The per-round cap logic (returns `True` when granted, `False` at cap) now lives with the state it guards, preserving the exact prior semantics.

## Tests
Adds `tests/test_wiring_setters_364.py` asserting the setters wire (and clear) the services and that `add_reaction_bonus` enforces the same per-round cap, is per-round independent, and is cleared by `reset_for_new_game` (#167 guard).

Full suite: 810 passed, 5 skipped. `ruff check custom_components/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)