### PR TITLE
fix: cancel admin-pause task on teardown + static WS dispatch table (#362, #363)

### DIFF
--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -55,6 +55,35 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Client → server message-type constants (#363)
+# ---------------------------------------------------------------------------
+# Single source of truth for the wire strings the dispatch table keys on, so
+# a typo is a NameError at import time instead of a silently-dead branch.
+# ``admin_connect`` and ``reset_game`` live OUTSIDE the dispatch table (special
+# authorization paths) but are named here for completeness. Keep in sync with
+# ``server/protocol.py::CLIENT_MESSAGE_TYPES``.
+MSG_ADMIN_CONNECT = "admin_connect"
+MSG_RESET_GAME = "reset_game"
+MSG_JOIN = "join"
+MSG_RECONNECT = "reconnect"
+MSG_GET_STATE = "get_state"
+MSG_SUBMIT_ANSWER = "submit_answer"
+MSG_SUBMIT_WAGER = "submit_wager"
+MSG_REACTION = "reaction"
+MSG_USE_POWERUP = "use_powerup"
+MSG_LIGHTNING_ANSWER = "lightning_answer"
+MSG_START_GAME = "start_game"
+MSG_NEXT_QUESTION = "next_question"
+MSG_NEXT_ROUND = "next_round"
+MSG_ADMIN_SKIP = "admin_skip"
+MSG_END_GAME = "end_game"
+MSG_PLAY_AGAIN = "play_again"
+MSG_PAUSE_GAME = "pause_game"
+MSG_RESUME_GAME = "resume_game"
+MSG_KICK_PLAYER = "kick_player"
+MSG_CONFIGURE_TTS = "configure_tts"
+
 
 def _coerce_toggle(value: Any, *, default: bool) -> bool:
     """Coerce a wire toggle value to a bool (#285).
@@ -327,7 +356,7 @@ class QuizifyWebSocketHandler:
         # ``admin_connect`` and ``reset_game`` use a different / special
         # authorization path than the boolean ``admin_required`` table below,
         # so they are handled out-of-band first.
-        if msg_type == "admin_connect":
+        if msg_type == MSG_ADMIN_CONNECT:
             # WS-level admin only (not the player-as-admin ``_is_authorized_admin``
             # relaxation) — an admin_connect must come from a real ?role=admin tab.
             if not is_admin:
@@ -336,7 +365,7 @@ class QuizifyWebSocketHandler:
             await self._handle_admin_connect(ws, game_state)
             return
 
-        if msg_type == "reset_game":
+        if msg_type == MSG_RESET_GAME:
             # Reset is the recovery escape-hatch (#207). Besides the normal
             # admin check, allow it whenever NO connected admin currently
             # holds the crown: in that orphaned-crown state (the legitimate
@@ -350,11 +379,10 @@ class QuizifyWebSocketHandler:
             await self._handle_reset_game(ws, game_state)
             return
 
-        handlers = self._message_dispatch(data, game_state)
         # msg_type comes from untyped client JSON and may be None (no "type"
         # field) — dict.get tolerates that and routes it to the unknown-type
         # branch below, so the arg-type mismatch is intentional.
-        entry = handlers.get(msg_type)  # type: ignore[arg-type]
+        entry = self._DISPATCH.get(msg_type)  # type: ignore[arg-type]
         if entry is None:
             _LOGGER.warning("Unknown message type: %s", msg_type)
             await self._conn.send_error(ws, ERR_INVALID_ACTION, "Unknown message type")
@@ -370,93 +398,30 @@ class QuizifyWebSocketHandler:
             await self._conn.send_error(ws, ERR_INVALID_ACTION, "Admin only")
             return
 
-        await handler(ws)
+        # Every handler in ``_DISPATCH`` is normalized to the uniform
+        # ``(self, ws, data, game_state)`` signature (arity mismatches are
+        # absorbed by the adapter lambdas), so the guarded dispatch is a single
+        # call regardless of what the underlying handler needs.
+        await handler(self, ws, data, game_state)
 
-    def _message_dispatch(
-        self, data: dict, game_state: QuizifyGameState
-    ) -> dict[str, tuple[Callable[[web.WebSocketResponse], Any], bool]]:
-        """Build the message-type → (handler, admin_required) dispatch table.
-
-        Each handler is normalized to a single ``(ws)`` coroutine so the
-        centralized guard in :meth:`_handle_message` can invoke them uniformly,
-        regardless of whether the underlying handler also needs ``data``. The
-        boolean is ``True`` iff the message type requires admin authorization.
-
-        ``admin_connect`` and ``reset_game`` are NOT in this table — they use
-        special authorization paths and are handled separately.
-        """
-
-        async def _get_state(ws: web.WebSocketResponse) -> None:
-            state_msg = game_state.get_state_snapshot()
-            # Project into the requesting PLAYER's frame (#286): the raw
-            # snapshot carries canonical answer order, but ``submit_answer``
-            # maps the tapped index through the player's OWN shuffle — sending
-            # canonical order here mis-scores ~2/3 of taps after a mid-round
-            # reconnect (the client auto-sends get_state on every join). Pure
-            # admin/dashboard sockets (no player session) keep canonical order.
-            player = game_state.get_player_by_ws(ws)
-            if player is not None:
-                state_msg = self._round_messages.project_snapshot_for_player(
-                    game_state, snapshot=state_msg, player=player
-                )
-            state_msg["type"] = "game_state"
-            await self._conn.send(ws, state_msg)
-
-        return {
-            # --- non-admin (player) message types ---
-            "join": (lambda ws: self._handle_join(ws, data, game_state), False),
-            "submit_answer": (
-                lambda ws: self._handle_submit_answer(ws, data, game_state),
-                False,
-            ),
-            "use_powerup": (
-                lambda ws: self._handle_use_powerup(ws, data, game_state),
-                False,
-            ),
-            "lightning_answer": (
-                lambda ws: self._handle_lightning_answer(ws, data, game_state),
-                False,
-            ),
-            "reconnect": (
-                lambda ws: self._handle_reconnect(ws, data, game_state),
-                False,
-            ),
-            "get_state": (_get_state, False),
-            "reaction": (lambda ws: self._handle_reaction(ws, data, game_state), False),
-            "submit_wager": (
-                lambda ws: self._handle_submit_wager(ws, data, game_state),
-                False,
-            ),
-            # --- admin-required message types ---
-            "start_game": (
-                lambda ws: self._handle_start_game(ws, data, game_state),
-                True,
-            ),
-            "next_question": (
-                lambda ws: self._handle_next_question(ws, game_state),
-                True,
-            ),
-            "next_round": (
-                lambda ws: self._handle_next_question(ws, game_state),
-                True,
-            ),
-            "admin_skip": (
-                lambda ws: self._handle_admin_skip(ws, game_state),
-                True,
-            ),
-            "end_game": (lambda ws: self._handle_end_game(ws, game_state), True),
-            "play_again": (lambda ws: self._handle_play_again(ws, game_state), True),
-            "pause_game": (lambda ws: self._handle_pause_game(ws, game_state), True),
-            "resume_game": (lambda ws: self._handle_resume_game(ws, game_state), True),
-            "kick_player": (
-                lambda ws: self._handle_kick_player(ws, data, game_state),
-                True,
-            ),
-            "configure_tts": (
-                lambda ws: self._handle_configure_tts(ws, data, game_state),
-                True,
-            ),
-        }
+    async def _handle_get_state(
+        self, ws: web.WebSocketResponse, data: dict, game_state: QuizifyGameState
+    ) -> None:
+        """Handle a ``get_state`` request (#286)."""
+        state_msg = game_state.get_state_snapshot()
+        # Project into the requesting PLAYER's frame (#286): the raw
+        # snapshot carries canonical answer order, but ``submit_answer``
+        # maps the tapped index through the player's OWN shuffle — sending
+        # canonical order here mis-scores ~2/3 of taps after a mid-round
+        # reconnect (the client auto-sends get_state on every join). Pure
+        # admin/dashboard sockets (no player session) keep canonical order.
+        player = game_state.get_player_by_ws(ws)
+        if player is not None:
+            state_msg = self._round_messages.project_snapshot_for_player(
+                game_state, snapshot=state_msg, player=player
+            )
+        state_msg["type"] = "game_state"
+        await self._conn.send(ws, state_msg)
 
     # ------------------------------------------------------------------
     # Admin connect
@@ -1400,6 +1365,9 @@ class QuizifyWebSocketHandler:
         """
         self._cancel_timer_tick()
         self._cancel_lightning_loop()
+        # Cancel the deferred admin-disconnect pause (#362) so a reset can't
+        # be undone by a pause firing right after the fresh lobby is built.
+        self._cancel_admin_pause()
         # Cancel any pending admin-disconnect timer and stale player-removal
         # tasks from the finished game.
         await self._conn.cleanup()
@@ -2180,6 +2148,9 @@ class QuizifyWebSocketHandler:
                 pass
 
         self._admin_pause_task = asyncio.ensure_future(pause_after_grace())
+        # Surface a crash in the deferred-pause loop (#362/#307) instead of
+        # letting "Task exception was never retrieved" leak at GC time.
+        self._admin_pause_task.add_done_callback(self._log_task_exception)
 
     def _cancel_admin_pause(self) -> None:
         """Cancel any pending deferred admin-disconnect pause."""
@@ -2392,5 +2363,106 @@ class QuizifyWebSocketHandler:
         self._cancel_timer_tick()
         self._cancel_lightning_loop()
         self._cancel_reaction_flush()
+        # Also cancel the deferred admin-disconnect pause (#362): a game
+        # teardown/reset that leaves it pending would fire a spurious pause
+        # (or hold a reference) after the game is already gone.
+        self._cancel_admin_pause()
         await self._conn.cleanup()
         _LOGGER.debug("Cleaned up all pending game tasks")
+
+    # ------------------------------------------------------------------
+    # Static message-dispatch table (#363)
+    # ------------------------------------------------------------------
+    # Built ONCE at class-definition time — NOT rebuilt per inbound message.
+    # Maps message-type → (handler, admin_required). Every handler is adapted
+    # to the uniform ``(self, ws, data, game_state)`` signature so the
+    # centralized guard in ``_handle_message`` invokes them identically,
+    # regardless of whether the underlying ``_handle_*`` method also needs
+    # ``data``. ``admin_connect`` / ``reset_game`` are intentionally absent —
+    # they take special authorization paths handled before this table.
+    _DISPATCH: dict[
+        str,
+        tuple[
+            Callable[
+                [QuizifyWebSocketHandler, web.WebSocketResponse, dict,
+                 QuizifyGameState],
+                Any,
+            ],
+            bool,
+        ],
+    ] = {
+        # --- non-admin (player) message types ---
+        MSG_JOIN: (
+            lambda self, ws, data, gs: self._handle_join(ws, data, gs),
+            False,
+        ),
+        MSG_SUBMIT_ANSWER: (
+            lambda self, ws, data, gs: self._handle_submit_answer(ws, data, gs),
+            False,
+        ),
+        MSG_USE_POWERUP: (
+            lambda self, ws, data, gs: self._handle_use_powerup(ws, data, gs),
+            False,
+        ),
+        MSG_LIGHTNING_ANSWER: (
+            lambda self, ws, data, gs: self._handle_lightning_answer(ws, data, gs),
+            False,
+        ),
+        MSG_RECONNECT: (
+            lambda self, ws, data, gs: self._handle_reconnect(ws, data, gs),
+            False,
+        ),
+        MSG_GET_STATE: (
+            lambda self, ws, data, gs: self._handle_get_state(ws, data, gs),
+            False,
+        ),
+        MSG_REACTION: (
+            lambda self, ws, data, gs: self._handle_reaction(ws, data, gs),
+            False,
+        ),
+        MSG_SUBMIT_WAGER: (
+            lambda self, ws, data, gs: self._handle_submit_wager(ws, data, gs),
+            False,
+        ),
+        # --- admin-required message types ---
+        MSG_START_GAME: (
+            lambda self, ws, data, gs: self._handle_start_game(ws, data, gs),
+            True,
+        ),
+        MSG_NEXT_QUESTION: (
+            lambda self, ws, data, gs: self._handle_next_question(ws, gs),
+            True,
+        ),
+        MSG_NEXT_ROUND: (
+            lambda self, ws, data, gs: self._handle_next_question(ws, gs),
+            True,
+        ),
+        MSG_ADMIN_SKIP: (
+            lambda self, ws, data, gs: self._handle_admin_skip(ws, gs),
+            True,
+        ),
+        MSG_END_GAME: (
+            lambda self, ws, data, gs: self._handle_end_game(ws, gs),
+            True,
+        ),
+        MSG_PLAY_AGAIN: (
+            lambda self, ws, data, gs: self._handle_play_again(ws, gs),
+            True,
+        ),
+        MSG_PAUSE_GAME: (
+            lambda self, ws, data, gs: self._handle_pause_game(ws, gs),
+            True,
+        ),
+        MSG_RESUME_GAME: (
+            lambda self, ws, data, gs: self._handle_resume_game(ws, gs),
+            True,
+        ),
+        MSG_KICK_PLAYER: (
+            lambda self, ws, data, gs: self._handle_kick_player(ws, data, gs),
+            True,
+        ),
+        MSG_CONFIGURE_TTS: (
+            lambda self, ws, data, gs: self._handle_configure_tts(ws, data, gs),
+            True,
+        ),
+    }

--- a/tests/test_admin_pause_cleanup_362.py
+++ b/tests/test_admin_pause_cleanup_362.py
@@ -1,0 +1,132 @@
+"""Regression tests for issue #362 — the deferred admin-pause task must be
+cancelled on game teardown/reset, and must surface its own crashes.
+
+Background: when the admin-as-player WS closes mid-question, the server
+schedules a deferred ``_admin_pause_task`` (fires ``ADMIN_REDIRECT_GRACE``
+seconds later unless the admin reconnects). Before the fix, neither
+``cleanup_game_tasks()`` nor ``_handle_reset_game()`` cancelled that task,
+so a teardown/reset could leave it pending — it would then fire a spurious
+"admin_disconnected" pause against the fresh lobby (or leak a reference and
+emit "Task exception was never retrieved" at GC time, because it was created
+with a bare ``ensure_future`` and no done-callback).
+
+The fix:
+  1. ``cleanup_game_tasks()`` and ``_handle_reset_game()`` both call
+     ``_cancel_admin_pause()``.
+  2. The pause task gets ``add_done_callback(self._log_task_exception)`` so a
+     crash in the deferred loop is logged instead of silently swallowed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import (  # noqa: E402
+    QuizifyGameState,
+)
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    ws.close = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    runtime = _FakeRuntime(tmp_path)
+    return QuizifyGameState(runtime=runtime, entry_id="test")
+
+
+@pytest.fixture
+def handler(game: QuizifyGameState, tmp_path: Path) -> QuizifyWebSocketHandler:
+    runtime = _FakeRuntime(tmp_path)
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    h._conn = ConnectionManager(runtime, lambda: game)
+    h._conn.broadcast = AsyncMock()
+    # Keep the grace long so the scheduled pause stays pending for the
+    # cancellation assertions (it must not fire on its own during the test).
+    h.ADMIN_REDIRECT_GRACE = 30.0
+    return h
+
+
+@pytest.mark.asyncio
+async def test_cleanup_game_tasks_cancels_pending_admin_pause(
+    handler: QuizifyWebSocketHandler,
+) -> None:
+    """A scheduled admin-pause task is cancelled by cleanup_game_tasks()."""
+    handler._schedule_admin_pause("Admin")
+    task = handler._admin_pause_task
+    assert task is not None
+    assert not task.done()
+
+    await handler.cleanup_game_tasks()
+
+    # The handle is cleared and the underlying task is actually cancelled.
+    assert handler._admin_pause_task is None
+    await asyncio.sleep(0)  # let the cancellation propagate
+    assert task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_reset_game_cancels_pending_admin_pause(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState
+) -> None:
+    """A scheduled admin-pause task is cancelled by _handle_reset_game()."""
+    handler._schedule_admin_pause("Admin")
+    task = handler._admin_pause_task
+    assert task is not None
+    assert not task.done()
+
+    admin_ws = _ws()
+    await handler._handle_reset_game(admin_ws, game)
+
+    assert handler._admin_pause_task is None
+    await asyncio.sleep(0)
+    assert task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_admin_pause_task_surfaces_its_exception(
+    handler: QuizifyWebSocketHandler, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The pause task carries the _log_task_exception done-callback (#362),
+    so a crash inside the deferred loop is logged rather than swallowed."""
+    handler.ADMIN_REDIRECT_GRACE = 0.0
+
+    def _boom() -> QuizifyGameState:
+        raise RuntimeError("boom")
+
+    handler._get_game_state = _boom  # type: ignore[assignment]
+
+    with caplog.at_level(logging.ERROR):
+        handler._schedule_admin_pause("Admin")
+        task = handler._admin_pause_task
+        assert task is not None
+        with pytest.raises(RuntimeError):
+            await task
+
+    assert any(
+        "Unhandled exception in background task" in rec.getMessage()
+        for rec in caplog.records
+    )

--- a/tests/test_dispatch_guard_270.py
+++ b/tests/test_dispatch_guard_270.py
@@ -148,8 +148,7 @@ async def test_admin_required_type_rejected_for_non_admin(
     assert game.phase == GamePhase.LOBBY
 
     # Spy on the handler the type dispatches to so we can assert it never ran.
-    dispatch = h._message_dispatch({"type": msg_type}, game)
-    handler_fn, admin_required = dispatch[msg_type]
+    handler_fn, admin_required = h._DISPATCH[msg_type]
     assert admin_required is True, f"{msg_type} should be admin_required"
 
     await h._handle_message(rogue_ws, {"type": msg_type}, is_admin=False)
@@ -192,7 +191,7 @@ def test_dispatch_table_admin_flags_match_expected(
     a future edit that adds/removes/flips a guard fails loudly. ``reset_game``
     and ``admin_connect`` are intentionally absent (special auth paths)."""
     h = _handler(game, tmp_path)
-    table = h._message_dispatch({}, game)
+    table = h._DISPATCH
 
     actual_admin = {t for t, (_, req) in table.items() if req}
     actual_non_admin = {t for t, (_, req) in table.items() if not req}

--- a/tests/test_dispatch_table_363.py
+++ b/tests/test_dispatch_table_363.py
@@ -1,0 +1,213 @@
+"""Regression tests for issue #363 — the STATIC websocket dispatch table.
+
+``_handle_message`` used to rebuild a dict of ~17 lambda closures on EVERY
+inbound message just to look up one key. #363 replaces that with a single
+class-level ``_DISPATCH`` table built ONCE at class-definition time, keyed on
+the ``MSG_*`` string constants and dispatched uniformly as
+``handler(self, ws, data, game_state)``.
+
+This must be strictly behaviour-preserving. These tests pin:
+  1. The table is a single shared object (built once, not per message/instance).
+  2. Every message type routes to the correct underlying ``_handle_*`` method
+     (including the ``next_question``/``next_round`` alias) and nothing else.
+  3. ``admin_connect`` / ``reset_game`` are NOT in the table (special paths).
+  4. An unknown type is rejected with "Unknown message type" and reaches no
+     handler.
+  5. Admin-required types are rejected with "Admin only" for a non-admin
+     connection and never reach their handler.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+from custom_components.quizify.server import websocket as ws_mod  # noqa: E402
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+# msg_type -> the _handle_* method it must dispatch to. ``next_round`` is an
+# intentional alias of ``next_question`` (#270). ``admin_connect`` /
+# ``reset_game`` are handled out-of-band and are NOT in this map.
+ROUTING = {
+    ws_mod.MSG_JOIN: "_handle_join",
+    ws_mod.MSG_SUBMIT_ANSWER: "_handle_submit_answer",
+    ws_mod.MSG_USE_POWERUP: "_handle_use_powerup",
+    ws_mod.MSG_LIGHTNING_ANSWER: "_handle_lightning_answer",
+    ws_mod.MSG_RECONNECT: "_handle_reconnect",
+    ws_mod.MSG_GET_STATE: "_handle_get_state",
+    ws_mod.MSG_REACTION: "_handle_reaction",
+    ws_mod.MSG_SUBMIT_WAGER: "_handle_submit_wager",
+    ws_mod.MSG_START_GAME: "_handle_start_game",
+    ws_mod.MSG_NEXT_QUESTION: "_handle_next_question",
+    ws_mod.MSG_NEXT_ROUND: "_handle_next_question",
+    ws_mod.MSG_ADMIN_SKIP: "_handle_admin_skip",
+    ws_mod.MSG_END_GAME: "_handle_end_game",
+    ws_mod.MSG_PLAY_AGAIN: "_handle_play_again",
+    ws_mod.MSG_PAUSE_GAME: "_handle_pause_game",
+    ws_mod.MSG_RESUME_GAME: "_handle_resume_game",
+    ws_mod.MSG_KICK_PLAYER: "_handle_kick_player",
+    ws_mod.MSG_CONFIGURE_TTS: "_handle_configure_tts",
+}
+
+ADMIN_REQUIRED = {
+    ws_mod.MSG_START_GAME,
+    ws_mod.MSG_NEXT_QUESTION,
+    ws_mod.MSG_NEXT_ROUND,
+    ws_mod.MSG_ADMIN_SKIP,
+    ws_mod.MSG_END_GAME,
+    ws_mod.MSG_PLAY_AGAIN,
+    ws_mod.MSG_PAUSE_GAME,
+    ws_mod.MSG_RESUME_GAME,
+    ws_mod.MSG_KICK_PLAYER,
+    ws_mod.MSG_CONFIGURE_TTS,
+}
+
+# The set of distinct underlying handler methods (next_round aliases
+# next_question, so it collapses).
+ALL_HANDLER_METHODS = set(ROUTING.values())
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    ws.close = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    runtime = _FakeRuntime(tmp_path)
+    return QuizifyGameState(runtime=runtime, entry_id="test")
+
+
+def _handler(game: QuizifyGameState, tmp_path: Path) -> QuizifyWebSocketHandler:
+    runtime = _FakeRuntime(tmp_path)
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    h._conn = ConnectionManager(runtime, lambda: game)
+    h._get_game_state = lambda: game  # type: ignore[assignment]
+
+    errors: dict[int, list[dict]] = {}
+
+    async def _send_error(ws, code, message) -> None:
+        errors.setdefault(id(ws), []).append({"code": code, "message": message})
+
+    h._conn.send_error = _send_error  # type: ignore[assignment]
+    h._conn.broadcast = AsyncMock()  # type: ignore[assignment]
+    h._errors = errors  # type: ignore[attr-defined]
+    return h
+
+
+def test_dispatch_table_is_built_once(
+    game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """The table is a single shared class object — not rebuilt per instance
+    (and, by construction, not per message)."""
+    h1 = _handler(game, tmp_path)
+    h2 = _handler(game, tmp_path)
+    assert h1._DISPATCH is QuizifyWebSocketHandler._DISPATCH
+    assert h2._DISPATCH is QuizifyWebSocketHandler._DISPATCH
+
+
+def test_special_types_not_in_table() -> None:
+    """admin_connect / reset_game use special auth paths and must stay out."""
+    assert ws_mod.MSG_ADMIN_CONNECT not in QuizifyWebSocketHandler._DISPATCH
+    assert ws_mod.MSG_RESET_GAME not in QuizifyWebSocketHandler._DISPATCH
+
+
+@pytest.mark.parametrize("msg_type", sorted(ROUTING))
+@pytest.mark.asyncio
+async def test_message_routes_to_correct_handler(
+    msg_type: str, game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """Each message type reaches its expected _handle_* method — and only
+    that one — when dispatched through _handle_message."""
+    h = _handler(game, tmp_path)
+    # Grant admin so admin-required types reach their handler.
+    h._is_authorized_admin = lambda *a, **k: True  # type: ignore[assignment]
+
+    # Replace every distinct handler with an AsyncMock spy so we can prove
+    # exactly one fired and no cross-talk happened.
+    spies = {name: AsyncMock() for name in ALL_HANDLER_METHODS}
+    for name, spy in spies.items():
+        setattr(h, name, spy)
+
+    ws = _ws()
+    await h._handle_message(ws, {"type": msg_type}, is_admin=True)
+
+    expected = ROUTING[msg_type]
+    assert spies[expected].await_count == 1, f"{msg_type} did not route to {expected}"
+    for name, spy in spies.items():
+        if name != expected:
+            assert spy.await_count == 0, f"{msg_type} wrongly also called {name}"
+
+    # Uniform dispatch: ws is first positional, the game_state is last.
+    call = spies[expected].await_args
+    assert call.args[0] is ws
+    assert call.args[-1] is game
+
+
+@pytest.mark.asyncio
+async def test_unknown_type_rejected_and_no_handler(
+    game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """An unknown message type is rejected and reaches no handler."""
+    h = _handler(game, tmp_path)
+    spies = {name: AsyncMock() for name in ALL_HANDLER_METHODS}
+    for name, spy in spies.items():
+        setattr(h, name, spy)
+
+    ws = _ws()
+    await h._handle_message(ws, {"type": "does_not_exist"}, is_admin=True)
+
+    errs = h._errors.get(id(ws), [])  # type: ignore[attr-defined]
+    assert errs and errs[-1]["message"] == "Unknown message type"
+    assert all(spy.await_count == 0 for spy in spies.values())
+
+
+@pytest.mark.parametrize("msg_type", sorted(ADMIN_REQUIRED))
+@pytest.mark.asyncio
+async def test_admin_required_rejected_without_admin(
+    msg_type: str, game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """Admin-required types are rejected with 'Admin only' for a non-admin
+    connection and never reach their handler."""
+    h = _handler(game, tmp_path)
+    # A legitimate admin holds the crown so the guard has something to check.
+    admin_ws = _ws()
+    h._conn.add_connection(admin_ws, is_admin=True, is_dashboard=False)
+    game.add_player("Host", admin_ws)
+    game.get_player("Host").is_admin = True
+
+    rogue_ws = _ws()
+    h._conn.add_connection(rogue_ws, is_admin=False, is_dashboard=False)
+    game.add_player("Rogue", rogue_ws)
+
+    spies = {name: AsyncMock() for name in ALL_HANDLER_METHODS}
+    for name, spy in spies.items():
+        setattr(h, name, spy)
+
+    assert game.phase == GamePhase.LOBBY
+    await h._handle_message(rogue_ws, {"type": msg_type}, is_admin=False)
+
+    errs = h._errors.get(id(rogue_ws), [])  # type: ignore[attr-defined]
+    assert errs and errs[-1]["message"] == "Admin only"
+    assert all(spy.await_count == 0 for spy in spies.values())


### PR DESCRIPTION
Fixes #362
Fixes #363

## #362 — deferred admin-pause task leaked on teardown/reset (P2 concurrency)
`_admin_pause_task` (the deferred "admin disconnected" pause scheduled when the admin-as-player WS closes mid-question) was never cancelled on game teardown/reset, and was created with a bare `asyncio.ensure_future` without the `_log_task_exception` done-callback used for every other fire-and-forget task.

- `cleanup_game_tasks()` and `_handle_reset_game()` now call `self._cancel_admin_pause()` (alongside the existing timer / lightning / reaction-flush cancels).
- The pause task now gets `add_done_callback(self._log_task_exception)`, so a crash in the deferred loop is logged instead of leaking "Task exception was never retrieved" at GC time.

## #363 — per-message dispatch dict rebuild (P2 perf/quality)
`_message_dispatch()` constructed a fresh dict of ~17 lambda closures on **every** inbound message just to look up one key.

- Replaced with a single static class-level `_DISPATCH` table, built **once** at class-definition time, keyed on new `MSG_*` string constants and dispatched uniformly as `handler(self, ws, data, game_state)` (arity differences absorbed by the adapter lambdas).
- Strictly behaviour-preserving: `admin_connect` / `reset_game` keep their special out-of-band auth paths, the centralized admin-required guard is unchanged, and `next_round` still aliases `next_question`.

## Tests
- New `tests/test_admin_pause_cleanup_362.py`: a scheduled admin-pause task is cancelled by `cleanup_game_tasks()` / `_handle_reset_game()`, plus the done-callback surfaces a crash.
- New `tests/test_dispatch_table_363.py`: every message type routes to the correct handler (incl. the `next_round` alias), unknown types are rejected, admin-required types are rejected without admin, and the table is a single shared object.
- Updated `tests/test_dispatch_guard_270.py` to reference the static `_DISPATCH` table.

Full suite: 839 passed, 5 skipped. `ruff check custom_components/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)