### PR TITLE
fix(security): move admin token out of WS URL + per-IP WS cap (#359, #361)

### DIFF
--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -79,6 +79,20 @@ class QuizifyWebSocketHandler:
 
     HEARTBEAT_INTERVAL = 30
 
+    # Per-IP WebSocket connection cap (#361). The existing flood guard is
+    # per-connection (keyed on id(ws)), so opening N sockets bypasses it
+    # entirely. This caps the number of *concurrent* sockets a single
+    # ``request.remote`` may hold. It is deliberately GENEROUS: in the common
+    # Quizify deployment every player is a distinct phone on the same wifi
+    # hitting HA directly, so each device has its own LAN IP and one device
+    # never legitimately needs anywhere near this many sockets (a page reload
+    # or reconnect briefly overlaps two, no more). The cap only bites a single
+    # host opening a flood of sockets. (If HA sits behind a reverse proxy that
+    # collapses every client to one source IP without X-Forwarded-For, raise
+    # this — but that is the uncommon setup for a local party game.) Refused
+    # connections get an HTTP 429 before the WebSocket is upgraded.
+    MAX_CONNECTIONS_PER_IP = 15
+
     # Admin-as-player redirect grace: when the admin clicks "Spiel starten"
     # from /quizify/admin, admin.js navigates the tab to /quizify/player so
     # the admin can answer questions. That navigation closes the admin's
@@ -148,6 +162,22 @@ class QuizifyWebSocketHandler:
             window=1.0,  # seconds
             clock=lambda: asyncio.get_event_loop().time(),
         )
+        # Per-IP concurrent-connection counter (#361). Incremented after a
+        # successful ws.prepare(), decremented in handle()'s finally on
+        # disconnect; a count that drops to zero is popped so the dict stays
+        # bounded by the number of *currently connected* source IPs.
+        self._ip_connections: dict[str, int] = {}
+        # Per-IP join-attempt flood guard (#361). Distinct from the
+        # per-connection message limiter above: a client that opens several
+        # sockets could otherwise fire a burst of joins, one per socket. The
+        # window is generous so a full room of players behind one NAT (each
+        # joining once, plus the odd reconnect) is never blocked; it only
+        # trips on an automated join flood.
+        self._join_limiter = SlidingWindowLimiter(
+            max_requests=30,  # max join attempts per window, per IP
+            window=60.0,  # seconds
+            clock=lambda: asyncio.get_event_loop().time(),
+        )
         # Routes named state events (round_evaluated / game_ended) to the
         # matching broadcast, falling back to a full-state push (#184).
         self._broadcast_dispatcher = BroadcastDispatcher(
@@ -199,61 +229,90 @@ class QuizifyWebSocketHandler:
         """Drop a connection's rate-limit state (called on disconnect)."""
         self._rate_limiter.forget(id(ws))
 
-    async def handle(self, request: web.Request) -> web.WebSocketResponse:
-        """Handle WebSocket connection."""
-        ws = web.WebSocketResponse(heartbeat=self.HEARTBEAT_INTERVAL)
-        await ws.prepare(request)
+    async def _grant_admin(
+        self, role: str | None, admin_token: str | None, request: web.Request
+    ) -> bool:
+        """Evaluate the admin-grant rules for a ``role=admin`` connection.
 
-        role = request.query.get("role")
-        is_dashboard = role == "dashboard"
-        admin_token = request.query.get("token")
-
-        # Admin role grant rules (#140 fix + #1 + #2 in logical review):
-        # 1. Valid session token in ?token= \u2192 always grant (reconnect path).
-        # 2. No token persisted to HA storage (fresh install / first-ever
-        #    admin) \u2192 grant once as bootstrap. Thereafter the token is
-        #    persisted via HA storage, survives restarts, and this branch
-        #    never fires again on this HA instance (close the LAN
-        #    takeover window that previously reopened on every restart).
-        # 3. Token exists but no matching token provided \u2192 reject.
-        #
+        Token-source-agnostic (#359): the token may arrive via the
+        ``X-Quizify-Token`` header, the deprecated ``?token=`` query param, or
+        a first-message ``admin_auth`` frame. FAIL SOFT — a bad/absent token
+        never rejects the socket, it only withholds the admin grant, so the
+        host can never lock itself out.
+        """
+        if role != "admin":
+            return False
         # Ensure the persisted token is loaded before evaluating rules.
         # async_load_admin_token() is idempotent and cheap after first call.
         await self._conn.async_load_admin_token()
-        is_admin = False
-        if role == "admin":
-            if admin_token and self._conn.validate_admin_token(admin_token):
-                is_admin = True
-                _LOGGER.info("Admin reconnected with valid session token")
-            elif await self._conn.try_bootstrap_admin():
-                # Bootstrap: no token has ever been issued on this HA
-                # instance. try_bootstrap_admin() grants + persists the token
-                # atomically under a lock, so exactly one of two racing
-                # first-connections wins (#168). The loser falls through to
-                # the no-token branches below and gets player role only.
-                is_admin = True
-                _LOGGER.warning(
-                    "ADMIN BOOTSTRAP: granting admin to first connection "
-                    "(ip=%s). Future restarts will require the persisted "
-                    "token. If this was NOT you, reset the integration.",
-                    request.remote,
-                )
-            elif admin_token:
-                # A token was presented but failed validation — this is the
-                # interesting signal (real intrusion attempt or stale token).
-                _LOGGER.warning(
-                    "Admin connection attempt with INVALID token rejected (ip=%s)",
-                    request.remote,
-                )
-            else:
-                # No token presented and one is already on disk — the most
-                # common cause is a fresh browser tab on the home LAN, not
-                # an attack. Log at DEBUG so it doesn't drown the real
-                # signal above. The connection still gets player role only.
-                _LOGGER.debug(
-                    "Admin connection attempt without token (ip=%s)",
-                    request.remote,
-                )
+        if admin_token and self._conn.validate_admin_token(admin_token):
+            _LOGGER.info("Admin authenticated with valid session token")
+            return True
+        if await self._conn.try_bootstrap_admin():
+            # Bootstrap: no token has ever been issued on this HA instance.
+            # try_bootstrap_admin() grants + persists the token atomically
+            # under a lock, so exactly one of two racing first-connections
+            # wins (#168). The loser gets player role only.
+            _LOGGER.warning(
+                "ADMIN BOOTSTRAP: granting admin to first connection "
+                "(ip=%s). Future restarts will require the persisted "
+                "token. If this was NOT you, reset the integration.",
+                request.remote,
+            )
+            return True
+        if admin_token:
+            # A token was presented but failed validation — this is the
+            # interesting signal (real intrusion attempt or stale token).
+            _LOGGER.warning(
+                "Admin connection attempt with INVALID token rejected (ip=%s)",
+                request.remote,
+            )
+        else:
+            # No token presented and one is already on disk — the most common
+            # cause is a fresh browser tab on the home LAN, not an attack.
+            _LOGGER.debug(
+                "Admin connection attempt without token (ip=%s)",
+                request.remote,
+            )
+        return False
+
+    async def handle(self, request: web.Request) -> web.StreamResponse:
+        """Handle WebSocket connection."""
+        remote = request.remote
+        # Per-IP connection cap (#361): refuse BEFORE upgrading the socket so
+        # a flood of sockets from one host can't exhaust resources. Checked
+        # before prepare() so we answer with a plain HTTP 429.
+        if (
+            remote is not None
+            and self._ip_connections.get(remote, 0) >= self.MAX_CONNECTIONS_PER_IP
+        ):
+            _LOGGER.warning(
+                "Refusing WebSocket from %s: per-IP connection cap (%d) reached",
+                remote,
+                self.MAX_CONNECTIONS_PER_IP,
+            )
+            return web.Response(
+                status=429, text="Too many connections from this address"
+            )
+
+        ws = web.WebSocketResponse(heartbeat=self.HEARTBEAT_INTERVAL)
+        await ws.prepare(request)
+        if remote is not None:
+            self._ip_connections[remote] = self._ip_connections.get(remote, 0) + 1
+
+        role = request.query.get("role")
+        is_dashboard = role == "dashboard"
+        # #359: prefer the token from the ``X-Quizify-Token`` header (kept out
+        # of aiohttp/reverse-proxy access logs and browser history); fall back
+        # to the deprecated ``?token=`` query param for backward compat. A
+        # browser WS handshake can't set headers, so the admin frontend also
+        # sends the token in a first-message ``admin_auth`` frame handled in
+        # the message loop below.
+        admin_token = request.headers.get("X-Quizify-Token") or request.query.get(
+            "token"
+        )
+
+        is_admin = await self._grant_admin(role, admin_token, request)
 
         self._conn.add_connection(ws, is_admin=is_admin, is_dashboard=is_dashboard)
 
@@ -283,6 +342,40 @@ class QuizifyWebSocketHandler:
                             ws, ERR_INVALID_ACTION, "Malformed message (invalid JSON)"
                         )
                         continue
+                    # First-message admin auth (#359): the token now travels in
+                    # this frame instead of the URL. Validate + upgrade the
+                    # connection to admin before any other traffic. FAIL SOFT —
+                    # a bad/absent token never closes the socket; it just stays
+                    # a plain player, so the host can never lock itself out.
+                    if data.get("type") == "admin_auth":
+                        if not is_admin and await self._grant_admin(
+                            role, data.get("token"), request
+                        ):
+                            is_admin = True
+                            self._conn.add_connection(
+                                ws, is_admin=True, is_dashboard=is_dashboard
+                            )
+                            _LOGGER.info(
+                                "Admin authenticated via admin_auth frame (ip=%s)",
+                                remote,
+                            )
+                        continue
+                    # Per-IP join flood guard (#361): keyed on the source IP so
+                    # opening extra sockets can't multiply join attempts. The
+                    # window is generous, so a full room behind one NAT (each
+                    # player joining once, plus the odd reconnect) never trips.
+                    if (
+                        data.get("type") == "join"
+                        and remote is not None
+                        and not self._join_limiter.check(remote)
+                    ):
+                        _LOGGER.warning(
+                            "Per-IP join rate limit exceeded for %s", remote
+                        )
+                        await self._conn.send_error(
+                            ws, ERR_INVALID_ACTION, "Too many join attempts"
+                        )
+                        continue
                     try:
                         await self._handle_message(ws, data, is_admin)
                     except Exception:  # noqa: BLE001
@@ -302,6 +395,15 @@ class QuizifyWebSocketHandler:
             was_admin = self._conn.is_admin_connection(ws)
             self._conn.remove_connection(ws)
             self._forget_rate_limit(ws)
+            # #361: release this connection's slot in the per-IP counter; drop
+            # the key entirely when it hits zero so the dict stays bounded by
+            # the number of *currently connected* source IPs.
+            if remote is not None:
+                remaining = self._ip_connections.get(remote, 0) - 1
+                if remaining > 0:
+                    self._ip_connections[remote] = remaining
+                else:
+                    self._ip_connections.pop(remote, None)
             await self._handle_disconnect(ws, was_admin=was_admin)
             _LOGGER.debug(
                 "WebSocket disconnected, total: %d", len(self._conn.connections)

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -939,13 +939,23 @@
     function connect() {
         var proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
         var savedToken = sessionStorage.getItem('quizify_admin_session_token');
+        // #359: the admin session token used to be appended to the WS URL as
+        // ?token=..., where it leaked into aiohttp / reverse-proxy access logs
+        // and browser history. It is now sent as the FIRST WebSocket frame
+        // (admin_auth) below, before admin_connect or any other traffic, so it
+        // never lands in a URL. The server still accepts ?token= as a
+        // deprecated fallback, but we no longer put it there.
         var url = proto + '//' + location.host + '/api/quizify/ws?role=admin';
-        if (savedToken) url += '&token=' + encodeURIComponent(savedToken);
         ws = new WebSocket(url);
 
         ws.onopen = function () {
             reconnectAttempts = 0;
             updateConnectionStatus('connected');
+            // Send the token out-of-URL first so the server can grant admin
+            // before admin_connect. On a fresh bootstrap there is no saved
+            // token yet — the server grants admin on the token-less handshake
+            // (bootstrap path), so skipping admin_auth here is safe.
+            if (savedToken) send('admin_auth', { token: savedToken });
             send('admin_connect', {});
             // Configure narration up-front so pre-game lobby joins narrate (#281).
             _pushTtsConfig();

--- a/tests/test_ws_per_ip_cap_361.py
+++ b/tests/test_ws_per_ip_cap_361.py
@@ -1,0 +1,184 @@
+"""Regression tests for issue #361 (P2 security).
+
+``handle()`` accepted unlimited WebSocket connections: the existing flood guard
+is per-connection (keyed on ``id(ws)``), so opening N sockets bypassed it. Fix:
+track connections per ``request.remote`` and refuse ``ws.prepare`` beyond a
+generous cap (returning HTTP 429), plus a per-IP ``SlidingWindowLimiter`` on
+join attempts. The per-IP count is released on disconnect.
+
+These drive the real ``handle()`` over a live aiohttp ``TestClient`` WebSocket
+(mirrors ``tests/test_ws_handle_integration_293.py``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+from aiohttp import WSServerHandshakeError, web
+from aiohttp.test_utils import TestClient, TestServer
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server import WS_PATH  # noqa: E402
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    def create_task(self, coro):  # noqa: ANN001, ANN202
+        return asyncio.ensure_future(coro)
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func, *args)
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+@pytest.fixture
+def handler(game: QuizifyGameState) -> QuizifyWebSocketHandler:
+    runtime = _FakeRuntime(game._runtime.data_dir)  # type: ignore[attr-defined]
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    h._conn = ConnectionManager(runtime, lambda: game)
+    return h
+
+
+async def _make_client(handler: QuizifyWebSocketHandler) -> TestClient:
+    app = web.Application()
+    app.router.add_get(WS_PATH, handler.handle)
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    return client
+
+
+async def _wait_conns(handler: QuizifyWebSocketHandler, count: int) -> None:
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if len(handler._conn.connections) == count:
+            return
+
+
+class TestPerIpConnectionCap:
+    @pytest.mark.asyncio
+    async def test_nth_connection_from_one_ip_is_refused(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """Once the per-IP cap is reached, the next connection from that IP is
+        refused with HTTP 429 (before the socket is upgraded); the earlier
+        sockets stay open."""
+        handler.MAX_CONNECTIONS_PER_IP = 3  # keep the test fast
+        client = await _make_client(handler)
+        opened = []
+        try:
+            for _ in range(handler.MAX_CONNECTIONS_PER_IP):
+                opened.append(await client.ws_connect(WS_PATH))
+            await _wait_conns(handler, handler.MAX_CONNECTIONS_PER_IP)
+
+            # The next (cap+1) connection from the same IP is refused.
+            with pytest.raises(WSServerHandshakeError) as exc:
+                await client.ws_connect(WS_PATH)
+            assert exc.value.status == 429
+
+            # The already-open sockets are unaffected.
+            assert len(handler._conn.connections) == handler.MAX_CONNECTIONS_PER_IP
+        finally:
+            for ws in opened:
+                await ws.close()
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_a_different_ip_is_unaffected(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """The cap is strictly per source IP: a foreign IP being maxed out must
+        not block connections from a different (real) client IP."""
+        handler.MAX_CONNECTIONS_PER_IP = 3
+        # Pretend a completely different IP has already saturated its own quota.
+        handler._ip_connections["10.13.37.99"] = 999
+        client = await _make_client(handler)  # this client is 127.0.0.1
+        try:
+            ws = await client.ws_connect(WS_PATH)
+            await _wait_conns(handler, 1)
+            assert len(handler._conn.connections) == 1
+            # The foreign IP's count is untouched and independent.
+            assert handler._ip_connections["10.13.37.99"] == 999
+            await ws.close()
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_count_is_released_on_disconnect(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """Disconnecting frees the per-IP slot; when the last one closes the
+        key is dropped entirely so the dict stays bounded."""
+        handler.MAX_CONNECTIONS_PER_IP = 3
+        client = await _make_client(handler)
+        try:
+            ws = await client.ws_connect(WS_PATH)
+            await _wait_conns(handler, 1)
+            # The source IP now has exactly one tracked connection.
+            assert sum(handler._ip_connections.values()) == 1
+            key = next(iter(handler._ip_connections))
+
+            await ws.close()
+            # Give the server's finally-block a moment to run.
+            for _ in range(50):
+                await asyncio.sleep(0.01)
+                if key not in handler._ip_connections:
+                    break
+            # Count released; empty key popped.
+            assert key not in handler._ip_connections
+        finally:
+            await client.close()
+
+
+class TestPerIpJoinLimiter:
+    @pytest.mark.asyncio
+    async def test_join_flood_from_one_ip_is_rate_limited(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        """A burst of join attempts from one IP beyond the per-IP window is
+        answered with an error rather than accepted."""
+        game.start_game(language="de", num_rounds=3, difficulty="easy")
+        # Shrink the window so the test doesn't need 30 joins.
+        from custom_components.quizify.server.rate_limit import SlidingWindowLimiter
+
+        handler._join_limiter = SlidingWindowLimiter(
+            max_requests=2, window=60.0, clock=lambda: asyncio.get_event_loop().time()
+        )
+        client = await _make_client(handler)
+        try:
+            ws = await client.ws_connect(WS_PATH)
+            await _wait_conns(handler, 1)
+
+            errors = []
+            for i in range(4):
+                await ws.send_json({"type": "join", "name": f"P{i}"})
+            # Drain a few frames and count "Too many join attempts" errors.
+            for _ in range(20):
+                try:
+                    msg = await asyncio.wait_for(ws.receive(), timeout=0.1)
+                except TimeoutError:
+                    break
+                if msg.type == web.WSMsgType.TEXT:
+                    data = msg.json()
+                    if "join" in str(data.get("message", "")).lower():
+                        errors.append(data)
+            assert errors, "expected at least one per-IP join rate-limit error"
+            await ws.close()
+        finally:
+            await client.close()

--- a/tests/test_ws_token_relocation_359.py
+++ b/tests/test_ws_token_relocation_359.py
@@ -1,0 +1,188 @@
+"""Regression tests for issue #359 (P2 security).
+
+The admin session token used to be read from the WS URL query string
+(``?token=...``), so the long-lived credential landed in aiohttp/HA access
+logs, reverse-proxy logs and browser history.
+
+Fix: the token is now accepted via an ``X-Quizify-Token`` header OR — because a
+browser WS handshake can't set headers — via a first-message ``admin_auth``
+frame validated *before* admin is granted. The deprecated ``?token=`` query
+param is kept as a backward-compatible fallback.
+
+These drive the real ``handle()`` over a live aiohttp ``TestClient`` WebSocket
+(mirrors ``tests/test_ws_handle_integration_293.py``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server import WS_PATH  # noqa: E402
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    def create_task(self, coro):  # noqa: ANN001, ANN202
+        return asyncio.ensure_future(coro)
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func, *args)
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+@pytest.fixture
+def handler(game: QuizifyGameState) -> QuizifyWebSocketHandler:
+    runtime = _FakeRuntime(game._runtime.data_dir)  # type: ignore[attr-defined]
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    h._conn = ConnectionManager(runtime, lambda: game)
+    return h
+
+
+async def _make_client(handler: QuizifyWebSocketHandler) -> TestClient:
+    app = web.Application()
+    app.router.add_get(WS_PATH, handler.handle)
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    return client
+
+
+async def _connect(client: TestClient, handler: QuizifyWebSocketHandler, query=""):
+    ws = await client.ws_connect(WS_PATH + query)
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if len(handler._conn.connections) >= 1:
+            break
+    return ws
+
+
+async def _wait_admin(handler: QuizifyWebSocketHandler, count: int) -> None:
+    for _ in range(50):
+        await asyncio.sleep(0.01)
+        if len(handler._conn._admin_connections) == count:
+            return
+
+
+class TestAdminAuthFirstMessage:
+    @pytest.mark.asyncio
+    async def test_admin_auth_frame_grants_admin(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """A first-message ``admin_auth`` frame carrying the valid token grants
+        admin — with NO token anywhere in the URL."""
+        token = handler._conn.get_or_create_admin_token()  # token already exists
+        client = await _make_client(handler)
+        try:
+            # Bare ?role=admin, no ?token= → not admin at handshake (a token
+            # already exists on disk, so the bootstrap path does not fire).
+            ws = await _connect(handler=handler, client=client, query="?role=admin")
+            assert len(handler._conn._admin_connections) == 0
+
+            # Now authenticate out-of-URL.
+            await ws.send_json({"type": "admin_auth", "token": token})
+            await _wait_admin(handler, 1)
+            assert len(handler._conn._admin_connections) == 1
+            await ws.close()
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_admin_auth_bad_token_stays_player_fail_soft(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """A bad ``admin_auth`` token never closes the socket — the connection
+        stays a plain player (fail-soft, host can't lock itself out)."""
+        handler._conn.get_or_create_admin_token()
+        client = await _make_client(handler)
+        try:
+            ws = await _connect(handler=handler, client=client, query="?role=admin")
+            await ws.send_json({"type": "admin_auth", "token": "wrong-token"})
+            await asyncio.sleep(0.1)
+            assert len(handler._conn._admin_connections) == 0
+            # Socket still open + usable.
+            assert not ws.closed
+            assert len(handler._conn.connections) == 1
+            await ws.close()
+        finally:
+            await client.close()
+
+
+class TestQueryParamFallback:
+    @pytest.mark.asyncio
+    async def test_deprecated_token_query_param_still_grants_admin(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """The deprecated ``?token=`` fallback must keep working for mixed
+        old/new clients."""
+        token = handler._conn.get_or_create_admin_token()
+        client = await _make_client(handler)
+        try:
+            ws = await _connect(
+                handler=handler, client=client, query=f"?role=admin&token={token}"
+            )
+            await _wait_admin(handler, 1)
+            assert len(handler._conn._admin_connections) == 1
+            await ws.close()
+        finally:
+            await client.close()
+
+
+class TestHeaderToken:
+    @pytest.mark.asyncio
+    async def test_x_quizify_token_header_grants_admin(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """The token may also arrive in the ``X-Quizify-Token`` header (kept
+        out of the URL / logs) for non-browser clients."""
+        token = handler._conn.get_or_create_admin_token()
+        client = await _make_client(handler)
+        try:
+            ws = await client.ws_connect(
+                WS_PATH + "?role=admin", headers={"X-Quizify-Token": token}
+            )
+            await _wait_admin(handler, 1)
+            assert len(handler._conn._admin_connections) == 1
+            await ws.close()
+        finally:
+            await client.close()
+
+
+class TestTokenNotRequiredInUrl:
+    @pytest.mark.asyncio
+    async def test_url_no_longer_carries_token(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """End-to-end proof that admin control is reachable without the token
+        ever appearing in the WS URL: bare ?role=admin + admin_auth frame."""
+        token = handler._conn.get_or_create_admin_token()
+        client = await _make_client(handler)
+        try:
+            ws = await _connect(handler=handler, client=client, query="?role=admin")
+            await ws.send_json({"type": "admin_auth", "token": token})
+            await _wait_admin(handler, 1)
+            assert handler._conn.is_admin_connection(
+                next(iter(handler._conn._admin_connections))
+            )
+            await ws.close()
+        finally:
+            await client.close()


### PR DESCRIPTION
Fixes #359
Fixes #361

Two related hardening fixes to the WebSocket `handle()` path, bundled together to avoid conflicts.

## #359 — admin token out of the WS URL (P2 security)
The admin session token was read from the WS URL query string (`admin_token = request.query.get("token")`), so the long-lived credential leaked into aiohttp/HA access logs, reverse-proxy logs and browser history.

- The token is now accepted via an `X-Quizify-Token` **header** OR a first-message **`admin_auth`** frame (browsers can't set headers on a WS handshake), validated **before** `is_admin` is granted.
- `?token=` is kept as a **deprecated fallback** (not removed) for backward compat / mixed old-new clients.
- The admin frontend (`admin.js`) now opens the socket and sends `{type:"admin_auth", token: ...}` first, and **no longer appends `&token=` to the URL**.
- **Fail-soft:** a bad/absent token never closes the socket — it just stays a plain player, so the host can never lock itself out. Fresh-install bootstrap (token-less `?role=admin`) still grants admin.

## #361 — per-IP WS connection + join cap (P2 security)
`handle()` accepted unlimited WebSocket connections; the existing flood guard is per-connection (keyed on `id(ws)`), so opening N sockets bypassed it entirely.

- Added a per-IP concurrent-connection counter keyed on `request.remote`, refused **before** `ws.prepare()` with HTTP 429 beyond `MAX_CONNECTIONS_PER_IP = 15` (generous — one device never legitimately needs that many; only a socket flood trips it).
- Added a per-IP `SlidingWindowLimiter` (30 joins / 60s) on join attempts.
- The per-IP count is decremented on disconnect and the key popped at zero, so the dict stays bounded by currently-connected IPs.
- Deliberately generous so legit multi-player-behind-one-NAT and reconnect churn are never blocked (safety over strictness). Caveat noted in-code: behind a reverse proxy that collapses all clients to one source IP without `X-Forwarded-For`, raise the cap.

## Tests
- `tests/test_ws_token_relocation_359.py` — admin_auth first-message grants admin; header token works; `?token=` fallback still works; bare `?role=admin` + admin_auth proves the URL no longer carries the token; bad token fails soft.
- `tests/test_ws_per_ip_cap_361.py` — Nth connection from one IP refused (429); different IP unaffected; count released on disconnect; per-IP join flood limited.
- Full suite: 814 passed, 5 skipped. `ruff check custom_components/` clean.

## ⚠️ Live-verify recommended before merge
This is the fragile admin path — please live-check on the real HA before shipping:
- The admin dashboard still connects and controls the game (start/next/reveal etc.) with the token sent via `admin_auth` instead of the URL.
- A fresh admin bootstrap (no persisted token yet) still works — first `?role=admin` tab claims admin.
- Legit multi-player from one network still joins (no false per-IP refusals for a normal room).

🤖 Generated with [Claude Code](https://claude.com/claude-code)