### PR TITLE
fix(ux): Cast-to-TV link on Android Companion + dashboard reduced-motion (#377, #381)

### DIFF
--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -1124,6 +1124,22 @@
             }
             .dashboard-left.has-image .dashboard-question-image { max-height: 32vh; }
         }
+
+        /* Honor prefers-reduced-motion: the always-on TV must respect the OS
+           reduced-motion setting. dashboard.html is self-contained (no
+           styles.css), so the house-style override from css/src/00-tokens.css
+           is duplicated here to tame the continuous animations above
+           (pulse-bar, fade-pulse, spotlight-in, award-appear) (#381). */
+        @media (prefers-reduced-motion: reduce) {
+            *,
+            *::before,
+            *::after {
+                animation-duration: 0.01ms !important;
+                animation-iteration-count: 1 !important;
+                transition-duration: 0.01ms !important;
+                scroll-behavior: auto !important;
+            }
+        }
     </style>
 </head>
 <body class="dashboard-body">

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -1984,12 +1984,30 @@
         }
     });
 
+    // The Android HA Companion WebView silently swallows target="_blank"
+    // (see launcher.html #348). Detect that context so we can navigate
+    // window.location directly instead of relying on a dead new-tab link.
+    function isAndroidCompanion() {
+        var ua = navigator.userAgent || '';
+        return /Android/i.test(ua) && /Home ?Assistant/i.test(ua);
+    }
+
     // ---- Generate join URL ----
     function initJoinUrl() {
         var joinUrl = window.location.origin + '/quizify/player';
         generateQR(joinUrl);
         if (els.dashboardLink) {
-            els.dashboardLink.href = window.location.origin + '/quizify/dashboard';
+            var dashboardUrl = window.location.origin + '/quizify/dashboard';
+            els.dashboardLink.href = dashboardUrl;
+            // Android Companion: bypass the dead target="_blank" — navigate the
+            // current frame so the dashboard ("Cast to TV") actually loads (#377).
+            // Every other context keeps the native new-tab behaviour.
+            els.dashboardLink.addEventListener('click', function (evt) {
+                if (isAndroidCompanion()) {
+                    evt.preventDefault();
+                    window.location.href = dashboardUrl;
+                }
+            });
         }
     }
 

--- a/tests/test_ux_castlink_motion_377_381.py
+++ b/tests/test_ux_castlink_motion_377_381.py
@@ -1,0 +1,40 @@
+"""Guard tests for two self-contained UX fixes.
+
+#377 — Cast-to-TV link dead in the Android HA Companion WebView (which
+       swallows target="_blank"). admin.js must detect the Companion and
+       navigate window.location to the dashboard instead.
+#381 — dashboard.html (self-contained, no styles.css) ignored the OS
+       prefers-reduced-motion setting on the always-on TV.
+
+These are static-source assertions: the frontend assets are not bundled,
+so we read them as text.
+"""
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WWW = _REPO_ROOT / "custom_components" / "quizify" / "www"
+
+
+def test_admin_js_intercepts_cast_link_on_android_companion() -> None:
+    """#377: admin.js must port the isAndroidCompanion workaround and, on
+    Companion Android, navigate to the dashboard instead of relying on the
+    dead target="_blank" Cast-to-TV link."""
+    admin_js = (_WWW / "js" / "admin.js").read_text(encoding="utf-8")
+    assert "isAndroidCompanion" in admin_js
+    # The helper must be wired to a click handler on the dashboard link.
+    assert "dashboardLink" in admin_js
+    assert "addEventListener('click'" in admin_js
+    assert "preventDefault" in admin_js
+    assert "/quizify/dashboard" in admin_js
+
+
+def test_dashboard_html_honors_prefers_reduced_motion() -> None:
+    """#381: dashboard.html's inline <style> must carry a reduced-motion
+    override block, since it does not load styles.css."""
+    dashboard = (_WWW / "dashboard.html").read_text(encoding="utf-8")
+    assert "@media (prefers-reduced-motion: reduce)" in dashboard
+    # Standard house-style override values (see css/src/00-tokens.css).
+    assert "animation-duration: 0.01ms !important" in dashboard
+    assert "animation-iteration-count: 1 !important" in dashboard
+    assert "transition-duration: 0.01ms !important" in dashboard


### PR DESCRIPTION
Fixes #377
Fixes #381

## #377 — Cast-to-TV link dead in the Android HA Companion
The admin "Cast to TV" link (`#dashboard-link`) uses `target="_blank"`, which the Android HA Companion WebView silently swallows, so tapping it did nothing. `launcher.html` already documents and works around this for the #348 launcher button via an `isAndroidCompanion()` UA check.

This ports that helper into `admin.js`: on Companion Android the click is `preventDefault()`ed and `window.location` is navigated to `/quizify/dashboard`. Desktop, iOS Companion, and standalone browsers keep the native new-tab behaviour.

## #381 — Dashboard ignores prefers-reduced-motion
`dashboard.html` is self-contained (it does NOT load `styles.css`) and its inline `<style>` runs continuous animations (`pulse-bar`, `fade-pulse`, `spotlight-in`, `award-appear`) with no reduced-motion guard. Added the standard `@media (prefers-reduced-motion: reduce)` override block (matching `css/src/00-tokens.css` house style) so the always-on TV honors the OS reduced-motion setting.

## Tests
Adds `tests/test_ux_castlink_motion_377_381.py` (static source assertions — assets are not bundled). Full suite: 865 passed, 5 skipped. `ruff check` clean.

## Mobile-verify needed before merge
- Android HA Companion: tapping "Cast to TV" in the admin panel opens the dashboard **inside** the Companion app (no dead link / no silent no-op). Desktop still opens a new tab.
- TV / dashboard: with OS "reduce motion" enabled, the dashboard animations (pulse bar, spotlight, award reveal) do not loop/animate continuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)