### PR TITLE
fix(ux): iOS safe-area on bottom bars + AA contrast on end screen (#375, #382)

### DIFF
--- a/custom_components/quizify/www/css/src/07-player.css
+++ b/custom_components/quizify/www/css/src/07-player.css
@@ -88,7 +88,8 @@
 .end-hero-conf--r { top: 12px; right: 24px; }
 .end-hero-crown { font-size: 30px; line-height: 1; }
 .end-hero-label {
-    font-size: 0.66rem;
+    /* 12px floor so the label clears WCAG AA min-size on small phones (#382). */
+    font-size: max(0.66rem, 12px);
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.1em;
@@ -161,7 +162,8 @@
 .rchip-disc.disc-sky   { background: rgba(127, 168, 196, 0.18); color: var(--color-accent-blue); }
 .rchip-main { min-width: 0; }
 .rchip-title {
-    font-size: 0.66rem;
+    /* 12px floor + AA-contrast muted token (#382). */
+    font-size: max(0.66rem, 12px);
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.04em;
@@ -177,9 +179,9 @@
     line-height: 1.1;
 }
 .rchip-who {
-    font-size: 0.64rem;
+    /* 12px floor; drop opacity trick so the muted token keeps its AA contrast (#382). */
+    font-size: max(0.64rem, 12px);
     color: var(--color-text-muted);
-    opacity: 0.85;
     margin-top: 1px;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -246,7 +248,8 @@
 .sb-badge { font-size: 0.82rem; line-height: 1; }
 .sb-you {
     flex-shrink: 0;
-    font-size: 9px;
+    /* 12px floor so the "YOU" badge label clears WCAG AA min-size (#382). */
+    font-size: 12px;
     font-weight: 800;
     letter-spacing: 0.04em;
     color: #fff;
@@ -438,9 +441,9 @@
 
 .end-hint {
     text-align: center;
-    color: var(--color-text-neon-muted);
-    font-size: 0.75rem;
-    opacity: 0.7;
+    /* AA-contrast muted token, no opacity trick; 12px floor (#382). */
+    color: var(--color-text-muted);
+    font-size: max(0.75rem, 12px);
 }
 
 .away-badge {
@@ -2081,6 +2084,9 @@
     align-items: center;
     justify-content: space-around;
     padding: var(--space-sm) var(--space-md);
+    /* iOS safe-area: viewport-fit=cover puts the home indicator over the
+       fixed bottom bar; pad the bottom by the inset so labels stay clear (#375). */
+    padding-bottom: calc(var(--space-sm) + env(safe-area-inset-bottom, 0px));
     /* Solid cream (was 96%-opaque + blur). A `position: fixed` element with
        `backdrop-filter` is a WebKit bug: Safari positions it relative to its
        container instead of the viewport, so the bar rendered mid-page on iOS

--- a/custom_components/quizify/www/css/src/08-responsive.css
+++ b/custom_components/quizify/www/css/src/08-responsive.css
@@ -884,7 +884,8 @@ body.is-admin .pl-result-hero--big .pl-result-big-points { font-size: 84px; }
   position: fixed;
   left: 16px;
   right: 16px;
-  bottom: 16px;
+  /* iOS safe-area: keep the sticky Next-Round bar above the home indicator (#375). */
+  bottom: calc(16px + env(safe-area-inset-bottom, 0px));
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 8px;

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -3105,7 +3105,8 @@ footer {
 .end-hero-conf--r { top: 12px; right: 24px; }
 .end-hero-crown { font-size: 30px; line-height: 1; }
 .end-hero-label {
-    font-size: 0.66rem;
+    /* 12px floor so the label clears WCAG AA min-size on small phones (#382). */
+    font-size: max(0.66rem, 12px);
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.1em;
@@ -3178,7 +3179,8 @@ footer {
 .rchip-disc.disc-sky   { background: rgba(127, 168, 196, 0.18); color: var(--color-accent-blue); }
 .rchip-main { min-width: 0; }
 .rchip-title {
-    font-size: 0.66rem;
+    /* 12px floor + AA-contrast muted token (#382). */
+    font-size: max(0.66rem, 12px);
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.04em;
@@ -3194,9 +3196,9 @@ footer {
     line-height: 1.1;
 }
 .rchip-who {
-    font-size: 0.64rem;
+    /* 12px floor; drop opacity trick so the muted token keeps its AA contrast (#382). */
+    font-size: max(0.64rem, 12px);
     color: var(--color-text-muted);
-    opacity: 0.85;
     margin-top: 1px;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -3263,7 +3265,8 @@ footer {
 .sb-badge { font-size: 0.82rem; line-height: 1; }
 .sb-you {
     flex-shrink: 0;
-    font-size: 9px;
+    /* 12px floor so the "YOU" badge label clears WCAG AA min-size (#382). */
+    font-size: 12px;
     font-weight: 800;
     letter-spacing: 0.04em;
     color: #fff;
@@ -3455,9 +3458,9 @@ footer {
 
 .end-hint {
     text-align: center;
-    color: var(--color-text-neon-muted);
-    font-size: 0.75rem;
-    opacity: 0.7;
+    /* AA-contrast muted token, no opacity trick; 12px floor (#382). */
+    color: var(--color-text-muted);
+    font-size: max(0.75rem, 12px);
 }
 
 .away-badge {
@@ -5098,6 +5101,9 @@ footer {
     align-items: center;
     justify-content: space-around;
     padding: var(--space-sm) var(--space-md);
+    /* iOS safe-area: viewport-fit=cover puts the home indicator over the
+       fixed bottom bar; pad the bottom by the inset so labels stay clear (#375). */
+    padding-bottom: calc(var(--space-sm) + env(safe-area-inset-bottom, 0px));
     /* Solid cream (was 96%-opaque + blur). A `position: fixed` element with
        `backdrop-filter` is a WebKit bug: Safari positions it relative to its
        container instead of the viewport, so the bar rendered mid-page on iOS
@@ -7479,7 +7485,8 @@ body.is-admin .pl-result-hero--big .pl-result-big-points { font-size: 84px; }
   position: fixed;
   left: 16px;
   right: 16px;
-  bottom: 16px;
+  /* iOS safe-area: keep the sticky Next-Round bar above the home indicator (#375). */
+  bottom: calc(16px + env(safe-area-inset-bottom, 0px));
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 8px;

--- a/tests/test_ux_css_375_382.py
+++ b/tests/test_ux_css_375_382.py
@@ -1,0 +1,54 @@
+"""Guard the two UX/CSS fixes for #375 (iOS safe-area) and #382 (AA contrast).
+
+These are text-level assertions over the committed CSS source modules — they
+lock in the safe-area padding on the fixed bottom bars and the 12px font-size
+floor on the celebratory end-screen labels so a later edit can't silently
+regress them.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = REPO / "custom_components" / "quizify" / "www" / "css" / "src"
+
+
+def _rule(css: str, selector: str) -> str:
+    """Return the declaration block for the first rule matching ``selector``."""
+    idx = css.index(selector)
+    start = css.index("{", idx)
+    end = css.index("}", start)
+    return css[start + 1 : end]
+
+
+def test_admin_control_bar_has_safe_area_bottom() -> None:
+    css = (SRC / "07-player.css").read_text("utf-8")
+    block = _rule(css, ".admin-control-bar {")
+    assert "env(safe-area-inset-bottom" in block, (
+        ".admin-control-bar must pad its bottom by the iOS safe-area inset (#375)"
+    )
+
+
+def test_pl_result_admin_bar_has_safe_area_bottom() -> None:
+    css = (SRC / "08-responsive.css").read_text("utf-8")
+    block = _rule(css, ".pl-result-admin-bar {")
+    assert "env(safe-area-inset-bottom" in block, (
+        ".pl-result-admin-bar bottom offset must include the iOS safe-area inset (#375)"
+    )
+
+
+def test_end_screen_labels_have_12px_font_floor() -> None:
+    """No sub-11px font-size on the celebratory end-screen labels (#382)."""
+    css = (SRC / "07-player.css").read_text("utf-8")
+    px_re = re.compile(r"font-size:\s*([0-9.]+)px")
+    rem_re = re.compile(r"font-size:\s*([0-9.]+)rem")
+    for selector in (".rchip-title {", ".rchip-who {", ".end-hero-label {", ".sb-you {", ".end-hint {"):
+        block = _rule(css, selector)
+        # A bare rem/px font-size under 11px (≈0.69rem at 16px root) is a regression.
+        for m in px_re.finditer(block):
+            assert float(m.group(1)) >= 11.0, f"{selector} has a sub-11px font-size (#382)"
+        for m in rem_re.finditer(block):
+            # A rem value only survives if it's floored via max(...) — checked below.
+            assert "max(" in block, f"{selector} rem font-size needs a 12px floor via max() (#382)"


### PR DESCRIPTION
Fixes #375
Fixes #382

## #375 — iOS safe-area cut-off
`player.html` uses `viewport-fit=cover`, so the two fixed bottom bars had their labels sitting under the iPhone home indicator.
- `.admin-control-bar` (`www/css/src/07-player.css`): added `padding-bottom: calc(var(--space-sm) + env(safe-area-inset-bottom, 0px))`, keeping the existing padding on the other sides.
- `.pl-result-admin-bar` (`www/css/src/08-responsive.css`): changed `bottom: 16px` to `bottom: calc(16px + env(safe-area-inset-bottom, 0px))`.

Matches the existing `safe-area-inset-bottom` pattern already used elsewhere in the stylesheet.

## #382 — sub-11px low-contrast end-screen text
Several celebratory end-screen labels rendered at ~9-10.5px in a muted ~3:1 color. In `www/css/src/07-player.css`:
- `.rchip-title`, `.rchip-who`, `.end-hero-label`, `.end-hint`: 12px floor via `font-size: max(<rem>, 12px)`.
- `.sb-you`: raised `9px` to `12px`.
- Switched `.rchip-who` and `.end-hint` off opacity tricks / `--color-text-neon-muted` to the AA-contrast `--color-text-muted` (~4.9:1) token.

Layout untouched — only size floor + color token.

Rebuilt `styles.css` from the `src/` modules (`scripts/build_css.py`). Added `tests/test_ux_css_375_382.py` as a text-level guard. Full suite (866 passed, 5 skipped) and `ruff` green.

## Mobile-verify needed before merge
On a 390x844 (iPhone) viewport with `viewport-fit=cover`:
- Admin bar buttons (Skip / Pause / Next / End) and the sticky Next-Round bar sit fully clear of the home indicator.
- End-screen chip labels (`.rchip-title` / `.rchip-who`), the "YOU" badge, hero label, and `.end-hint` are legible (>=12px, AA contrast).

🤖 Generated with [Claude Code](https://claude.com/claude-code)