### PR TITLE
fix: guard start-grace continuation + drain reaction flush (#352, #354)

### DIFF
--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -1107,6 +1107,17 @@ class QuizifyWebSocketHandler:
                 "player_name": player_name,
             })
 
+        # Reactions that arrived DURING the broadcasts above were appended to
+        # the buffer, but _enqueue_reaction won't start a new flush while this
+        # task is still running (it isn't None/done yet) — so without this the
+        # tail would sit unbroadcast until some future reaction happened to
+        # arrive (#354). Re-arm the flush ourselves so the buffer always
+        # drains: one more window, then another pass. Loops until empty.
+        if self._reaction_buffer:
+            self._reaction_flush_task = self._runtime.create_task(
+                self._flush_reactions_after_window()
+            )
+
     def _cancel_reaction_flush(self) -> None:
         """Cancel any pending reaction-flush task (called on cleanup)."""
         if self._reaction_flush_task is not None:
@@ -1335,6 +1346,13 @@ class QuizifyWebSocketHandler:
         # wired (standalone dev server, HA without a TTS entity).
         self._apply_tts_config(data.get("tts") or {})
 
+        # Snapshot the game_id start_game just minted (#352). We're about to
+        # yield the loop for the grace sleep below; another admin socket can
+        # slip in a reset_game (game_id -> None) or a second start_game (new
+        # game_id) during that window. Both re-arm state under us, so we must
+        # re-validate before firing the stale continuation.
+        started_game_id = game_state.game_id
+
         # Grace period before round 1's timer starts.
         # The admin-as-player flow redirects the admin tab from /quizify/admin
         # to /quizify/player AFTER sending start_game. That navigation +
@@ -1346,6 +1364,21 @@ class QuizifyWebSocketHandler:
         # rounds (Next Round button click) don't have this gap since the
         # admin is already on the player view.
         await asyncio.sleep(self.START_REDIRECT_GRACE)
+
+        # Re-validate after waking (#352): if a concurrent reset_game or a
+        # second start_game landed during the grace window, game_id changed
+        # (or phase moved past LOBBY) — firing the first question now would
+        # push a round into a reset/zero-player lobby or double-advance and
+        # wedge the round. Bail instead; the winning command owns the game.
+        if game_state.game_id != started_game_id or game_state.phase != GamePhase.LOBBY:
+            _LOGGER.info(
+                "start_game grace continuation aborted: game changed during "
+                "grace window (game_id %s -> %s, phase %s)",
+                started_game_id,
+                game_state.game_id,
+                game_state.phase,
+            )
+            return
 
         # Start the first question
         await self._start_next_question(game_state)
@@ -1479,9 +1512,23 @@ class QuizifyWebSocketHandler:
         except ValueError as err:
             await self._conn.send_error(ws, ERR_GAME_ALREADY_STARTED, str(err))
             return
+        # Snapshot the freshly-minted game_id before the grace sleep (#352) —
+        # same concurrency guard as _handle_start_game: a reset_game or a
+        # second start/play_again from another admin socket during the grace
+        # window re-arms state, and the stale continuation must not fire.
+        started_game_id = game_state.game_id
         # Same redirect grace as start_game — admin tab is still on the finale
         # view and needs to redirect/reconnect before round 1's timer ticks.
         await asyncio.sleep(self.START_REDIRECT_GRACE)
+        if game_state.game_id != started_game_id or game_state.phase != GamePhase.LOBBY:
+            _LOGGER.info(
+                "play_again grace continuation aborted: game changed during "
+                "grace window (game_id %s -> %s, phase %s)",
+                started_game_id,
+                game_state.game_id,
+                game_state.phase,
+            )
+            return
         await self._start_next_question(game_state)
 
     async def _handle_reset_game(

--- a/tests/test_reaction_flush_drain_354.py
+++ b/tests/test_reaction_flush_drain_354.py
@@ -1,0 +1,140 @@
+"""Regression test (#354): reactions that arrive DURING a flush must
+still be broadcast.
+
+_flush_reactions_after_window snapshots + clears _reaction_buffer, then
+awaits one broadcast per entry. A reaction arriving during those awaits
+is appended to the buffer, but _enqueue_reaction only arms a NEW flush
+task when the current one is None/done — and mid-flush it is neither.
+Previously the flush coroutine returned without re-checking the buffer,
+so the late reaction sat unbroadcast until some future reaction happened
+to arrive (or was dropped on cleanup).
+
+The fix re-arms the flush task at the end of the coroutine whenever the
+buffer is non-empty, looping until the buffer is drained.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    def create_task(self, coro):
+        return asyncio.ensure_future(coro)
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    runtime = _FakeRuntime(tmp_path)
+    return QuizifyGameState(runtime=runtime, entry_id="test")
+
+
+@pytest.fixture
+def handler(game: QuizifyGameState) -> QuizifyWebSocketHandler:
+    runtime = _FakeRuntime(game._runtime.data_dir)  # type: ignore[attr-defined]
+    h = QuizifyWebSocketHandler(
+        runtime=runtime,
+        game_state_provider=lambda: game,
+    )
+    h._conn = ConnectionManager(runtime, lambda: game)
+    # Fast window so the tests don't crawl.
+    h._REACTION_FLUSH_WINDOW = 0.02
+    return h
+
+
+async def _wait_flush_idle(handler: QuizifyWebSocketHandler, timeout: float = 2.0):
+    """Wait until the buffer is drained and no flush task is pending."""
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        task = handler._reaction_flush_task
+        idle = (task is None or task.done()) and not handler._reaction_buffer
+        if idle:
+            return
+        await asyncio.sleep(handler._REACTION_FLUSH_WINDOW / 2)
+    raise AssertionError("flush never went idle (buffer not drained)")
+
+
+class TestReactionFlushDrain:
+    @pytest.mark.asyncio
+    async def test_reaction_arriving_during_flush_is_broadcast(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        broadcasts: list[dict] = []
+        injected = {"done": False}
+
+        async def fake_broadcast(msg: dict) -> None:
+            broadcasts.append(msg)
+            # Simulate a reaction landing WHILE the first flush is awaiting
+            # its broadcasts — exactly the window the bug stranded.
+            if not injected["done"]:
+                injected["done"] = True
+                handler._enqueue_reaction("Bob", "🎉")
+
+        handler._conn.broadcast = fake_broadcast  # type: ignore[assignment]
+
+        handler._enqueue_reaction("Alice", "👏")
+        await _wait_flush_idle(handler)
+
+        pairs = {(m["player_name"], m["emoji"]) for m in broadcasts}
+        assert ("Alice", "👏") in pairs
+        # The late reaction was NOT stranded — it got broadcast too.
+        assert ("Bob", "🎉") in pairs
+
+    @pytest.mark.asyncio
+    async def test_multiple_late_reactions_all_drain(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """Several reactions arriving across successive flush passes all
+        eventually broadcast; the buffer ends empty (loop terminates)."""
+        broadcasts: list[dict] = []
+        remaining = ["🔥", "😂", "🎯"]
+
+        async def fake_broadcast(msg: dict) -> None:
+            broadcasts.append(msg)
+            if remaining:
+                handler._enqueue_reaction("Bob", remaining.pop(0))
+
+        handler._conn.broadcast = fake_broadcast  # type: ignore[assignment]
+
+        handler._enqueue_reaction("Alice", "👏")
+        await _wait_flush_idle(handler)
+
+        pairs = {(m["player_name"], m["emoji"]) for m in broadcasts}
+        for emoji in ("👏", "🔥", "😂", "🎯"):
+            assert ("Bob", emoji) in pairs or ("Alice", emoji) in pairs
+        assert not handler._reaction_buffer
+
+    @pytest.mark.asyncio
+    async def test_no_late_reaction_terminates_cleanly(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """The happy path still stops after one window — no runaway
+        re-arming when nothing arrives during the flush."""
+        handler._conn.broadcast = AsyncMock()
+
+        handler._enqueue_reaction("Alice", "👏")
+        await _wait_flush_idle(handler)
+
+        handler._conn.broadcast.assert_awaited_once()
+        assert not handler._reaction_buffer
+        assert (
+            handler._reaction_flush_task is None
+            or handler._reaction_flush_task.done()
+        )

--- a/tests/test_start_grace_guard_352.py
+++ b/tests/test_start_grace_guard_352.py
@@ -1,0 +1,196 @@
+"""Regression test (#352): the start_game / play_again grace-window
+continuation must re-validate game state before firing round 1.
+
+Both _handle_start_game and _handle_play_again mint a fresh game_id,
+then `await asyncio.sleep(START_REDIRECT_GRACE)` (~2.5s) to give the
+admin-as-player tab time to redirect+reconnect, then UNCONDITIONALLY
+called `_start_next_question`. During that yield another admin socket
+can:
+
+  * send reset_game  -> game_id cleared, players dropped. The stale
+    continuation would fire round 1 into a reset / zero-player lobby.
+  * send a second start_game -> a NEW game_id is minted. The first
+    continuation would then double-advance and wedge the round (two
+    _start_next_question calls, timers fighting).
+
+The fix snapshots the minted game_id BEFORE the sleep and, after
+waking, only starts the question when `game_id` is unchanged AND the
+phase is still LOBBY. Otherwise it bails.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    def create_task(self, coro):
+        return asyncio.ensure_future(coro)
+
+
+def _ws(closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    ws.send_json = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    runtime = _FakeRuntime(tmp_path)
+    return QuizifyGameState(runtime=runtime, entry_id="test")
+
+
+@pytest.fixture
+def handler(game: QuizifyGameState) -> QuizifyWebSocketHandler:
+    runtime = _FakeRuntime(game._runtime.data_dir)  # type: ignore[attr-defined]
+    h = QuizifyWebSocketHandler(
+        runtime=runtime,
+        game_state_provider=lambda: game,
+    )
+    h._conn = ConnectionManager(runtime, lambda: game)
+    h._conn.broadcast = AsyncMock()
+    # Short grace so the tests don't wait 2.5s.
+    h.START_REDIRECT_GRACE = 0.1
+    return h
+
+
+_START_DATA = {
+    "num_rounds": 3,
+    "difficulty": "easy",
+    "language": "de",
+    "lightning_enabled": False,
+}
+
+
+class TestStartGraceGuard:
+    @pytest.mark.asyncio
+    async def test_reset_during_grace_starts_no_question(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        """A reset_game landing during the grace window (game_id cleared)
+        must abort the stale continuation — no round is started into the
+        reset lobby."""
+        admin_ws = _ws()
+        game.add_player("Admin", admin_ws)
+        game.get_player("Admin").is_admin = True
+
+        start_spy = AsyncMock()
+        handler._start_next_question = start_spy  # type: ignore[assignment]
+
+        task = asyncio.ensure_future(
+            handler._handle_start_game(admin_ws, dict(_START_DATA), game)
+        )
+        # Let it reach start_game + the grace sleep.
+        await asyncio.sleep(handler.START_REDIRECT_GRACE / 2)
+        assert game.game_id is not None  # start_game minted an id
+        assert game.phase == GamePhase.LOBBY
+
+        # Concurrent reset_game lands: clears game_id, back to a fresh lobby.
+        game.reset_to_lobby()
+        assert game.game_id is None
+
+        await task
+
+        start_spy.assert_not_called()
+        assert game.phase == GamePhase.LOBBY
+
+    @pytest.mark.asyncio
+    async def test_second_start_during_grace_does_not_wedge(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        """A second start_game arriving during the first one's grace window
+        mints a new game_id. Exactly ONE question must start (the winner's),
+        not two — otherwise the round double-advances / wedges."""
+        admin_ws = _ws()
+        game.add_player("Admin", admin_ws)
+        game.get_player("Admin").is_admin = True
+
+        start_spy = AsyncMock()
+        handler._start_next_question = start_spy  # type: ignore[assignment]
+
+        first = asyncio.ensure_future(
+            handler._handle_start_game(admin_ws, dict(_START_DATA), game)
+        )
+        # Let the first reach its grace sleep.
+        await asyncio.sleep(handler.START_REDIRECT_GRACE / 2)
+        first_game_id = game.game_id
+        assert first_game_id is not None
+
+        # Second start_game from another admin socket, while first is asleep.
+        second = asyncio.ensure_future(
+            handler._handle_start_game(admin_ws, dict(_START_DATA), game)
+        )
+        await asyncio.sleep(handler.START_REDIRECT_GRACE / 4)
+        # A brand-new game_id was minted by the second start.
+        assert game.game_id is not None
+        assert game.game_id != first_game_id
+
+        await asyncio.gather(first, second)
+
+        # Only the winning (second) continuation fired the question.
+        assert start_spy.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_clean_start_still_starts_question(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        """No interference: the continuation must still fire normally."""
+        admin_ws = _ws()
+        game.add_player("Admin", admin_ws)
+        game.get_player("Admin").is_admin = True
+
+        start_spy = AsyncMock()
+        handler._start_next_question = start_spy  # type: ignore[assignment]
+
+        await handler._handle_start_game(admin_ws, dict(_START_DATA), game)
+
+        start_spy.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_play_again_reset_during_grace_starts_no_question(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        """Same guard on the play_again path: a reset during its grace
+        window aborts the continuation."""
+        admin_ws = _ws()
+        game.add_player("Admin", admin_ws)
+        game.get_player("Admin").is_admin = True
+        # Prime last_settings so play_again takes the rematch path.
+        game.start_game(num_rounds=3, difficulty="easy", language="de")
+        game.reset_to_lobby()
+        assert game.last_settings
+
+        start_spy = AsyncMock()
+        handler._start_next_question = start_spy  # type: ignore[assignment]
+
+        task = asyncio.ensure_future(handler._handle_play_again(admin_ws, game))
+        await asyncio.sleep(handler.START_REDIRECT_GRACE / 2)
+        assert game.game_id is not None
+
+        game.reset_to_lobby()  # concurrent reset lands
+
+        await task
+
+        start_spy.assert_not_called()
+        assert game.phase == GamePhase.LOBBY


### PR DESCRIPTION
Fixes #352
Fixes #354

## #352 — start-grace continuation guard (P1 concurrency)

`_handle_start_game` and `_handle_play_again` mint a fresh `game_id`, then `await asyncio.sleep(START_REDIRECT_GRACE)` (~2.5s) before unconditionally calling `_start_next_question`. During that yield another admin socket can send `reset_game` (clears `game_id`, drops players) or a second `start_game` (mints a new `game_id`). The stale continuation then fired round 1 into a reset / zero-player lobby, or double-advanced and wedged the round (two `_start_next_question` calls, no timer ticks).

Fix: snapshot the minted `game_id` before the grace sleep and, after waking, only start the question when `game_state.game_id` is unchanged **and** the phase is still `LOBBY`; otherwise log and bail. Applied to both handlers.

## #354 — reaction flush drain (P2)

`_flush_reactions_after_window` snapshots + clears `_reaction_buffer`, then awaits one broadcast per entry. Reactions arriving during those awaits are appended to the buffer, but `_enqueue_reaction` won't arm a new flush while the current task is still running, and the coroutine returned without re-checking — so the tail sat unbroadcast until some future reaction arrived (or was dropped on cleanup).

Fix: at the end of the coroutine, if the buffer is non-empty, re-arm the flush task; it loops until drained. Windowing behavior is unchanged.

## Tests

- `tests/test_start_grace_guard_352.py` — reset during grace starts no question; a second start doesn't wedge (exactly one question starts); clean start still fires; play_again path guarded.
- `tests/test_reaction_flush_drain_354.py` — reactions enqueued during a flush are eventually broadcast; multiple late arrivals all drain; happy path terminates cleanly.

Full suite: 883 passed, 5 skipped. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)