### PR TITLE
fix(a11y): expand sub-44px touch targets — sound toggle + setup chips (#379)

### DIFF
--- a/custom_components/quizify/www/css/src/01-base.css
+++ b/custom_components/quizify/www/css/src/01-base.css
@@ -317,6 +317,7 @@ body {
    default (warm card-alt fill, reduced opacity); dims further when muted.
    Behaviour + persistence unchanged (player-core.js setupSoundToggle). */
 .sound-toggle-btn {
+    position: relative;
     flex: 0 0 auto;
     width: 30px;
     height: 30px;
@@ -333,6 +334,15 @@ body {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+}
+/* Expand the tap target to >=44px (WCAG 2.5.8 / Apple HIG) without growing
+   the visible 30px disc: a transparent ::before overlay with negative inset
+   extends the hit area to 44x44 (30 + 2*7) (#379). */
+.sound-toggle-btn::before {
+    content: '';
+    position: absolute;
+    inset: -7px;
+    border-radius: inherit;
 }
 .sound-toggle-btn:hover { opacity: 1; }
 .sound-toggle-btn.is-muted { opacity: 0.5; }

--- a/custom_components/quizify/www/css/src/02-shared.css
+++ b/custom_components/quizify/www/css/src/02-shared.css
@@ -256,8 +256,15 @@ button, .btn {
 }
 
 .chip {
-    padding: 4px 10px;
-    font-size: 0.75rem;
+    /* min-height 44px keeps difficulty/rounds/timer chips finger-friendly
+       (WCAG 2.5.8 / Apple HIG >=44px) (#379). The flag-chip variant below
+       re-declares its own padding/min-height, so it is unaffected. */
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    padding: 10px 14px;
+    font-size: 0.85rem;
     font-weight: 500;
     background: #F3EEDF;
     border: 1px solid #E5DFCF;

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -645,6 +645,7 @@ body {
    default (warm card-alt fill, reduced opacity); dims further when muted.
    Behaviour + persistence unchanged (player-core.js setupSoundToggle). */
 .sound-toggle-btn {
+    position: relative;
     flex: 0 0 auto;
     width: 30px;
     height: 30px;
@@ -661,6 +662,15 @@ body {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+}
+/* Expand the tap target to >=44px (WCAG 2.5.8 / Apple HIG) without growing
+   the visible 30px disc: a transparent ::before overlay with negative inset
+   extends the hit area to 44x44 (30 + 2*7) (#379). */
+.sound-toggle-btn::before {
+    content: '';
+    position: absolute;
+    inset: -7px;
+    border-radius: inherit;
 }
 .sound-toggle-btn:hover { opacity: 1; }
 .sound-toggle-btn.is-muted { opacity: 0.5; }
@@ -942,8 +952,15 @@ button, .btn {
 }
 
 .chip {
-    padding: 4px 10px;
-    font-size: 0.75rem;
+    /* min-height 44px keeps difficulty/rounds/timer chips finger-friendly
+       (WCAG 2.5.8 / Apple HIG >=44px) (#379). The flag-chip variant below
+       re-declares its own padding/min-height, so it is unaffected. */
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    padding: 10px 14px;
+    font-size: 0.85rem;
     font-weight: 500;
     background: #F3EEDF;
     border: 1px solid #E5DFCF;

--- a/tests/test_ux_touch_targets_379.py
+++ b/tests/test_ux_touch_targets_379.py
@@ -1,0 +1,49 @@
+"""Guard the two touch-target fixes for #379 (WCAG 2.5.8 / Apple HIG >=44px).
+
+Text-level assertions over the generated styles.css so a later edit can't
+silently shrink the tap targets back below 44px:
+- ``.sound-toggle-btn`` keeps its 30px visible disc but a ``::before`` overlay
+  with negative inset expands the hit area to 44x44.
+- the base ``.chip`` gains a >=40px ``min-height`` (rounds/difficulty/timer
+  chips in the admin setup).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+STYLES = REPO / "custom_components" / "quizify" / "www" / "css" / "styles.css"
+
+
+def _rule(css: str, selector: str) -> str:
+    """Return the declaration block for the first rule matching ``selector``."""
+    idx = css.index(selector)
+    start = css.index("{", idx)
+    end = css.index("}", start)
+    return css[start + 1 : end]
+
+
+def test_sound_toggle_hit_area_at_least_44px() -> None:
+    css = STYLES.read_text("utf-8")
+    # The visible disc stays 30px; the ::before overlay extends the hit area.
+    block = _rule(css, ".sound-toggle-btn::before")
+    assert "position: absolute" in block
+    m = re.search(r"inset:\s*(-?\d+)px", block)
+    assert m, ".sound-toggle-btn::before must set a negative inset"
+    inset = int(m.group(1))
+    # disc is 30px; hit area = 30 + 2*|inset| must be >= 44 -> |inset| >= 7
+    assert 30 + 2 * abs(inset) >= 44, (
+        ".sound-toggle-btn tap target must be >=44px (#379)"
+    )
+
+
+def test_base_chip_min_height_at_least_40px() -> None:
+    css = STYLES.read_text("utf-8")
+    block = _rule(css, ".chip {")
+    m = re.search(r"min-height:\s*(\d+)px", block)
+    assert m, "base .chip must declare a min-height (#379)"
+    assert int(m.group(1)) >= 40, (
+        "base .chip min-height must be >=40px for a finger-friendly target (#379)"
+    )


### PR DESCRIPTION
Fixes #379.

Two controls had hit areas below the WCAG 2.5.8 / Apple HIG 44px minimum. Both are fixed without altering the intended visual sizing.

## Size values chosen (for sign-off)

**`.sound-toggle-btn`** (player header sound toggle)
- Visible disc: **unchanged at 30×30px**
- Added `position: relative` + a transparent `::before` overlay with `inset: -7px` → tap target **44×44px** (30 + 2×7). No visual change.

**`.chip`** (base — difficulty / rounds / timer chips in admin setup)
- `min-height`: none → **44px**
- `padding`: `4px 10px` → **`10px 14px`**
- `font-size`: `0.75rem` → **`0.85rem`**
- Added `display: inline-flex` + centering so the taller box stays balanced.
- The `.chip-group--flags` variant re-declares its own `padding` (`6px 12px`), `min-height` (`40px`) and `font-size` (`1.5rem`), so flag chips are unaffected.

## Notes
- Edited the CSS **source** modules (`www/css/src/01-base.css`, `02-shared.css`) and regenerated `styles.css` via `scripts/build_css.py` (drift test green).
- Added `tests/test_ux_touch_targets_379.py` (text-level guard over the generated `styles.css`): asserts the sound-toggle hit area ≥44px and the base chip `min-height` ≥40px.
- Full suite: 893 passed, 5 skipped. Ruff: clean.

## Mobile-verify needed before merge
On 390×844 (iPhone 14): confirm the player-header sound toggle and the difficulty / rounds / timer chips in admin setup are comfortably tappable, and that the visuals are unchanged (30px disc still 30px, chips only slightly taller). Flag chips (#335) still render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)