### PR TITLE
fix(ux): scale dashboard reveal/standings text for couch legibility (#376)

### DIFF
--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -492,7 +492,8 @@
             border-left: 3px solid var(--dash-accent-primary);
             border-radius: 10px;
             font-family: 'DM Sans', sans-serif;
-            font-size: 1rem;
+            /* #376: scale for TV couch legibility (viewed from 2-3m) */
+            font-size: clamp(18px, 1.8vw, 26px);
             line-height: 1.6;
             color: var(--dash-text-neon-muted);
             transform: translateY(16px);
@@ -556,7 +557,8 @@
             background: var(--dash-surface-dark);
             border: 1px solid var(--dash-border-neon);
             font-family: 'DM Sans', sans-serif;
-            font-size: 1rem;
+            /* #376: scale for TV couch legibility */
+            font-size: clamp(16px, 1.6vw, 24px);
             color: var(--dash-text-white);
             transition: border-color 120ms ease-out, background 120ms ease-out;
         }
@@ -568,7 +570,8 @@
             width: 32px;
             height: 32px;
             font-family: 'JetBrains Mono', ui-monospace, monospace;
-            font-size: 14px;
+            /* #376: scale rank badge with rows */
+            font-size: clamp(15px, 1.5vw, 22px);
             font-weight: 700;
             color: var(--dash-text-neon-muted);
             flex-shrink: 0;
@@ -590,7 +593,8 @@
 
         .dashboard-leaderboard .leaderboard-score {
             font-family: 'JetBrains Mono', ui-monospace, monospace;
-            font-size: 14px;
+            /* #376: scale for TV couch legibility */
+            font-size: clamp(16px, 1.7vw, 26px);
             font-weight: 700;
             color: var(--dash-accent-primary);
             font-variant-numeric: tabular-nums;
@@ -924,14 +928,16 @@
         }
         .podium-other-name {
             flex: 1 1 auto;
-            font-size: 14px;
+            /* #376: scale for TV couch legibility */
+            font-size: clamp(15px, 1.4vw, 20px);
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
         }
         .podium-other-score {
             font-family: 'JetBrains Mono', ui-monospace, monospace;
-            font-size: 13px;
+            /* #376: scale for TV couch legibility */
+            font-size: clamp(14px, 1.3vw, 20px);
             color: var(--dash-accent-primary);
             font-variant-numeric: tabular-nums;
         }
@@ -955,7 +961,8 @@
 
         .podium-score {
             font-family: 'JetBrains Mono', ui-monospace, monospace;
-            font-size: 13px;
+            /* #376: scale for TV couch legibility */
+            font-size: clamp(16px, 1.8vw, 26px);
             font-weight: 700;
             color: var(--dash-accent-primary);
             font-variant-numeric: tabular-nums;
@@ -1080,7 +1087,8 @@
 
         .award-detail {
             font-family: 'DM Sans', sans-serif;
-            font-size: 0.85rem;
+            /* #376: scale for TV couch legibility */
+            font-size: clamp(15px, 1.4vw, 22px);
             color: var(--dash-text-neon-muted);
         }
 

--- a/tests/test_ux_tv_text_376.py
+++ b/tests/test_ux_tv_text_376.py
@@ -1,0 +1,62 @@
+"""Guard the #376 TV-legibility fix for the dashboard reveal/standings text.
+
+The dashboard is a self-contained ``www/dashboard.html`` with an inline
+``<style>`` block (it does NOT load styles.css). Several reveal/standings
+elements used to be pinned at small, non-scaling sizes (~1rem / 13-14px /
+0.85rem) while the question already scaled with ``clamp(..., vw, ...)`` — so
+they were unreadable from a couch 2-3m away. This test locks in that those
+selectors now use a ``clamp()``/``vw`` fluid font-size so a later edit can't
+silently regress them back to a bare small px/rem.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DASHBOARD = REPO / "custom_components" / "quizify" / "www" / "dashboard.html"
+
+
+def _rule(css: str, selector: str) -> str:
+    """Return the declaration block for the first rule matching ``selector``."""
+    idx = css.index(selector)
+    start = css.index("{", idx)
+    end = css.index("}", start)
+    return css[start + 1 : end]
+
+
+# Selectors that must scale for TV couch legibility (#376).
+SCALED_SELECTORS = (
+    ".dashboard-funfact {",
+    ".dashboard-leaderboard .leaderboard-row {",
+    ".dashboard-leaderboard .leaderboard-score {",
+    ".award-detail {",
+    ".podium-score {",
+    ".podium-other-name {",
+)
+
+
+def test_reveal_standings_text_scales_with_clamp() -> None:
+    html = DASHBOARD.read_text("utf-8")
+    for selector in SCALED_SELECTORS:
+        block = _rule(html, selector)
+        assert "font-size:" in block, f"{selector} lost its font-size (#376)"
+        assert "clamp(" in block and "vw" in block, (
+            f"{selector} must use a clamp()/vw fluid font-size for TV legibility (#376), "
+            f"not a bare small px/rem"
+        )
+
+
+def test_reveal_standings_font_floors_are_legible() -> None:
+    """The clamp() lower bound must be a >=15px pixel floor (readable on TV)."""
+    import re
+
+    html = DASHBOARD.read_text("utf-8")
+    floor_re = re.compile(r"font-size:\s*clamp\(\s*([0-9.]+)px")
+    for selector in SCALED_SELECTORS:
+        block = _rule(html, selector)
+        m = floor_re.search(block)
+        assert m is not None, f"{selector} clamp() floor must be an explicit px value (#376)"
+        assert float(m.group(1)) >= 15.0, (
+            f"{selector} clamp() floor is below 15px — too small for a TV (#376)"
+        )


### PR DESCRIPTION
Fixes #376

The TV dashboard `.dashboard-question` already scaled fluidly with `clamp(32px, 4.2vw, 56px)`, but the reveal/standings elements were pinned at small, non-scaling sizes (~1rem / 13–14px / 0.85rem) — unreadable from a couch 2–3m away. This switches them to the same `clamp()`/`vw` fluid-scaling approach, with legible pixel floors. The mobile `@media (max-width:768px)` block and the layout are untouched (the clamp floors ARE the mobile sizes).

## Chosen clamp() values (per element — for sign-off)
| Element | Before | After |
| --- | --- | --- |
| `.dashboard-funfact` | `1rem` | `clamp(18px, 1.8vw, 26px)` |
| `.dashboard-leaderboard .leaderboard-row` (rows/names) | `1rem` | `clamp(16px, 1.6vw, 24px)` |
| `.dashboard-leaderboard .leaderboard-rank` (rank badge) | `14px` | `clamp(15px, 1.5vw, 22px)` |
| `.dashboard-leaderboard .leaderboard-score` | `14px` | `clamp(16px, 1.7vw, 26px)` |
| `.award-detail` | `0.85rem` | `clamp(15px, 1.4vw, 22px)` |
| `.podium-score` | `13px` | `clamp(16px, 1.8vw, 26px)` |
| `.podium-other-name` | `14px` | `clamp(15px, 1.4vw, 20px)` |
| `.podium-other-score` | `13px` | `clamp(14px, 1.3vw, 20px)` |

(The rank badge and podium-other-score were bumped alongside the requested set so scores/ranks stay balanced against their now-larger names. Values are starting points — adjust to taste.)

## Tests
- New guard test `tests/test_ux_tv_text_376.py` asserts the six primary selectors use `clamp(`/`vw` scaling (no bare small px/rem) and have a ≥15px floor.
- Full suite: 893 passed, 5 skipped. `ruff check custom_components/`: clean.

## Mobile-verify needed before merge
Not yet verified on the actual TV via browser-harness. Before merge, confirm on the real TV (viewed from 2–3m):
- Fun fact legible.
- Leaderboard names + scores + rank badges legible; long names still ellipsize, rows don't overflow.
- Award detail lines legible.
- Podium winner score + runner-up names/scores legible; nothing clips or overflows the podium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)