### PR TITLE
feat(ux): show join QR + live player roster on the TV lobby (#374)

### DIFF
--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -1171,6 +1171,19 @@
                     <span class="wordmark-quiz">Quiz</span><span class="wordmark-ify">ify</span>
                 </h1>
                 <p class="dashboard-waiting-text" data-i18n="dashboard.waitingForStart">Waiting for game to start…</p>
+                <!-- #374: the TV is the one screen everyone sees, so the join QR
+                     and the live "who's in" roster live here during LOBBY. The
+                     QR encodes the SAME join URL the admin QR uses
+                     (origin + /quizify/player). The <div>s below reuse the
+                     dormant .dashboard-qr-section / .dashboard-player-list /
+                     .dashboard-player-chip styles already in this file. The
+                     JS renders the QR once and refreshes the roster on every
+                     player_joined / player_left / game_state (LOBBY) message. -->
+                <div id="lobby-qr" class="dashboard-qr-section">
+                    <div id="lobby-qr-code"></div>
+                    <div class="dashboard-waiting-text" data-i18n="lobby.scanToJoin">Scan to join the game</div>
+                </div>
+                <div id="lobby-players" class="dashboard-player-list"></div>
             </div>
         </div>
 
@@ -1289,6 +1302,9 @@
 
     <script src="/quizify/static/js/i18n.js?v={{ASSET_VER}}"></script>
     <script src="/quizify/static/js/utils.js?v={{ASSET_VER}}"></script>
+    <!-- #374: QR library for the TV lobby join code (same lib admin.html uses).
+         Exposes the global QRCode used by renderLobbyQr() below. -->
+    <script src="/quizify/static/js/vendor/qrcode.min.js?v={{ASSET_VER}}"></script>
     <script>
     (function() {
         'use strict';
@@ -1312,6 +1328,9 @@
             lightningRecap: document.getElementById('lightning-recap-view'),
         };
         var els = {
+            // #374: TV lobby join QR + live player roster.
+            lobbyQrCode: document.getElementById('lobby-qr-code'),
+            lobbyPlayers: document.getElementById('lobby-players'),
             roundIndicator: document.getElementById('round-indicator'),
             timerFill: document.getElementById('timer-fill'),
             questionCategory: document.getElementById('question-category'),
@@ -1351,6 +1370,57 @@
         function showView(name) {
             Object.values(views).forEach(function(v) { v.classList.remove('active'); });
             if (views[name]) views[name].classList.add('active');
+        }
+
+        // ---- #374: TV lobby join QR + live player roster ----
+        // The join URL is derived exactly like admin.js's initJoinUrl():
+        // origin + '/quizify/player' (same origin as this dashboard). The QR
+        // is rendered once (the URL never changes for a running server) and the
+        // roster refreshes on every LOBBY snapshot / player_joined / player_left.
+        var _lobbyQrRendered = false;
+        function lobbyJoinUrl() {
+            return window.location.origin + '/quizify/player';
+        }
+        function renderLobbyQr() {
+            if (_lobbyQrRendered) return;
+            var container = els.lobbyQrCode;
+            if (!container) return;
+            container.innerHTML = '';
+            var url = lobbyJoinUrl();
+            if (typeof QRCode !== 'undefined') {
+                // Large, high-contrast code so it scans from across the room.
+                new QRCode(container, {
+                    text: url, width: 280, height: 280,
+                    colorDark: '#0b0e1a', colorLight: '#ffffff',
+                    correctLevel: QRCode.CorrectLevel.M,
+                });
+                _lobbyQrRendered = true;
+            } else {
+                // Defensive fallback if the vendor lib failed to load — show
+                // the raw URL so players can still type it in.
+                container.innerHTML = '<div style="padding:20px;word-break:break-all;' +
+                    'font-size:14px;color:#fff;">' + escapeHtml(url) + '</div>';
+            }
+        }
+        function renderLobbyPlayers(players) {
+            var container = els.lobbyPlayers;
+            if (!container) return;
+            var list = Array.isArray(players)
+                ? players
+                : (players && typeof players === 'object' ? Object.values(players) : []);
+            container.innerHTML = list.map(function(p) {
+                var name = (p && p.name != null) ? p.name : '';
+                // 👑 marks the host, mirroring player-lobby.js's is_admin chip.
+                var crown = (p && p.is_admin)
+                    ? '<span aria-hidden="true">👑</span> ' : '';
+                return '<div class="dashboard-player-chip">' + crown +
+                    '<span>' + escapeHtml(name) + '</span></div>';
+            }).join('');
+        }
+        // Called on every LOBBY snapshot: paint the QR once, refresh the roster.
+        function renderLobby(players) {
+            renderLobbyQr();
+            renderLobbyPlayers(players);
         }
 
         // #296: the paused scrim sits on top of whatever view is active.
@@ -1442,6 +1512,9 @@
                 case 'game_reset':
                     setPaused(false);
                     showView('waiting');
+                    // #374: back to the lobby — repaint QR + roster (a reset
+                    // may carry an already-trimmed player list, else empty).
+                    renderLobby(msg.players);
                     els.roundIndicator.textContent = '';
                     els.timerFill.style.width = '0%';
                     break;
@@ -1462,6 +1535,10 @@
                     break;
                 case 'player_joined':
                 case 'player_left':
+                    // #374: keep the TV lobby roster live as players come/go.
+                    // The chips live inside #waiting-view, so this is a no-op
+                    // visually once the game leaves LOBBY (that view is hidden).
+                    renderLobbyPlayers(msg.players);
                     break;
             }
         }
@@ -1476,6 +1553,8 @@
             switch (msg.phase) {
                 case 'LOBBY':
                     showView('waiting');
+                    // #374: render the join QR + live roster on the TV lobby.
+                    renderLobby(msg.players);
                     break;
                 case 'QUESTION_ACTIVE':
                     if (msg.question) {

--- a/tests/test_tv_lobby_qr_374.py
+++ b/tests/test_tv_lobby_qr_374.py
@@ -1,0 +1,69 @@
+"""Guard the #374 TV-lobby join-QR + live player roster.
+
+The dashboard is a self-contained ``www/dashboard.html`` with an inline
+``<style>`` block and its own inline script (it does NOT bundle player-*.js).
+Before #374 its ``#waiting-view`` (LOBBY) rendered only the wordmark + a
+"Waiting for game to start…" line, even though the ``.dashboard-qr-section`` /
+``.dashboard-player-list`` / ``.dashboard-player-chip`` CSS already existed but
+was dormant, and ``qrcode.min.js`` was never loaded on the dashboard.
+
+This test locks in that the dashboard now:
+  * loads the ``qrcode.min.js`` vendor lib (same one admin.html uses), and
+  * wires the dormant QR-section + player-list markup into ``#waiting-view``,
+
+so a later edit can't silently regress the lobby back to a blank waiting view.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DASHBOARD = REPO / "custom_components" / "quizify" / "www" / "dashboard.html"
+
+
+def _waiting_view_block(html: str) -> str:
+    """Return the ``#waiting-view`` markup up to the next dashboard view."""
+    start = html.index('id="waiting-view"')
+    # The QUESTION VIEW is the next sibling dashboard-view after waiting.
+    end = html.index('id="question-view"', start)
+    return html[start:end]
+
+
+def test_dashboard_loads_qrcode_lib() -> None:
+    html = DASHBOARD.read_text("utf-8")
+    assert "js/vendor/qrcode.min.js" in html, (
+        "dashboard.html must load the qrcode.min.js vendor lib for the "
+        "TV-lobby join QR (#374)"
+    )
+    # Cache-buster like every other asset include on the page.
+    assert "js/vendor/qrcode.min.js?v={{ASSET_VER}}" in html, (
+        "the qrcode.min.js include needs the ?v={{ASSET_VER}} cache-buster (#374)"
+    )
+
+
+def test_waiting_view_uses_dormant_qr_and_roster_css() -> None:
+    html = DASHBOARD.read_text("utf-8")
+    waiting = _waiting_view_block(html)
+    assert "dashboard-qr-section" in waiting, (
+        "#waiting-view must render the join QR via the existing "
+        ".dashboard-qr-section markup (#374)"
+    )
+    assert "dashboard-player-list" in waiting, (
+        "#waiting-view must render the live roster via the existing "
+        ".dashboard-player-list markup (#374)"
+    )
+
+
+def test_dashboard_join_url_matches_admin() -> None:
+    """The lobby QR encodes the SAME join URL admin.js builds.
+
+    admin.js uses ``window.location.origin + '/quizify/player'`` — the dashboard
+    must derive it identically so the phone that scans the TV lands on the same
+    join page the admin QR points at.
+    """
+    html = DASHBOARD.read_text("utf-8")
+    assert "window.location.origin + '/quizify/player'" in html, (
+        "dashboard lobby QR must encode origin + '/quizify/player', the same "
+        "join URL admin.js uses (#374)"
+    )


### PR DESCRIPTION
Fixes #374

## What & why
During the LOBBY phase the dashboard's `#waiting-view` rendered only the Quizify wordmark and a "Waiting for game to start…" line. The TV is the one screen everyone in the room sees, so the join QR and a live "who's in" roster belong there instead of being buried on the admin tab.

## Approach
1. **QR library** — added the `www/js/vendor/qrcode.min.js?v={{ASSET_VER}}` include to `dashboard.html` (the exact vendor lib + cache-buster `admin.html` already uses; exposes the `QRCode` global). No bundle rebuild needed — `dashboard.html` is self-contained and not part of `player.bundle.js`.
2. **Reused dormant CSS as-is** — the `.dashboard-qr-section`, `.dashboard-player-list` and `.dashboard-player-chip` rules already existed in the inline `<style>` but nothing used them. `#waiting-view` now renders:
   - `.dashboard-qr-section` → a large (280px), centered join QR + a `lobby.scanToJoin` caption.
   - `.dashboard-player-list` → one `.dashboard-player-chip` per connected player, showing the name; the host is marked with 👑 via `is_admin` (mirroring `player-lobby.js`).
3. **Live updates** — the dashboard's WS handler already receives the player list. The QR is painted once (URL never changes) and the roster refreshes on every `game_state` (LOBBY), `player_joined` and `player_left` message. On `game_reset` the lobby repaints. Everything lives inside `#waiting-view`, so it hides cleanly the moment the game leaves LOBBY (question / reveal / lightning / finale) — no extra teardown.

## How the join URL is obtained
Derived identically to `admin.js`'s `initJoinUrl()`: `window.location.origin + '/quizify/player'`. The dashboard is served from the same origin, so the QR points at the exact same join page the admin QR does — no new server field needed.

Defensive throughout: no crashes on missing fields, and if the vendor lib fails to load the QR container falls back to the raw URL text.

## Tests
`tests/test_tv_lobby_qr_374.py` asserts the lib is now loaded (with cache-buster), that `#waiting-view` references `.dashboard-qr-section` + `.dashboard-player-list`, and that the encoded join URL matches admin's. Full suite (898 passed, 5 skipped) + ruff + drift green.

## ⚠️ Mobile/TV-verify needed before merge
This is a UI change to the always-on TV screen and has NOT been live-verified. On the actual TV during LOBBY, confirm:
- the join QR is **scannable from a phone** across the room and lands on `/quizify/player`;
- the roster **updates as players join/leave** (names appear, host shows 👑);
- the lobby layout (wordmark + QR + caption + chips) is **not clipped** at TV resolution (720p/1080p) and wraps cleanly with many players;
- the view **leaves LOBBY cleanly** — QR/roster disappear when the first question starts and don't bleed into question/reveal/finale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)