### PR TITLE
fix: keep game_active sensor on during Lightning Round (#409)

### DIFF
--- a/custom_components/quizify/binary_sensor.py
+++ b/custom_components/quizify/binary_sensor.py
@@ -36,7 +36,8 @@ async def async_setup_entry(
 
 class QuizifyGameActiveSensor(BinarySensorEntity):
     """On while a Quizify game is mid-flight (QUESTION_ACTIVE, ANSWER_REVEAL,
-    or PAUSED). Off in LOBBY and FINALE."""
+    PAUSED, or the mid-game Lightning Round detour LIGHTNING/LIGHTNING_RECAP).
+    Off in LOBBY and FINALE."""
 
     _attr_should_poll = False
     _attr_has_entity_name = True
@@ -63,6 +64,8 @@ class QuizifyGameActiveSensor(BinarySensorEntity):
             GamePhase.QUESTION_ACTIVE,
             GamePhase.ANSWER_REVEAL,
             GamePhase.PAUSED,
+            GamePhase.LIGHTNING,
+            GamePhase.LIGHTNING_RECAP,
         )
 
     @property

--- a/tests/test_binary_sensor_271.py
+++ b/tests/test_binary_sensor_271.py
@@ -61,6 +61,10 @@ def _make_state(
         ("g1", GamePhase.QUESTION_ACTIVE, True),
         ("g1", GamePhase.ANSWER_REVEAL, True),
         ("g1", GamePhase.PAUSED, True),
+        # Mid-game Lightning Round detour (#285/#409) -> stays on so
+        # game_active automations don't toggle spuriously mid-game.
+        ("g1", GamePhase.LIGHTNING, True),
+        ("g1", GamePhase.LIGHTNING_RECAP, True),
         # Idle / boundary phases -> off.
         ("g1", GamePhase.LOBBY, False),
         ("g1", GamePhase.FINALE, False),


### PR DESCRIPTION
Fixes #409.

Since #285 the Lightning Round fires automatically mid-game, moving the game through the `LIGHTNING` and `LIGHTNING_RECAP` phases. `binary_sensor.quizify_game_active`'s `is_on` tuple only covered `QUESTION_ACTIVE`, `ANSWER_REVEAL` and `PAUSED`, so the "game active" sensor flipped OFF during the lightning detour and back ON afterwards — user automations keyed on it toggled spuriously mid-game.

## Fix
- Add `GamePhase.LIGHTNING` and `GamePhase.LIGHTNING_RECAP` to the `is_on` phase tuple.
- Extend the parametrized phase-mapping test to assert `is_on` is `True` in both lightning phases.

## Verification
- `pytest tests/ -q`: 898 passed, 5 skipped.
- `ruff check custom_components/`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)