### PR TITLE
fix: gate power-ups + streak on estimate rounds (#406, #408)

### DIFF
--- a/custom_components/quizify/game/powerups.py
+++ b/custom_components/quizify/game/powerups.py
@@ -65,13 +65,20 @@ class PowerUpManager:
         """Whether the player has already been granted a power-up this game."""
         return player_id in self._granted_this_game
 
-    def assign_random_powerup(self, player_id: str) -> PowerUpType:
+    def assign_random_powerup(
+        self, player_id: str, allowed_types: list[PowerUpType] | None = None
+    ) -> PowerUpType:
         """Assign a random power-up to a player, replacing any held one.
 
         Records the player in the per-game granted set (#340) so they are not
         granted another power-up later in the same game.
+
+        ``allowed_types`` restricts the pool the choice is drawn from — used to
+        keep estimate rounds from handing out power-ups that no-op there (#406).
+        Defaults to all types.
         """
-        powerup = random.choice(list(PowerUpType))
+        pool = allowed_types or list(PowerUpType)
+        powerup = random.choice(pool)
         self._inventory[player_id] = powerup
         self._granted_this_game.add(player_id)
         return powerup

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -641,7 +641,17 @@ class QuizifyGameState:
         ]
         if eligible:
             lucky_player = random.choice(eligible)
-            powerup = self._powerup_manager.assign_random_powerup(lucky_player.name)
+            # On estimate rounds only hand out power-ups that actually do
+            # something there (#406): JOKER/DOUBLE_POINTS/STEAL no-op on the
+            # estimate scoring path, so restrict the pool to FREEZE/TIME_BOOST.
+            allowed_types = (
+                [PowerUpType.FREEZE, PowerUpType.TIME_BOOST]
+                if question.is_estimate
+                else None
+            )
+            powerup = self._powerup_manager.assign_random_powerup(
+                lucky_player.name, allowed_types=allowed_types
+            )
             _LOGGER.debug(
                 "Power-up %s assigned to %s", powerup.value, lucky_player.name
             )
@@ -1032,9 +1042,17 @@ class QuizifyGameState:
                 points = entry["points"]
                 # Closeness scoring has no streak/speed concept; surface the
                 # estimate-specific breakdown so the reveal can show distance.
-                player.streak += 1
-                if player.streak > player.max_streak:
-                    player.max_streak = player.streak
+                # Streak only advances on an EXACT hit — a non-exact guess is
+                # recorded as "wrong" below, so growing the streak on it would
+                # let a wrong guess step past a STREAK_MILESTONES value without
+                # ever paying the milestone (only MC awards them) (#408). Keep
+                # streak bookkeeping in agreement with the recorded correctness.
+                if entry["exact"]:
+                    player.streak += 1
+                    if player.streak > player.max_streak:
+                        player.max_streak = player.streak
+                else:
+                    player.streak = 0
                 player.round_score = points
                 player.round_score_breakdown = {
                     "speed_bonus": 0,
@@ -1585,6 +1603,22 @@ class QuizifyGameState:
             return ERR_INVALID_ACTION
 
         held = self._powerup_manager.get_powerup(player_id)
+
+        # Estimate-round no-op gate (#406). On estimate rounds the scoring path
+        # (_evaluate_estimate_round) applies points later at reveal, never reads
+        # is_double_points_active, and the question carries no MC answers. So
+        # STEAL reads a still-zero target.round_score (steals 0), DOUBLE_POINTS
+        # is silently ignored, and JOKER has an empty question.answers to prune —
+        # all three would burn the once-per-game power-up for nothing. Reject
+        # them so the inventory survives for a later MC round. FREEZE/TIME_BOOST
+        # are pure timer effects that behave identically on estimate rounds and
+        # stay usable.
+        if question.is_estimate and held in (
+            PowerUpType.JOKER,
+            PowerUpType.DOUBLE_POINTS,
+            PowerUpType.STEAL,
+        ):
+            return ERR_INVALID_ACTION
 
         # Post-submit no-op gate. Joker/Double/TimeBoost only help BEFORE
         # the source locks in their answer — activating them afterward

--- a/tests/test_estimate_powerup_streak_406_408.py
+++ b/tests/test_estimate_powerup_streak_406_408.py
@@ -1,0 +1,188 @@
+"""Regression tests for the two estimate-round bugs #406 and #408.
+
+#406 — power-ups that no-op on the estimate scoring path (JOKER, DOUBLE_POINTS,
+STEAL) must be rejected up front so they aren't burned for nothing, and must
+not be handed out on estimate rounds in the first place. FREEZE and TIME_BOOST
+are pure timer effects that work identically on estimate rounds and stay usable.
+
+#408 — the estimate evaluator recorded a non-exact guess as "wrong" yet still
+grew the player's streak, letting a wrong guess step past a STREAK_MILESTONES
+value without paying the milestone. Streak must only advance on an exact hit and
+reset otherwise, so scoring and the recorded correctness agree.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.const import ERR_INVALID_ACTION  # noqa: E402
+from custom_components.quizify.game.phase_controller import GamePhase  # noqa: E402
+from custom_components.quizify.game.powerups import (  # noqa: E402
+    PowerUpEffect,
+    PowerUpType,
+)
+from custom_components.quizify.game.questions import (  # noqa: E402
+    QUESTION_TYPE_ESTIMATE,
+    Question,
+)
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _fake_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+def _make_estimate_question() -> Question:
+    return Question(
+        id="e-flow",
+        question="How many bones?",
+        answers=[],
+        type=QUESTION_TYPE_ESTIMATE,
+        estimate_answer=206,
+        estimate_min=0,
+        estimate_max=500,
+        estimate_unit="bones",
+        estimate_step=1,
+    )
+
+
+@pytest.fixture
+def est_state(tmp_path: Path) -> QuizifyGameState:
+    """A game state forced into an active estimate round with 3 players."""
+    state = QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+    state.add_player("Anna", _fake_ws())
+    state.add_player("Tom", _fake_ws())
+    state.add_player("Marina", _fake_ws())
+    state.start_game(language="de", num_rounds=3, timer_duration=30)
+    state.start_next_question()
+    # Force the active question to a known estimate question.
+    state._current_question = _make_estimate_question()
+    for p in state._player_registry.players.values():
+        p.reset_round()
+    return state
+
+
+# ---------------------------------------------------------------------------
+# #406 — power-up gating on estimate rounds
+# ---------------------------------------------------------------------------
+
+
+class TestEstimatePowerupGate:
+    @pytest.mark.parametrize(
+        "powerup",
+        [PowerUpType.JOKER, PowerUpType.DOUBLE_POINTS, PowerUpType.STEAL],
+    )
+    def test_noop_powerups_rejected_and_not_consumed(
+        self, est_state: QuizifyGameState, powerup: PowerUpType
+    ) -> None:
+        est_state._powerup_manager._inventory["Anna"] = powerup
+        # Tom is a valid, un-submitted opponent (would satisfy STEAL's
+        # target resolution if the estimate gate weren't hit first).
+        result = est_state.use_powerup("Anna", target_id="Tom")
+        assert result == ERR_INVALID_ACTION
+        # The once-per-game power-up survives for a later MC round.
+        assert est_state._powerup_manager.has_powerup("Anna")
+        assert est_state._powerup_manager.get_powerup("Anna") == powerup
+
+    def test_freeze_still_works_on_estimate(
+        self, est_state: QuizifyGameState
+    ) -> None:
+        est_state._powerup_manager._inventory["Anna"] = PowerUpType.FREEZE
+        result = est_state.use_powerup("Anna", target_id="Tom")
+        assert isinstance(result, PowerUpEffect)
+        assert result.type == PowerUpType.FREEZE
+        assert not est_state._powerup_manager.has_powerup("Anna")  # consumed
+
+    def test_time_boost_still_works_on_estimate(
+        self, est_state: QuizifyGameState
+    ) -> None:
+        est_state._powerup_manager._inventory["Anna"] = PowerUpType.TIME_BOOST
+        result = est_state.use_powerup("Anna", target_id=None)
+        assert isinstance(result, PowerUpEffect)
+        assert result.type == PowerUpType.TIME_BOOST
+        assert not est_state._powerup_manager.has_powerup("Anna")  # consumed
+
+    def test_estimate_round_only_grants_timer_powerups(
+        self, tmp_path: Path
+    ) -> None:
+        # Over many estimate rounds, the granted power-up is always one of the
+        # two that actually work there — never a JOKER/DOUBLE/STEAL no-op.
+        for _ in range(40):
+            state = QuizifyGameState(
+                runtime=_FakeRuntime(tmp_path), entry_id="test"
+            )
+            state.add_player("Solo", _fake_ws())
+            state.start_game(language="de", num_rounds=3)
+            # Force the next-served question to an estimate question so the
+            # grant path sees is_estimate.
+            state._question_bank.get_next_question = (  # type: ignore[method-assign]
+                lambda *a, **k: _make_estimate_question()
+            )
+            state.start_next_question()
+            granted = state._powerup_manager.get_powerup("Solo")
+            assert granted in (PowerUpType.FREEZE, PowerUpType.TIME_BOOST)
+
+
+# ---------------------------------------------------------------------------
+# #408 — streak only advances on an exact estimate hit
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateStreak:
+    def test_non_exact_guess_resets_streak(
+        self, est_state: QuizifyGameState
+    ) -> None:
+        anna = est_state._player_registry.get_player("Anna")
+        anna.streak = 2  # coming off a 2-round MC streak
+        # All three guess non-exactly → auto-evaluate.
+        est_state.submit_guess("Anna", 210)  # 4 off, not exact
+        est_state.submit_guess("Tom", 150)
+        est_state.submit_guess("Marina", 240)
+        assert est_state.phase == GamePhase.ANSWER_REVEAL
+        # A non-exact guess is recorded "wrong" → streak must reset, not grow.
+        assert anna.streak == 0
+        assert anna.round_history[-1] == "wrong"
+
+    def test_exact_guess_grows_streak(
+        self, est_state: QuizifyGameState
+    ) -> None:
+        marina = est_state._player_registry.get_player("Marina")
+        marina.streak = 2
+        est_state.submit_guess("Anna", 210)
+        est_state.submit_guess("Tom", 150)
+        est_state.submit_guess("Marina", 206)  # exact
+        assert est_state.phase == GamePhase.ANSWER_REVEAL
+        # An exact hit is recorded "correct" → streak advances.
+        assert marina.streak == 3
+        assert marina.max_streak >= 3
+        assert marina.round_history[-1] == "correct"
+
+    def test_streak_and_recorded_result_agree(
+        self, est_state: QuizifyGameState
+    ) -> None:
+        # For every guesser, a grown streak implies a "correct" record and a
+        # reset streak implies "wrong" — the two must never disagree (#408).
+        est_state.submit_guess("Anna", 206)  # exact
+        est_state.submit_guess("Tom", 150)   # wrong
+        est_state.submit_guess("Marina", 240)  # wrong
+        for name in ("Anna", "Tom", "Marina"):
+            p = est_state._player_registry.get_player(name)
+            if p.round_history[-1] == "correct":
+                assert p.streak >= 1
+            else:
+                assert p.streak == 0


### PR DESCRIPTION
Fixes #406
Fixes #408

## #406 — power-ups no-op'd but were consumed on estimate rounds
On estimate rounds JOKER/DOUBLE_POINTS/STEAL do nothing: STEAL reads a target `round_score` that isn't set until points are applied at reveal (steals 0), DOUBLE_POINTS is never honored by `_evaluate_estimate_round`, and JOKER has an empty `question.answers` to prune. All three still burned the once-per-game power-up. Now `use_powerup` returns `ERR_INVALID_ACTION` for those three when the active question `is_estimate` (inventory survives for a later MC round), and the round-start grant restricts the pool to FREEZE/TIME_BOOST on estimate rounds. FREEZE/TIME_BOOST are pure timer effects that keep working on estimates.

## #408 — non-exact estimate guess grew the streak
`_evaluate_estimate_round` incremented `streak`/`max_streak` for every guesser while recording `correct` only on an exact hit, so a wrong (non-exact) guess could step past a `STREAK_MILESTONES` value without ever paying the milestone. Streak now advances only on an exact hit and resets otherwise, keeping scoring and the recorded correctness in agreement.

## Tests
New `tests/test_estimate_powerup_streak_406_408.py`: estimate power-ups rejected + not consumed, estimate rounds only grant FREEZE/TIME_BOOST, FREEZE/TIME_BOOST still usable, non-exact guess resets streak, exact guess grows it, streak/recorded-result agree. Full suite (907 passed, 5 skipped) + ruff green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)