### PR TITLE
fix: reject stale lightning answers via question-index stamp (#405)

### DIFF
--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -1753,6 +1753,23 @@ class QuizifyWebSocketHandler:
             await self._conn.send_error(ws, ERR_INVALID_ACTION, "Invalid answer index")
             return
 
+        # #405: a tap fired at ~0s can land AFTER the loop's advance() has
+        # already armed the NEXT question (new clock + fresh shuffles). Without
+        # a question-index guard the stale tap is recorded against the next
+        # question through a random shuffle, and record_answer's one-per-Q rule
+        # then silently drops the player's real answer to that question. The
+        # client stamps every tap with the index it currently holds; reject the
+        # message when that no longer matches the live question. Index-less
+        # messages (older clients) are still accepted, but only while the
+        # current question's window is genuinely open — once it has expired the
+        # race window is exactly where a stale index-less tap would land wrong.
+        stamped_index = data.get("index")
+        if isinstance(stamped_index, int):
+            if stamped_index != lr.index:
+                return  # stale tap for an already-advanced question — drop it
+        elif lr.time_remaining() <= 0:
+            return  # index-less legacy tap after the window closed — drop it
+
         result = lr.record_answer(player.name, shuffled_index)
         if result is None:
             return  # rejected (already answered / expired) — stay silent

--- a/custom_components/quizify/www/js/player-lightning.js
+++ b/custom_components/quizify/www/js/player-lightning.js
@@ -24,7 +24,8 @@
         return fn(key, vars);
     }
 
-    var _answeredIndex = -1; // server question index we've answered
+    var _answeredIndex = -1; // shuffled button index we've answered
+    var _questionIndex = -1; // #405: server question index of the live question
 
     // ------------------------------------------------------------------
     // Intro splash (issue #201 — "Bolt Burst")
@@ -55,6 +56,8 @@
 
     function handleLightningQuestion(msg) {
         pu.showView('lightning-view');
+
+        _questionIndex = (typeof msg.index === 'number') ? msg.index : -1;
 
         var prog = document.getElementById('lightning-progress');
         if (prog) prog.textContent = ((msg.index || 0) + 1) + ' / ' + (msg.num_questions || 5);
@@ -115,7 +118,9 @@
         // One answer per question; ignore re-taps.
         if (_answeredIndex !== -1) return;
         _answeredIndex = shuffledIndex;
-        _send('lightning_answer', { answer_index: shuffledIndex });
+        // #405: stamp the tap with the live question index so the server can
+        // drop it if the lightning loop has already advanced to the next Q.
+        _send('lightning_answer', { answer_index: shuffledIndex, index: _questionIndex });
 
         // Lock buttons + mark the chosen one. No correctness shown until
         // the recap (no reveal between questions) — except the lightweight

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -2718,7 +2718,8 @@
         return fn(key, vars);
     }
 
-    var _answeredIndex = -1; // server question index we've answered
+    var _answeredIndex = -1; // shuffled button index we've answered
+    var _questionIndex = -1; // #405: server question index of the live question
 
     // ------------------------------------------------------------------
     // Intro splash (issue #201 — "Bolt Burst")
@@ -2749,6 +2750,8 @@
 
     function handleLightningQuestion(msg) {
         pu.showView('lightning-view');
+
+        _questionIndex = (typeof msg.index === 'number') ? msg.index : -1;
 
         var prog = document.getElementById('lightning-progress');
         if (prog) prog.textContent = ((msg.index || 0) + 1) + ' / ' + (msg.num_questions || 5);
@@ -2809,7 +2812,9 @@
         // One answer per question; ignore re-taps.
         if (_answeredIndex !== -1) return;
         _answeredIndex = shuffledIndex;
-        _send('lightning_answer', { answer_index: shuffledIndex });
+        // #405: stamp the tap with the live question index so the server can
+        // drop it if the lightning loop has already advanced to the next Q.
+        _send('lightning_answer', { answer_index: shuffledIndex, index: _questionIndex });
 
         // Lock buttons + mark the chosen one. No correctness shown until
         // the recap (no reveal between questions) — except the lightweight

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import sys
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -402,6 +403,73 @@ class TestLightningWsLoop:
 
         assert state.phase == GamePhase.LIGHTNING_RECAP
         assert lr.scores["A"] == LIGHTNING_POINTS_PER_CORRECT
+
+    @pytest.mark.asyncio
+    async def test_stale_index_answer_rejected_after_advance(
+        self, state: QuizifyGameState
+    ) -> None:
+        """#405: a lightning tap stamped with the previous question's index —
+        landing after the loop's advance() armed the next Q with a fresh clock
+        and new shuffles — is dropped, so it cannot occupy the player's single
+        answer slot on the new question. The real answer to the new question,
+        correctly stamped, is then still accepted and scored."""
+        state.add_player("A", _fake_ws())
+        h = _handler(state)
+        assert state.start_lightning_round() is True
+        lr = state.lightning
+        ws = state.get_player("A").ws
+
+        # Player is on Q0 and holds that index; capture a pick for it.
+        stale_index = lr.index  # 0
+        stale_pick = _correct_shuffled_index(lr, "A")
+
+        # Timeout advance: Q1 is armed with a fresh (unexpired) clock + shuffles.
+        assert lr.advance() is True
+        assert lr.index == stale_index + 1
+        assert lr.time_remaining() > 0  # new window is genuinely open
+
+        # The stale tap (still stamped with the OLD index) must be dropped and
+        # must NOT be recorded against the new question.
+        await h._handle_lightning_answer(
+            ws, {"answer_index": stale_pick, "index": stale_index}, state
+        )
+        assert "A" not in lr._answers.get(lr.index, {})
+
+        # A's real answer to the new question (correctly stamped) is accepted.
+        real_pick = _correct_shuffled_index(lr, "A")
+        await h._handle_lightning_answer(
+            ws, {"answer_index": real_pick, "index": lr.index}, state
+        )
+        assert "A" in lr._answers[lr.index]
+        lr.advance()  # score the new question
+        assert lr.scores["A"] == LIGHTNING_POINTS_PER_CORRECT
+
+    @pytest.mark.asyncio
+    async def test_indexless_legacy_answer_gated_by_window(
+        self, state: QuizifyGameState
+    ) -> None:
+        """#405 backward compat: an index-less tap (older client) is accepted
+        while the current window is open, but dropped once it has expired — the
+        exact spot where a stale index-less tap would otherwise land wrong."""
+        state.add_player("A", _fake_ws())
+        h = _handler(state)
+        state.start_lightning_round()
+        lr = state.lightning
+        ws = state.get_player("A").ws
+
+        # Window open → index-less tap is accepted (legacy path preserved).
+        await h._handle_lightning_answer(
+            ws, {"answer_index": _correct_shuffled_index(lr, "A")}, state
+        )
+        assert "A" in lr._answers[lr.index]
+
+        # New question, then force its window closed → index-less tap dropped.
+        assert lr.advance() is True
+        lr._question_start = time.monotonic() - lr.seconds_per_question - 1.0
+        await h._handle_lightning_answer(
+            ws, {"answer_index": _correct_shuffled_index(lr, "A")}, state
+        )
+        assert "A" not in lr._answers.get(lr.index, {})
 
 
 # ---------- WS handler: #285 auto-trigger entry + resume ----------


### PR DESCRIPTION
Fixes #405.

## Problem
`server/websocket.py` `_handle_lightning_answer` read only `data['answer_index']` with no question-index check. The lightning loop advances on timeout via `lr.advance()`, and `LightningRound._arm_current()` restarts the clock + wipes shuffles. A tap sent at ~0s that landed AFTER `advance()` was recorded against the NEXT question through a new random shuffle (random correctness). `record_answer`'s one-answer-per-question rule then silently rejected the player's real answer to that next question.

## Fix
- Client (`www/js/player-lightning.js`) now stamps every `lightning_answer` with the question index it currently holds (already received via `lightning_question`).
- `_handle_lightning_answer` drops the message when `data.get('index') != lr.index`.
- Index-less messages (older clients) stay accepted only while `lr.time_remaining() > 0`, for backward compat.
- Rebuilt `player.bundle.js` (player-lightning.js is bundled).

## Tests
- New regression test: a lightning answer stamped with the old index is rejected after `advance()`, and the real answer to the new question is accepted + scored.
- New test for the index-less legacy path being gated by the open window.
- Full suite: 900 passed, 5 skipped. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)