### PR TITLE
fix: preserve TTS/lobby-music runtime config across options reload (#411)

### DIFF
--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -274,6 +274,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         pl: QuizifyPartyLights | None = domain_data.get("party_lights")
         tts: QuizifyTTSAnnouncer | None = domain_data.get("tts_announcer")
         lm: QuizifyLobbyMusic | None = domain_data.get("lobby_music")
+        # Snapshot the old announcer's live per-game narration config BEFORE we
+        # tear it down (#411). Rebuilding from the config entry resets
+        # ``_enabled`` to False and drops the admin's per-game entity overrides,
+        # which would silently kill narration mid-game until the next start_game.
+        tts_snapshot = tts.export_runtime_config() if tts is not None else None
         if pl is not None:
             pl.detach()
         if tts is not None:
@@ -292,6 +297,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             media_player_entity_id=opts.get(CONF_MEDIA_PLAYER_ENTITY) or None,
             game_state=game_state,
         )
+        # Carry the runtime narration config across the reload so an in-flight
+        # game keeps narrating (#411).
+        new_tts.restore_runtime_config(tts_snapshot)
         new_tts.attach()
         new_lm = QuizifyLobbyMusic(
             hass=_hass,

--- a/custom_components/quizify/lobby_music.py
+++ b/custom_components/quizify/lobby_music.py
@@ -57,6 +57,13 @@ class QuizifyLobbyMusic:
 
     def attach(self) -> None:
         self._game.register_state_callback(self._on_state_changed)
+        # Evaluate the current phase once on attach (#411). The state-callback
+        # path only fires on a phase *change*, so a fresh instance built by an
+        # options reload while the game already sits in the LOBBY would never
+        # start the music until the phase moved away and back. Reusing
+        # ``_on_state_changed`` (with ``_last_phase is None``) resumes LOBBY
+        # music immediately and is a safe no-op for any non-lobby phase.
+        self._on_state_changed()
 
     def detach(self) -> None:
         self._game.unregister_state_callback(self._on_state_changed)

--- a/custom_components/quizify/tts.py
+++ b/custom_components/quizify/tts.py
@@ -135,6 +135,64 @@ class QuizifyTTSAnnouncer:
         self._media_player_override = (media_player or "").strip() or None
         self._previous_leader = None
 
+    def export_runtime_config(self) -> dict[str, Any]:
+        """Snapshot the mutable per-game narration config (#411).
+
+        An options reload rebuilds this announcer from the config entry, which
+        would otherwise reset ``_enabled`` back to ``False`` and drop the admin's
+        per-game entity overrides — silently killing narration mid-game until the
+        next ``start_game``. The listener snapshots the live config here and
+        restores it onto the fresh instance via :meth:`restore_runtime_config`.
+        """
+        return {
+            "enabled": self._enabled,
+            "announce_question": self._announce_question,
+            "announce_options": self._announce_options,
+            "announce_reveal": self._announce_reveal,
+            "announce_standings": self._announce_standings,
+            "announce_join": self._announce_join,
+            "announce_countdown": self._announce_countdown,
+            "tts_entity_override": self._tts_entity_override,
+            "media_player_override": self._media_player_override,
+        }
+
+    def restore_runtime_config(self, snapshot: dict[str, Any] | None) -> None:
+        """Restore a config snapshot from :meth:`export_runtime_config` (#411).
+
+        Defensive: a falsy/empty snapshot is a no-op, and each field falls back
+        to the current value when absent, so a partial snapshot never clobbers
+        an unrelated default.
+        """
+        if not snapshot:
+            return
+        self._enabled = bool(snapshot.get("enabled", self._enabled))
+        self._announce_question = bool(
+            snapshot.get("announce_question", self._announce_question)
+        )
+        self._announce_options = bool(
+            snapshot.get("announce_options", self._announce_options)
+        )
+        self._announce_reveal = bool(
+            snapshot.get("announce_reveal", self._announce_reveal)
+        )
+        self._announce_standings = bool(
+            snapshot.get("announce_standings", self._announce_standings)
+        )
+        self._announce_join = bool(
+            snapshot.get("announce_join", self._announce_join)
+        )
+        self._announce_countdown = bool(
+            snapshot.get("announce_countdown", self._announce_countdown)
+        )
+        self._tts_entity_override = (
+            snapshot.get("tts_entity_override", self._tts_entity_override)
+            or None
+        )
+        self._media_player_override = (
+            snapshot.get("media_player_override", self._media_player_override)
+            or None
+        )
+
     @property
     def _active_tts_entity(self) -> str | None:
         """Per-game override if set, else the config-entry default."""

--- a/tests/test_init_reattach_328.py
+++ b/tests/test_init_reattach_328.py
@@ -213,3 +213,78 @@ async def test_options_update_clears_fields_when_emptied(
     assert data["ctx"].community_submit_url is None
     # An unconfigured party-lights helper is re-attached (no entity ids given).
     assert data["party_lights"].is_configured is False
+
+
+async def test_options_reload_preserves_live_narration_config(
+    http_hass: HomeAssistant,
+) -> None:
+    """An options change mid-game must NOT silently kill narration (#411).
+
+    ``configure()`` (called from the admin start_game payload) flips the master
+    switch on and stores per-game entity overrides. Before the fix, the reload
+    rebuilt the announcer from the config entry, resetting ``_enabled`` back to
+    ``False`` — so narration went silent until the next game. The listener now
+    snapshots + restores the live runtime config onto the fresh instance.
+    """
+    hass = http_hass
+    entry = await _setup(hass)
+
+    old_tts = hass.data[DOMAIN]["tts_announcer"]
+    # Simulate a start_game turning narration ON with per-game entity overrides.
+    old_tts.configure(
+        enabled=True,
+        announce_question=True,
+        announce_reveal=False,
+        announce_standings=True,
+        announce_options=False,
+        announce_join=True,
+        announce_countdown=False,
+        tts_entity="tts.game_engine",
+        media_player="media_player.party",
+    )
+
+    # An unrelated options change (party lights) fires the reload listener.
+    hass.config_entries.async_update_entry(
+        entry, options={CONF_PARTY_LIGHT_ENTITIES: ["light.den"]}
+    )
+    await hass.async_block_till_done()
+
+    new_tts = hass.data[DOMAIN]["tts_announcer"]
+    assert new_tts is not old_tts
+    # Master switch and per-event toggles survived the reload…
+    assert new_tts._enabled is True
+    assert new_tts._announce_reveal is False
+    assert new_tts._announce_options is False
+    assert new_tts._announce_countdown is False
+    # …and so did the per-game entity overrides.
+    assert new_tts._active_tts_entity == "tts.game_engine"
+    assert new_tts._active_media_player == "media_player.party"
+
+
+async def test_options_reload_resumes_lobby_music_on_attach(
+    http_hass: HomeAssistant,
+) -> None:
+    """LOBBY music must resume after a reload while still in the lobby (#411).
+
+    The state-callback path only reacts to a phase *change*; a freshly-built
+    lobby-music instance starts with ``_last_phase=None`` and would never emit a
+    start until the phase moved away and back. ``attach()`` now evaluates the
+    current phase once, so a reload mid-lobby restarts the music immediately.
+    """
+    hass = http_hass
+    entry = await _setup(hass)
+
+    # Configure a media player + lobby URL; the game sits in LOBBY at setup.
+    hass.config_entries.async_update_entry(
+        entry,
+        options={
+            CONF_MEDIA_PLAYER_ENTITY: "media_player.living_room",
+            CONF_LOBBY_MUSIC_URL: "http://example.test/lobby.mp3",
+        },
+    )
+    await hass.async_block_till_done()
+
+    lm = hass.data[DOMAIN]["lobby_music"]
+    assert lm.is_configured is True
+    # The re-attached instance evaluated the LOBBY phase on attach and started.
+    assert lm._playing is True

--- a/tests/test_tts_lobby_reload_411.py
+++ b/tests/test_tts_lobby_reload_411.py
@@ -1,0 +1,167 @@
+"""Unit regression for the options-reload continuity fix (issue #411).
+
+The ``_update_listener`` in ``custom_components.quizify.__init__`` rebuilds the
+TTS announcer and lobby-music helper from the config entry on every options
+change. That reset silently broke two mid-game behaviours:
+
+* the fresh announcer started ``_enabled=False`` with empty per-game overrides,
+  killing narration until the next ``start_game``;
+* the fresh lobby-music instance started ``_last_phase=None`` and only reacted
+  to a phase *change*, so LOBBY music never resumed after a reload while still
+  in the lobby.
+
+These drive the announcer/lobby helpers directly with a fake hass (no Home
+Assistant install needed), so they run everywhere — mirroring the harness in
+``test_tts_announcer_281``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+from custom_components.quizify.lobby_music import QuizifyLobbyMusic  # noqa: E402
+from custom_components.quizify.tts import QuizifyTTSAnnouncer  # noqa: E402
+
+
+class _FakeHass:
+    """Records service calls so tests can assert playback/narration intent."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict]] = []
+        self.states = MagicMock()
+        self.states.get = lambda eid: MagicMock(state="on")
+        self.services = MagicMock()
+
+        async def _async_call(domain, service, data, blocking=False):  # noqa: ANN001
+            self.calls.append((domain, service, dict(data)))
+
+        self.services.async_call = _async_call
+
+    def async_create_task(self, coro):  # noqa: ANN001
+        return asyncio.ensure_future(coro)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+@pytest.fixture
+def game(tmp_path):
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="t")
+
+
+def _reload_announcer(
+    old: QuizifyTTSAnnouncer, hass, game
+) -> QuizifyTTSAnnouncer:
+    """Mimic the __init__ listener: snapshot old → rebuild → restore."""
+    snapshot = old.export_runtime_config()
+    old.detach()
+    new = QuizifyTTSAnnouncer(
+        hass=hass,
+        tts_entity_id="tts.cloud",
+        media_player_entity_id="media_player.kitchen",
+        game_state=game,
+    )
+    new.restore_runtime_config(snapshot)
+    new.attach()
+    return new
+
+
+def test_reload_preserves_enabled_and_overrides(game):
+    hass = _FakeHass()
+    old = QuizifyTTSAnnouncer(
+        hass=hass,
+        tts_entity_id="tts.cloud",
+        media_player_entity_id="media_player.kitchen",
+        game_state=game,
+    )
+    old.attach()
+    old.configure(
+        enabled=True,
+        announce_question=True,
+        announce_reveal=False,
+        announce_standings=True,
+        announce_options=False,
+        announce_join=True,
+        announce_countdown=False,
+        tts_entity="tts.game_engine",
+        media_player="media_player.party",
+    )
+
+    new = _reload_announcer(old, hass, game)
+
+    assert new is not old
+    assert new._enabled is True
+    assert new._announce_reveal is False
+    assert new._announce_options is False
+    assert new._announce_countdown is False
+    assert new._active_tts_entity == "tts.game_engine"
+    assert new._active_media_player == "media_player.party"
+
+
+def test_restore_runtime_config_is_defensive(game):
+    hass = _FakeHass()
+    tts = QuizifyTTSAnnouncer(
+        hass=hass,
+        tts_entity_id="tts.cloud",
+        media_player_entity_id="media_player.kitchen",
+        game_state=game,
+    )
+    tts._enabled = True
+    # An empty / None snapshot must never clobber the current config.
+    tts.restore_runtime_config(None)
+    tts.restore_runtime_config({})
+    assert tts._enabled is True
+    # A partial snapshot only touches the keys it carries.
+    tts.restore_runtime_config({"announce_join": False})
+    assert tts._enabled is True
+    assert tts._announce_join is False
+
+
+async def test_lobby_music_resumes_on_attach_in_lobby(game):
+    hass = _FakeHass()
+    game.lobby_music_url = "http://example.test/lobby.mp3"
+    assert game.phase == GamePhase.LOBBY
+
+    lm = QuizifyLobbyMusic(
+        hass=hass,
+        media_player_entity_id="media_player.kitchen",
+        game_state=game,
+    )
+    # attach() evaluates the current phase once (#411) — no phase change needed.
+    lm.attach()
+    await asyncio.sleep(0)  # let the fire-and-forget service call run
+
+    assert lm._playing is True
+    services = [(d, s) for d, s, _ in hass.calls]
+    assert ("media_player", "play_media") in services
+
+
+async def test_lobby_music_attach_noop_when_not_in_lobby(game):
+    hass = _FakeHass()
+    game.lobby_music_url = "http://example.test/lobby.mp3"
+    game.phase = GamePhase.QUESTION_ACTIVE
+
+    lm = QuizifyLobbyMusic(
+        hass=hass,
+        media_player_entity_id="media_player.kitchen",
+        game_state=game,
+    )
+    lm.attach()
+    await asyncio.sleep(0)
+
+    assert lm._playing is False
+    assert hass.calls == []


### PR DESCRIPTION
Fixes #411.

## Problem
`_update_listener` in `custom_components/quizify/__init__.py` replaces the `QuizifyTTSAnnouncer` and `QuizifyLobbyMusic` instances on every options change. Two mid-game behaviours broke silently:

- The new announcer started `_enabled=False` with empty per-game overrides (`configure()` is only called from the admin `start_game` payload), so an options change mid-game killed narration until the next game.
- The new lobby-music instance's `_last_phase=None` only reacted to a phase *change*, so LOBBY music stayed off after a reload while still in the lobby.

## Fix
- Added `export_runtime_config()` / `restore_runtime_config()` to `QuizifyTTSAnnouncer` (the `_enabled` / `_announce_*` / entity-override fields). `_update_listener` snapshots the old announcer's live config before teardown and restores it onto the fresh instance. Restore is defensive — an empty or partial snapshot never clobbers a default.
- `QuizifyLobbyMusic.attach()` now evaluates the current phase once (reusing `_on_state_changed` with `_last_phase=None`), so LOBBY music resumes immediately after a reload and stays a no-op for any non-lobby phase.

Existing behaviour is otherwise preserved.

## Tests
- `tests/test_tts_lobby_reload_411.py` (runs without an HA install): reload keeps narration enabled + overrides; `restore_runtime_config` is defensive; lobby music starts on attach in the lobby and stays quiet otherwise.
- `tests/test_init_reattach_328.py`: two new end-to-end cases through the real config-entries state machine (narration config survives an options reload; lobby music resumes on the re-attached instance).

Full suite: 902 passed, 5 skipped (HA-harness tests, run in CI). `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)