### PR TITLE
perf: guard pack_versions executor hop + memoize analytics metrics (#417, #418)

### DIFF
--- a/custom_components/quizify/analytics.py
+++ b/custom_components/quizify/analytics.py
@@ -74,6 +74,13 @@ class QuizifyAnalytics:
         self._data: AnalyticsData = self._empty_data()
         self._games_since_prune = 0
         self._save_lock = asyncio.Lock()
+        # #418: memoize compute_metrics per period. The game history only
+        # changes at game end (add_game) or on prune, so recomputing on every
+        # GET /analytics/data + every even-day featured-pack request wastes
+        # full O(n) passes over up to 1000 records. Cache value is
+        # ``(fingerprint, result)`` where fingerprint = (total_games,
+        # last ended_at); a mismatch (append or prune) recomputes.
+        self._metrics_cache: dict[str, tuple[tuple[int, int], dict[str, Any]]] = {}
 
     def _empty_data(self) -> AnalyticsData:
         """Return empty analytics data structure."""
@@ -269,6 +276,11 @@ class QuizifyAnalytics:
         """Add game record and schedule save."""
         self._data["games"].append(record)
         self._games_since_prune += 1
+        # #418: new game → drop the memoized metrics so the next request
+        # recomputes. The fingerprint check in compute_metrics would already
+        # catch this, but clearing here keeps the cache from carrying stale
+        # per-period entries and bounds its size.
+        self._metrics_cache.clear()
 
         if self._games_since_prune >= PRUNE_INTERVAL:
             await self._prune_old_records()
@@ -323,7 +335,26 @@ class QuizifyAnalytics:
         return len(self._data["games"])
 
     def compute_metrics(self, period: str = "30d") -> dict[str, Any]:
-        """Compute dashboard metrics for a given period."""
+        """Compute dashboard metrics for a given period.
+
+        Results are memoized per ``period`` (#418): the game history only
+        changes at game end / prune, so a fingerprint of ``(total_games,
+        last ended_at)`` lets repeated reads reuse the last result instead of
+        re-scanning every record. ``add_game`` clears the cache; a prune shifts
+        the fingerprint, so both paths recompute.
+        """
+        games = self._data["games"]
+        fingerprint = (len(games), games[-1]["ended_at"] if games else 0)
+        cached = self._metrics_cache.get(period)
+        if cached is not None and cached[0] == fingerprint:
+            return cached[1]
+
+        result = self._compute_metrics_uncached(period)
+        self._metrics_cache[period] = (fingerprint, result)
+        return result
+
+    def _compute_metrics_uncached(self, period: str) -> dict[str, Any]:
+        """Compute dashboard metrics for a given period (no memoization)."""
         now = int(time.time())
         days_map = {"7d": 7, "30d": 30, "90d": 90, "all": 365 * 10}
         days = days_map.get(period, 30)

--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -858,8 +858,14 @@ async def pack_versions_view(request: web.Request) -> web.Response:
     badge without re-implementing the date math client-side.
     """
     ctx = _get_ctx(request)
-    await ctx.runtime.run_in_executor(ctx.game.question_bank.load_all_categories)
-    installed = ctx.game.question_bank.get_pack_versions()
+    bank = ctx.game.question_bank
+    # Packs are cached in memory after the first load; only pay the executor
+    # hop + disk read when they haven't been loaded yet (mirrors
+    # ``pack_update_check_view``). The bank is preloaded on setup, so this GET
+    # is normally a pure in-memory read.
+    if not bank.is_loaded:
+        await ctx.runtime.run_in_executor(bank.load_all_categories)
+    installed = bank.get_pack_versions()
 
     today = _dt.date.today()
     # ``get_pack_versions`` returns a shallow copy: the inner meta dicts are the

--- a/tests/test_perf_views_analytics_417_418.py
+++ b/tests/test_perf_views_analytics_417_418.py
@@ -1,0 +1,194 @@
+"""Perf regressions for pack_versions + analytics metrics (#417, #418).
+
+#417: ``pack_versions_view`` (``GET /api/quizify/packs``) used to unconditionally
+await ``run_in_executor(bank.load_all_categories)`` on every request even though
+``load_all_categories`` is a guarded no-op once the preloaded bank is loaded.
+The fix mirrors the ``pack_update_check_view`` guard so the executor hop is
+skipped when the bank is already loaded.
+
+#418: ``compute_metrics`` re-scanned up to 1000 ``GameRecord``s on every
+analytics-data read and every even-day featured-pack request, though the game
+history only changes at game end / prune. The fix memoizes the result per
+period keyed on ``(total_games, last ended_at)`` and clears the cache in
+``add_game``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.analytics import QuizifyAnalytics  # noqa: E402
+from custom_components.quizify.server import views  # noqa: E402
+from custom_components.quizify.server.context import APP_CTX_KEY  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# #417 — pack_versions_view executor guard
+# --------------------------------------------------------------------------- #
+class _FakeBank:
+    """Minimal QuestionBank double tracking reload calls."""
+
+    def __init__(self, versions: dict, loaded: bool = True) -> None:
+        self._versions = versions
+        self._loaded = loaded
+        self.load_calls = 0
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._loaded
+
+    def load_all_categories(self) -> dict:
+        self.load_calls += 1
+        self._loaded = True
+        return {}
+
+    def get_pack_versions(self) -> dict:
+        return {slug: dict(meta) for slug, meta in self._versions.items()}
+
+
+class _FakeRuntime:
+    def __init__(self) -> None:
+        self.exec_calls = 0
+
+    async def run_in_executor(self, fn, *args):  # noqa: ANN001, ANN002
+        self.exec_calls += 1
+        return fn(*args)
+
+
+class _FakeRequest:
+    def __init__(self, ctx) -> None:  # noqa: ANN001
+        self.app = {APP_CTX_KEY: ctx}
+        self.query: dict[str, str] = {}
+        self.headers: dict[str, str] = {}
+
+
+def _make_ctx(bank: _FakeBank) -> SimpleNamespace:
+    return SimpleNamespace(
+        game=SimpleNamespace(question_bank=bank),
+        runtime=_FakeRuntime(),
+    )
+
+
+def _call_packs(ctx) -> dict:  # noqa: ANN001
+    resp = asyncio.run(views.pack_versions_view(_FakeRequest(ctx)))  # type: ignore[arg-type]
+    return json.loads(resp.body)
+
+
+def test_pack_versions_loaded_bank_skips_executor_reload() -> None:
+    """A preloaded bank serves the packs view without an executor reload."""
+    bank = _FakeBank(
+        {"animals": {"version": "1.0.0", "name": "Animals"}}, loaded=True
+    )
+    ctx = _make_ctx(bank)
+
+    out = _call_packs(ctx)
+
+    assert bank.load_calls == 0
+    assert ctx.runtime.exec_calls == 0
+    # Response shape preserved + per-request season annotation added.
+    assert out["animals"]["version"] == "1.0.0"
+    assert out["animals"]["is_seasonal"] is False
+    assert out["animals"]["season_label"] == ""
+
+
+def test_pack_versions_unloaded_bank_loads_once_via_executor() -> None:
+    """A cold bank is loaded through the executor exactly once."""
+    bank = _FakeBank(
+        {"animals": {"version": "1.0.0", "name": "Animals"}}, loaded=False
+    )
+    ctx = _make_ctx(bank)
+
+    _call_packs(ctx)
+
+    assert bank.load_calls == 1
+    assert ctx.runtime.exec_calls == 1
+
+
+# --------------------------------------------------------------------------- #
+# #418 — compute_metrics memoization
+# --------------------------------------------------------------------------- #
+class _AnalyticsRuntime:
+    def __init__(self, data_dir: Path) -> None:
+        self.data_dir = data_dir
+
+    async def run_in_executor(self, fn, *args):  # noqa: ANN001, ANN002
+        return fn(*args)
+
+
+def _game(game_id: str, ended_at: int, player_count: int = 3) -> dict:
+    return {
+        "game_id": game_id,
+        "started_at": ended_at - 600,
+        "ended_at": ended_at,
+        "duration_seconds": 600,
+        "player_count": player_count,
+        "category": "animals",
+        "question_count": 10,
+        "rounds_played": 10,
+        "average_score": 100.0,
+        "difficulty": "medium",
+        "player_scores": {"Alice": 120, "Bob": 80},
+        "winner": "Alice",
+    }
+
+
+def _make_analytics(tmp_path: Path) -> QuizifyAnalytics:
+    return QuizifyAnalytics(_AnalyticsRuntime(tmp_path))
+
+
+def test_compute_metrics_returns_cached_result_until_add_game(tmp_path) -> None:
+    """Repeat reads reuse the memoized result; add_game invalidates it."""
+    analytics = _make_analytics(tmp_path)
+    # Avoid scheduling real save tasks — we only exercise the cache path.
+    analytics.schedule_save = lambda: None  # type: ignore[assignment]
+
+    now = int(time.time())
+    analytics._data["games"] = [_game("g1", now - 100), _game("g2", now - 50)]
+
+    first = analytics.compute_metrics("30d")
+    second = analytics.compute_metrics("30d")
+
+    # Same fingerprint → the exact same cached object is returned (no recompute).
+    assert second is first
+    assert first["total_games"] == 2
+
+    # Mutate an existing record *without* changing the fingerprint
+    # (len + last ended_at unchanged). A memoized read stays stale.
+    analytics._data["games"][-1]["player_count"] = 99
+    stale = analytics.compute_metrics("30d")
+    assert stale is first  # still the cached object, mutation not reflected
+
+    # add_game clears the cache → the next read recomputes from live data.
+    asyncio.run(analytics.add_game(_game("g3", now - 10)))
+    fresh = analytics.compute_metrics("30d")
+
+    assert fresh is not first
+    assert fresh["total_games"] == 3
+    # The previously-hidden mutation now flows through (99 + 3 + 3).
+    assert fresh["avg_players_per_game"] == round((99 + 3 + 3) / 3, 1)
+
+
+def test_compute_metrics_cache_is_per_period(tmp_path) -> None:
+    """Distinct periods are cached independently and stay correct."""
+    analytics = _make_analytics(tmp_path)
+    analytics.schedule_save = lambda: None  # type: ignore[assignment]
+
+    now = int(time.time())
+    analytics._data["games"] = [_game("g1", now - 100)]
+
+    m30 = analytics.compute_metrics("30d")
+    m7 = analytics.compute_metrics("7d")
+
+    assert m30["period"] == "30d"
+    assert m7["period"] == "7d"
+    # Re-reads hit the cache per period.
+    assert analytics.compute_metrics("30d") is m30
+    assert analytics.compute_metrics("7d") is m7

--- a/tests/test_seasonal_packs_276.py
+++ b/tests/test_seasonal_packs_276.py
@@ -228,6 +228,10 @@ class _FakeBank:
         self._categories = categories
 
     @property
+    def is_loaded(self) -> bool:
+        return True
+
+    @property
     def categories(self) -> dict:
         return dict(self._categories)
 


### PR DESCRIPTION
Fixes #417
Fixes #418

## #417 — pack_versions executor guard
`pack_versions_view` (`GET /api/quizify/packs`) unconditionally awaited `run_in_executor(bank.load_all_categories)` on every request, though the bank is preloaded and `load_all_categories` is a guarded no-op once loaded. This mirrors the existing `pack_update_check_view` guard (`if not bank.is_loaded`) so the executor hop + disk read are skipped when the bank is already loaded — the normal case is now a pure in-memory read.

## #418 — analytics metrics memoization
`compute_metrics` ran synchronously on the event loop for every `GET /api/quizify/analytics/data` and every even-day featured-pack request — 4+ full passes over up to 1000 `GameRecord`s, recomputed though the data only changes at game end. Now memoized per period keyed on `(total_games, last ended_at)`. `add_game` clears the cache; a prune shifts the fingerprint — so both invalidation paths recompute.

## Tests
- New `tests/test_perf_views_analytics_417_418.py`: pack_versions skips the executor reload when the bank is loaded (and still loads once when cold); compute_metrics returns the cached object across repeat reads and stays stale under a fingerprint-preserving mutation until `add_game` invalidates it; per-period cache isolation.
- Updated the #276 seasonal fake bank with `is_loaded`.
- Full suite: 902 passed, 5 skipped. `ruff check custom_components/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)