### PR TITLE
fix(ux): player/global batch — invite button, join-error msg, dead confirm modal, touch kick, safe-area headroom, sub-44px targets, conn a11y (#419,#420,#422,#423,#424,#426,#430)

### DIFF
--- a/custom_components/quizify/www/css/src/00-tokens.css
+++ b/custom_components/quizify/www/css/src/00-tokens.css
@@ -299,6 +299,7 @@ a:focus-visible,
    click POSTs to /api/quizify/flag-question. Sized for thumbs but
    visually quiet so it doesn't shout next to the fun fact. */
 .flag-question-btn {
+    position: relative;
     margin-left: auto;
     border: 0;
     background: transparent;
@@ -308,8 +309,17 @@ a:focus-visible,
     height: 36px;
     border-radius: 50%;
     cursor: pointer;
-    opacity: 0.45;
+    /* Raised from 0.45 so the resting affordance is discoverable (#423). */
+    opacity: 0.6;
     transition: opacity 120ms ease-out, background 120ms ease-out;
+}
+/* Transparent ::before lifts the 36px disc to a >=44px tap target
+   (#423, WCAG 2.5.8) without enlarging the visible circle. */
+.flag-question-btn::before {
+    content: '';
+    position: absolute;
+    inset: -4px;
+    border-radius: inherit;
 }
 .flag-question-btn:hover,
 .flag-question-btn:focus-visible {

--- a/custom_components/quizify/www/css/src/02-shared.css
+++ b/custom_components/quizify/www/css/src/02-shared.css
@@ -622,6 +622,7 @@ button, .btn {
     margin-bottom: 10px;
 }
 .featured-spotlight .spotlight-play-btn {
+    position: relative;
     appearance: none;
     -webkit-appearance: none;
     background: rgba(255, 255, 255, 0.95);
@@ -635,6 +636,13 @@ button, .btn {
     min-width: 0;
     min-height: 0;
     font-family: inherit;
+}
+/* Transparent ::before lifts the tap target to >=44px tall (the pill is
+   only ~31px) without changing the visible chrome (#423, WCAG 2.5.8). */
+.featured-spotlight .spotlight-play-btn::before {
+    content: '';
+    position: absolute;
+    inset: -7px;
 }
 .featured-spotlight .spotlight-play-btn:hover {
     background: #fff;
@@ -664,6 +672,7 @@ button, .btn {
    and the tabs end up rendering as fat blue-text iOS buttons instead of
    the small dark/cream pills the mockup calls for. */
 .theme-tab {
+    position: relative;
     appearance: none;
     -webkit-appearance: none;
     flex: 0 0 auto;
@@ -687,6 +696,14 @@ button, .btn {
     white-space: nowrap;
     transition: all 0.12s ease;
     font-family: inherit;
+}
+/* Transparent ::before extends the tap target to >=44px tall (the pill
+   is only ~27px) without enlarging the visible pill (#423, WCAG 2.5.8).
+   Vertical-only inset so adjacent tabs' hit areas don't overlap. */
+.theme-tab::before {
+    content: '';
+    position: absolute;
+    inset: -9px 0;
 }
 /* "Alle" + any text-only tab: no icon, so restore symmetric padding. */
 .theme-tab:not(:has(.qz-icon)) {

--- a/custom_components/quizify/www/css/src/03-question.css
+++ b/custom_components/quizify/www/css/src/03-question.css
@@ -128,6 +128,13 @@
     align-items: center;
     justify-content: center;
 }
+/* Transparent ::before lifts the 34px button to a >=44px tap target
+   (#423, WCAG 2.5.8) without enlarging the visible chrome. */
+.question-image-zoom::before {
+    content: '';
+    position: absolute;
+    inset: -5px;
+}
 .question-image-zoom:hover { background: rgba(42, 40, 32, 0.75); }
 
 /* Fullscreen zoom overlay */

--- a/custom_components/quizify/www/css/src/07-player.css
+++ b/custom_components/quizify/www/css/src/07-player.css
@@ -1698,6 +1698,20 @@
     font-weight: 600;
 }
 
+/* Invite-players button (#419) — centered, quiet secondary action
+   under the orbit row that opens the QR + copy-link sheet. */
+.pl-invite-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin: var(--space-md) auto 0;
+}
+.pl-invite-btn-icon {
+    font-size: 1rem;
+    line-height: 1;
+}
+
 /* Variant D — rules block below the hero+orbits. */
 .pl-rules {
     background: var(--color-bg-surface);
@@ -1971,6 +1985,7 @@
    styling the browser default eats the .name's flex column at narrow
    viewports (observed: kick = 48 px, name = 0 px). */
 .lobby-e-row-card .player-chip-kick {
+    position: relative;
     background: transparent;
     border: 0;
     color: var(--color-text-muted);
@@ -1983,6 +1998,13 @@
     border-radius: 4px;
     flex-shrink: 0;
 }
+/* Transparent ::before extends the tap target to >=44px (WCAG 2.5.8)
+   without growing the visible glyph — the padded box is only ~28px. */
+.lobby-e-row-card .player-chip-kick::before {
+    content: '';
+    position: absolute;
+    inset: -8px;
+}
 .lobby-e-row-card:hover .player-chip-kick,
 .lobby-e-row-card:focus-within .player-chip-kick {
     opacity: 0.7;
@@ -1991,6 +2013,19 @@
     opacity: 1;
     color: var(--color-error);
     background: var(--color-error-bg);
+}
+/* On touch devices there is no hover, so opacity:0 makes the kick
+   button invisible and effectively untappable (#420). Reveal it at a
+   quiet resting opacity on coarse pointers so hosts can still remove a
+   player on a phone/tablet. */
+@media (hover: none) {
+    .lobby-e-row-card .player-chip-kick {
+        opacity: 0.45;
+    }
+    .lobby-e-row-card .player-chip-kick:active {
+        opacity: 1;
+        color: var(--color-error);
+    }
 }
 
 .lobby-e-row-empty {
@@ -2104,7 +2139,11 @@
    :has() selector is supported on every browser HA ships with. */
 body:has(.admin-control-bar:not(.hidden)) #reveal-view,
 body:has(.admin-control-bar:not(.hidden)) #game-view {
-    padding-bottom: 96px;
+    /* Add the iOS home-indicator inset on top of the 96px bar height:
+       since #375 the bar itself pads by env(safe-area-inset-bottom), so
+       it's taller than 96px on notched iPhones and would otherwise cover
+       the bottom content (#422). */
+    padding-bottom: calc(96px + env(safe-area-inset-bottom, 0px));
 }
 
 .control-btn {
@@ -2163,7 +2202,9 @@ body:has(.admin-control-bar:not(.hidden)) #game-view {
    reaction row above the ~80 px bar height so admins still see the
    full row of buttons. Non-admins fall through to the default padding. */
 body.is-admin .reaction-bar {
-    margin-bottom: 80px;
+    /* Clear the sticky admin bar plus the home-indicator inset it now
+       carries (#375) so the reaction row isn't hidden behind it (#422). */
+    margin-bottom: calc(80px + env(safe-area-inset-bottom, 0px));
 }
 
 .reaction-bar-container {
@@ -2843,21 +2884,6 @@ body.is-admin .reaction-bar {
     .powerup-target-modal {
         align-items: center;
     }
-}
-
-/* Confirm modal */
-.confirm-modal-title {
-    font-family: var(--font-display);
-    font-size: 1.1rem;
-    font-weight: 700;
-    color: var(--color-text-white);                  /* parchment on dark surface */
-    margin-bottom: var(--space-sm);
-}
-
-.confirm-modal-message {
-    font-size: 0.9rem;
-    color: var(--color-text-neon-muted);             /* muted blue-gray on dark */
-    line-height: 1.5;
 }
 
 /* ==========================================

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -301,6 +301,7 @@ a:focus-visible,
    click POSTs to /api/quizify/flag-question. Sized for thumbs but
    visually quiet so it doesn't shout next to the fun fact. */
 .flag-question-btn {
+    position: relative;
     margin-left: auto;
     border: 0;
     background: transparent;
@@ -310,8 +311,17 @@ a:focus-visible,
     height: 36px;
     border-radius: 50%;
     cursor: pointer;
-    opacity: 0.45;
+    /* Raised from 0.45 so the resting affordance is discoverable (#423). */
+    opacity: 0.6;
     transition: opacity 120ms ease-out, background 120ms ease-out;
+}
+/* Transparent ::before lifts the 36px disc to a >=44px tap target
+   (#423, WCAG 2.5.8) without enlarging the visible circle. */
+.flag-question-btn::before {
+    content: '';
+    position: absolute;
+    inset: -4px;
+    border-radius: inherit;
 }
 .flag-question-btn:hover,
 .flag-question-btn:focus-visible {
@@ -1318,6 +1328,7 @@ button, .btn {
     margin-bottom: 10px;
 }
 .featured-spotlight .spotlight-play-btn {
+    position: relative;
     appearance: none;
     -webkit-appearance: none;
     background: rgba(255, 255, 255, 0.95);
@@ -1331,6 +1342,13 @@ button, .btn {
     min-width: 0;
     min-height: 0;
     font-family: inherit;
+}
+/* Transparent ::before lifts the tap target to >=44px tall (the pill is
+   only ~31px) without changing the visible chrome (#423, WCAG 2.5.8). */
+.featured-spotlight .spotlight-play-btn::before {
+    content: '';
+    position: absolute;
+    inset: -7px;
 }
 .featured-spotlight .spotlight-play-btn:hover {
     background: #fff;
@@ -1360,6 +1378,7 @@ button, .btn {
    and the tabs end up rendering as fat blue-text iOS buttons instead of
    the small dark/cream pills the mockup calls for. */
 .theme-tab {
+    position: relative;
     appearance: none;
     -webkit-appearance: none;
     flex: 0 0 auto;
@@ -1383,6 +1402,14 @@ button, .btn {
     white-space: nowrap;
     transition: all 0.12s ease;
     font-family: inherit;
+}
+/* Transparent ::before extends the tap target to >=44px tall (the pill
+   is only ~27px) without enlarging the visible pill (#423, WCAG 2.5.8).
+   Vertical-only inset so adjacent tabs' hit areas don't overlap. */
+.theme-tab::before {
+    content: '';
+    position: absolute;
+    inset: -9px 0;
 }
 /* "Alle" + any text-only tab: no icon, so restore symmetric padding. */
 .theme-tab:not(:has(.qz-icon)) {
@@ -1628,6 +1655,13 @@ button, .btn {
     display: flex;
     align-items: center;
     justify-content: center;
+}
+/* Transparent ::before lifts the 34px button to a >=44px tap target
+   (#423, WCAG 2.5.8) without enlarging the visible chrome. */
+.question-image-zoom::before {
+    content: '';
+    position: absolute;
+    inset: -5px;
 }
 .question-image-zoom:hover { background: rgba(42, 40, 32, 0.75); }
 
@@ -4624,6 +4658,20 @@ footer {
     font-weight: 600;
 }
 
+/* Invite-players button (#419) — centered, quiet secondary action
+   under the orbit row that opens the QR + copy-link sheet. */
+.pl-invite-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin: var(--space-md) auto 0;
+}
+.pl-invite-btn-icon {
+    font-size: 1rem;
+    line-height: 1;
+}
+
 /* Variant D — rules block below the hero+orbits. */
 .pl-rules {
     background: var(--color-bg-surface);
@@ -4897,6 +4945,7 @@ footer {
    styling the browser default eats the .name's flex column at narrow
    viewports (observed: kick = 48 px, name = 0 px). */
 .lobby-e-row-card .player-chip-kick {
+    position: relative;
     background: transparent;
     border: 0;
     color: var(--color-text-muted);
@@ -4909,6 +4958,13 @@ footer {
     border-radius: 4px;
     flex-shrink: 0;
 }
+/* Transparent ::before extends the tap target to >=44px (WCAG 2.5.8)
+   without growing the visible glyph — the padded box is only ~28px. */
+.lobby-e-row-card .player-chip-kick::before {
+    content: '';
+    position: absolute;
+    inset: -8px;
+}
 .lobby-e-row-card:hover .player-chip-kick,
 .lobby-e-row-card:focus-within .player-chip-kick {
     opacity: 0.7;
@@ -4917,6 +4973,19 @@ footer {
     opacity: 1;
     color: var(--color-error);
     background: var(--color-error-bg);
+}
+/* On touch devices there is no hover, so opacity:0 makes the kick
+   button invisible and effectively untappable (#420). Reveal it at a
+   quiet resting opacity on coarse pointers so hosts can still remove a
+   player on a phone/tablet. */
+@media (hover: none) {
+    .lobby-e-row-card .player-chip-kick {
+        opacity: 0.45;
+    }
+    .lobby-e-row-card .player-chip-kick:active {
+        opacity: 1;
+        color: var(--color-error);
+    }
 }
 
 .lobby-e-row-empty {
@@ -5030,7 +5099,11 @@ footer {
    :has() selector is supported on every browser HA ships with. */
 body:has(.admin-control-bar:not(.hidden)) #reveal-view,
 body:has(.admin-control-bar:not(.hidden)) #game-view {
-    padding-bottom: 96px;
+    /* Add the iOS home-indicator inset on top of the 96px bar height:
+       since #375 the bar itself pads by env(safe-area-inset-bottom), so
+       it's taller than 96px on notched iPhones and would otherwise cover
+       the bottom content (#422). */
+    padding-bottom: calc(96px + env(safe-area-inset-bottom, 0px));
 }
 
 .control-btn {
@@ -5089,7 +5162,9 @@ body:has(.admin-control-bar:not(.hidden)) #game-view {
    reaction row above the ~80 px bar height so admins still see the
    full row of buttons. Non-admins fall through to the default padding. */
 body.is-admin .reaction-bar {
-    margin-bottom: 80px;
+    /* Clear the sticky admin bar plus the home-indicator inset it now
+       carries (#375) so the reaction row isn't hidden behind it (#422). */
+    margin-bottom: calc(80px + env(safe-area-inset-bottom, 0px));
 }
 
 .reaction-bar-container {
@@ -5769,21 +5844,6 @@ body.is-admin .reaction-bar {
     .powerup-target-modal {
         align-items: center;
     }
-}
-
-/* Confirm modal */
-.confirm-modal-title {
-    font-family: var(--font-display);
-    font-size: 1.1rem;
-    font-weight: 700;
-    color: var(--color-text-white);                  /* parchment on dark surface */
-    margin-bottom: var(--space-sm);
-}
-
-.confirm-modal-message {
-    font-size: 0.9rem;
-    color: var(--color-text-neon-muted);             /* muted blue-gray on dark */
-    line-height: 1.5;
 }
 
 /* ==========================================

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -982,6 +982,16 @@
             els.joinBtn.disabled = false;
             els.joinBtn.textContent = t('join.joinButton');
             if (els.nameInput) els.nameInput.style.borderColor = '#D65858';
+            // The toast fades after a few seconds, taking the reason with it;
+            // the red border alone doesn't say *why* the join failed (#426).
+            // Persist the translated reason in the inline validation message
+            // (the input's aria-describedby target) so it stays visible and
+            // is announced to screen readers. Cleared on the next input.
+            var vmsg = document.getElementById('name-validation-msg');
+            if (vmsg) {
+                vmsg.textContent = userMsg;
+                vmsg.classList.remove('hidden');
+            }
         }
     }
 
@@ -995,6 +1005,14 @@
         els.nameInput.addEventListener('input', function () {
             var result = pu.validateName(this.value);
             els.joinBtn.disabled = !result.valid;
+            // Clear a stale join-error reason (#426) once the user edits the
+            // name again, and drop the red border set by handleError.
+            var vmsg = document.getElementById('name-validation-msg');
+            if (vmsg && vmsg.textContent) {
+                vmsg.textContent = '';
+                vmsg.classList.add('hidden');
+            }
+            this.style.borderColor = '';
         });
 
         els.joinBtn.addEventListener('click', handleJoinClick);

--- a/custom_components/quizify/www/js/player-utils.js
+++ b/custom_components/quizify/www/js/player-utils.js
@@ -201,9 +201,24 @@
         var glow = { connected: 'rgba(127,168,151,0.45)', reconnecting: 'rgba(232,196,127,0.45)', disconnected: 'rgba(214,106,106,0.45)' };
         var color = colors[status] || '#6E6A5C';
         var glowColor = glow[status] || 'rgba(110,106,92,0.25)';
-        // Dot only — no text label
+        var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
+        // A bare colored dot is invisible to screen readers and ambiguous for
+        // color-blind users (#424). Not-connected states get a shape/label,
+        // not hue alone: reconnecting shows an "…" glyph, disconnected an
+        // "offline" slash glyph next to the dot.
+        var glyph = { reconnecting: '…', disconnected: '⊘' };
+        var mark = glyph[status]
+            ? '<span aria-hidden="true" style="font-size:0.85rem;line-height:1;color:' + color + ';">' + glyph[status] + '</span>'
+            : '';
         el.innerHTML = '<span style="width:10px;height:10px;border-radius:50%;display:inline-block;background:' +
-            color + ';box-shadow:0 0 10px ' + glowColor + ';"></span>';
+            color + ';box-shadow:0 0 10px ' + glowColor + ';"></span>' + mark;
+        // Announce the state to assistive tech via the polite live region.
+        var announce = document.getElementById('conn-status-announce');
+        if (announce) {
+            var msg = t('connection.' + status);
+            if (!msg || msg === 'connection.' + status) msg = status;
+            announce.textContent = msg;
+        }
     }
 
     // ============================================

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -206,9 +206,24 @@
         var glow = { connected: 'rgba(127,168,151,0.45)', reconnecting: 'rgba(232,196,127,0.45)', disconnected: 'rgba(214,106,106,0.45)' };
         var color = colors[status] || '#6E6A5C';
         var glowColor = glow[status] || 'rgba(110,106,92,0.25)';
-        // Dot only — no text label
+        var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
+        // A bare colored dot is invisible to screen readers and ambiguous for
+        // color-blind users (#424). Not-connected states get a shape/label,
+        // not hue alone: reconnecting shows an "…" glyph, disconnected an
+        // "offline" slash glyph next to the dot.
+        var glyph = { reconnecting: '…', disconnected: '⊘' };
+        var mark = glyph[status]
+            ? '<span aria-hidden="true" style="font-size:0.85rem;line-height:1;color:' + color + ';">' + glyph[status] + '</span>'
+            : '';
         el.innerHTML = '<span style="width:10px;height:10px;border-radius:50%;display:inline-block;background:' +
-            color + ';box-shadow:0 0 10px ' + glowColor + ';"></span>';
+            color + ';box-shadow:0 0 10px ' + glowColor + ';"></span>' + mark;
+        // Announce the state to assistive tech via the polite live region.
+        var announce = document.getElementById('conn-status-announce');
+        if (announce) {
+            var msg = t('connection.' + status);
+            if (!msg || msg === 'connection.' + status) msg = status;
+            announce.textContent = msg;
+        }
     }
 
     // ============================================
@@ -5117,6 +5132,16 @@
             els.joinBtn.disabled = false;
             els.joinBtn.textContent = t('join.joinButton');
             if (els.nameInput) els.nameInput.style.borderColor = '#D65858';
+            // The toast fades after a few seconds, taking the reason with it;
+            // the red border alone doesn't say *why* the join failed (#426).
+            // Persist the translated reason in the inline validation message
+            // (the input's aria-describedby target) so it stays visible and
+            // is announced to screen readers. Cleared on the next input.
+            var vmsg = document.getElementById('name-validation-msg');
+            if (vmsg) {
+                vmsg.textContent = userMsg;
+                vmsg.classList.remove('hidden');
+            }
         }
     }
 
@@ -5130,6 +5155,14 @@
         els.nameInput.addEventListener('input', function () {
             var result = pu.validateName(this.value);
             els.joinBtn.disabled = !result.valid;
+            // Clear a stale join-error reason (#426) once the user edits the
+            // name again, and drop the red border set by handleError.
+            var vmsg = document.getElementById('name-validation-msg');
+            if (vmsg && vmsg.textContent) {
+                vmsg.textContent = '';
+                vmsg.classList.add('hidden');
+            }
+            this.style.borderColor = '';
         });
 
         els.joinBtn.addEventListener('click', handleJoinClick);

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -54,6 +54,12 @@
         </span>
         <!-- Connection status dot — JS updates via conn-status div -->
         <div id="connection-indicator" class="connection-indicator" aria-hidden="true"></div>
+        <!-- Screen-reader announcement of the connection state (#424). The dot
+             above is aria-hidden + color-only; this polite live region speaks
+             the localized "Connected / Reconnecting / Disconnected" text so
+             AT users (and, via the glyph, color-blind users) get the state. -->
+        <div id="conn-status-announce" class="sr-only" role="status"
+             aria-live="polite" aria-atomic="true"></div>
     </header>
 
     <main class="player-container">
@@ -131,6 +137,16 @@
             <div class="pl-orbits" id="player-list" aria-live="polite">
                 <!-- Player cards rendered by JS — orbit chips for B layout. -->
             </div>
+
+            <!-- Invite players — opens the QR + copy-link sheet (#419).
+                 Visible to every player so anyone can share the join link;
+                 wired to openInviteModal() by player-lobby.setupInviteModal. -->
+            <button id="invite-players-btn" type="button"
+                    class="btn btn-secondary pl-invite-btn"
+                    data-i18n-aria-label="a11y.invitePlayersAria">
+                <span class="pl-invite-btn-icon" aria-hidden="true">🔗</span>
+                <span data-i18n="lobby.invitePlayers">Invite Players</span>
+            </button>
 
             <!-- Variant D: rules. Always visible (was collapsible). -->
             <section class="pl-rules">
@@ -812,19 +828,6 @@
             <p id="invite-copy-feedback" class="invite-copy-feedback hidden" data-i18n="lobby.copied">Copied!</p>
             <button id="invite-modal-close" class="btn btn-secondary invite-modal-close"
                     aria-label="Close invite popup" data-i18n="common.close">Close</button>
-        </div>
-    </div>
-
-    <!-- Generic Confirmation Modal -->
-    <div id="confirm-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="confirm-modal-title">
-        <div class="modal-backdrop"></div>
-        <div class="modal-content">
-            <h2 id="confirm-modal-title">Confirm</h2>
-            <p id="confirm-modal-message"></p>
-            <div class="modal-actions">
-                <button id="confirm-modal-yes" class="btn btn-primary" data-i18n="common.confirm">Confirm</button>
-                <button id="confirm-modal-no" class="btn btn-secondary" data-i18n="common.cancel">Cancel</button>
-            </div>
         </div>
     </div>
 

--- a/tests/test_ux_player_css_w3b.py
+++ b/tests/test_ux_player_css_w3b.py
@@ -1,0 +1,189 @@
+"""Guard the player/global UX batch (w3b): #419, #420, #422, #423, #424, #426, #430.
+
+Text-level assertions over the committed front-end sources (HTML, JS modules,
+CSS source modules and the built styles.css). They lock in each fix so a later
+edit can't silently regress it.
+
+* #419 — a visible "Invite players" button exists in the lobby and is wired to
+  openInviteModal via #invite-players-btn.
+* #420 — the lobby kick button is revealed on coarse pointers.
+* #422 — the admin-bar scroll/reaction headroom includes the iOS safe-area inset.
+* #423 — theme-tab / spotlight-play-btn / flag-question-btn / question-image-zoom
+  all carry a ::before hit-area extension in the built stylesheet.
+* #424 — a polite sr-only connection-status live region exists and is populated.
+* #426 — a join error is written into #name-validation-msg (and cleared on input).
+* #430 — the dead #confirm-modal markup and its CSS were removed.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+WWW = REPO / "custom_components" / "quizify" / "www"
+SRC = WWW / "css" / "src"
+JS = WWW / "js"
+
+
+def _rule(css: str, selector: str) -> str:
+    """Return the declaration block for the first rule matching ``selector``."""
+    idx = css.index(selector)
+    start = css.index("{", idx)
+    end = css.index("}", start)
+    return css[start + 1 : end]
+
+
+# ---------------------------------------------------------------------------
+# #419 — invite button exists + wired
+# ---------------------------------------------------------------------------
+
+def test_invite_button_present_in_lobby() -> None:
+    html = (WWW / "player.html").read_text("utf-8")
+    assert 'id="invite-players-btn"' in html, (
+        "player lobby must expose a visible #invite-players-btn (#419)"
+    )
+    assert 'data-i18n="lobby.invitePlayers"' in html
+
+
+def test_invite_button_wired_to_modal() -> None:
+    js = (JS / "player-lobby.js").read_text("utf-8")
+    # setupInviteModal looks up the button and binds openInviteModal.
+    assert "getElementById('invite-players-btn')" in js
+    assert "openInviteModal" in js
+
+
+# ---------------------------------------------------------------------------
+# #426 — name-validation-msg populated on join error, cleared on input
+# ---------------------------------------------------------------------------
+
+def test_join_error_populates_validation_msg() -> None:
+    js = (JS / "player-core.js").read_text("utf-8")
+    block = js[js.index("function handleError"):]
+    block = block[: block.index("function setupJoinForm")]
+    assert "name-validation-msg" in block, (
+        "handleError must write the reason into #name-validation-msg on join errors (#426)"
+    )
+
+
+def test_validation_msg_cleared_on_input() -> None:
+    js = (JS / "player-core.js").read_text("utf-8")
+    setup = js[js.index("function setupJoinForm"):]
+    setup = setup[: setup.index("function handleJoinClick")]
+    assert "name-validation-msg" in setup, (
+        "the name input handler must clear #name-validation-msg on edit (#426)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #423 — sub-44px targets get a ::before hit-area in the built stylesheet
+# ---------------------------------------------------------------------------
+
+def test_sub_44_targets_have_hit_area_extension() -> None:
+    css = (WWW / "css" / "styles.css").read_text("utf-8")
+    for selector in (
+        ".theme-tab::before",
+        ".spotlight-play-btn::before",
+        ".flag-question-btn::before",
+        ".question-image-zoom::before",
+    ):
+        assert selector in css, f"missing hit-area extension {selector} (#423)"
+        block = _rule(css, selector)
+        assert "inset:" in block and "-" in block, (
+            f"{selector} needs a negative inset to enlarge the tap target (#423)"
+        )
+
+
+def test_flag_button_resting_opacity_raised() -> None:
+    css = (SRC / "00-tokens.css").read_text("utf-8")
+    block = _rule(css, ".flag-question-btn {")
+    m = re.search(r"opacity:\s*([0-9.]+)", block)
+    assert m and float(m.group(1)) >= 0.55, (
+        ".flag-question-btn resting opacity should be raised to ~0.6 (#423)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #422 — safe-area calc on the admin-bar headroom
+# ---------------------------------------------------------------------------
+
+def test_admin_bar_headroom_has_safe_area_calc() -> None:
+    css = (SRC / "07-player.css").read_text("utf-8")
+    # #reveal-view / #game-view scroll headroom
+    idx = css.index("body:has(.admin-control-bar:not(.hidden)) #game-view")
+    block = css[css.index("{", idx) + 1 : css.index("}", idx)]
+    assert "calc(96px + env(safe-area-inset-bottom" in block, (
+        "reveal/game scroll headroom must add the safe-area inset (#422)"
+    )
+    # reaction bar margin
+    reaction = _rule(css, "body.is-admin .reaction-bar {")
+    assert "calc(80px + env(safe-area-inset-bottom" in reaction, (
+        ".reaction-bar margin must add the safe-area inset (#422)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #420 — kick button visible on touch (coarse pointer)
+# ---------------------------------------------------------------------------
+
+def test_kick_button_visible_on_touch() -> None:
+    css = (SRC / "07-player.css").read_text("utf-8")
+    assert "@media (hover: none)" in css
+    # locate the hover:none block that sets a non-zero resting opacity on the kick.
+    idx = css.index("@media (hover: none)")
+    block = css[idx : idx + 400]
+    assert "player-chip-kick" in block and "opacity: 0.45" in block, (
+        "kick button must show at ~0.45 opacity on coarse pointers (#420)"
+    )
+
+
+def test_kick_button_has_hit_area() -> None:
+    css = (SRC / "07-player.css").read_text("utf-8")
+    block = _rule(css, ".lobby-e-row-card .player-chip-kick::before")
+    assert "inset:" in block and "-" in block, (
+        "kick button needs a ::before hit-area extension (#420)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #424 — connection status sr-only live region
+# ---------------------------------------------------------------------------
+
+def test_conn_sr_live_region_present() -> None:
+    html = (WWW / "player.html").read_text("utf-8")
+    idx = html.index('id="conn-status-announce"')
+    frag = html[idx - 120 : idx + 120]
+    assert 'aria-live="polite"' in frag, (
+        "connection status needs a polite sr-only aria-live region (#424)"
+    )
+
+
+def test_conn_indicator_updates_live_region() -> None:
+    js = (JS / "player-utils.js").read_text("utf-8")
+    block = js[js.index("function updateConnectionIndicator"):]
+    block = block[: block.index("Reconnecting Overlay")]
+    assert "conn-status-announce" in block, (
+        "updateConnectionIndicator must populate the sr-only live region (#424)"
+    )
+    # not hue-only: a shape/glyph marker for non-connected states.
+    assert "glyph" in block or "⊘" in block, (
+        "disconnected state must pair with a shape/glyph, not hue alone (#424)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# #430 — dead confirm-modal removed
+# ---------------------------------------------------------------------------
+
+def test_confirm_modal_markup_removed() -> None:
+    html = (WWW / "player.html").read_text("utf-8")
+    assert 'id="confirm-modal"' not in html, (
+        "dead #confirm-modal markup must be removed (#430)"
+    )
+
+
+def test_confirm_modal_css_removed() -> None:
+    css = (SRC / "07-player.css").read_text("utf-8")
+    assert ".confirm-modal-title" not in css and ".confirm-modal-message" not in css, (
+        "dead confirm-modal CSS must be removed (#430)"
+    )


### PR DESCRIPTION
Fixes #419
Fixes #420
Fixes #422
Fixes #423
Fixes #424
Fixes #426
Fixes #430

Bundled player/global UX batch (one branch to avoid same-file conflicts across player.html, player-*.js and the CSS modules).

## Changes
- **#419 (high):** `player-lobby.js` wired `#invite-players-btn` but no such element existed, so the whole invite sheet (QR + copy-link) was unreachable. Added a visible "Invite players" button in the lobby, wired to the existing `openInviteModal()`. Reuses `lobby.invitePlayers` / `a11y.invitePlayersAria` i18n keys.
- **#426 (medium):** join failures showed a toast + red border but left the inline `#name-validation-msg` (the `aria-describedby` target) empty — the reason vanished with the toast. Now the translated message is written into `#name-validation-msg` on join-phase errors and cleared on the next input.
- **#430 (low):** removed the dead `#confirm-modal` markup (untranslated `<h2>Confirm`) and its unused `.confirm-modal-*` CSS. The reveal-bar destructive actions already use their own two-tap arm/disarm affordance, so nothing referenced it — removing was the clean choice.
- **#420 (high):** the lobby `.player-chip-kick` was `opacity:0` (hover/focus only) — invisible/untappable on touch. Now shown at ~0.45 opacity on coarse pointers via `@media (hover: none)`, with a `::before` hit-area to ≥44px.
- **#422 (medium, follow-up #375):** admin-bar scroll headroom (`#reveal-view`/`#game-view`) and `.reaction-bar` margin now use `calc(96px + env(safe-area-inset-bottom, 0px))` / `calc(80px + …)` so content clears the safe-area the bar itself adds since #375.
- **#423 (medium, follow-up #379):** `.theme-tab`, `.spotlight-play-btn`, `.flag-question-btn`, `.question-image-zoom` each get an invisible `::before` hit-area to ≥44px (same pattern as the #402 sound-toggle fix); flag button resting opacity raised to 0.6.
- **#424 (medium):** the connection status was a color-only dot invisible to screen readers. Added an sr-only polite `aria-live` region announcing the localized Connected/Reconnecting/Disconnected state, and paired non-connected states with a shape/glyph (not hue alone).

Adds guard tests in `tests/test_ux_player_css_w3b.py`. `styles.css` and `player.bundle.js` regenerated (drift + bundle-drift green). Full suite (930 passed) + ruff clean.

## Mobile-verify needed before merge
CSS layout / touch-target changes must be verified on a real 390x844 iPhone viewport (invite button placement, kick-button touch visibility, safe-area headroom on a home-indicator iPhone, sub-44px hit areas) before shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)