### PR TITLE
fix+perf: websocket/state batch — start-reset cancel, malformed-frame guard, last-player eval, tick/summary/finale/reaction efficiency (#407,#410,#412,#413,#414,#415,#416)

### DIFF
--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -155,6 +155,16 @@ class QuizifyGameState:
         self._current_question: Question | None = None
         self._round_summary: RoundSummary | None = None
 
+        # Memoized round-summary message dict (#414), keyed on
+        # ``(game_id, round)``. ``RoundMessageBuilder.build_round_summary`` is
+        # recipient-independent but was recomputed on every call — once for the
+        # live broadcast and again for every join/reconnect/get_state during
+        # ANSWER_REVEAL (O(P) each, O(P²) under a reconnect storm). Build it
+        # once per round and reuse; invalidated in ``start_next_question`` and
+        # ``reset_to_lobby``.
+        self._round_summary_msg: dict[str, Any] | None = None
+        self._round_summary_msg_key: tuple[str | None, int] | None = None
+
         # Optional admin-chosen timer override (seconds). When set,
         # overrides the difficulty-derived TIME_LIMITS lookup in
         # start_next_question. Cleared on reset_to_lobby/end_game.
@@ -663,6 +673,10 @@ class QuizifyGameState:
 
         self._phase_controller.enter_question_active()
         self._round_summary = None
+        # Invalidate the memoized round-summary message (#414): a new round is
+        # live, so the previous round's cached dict must not be served.
+        self._round_summary_msg = None
+        self._round_summary_msg_key = None
 
         _LOGGER.info(
             "Round %d/%d started: %s (%.0fs)",
@@ -1394,6 +1408,10 @@ class QuizifyGameState:
         self.round = 0
         self._current_question = None
         self._round_summary = None
+        # Drop the memoized round-summary message (#414) with the rest of the
+        # round state so a fresh game never serves a stale summary.
+        self._round_summary_msg = None
+        self._round_summary_msg_key = None
         self._phase_controller.clear_timers()
         self._powerup_manager.reset()
         self._finale_podium = None
@@ -1869,6 +1887,44 @@ class QuizifyGameState:
     def get_round_summary(self) -> RoundSummary | None:
         """Return the last round summary."""
         return self._round_summary
+
+    def all_submitted(self) -> bool:
+        """Whether every active, non-late participant has submitted (#412).
+
+        Public accessor over the registry check so the WS layer can re-test the
+        all-answered condition (e.g. after the last unanswered player drops
+        mid-question) without reaching into ``_player_registry``.
+        """
+        return self._player_registry.all_submitted()
+
+    def get_cached_round_summary_msg(
+        self, key: tuple[str | None, int]
+    ) -> dict[str, Any] | None:
+        """Return the memoized round-summary message for ``key`` (#414).
+
+        ``key`` is ``(game_id, round)``. Returns ``None`` on a miss; callers
+        must build the dict and store it via ``store_round_summary_msg``. The
+        returned dict is shared — treat it read-only or ``dict()``-copy before
+        mutating.
+        """
+        if self._round_summary_msg_key == key:
+            return self._round_summary_msg
+        return None
+
+    def store_round_summary_msg(
+        self, key: tuple[str | None, int], msg: dict[str, Any]
+    ) -> None:
+        """Memoize the round-summary message ``msg`` under ``key`` (#414)."""
+        self._round_summary_msg_key = key
+        self._round_summary_msg = msg
+
+    def get_finale_podium(self) -> list | None:
+        """Return the finale podium cached by ``end_game`` (#415), or None."""
+        return self._finale_podium
+
+    def get_finale_superlatives(self) -> list | None:
+        """Return the finale superlatives cached by ``end_game`` (#415)."""
+        return self._finale_superlatives
 
     def get_state_snapshot(self) -> dict[str, Any]:
         """Build a full state snapshot for WebSocket serialization."""

--- a/custom_components/quizify/server/round_message_builder.py
+++ b/custom_components/quizify/server/round_message_builder.py
@@ -253,6 +253,24 @@ class RoundMessageBuilder:
         if not summary:
             return None
 
+        # Memoize the built dict per round (#414). This method is
+        # recipient-independent — it is called once for the live broadcast and
+        # again for every join/reconnect/get_state projection during
+        # ANSWER_REVEAL — so recomputing it (O(P) each, O(P²) under a reconnect
+        # storm) is wasted work. Keyed on (game_id, round); invalidated by
+        # ``start_next_question``/``reset_to_lobby``. Callers treat the returned
+        # dict read-only or ``dict()``-copy it (``project_snapshot_for_player``
+        # copies before merging), so sharing the cached instance is safe. The
+        # cache accessors are resolved via getattr so lightweight test doubles
+        # that don't implement them simply skip memoization.
+        get_cached = getattr(game_state, "get_cached_round_summary_msg", None)
+        store_cached = getattr(game_state, "store_round_summary_msg", None)
+        cache_key = (getattr(game_state, "game_id", None), game_state.round)
+        if get_cached is not None:
+            cached = get_cached(cache_key)
+            if cached is not None:
+                return cached
+
         question = summary.question
 
         # Estimate rounds (#275) carry no shuffled answers and no correct-tile
@@ -264,7 +282,7 @@ class RoundMessageBuilder:
             leaderboard = serialize_leaderboard(game_state.get_players())
             players_list = serialize_player_list(game_state.get_players())
             last_round_est = game_state.round >= game_state.total_rounds
-            return serialize_round_summary(
+            est_msg = serialize_round_summary(
                 correct_answer_index=-1,
                 correct_answer_index_original=-1,
                 correct_answer_text=summary.correct_answer.text,
@@ -281,6 +299,9 @@ class RoundMessageBuilder:
                 question_type=question.type,
                 estimate=summary.estimate,
             )
+            if store_cached is not None:
+                store_cached(cache_key, est_msg)
+            return est_msg
 
         # Find the correct answer's shuffled index (canonical) AND its
         # original index in question.answers — dashboard needs the latter
@@ -373,7 +394,7 @@ class RoundMessageBuilder:
         players_list = serialize_player_list(game_state.get_players())
         last_round = game_state.round >= game_state.total_rounds
 
-        return serialize_round_summary(
+        msg = serialize_round_summary(
             correct_answer_index=correct_shuffled_idx,
             correct_answer_index_original=correct_original_idx,
             correct_answer_text=summary.correct_answer.text,
@@ -388,3 +409,6 @@ class RoundMessageBuilder:
             last_round=last_round,
             question_id=summary.question.id,
         )
+        if store_cached is not None:
+            store_cached(cache_key, msg)
+        return msg

--- a/custom_components/quizify/server/serializers.py
+++ b/custom_components/quizify/server/serializers.py
@@ -205,11 +205,14 @@ def serialize_finale(
             _rank = i + 1
             _prev = p.score
         podium_entries.append({"rank": _rank, "name": p.name, "score": p.score})
+    # ``leaderboard`` and ``all_players`` carry the identical sorted list —
+    # serialize it once instead of twice (#415).
+    lb = serialize_leaderboard(all_players)
     result = {
         "type": "finale",
         "podium": podium_entries,
-        "leaderboard": serialize_leaderboard(all_players),
-        "all_players": serialize_leaderboard(all_players),
+        "leaderboard": lb,
+        "all_players": lb,
     }
     if superlatives:
         result["superlatives"] = superlatives

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -231,6 +231,16 @@ class QuizifyWebSocketHandler:
         # one ``reaction`` message per distinct buffered reaction.
         self._reaction_buffer: dict[tuple[str, str], None] = {}
         self._reaction_flush_task: asyncio.Task | None = None
+        # Reveal reaction-BONUS coalescing (#416). Each distinct reactor's first
+        # reveal reaction used to broadcast its own ``reaction_bonus`` carrying a
+        # FULL serialized leaderboard (up to P×P frames in a reaction-mashing
+        # room). The point awards stay synchronous (scores + per-round caps must
+        # settle immediately), but the broadcast is deferred into the same
+        # ~150ms flush window and collapsed to ONE ``reaction_bonus`` with a
+        # single leaderboard reflecting the whole batch. Ordered dicts so the
+        # union of reactors/recipients keeps first-seen order.
+        self._reaction_bonus_from: dict[str, None] = {}
+        self._reaction_bonus_to: dict[str, None] = {}
 
     # Coalescing window for visual reactions (#304), seconds.
     _REACTION_FLUSH_WINDOW = 0.15
@@ -369,6 +379,17 @@ class QuizifyWebSocketHandler:
                     except ValueError:
                         await self._conn.send_error(
                             ws, ERR_INVALID_ACTION, "Malformed message (invalid JSON)"
+                        )
+                        continue
+                    # #410: ``msg.json()`` happily parses any valid JSON value —
+                    # ``[1,2]``, ``"x"``, ``5`` — but the ``admin_auth`` and
+                    # ``join`` guards below call ``data.get(...)``, which raises
+                    # AttributeError on a non-dict OUTSIDE the try/except around
+                    # ``_handle_message``, tearing down the connection with a
+                    # traceback. Reject anything that isn't a JSON object here.
+                    if not isinstance(data, dict):
+                        await self._conn.send_error(
+                            ws, ERR_INVALID_ACTION, "Malformed message"
                         )
                         continue
                     # First-message admin auth (#359): the token now travels in
@@ -1060,14 +1081,16 @@ class QuizifyWebSocketHandler:
             bonus_recipients.append(recipient.name)
 
         if bonus_recipients:
-            # Broadcast a leaderboard update so phones see the bonus tick.
-            leaderboard = serialize_leaderboard(game_state.get_players())
-            await self._conn.broadcast({
-                "type": "reaction_bonus",
-                "from_player": reactor.name,
-                "to_players": bonus_recipients,
-                "leaderboard": leaderboard,
-            })
+            # #416: defer + coalesce the leaderboard broadcast into the shared
+            # ~150ms flush window instead of emitting a full-leaderboard frame
+            # per reactor right here. The points are already awarded above; the
+            # flush builds one ``reaction_bonus`` reflecting the whole batch.
+            self._reaction_bonus_from[reactor.name] = None
+            for recipient_name in bonus_recipients:
+                self._reaction_bonus_to[recipient_name] = None
+            # The visual reaction above already armed the flush task, but arm it
+            # defensively so a bonus can never sit undrained.
+            self._ensure_reaction_flush()
 
     def _enqueue_reaction(self, player_name: str, emoji: str) -> None:
         """Buffer a visual reaction and ensure a flush task is pending (#304).
@@ -1079,6 +1102,15 @@ class QuizifyWebSocketHandler:
         exactly one window before draining.
         """
         self._reaction_buffer[(player_name, emoji)] = None
+        self._ensure_reaction_flush()
+
+    def _ensure_reaction_flush(self) -> None:
+        """(Re)arm the coalescing flush task if one isn't already pending.
+
+        Shared by the visual-reaction buffer (#304) and the reveal
+        reaction-bonus buffer (#416) so either kind of buffered event guarantees
+        a flush within one window.
+        """
         if self._reaction_flush_task is None or self._reaction_flush_task.done():
             self._reaction_flush_task = self._runtime.create_task(
                 self._flush_reactions_after_window()
@@ -1097,23 +1129,53 @@ class QuizifyWebSocketHandler:
             # Cancelled on cleanup — drop whatever was buffered (best-effort
             # eye-candy, nothing to persist) and re-raise so the task ends.
             self._reaction_buffer.clear()
+            self._reaction_bonus_from.clear()
+            self._reaction_bonus_to.clear()
             raise
         buffered = list(self._reaction_buffer)
         self._reaction_buffer.clear()
-        for player_name, emoji in buffered:
-            await self._conn.broadcast({
+        # Collect every broadcast for this window, then fan them all out in a
+        # single gather (#416) instead of awaiting them one at a time.
+        broadcasts = [
+            self._conn.broadcast({
                 "type": "reaction",
                 "emoji": emoji,
                 "player_name": player_name,
             })
+            for player_name, emoji in buffered
+        ]
 
-        # Reactions that arrived DURING the broadcasts above were appended to
-        # the buffer, but _enqueue_reaction won't start a new flush while this
-        # task is still running (it isn't None/done yet) — so without this the
-        # tail would sit unbroadcast until some future reaction happened to
-        # arrive (#354). Re-arm the flush ourselves so the buffer always
-        # drains: one more window, then another pass. Loops until empty.
-        if self._reaction_buffer:
+        # #416: collapse the reveal reaction-bonus events buffered this window
+        # into ONE ``reaction_bonus``. The leaderboard is serialized once, now —
+        # after every point award in the window has settled — so it reflects the
+        # whole batch. ``from_player`` keeps the existing single-name wire field
+        # (first reactor) for the client toast; ``from_players`` carries the full
+        # set for completeness.
+        if self._reaction_bonus_to:
+            from_players = list(self._reaction_bonus_from)
+            to_players = list(self._reaction_bonus_to)
+            self._reaction_bonus_from.clear()
+            self._reaction_bonus_to.clear()
+            gs = self._get_game_state()
+            if gs is not None and from_players:
+                broadcasts.append(self._conn.broadcast({
+                    "type": "reaction_bonus",
+                    "from_player": from_players[0],
+                    "from_players": from_players,
+                    "to_players": to_players,
+                    "leaderboard": serialize_leaderboard(gs.get_players()),
+                }))
+
+        if broadcasts:
+            await asyncio.gather(*broadcasts)
+
+        # Reactions/bonuses that arrived DURING the broadcasts above were
+        # appended to the buffers, but _ensure_reaction_flush won't start a new
+        # flush while this task is still running (it isn't None/done yet) — so
+        # without this the tail would sit unbroadcast until some future event
+        # happened to arrive (#354). Re-arm the flush ourselves so the buffers
+        # always drain: one more window, then another pass. Loops until empty.
+        if self._reaction_buffer or self._reaction_bonus_to:
             self._reaction_flush_task = self._runtime.create_task(
                 self._flush_reactions_after_window()
             )
@@ -1124,6 +1186,8 @@ class QuizifyWebSocketHandler:
             self._reaction_flush_task.cancel()
             self._reaction_flush_task = None
         self._reaction_buffer.clear()
+        self._reaction_bonus_from.clear()
+        self._reaction_bonus_to.clear()
 
     # ------------------------------------------------------------------
     # Wager (gameplay idea #3 — Jeopardy-style final round)
@@ -1287,6 +1351,13 @@ class QuizifyWebSocketHandler:
         # fresh settings always take effect. Mirrors _handle_play_again.
         if game_state.phase != GamePhase.LOBBY:
             self._cancel_timer_tick()
+            # #407 (follow-up to #362): cancel the lightning loop and any
+            # deferred admin-disconnect pause too, exactly like
+            # ``_handle_reset_game``. Otherwise a stale admin-pause task can
+            # pause round 1 of the NEW game, and a start during a LIGHTNING
+            # detour leaves ``_lightning_task`` broadcasting stale frames.
+            self._cancel_lightning_loop()
+            self._cancel_admin_pause()
             game_state.reset_to_lobby()
 
         raw_category = data.get("category")
@@ -1517,6 +1588,12 @@ class QuizifyWebSocketHandler:
             return
         settings = game_state.last_settings
         self._cancel_timer_tick()
+        # #407 (follow-up to #362): mirror ``_handle_reset_game`` — cancel the
+        # lightning loop and any deferred admin-disconnect pause before the new
+        # game, or a stale pause task pauses round 1 and a lingering lightning
+        # loop keeps broadcasting stale frames into the rematch.
+        self._cancel_lightning_loop()
+        self._cancel_admin_pause()
         # Reset to LOBBY first so start_game's phase guard passes; keeps
         # players (reset_to_lobby leaves connected players in place).
         game_state.reset_to_lobby()
@@ -2098,7 +2175,19 @@ class QuizifyWebSocketHandler:
         """
         self._cancel_timer_tick()
 
+        # #413: the client renders ``Math.ceil(remaining)`` WHOLE seconds, but
+        # the loop ticks every ~0.5s — so half the frames redraw the same
+        # number and are pure waste (at the 20-player cap: 20 sockets × the
+        # dead frame, every tick). Coalesce like the lightning loop already
+        # does: remember the last displayed second per recipient and only emit
+        # a ``timer_tick`` when that second actually changes. The sleep cadence
+        # is unchanged, so the countdown accuracy and the auto-evaluate timing
+        # are unaffected — only the redundant frames are dropped.
+        last_shown_by_name: dict[str, int] = {}
+        last_dashboard_shown: int | None = None
+
         async def tick_loop() -> None:
+            nonlocal last_dashboard_shown
             try:
                 while game_state.phase == GamePhase.QUESTION_ACTIVE:
                     players = game_state.get_players()
@@ -2111,31 +2200,37 @@ class QuizifyWebSocketHandler:
                     # longer delays the whole room — ConnectionManager.send
                     # swallows errors so a plain gather is safe.
                     sends = []
-                    # Each connected player gets their authoritative remaining.
+                    # Each connected player gets their authoritative remaining,
+                    # but only when their displayed second changed (#413).
                     for name, remaining in tick.per_player:
                         p = by_name.get(name)
                         if p is None or not p.connected:
                             continue
+                        shown = math.ceil(max(0.0, remaining))
+                        if last_shown_by_name.get(name) == shown:
+                            continue
+                        last_shown_by_name[name] = shown
                         sends.append(self._conn.send(p.ws, {
                             "type": "timer_tick",
                             "remaining": round(remaining, 1),
                         }))
                     # Broadcast the minimum remaining to dashboards/admins so
-                    # the TV view shows a consistent countdown.
+                    # the TV view shows a consistent countdown — again only when
+                    # its displayed second changes. Pre-serialized ONCE and fanned
+                    # out via the broadcast string path (admin-as-player already
+                    # excluded there) instead of a per-socket send_json (#413/#258).
                     min_remaining = tick.dashboard_remaining
                     # Spoken "time running out" warning (#281), once per round.
                     self._notify_tts_countdown(min_remaining)
-                    for ws, is_admin in self._conn.iter_admin_and_dashboard_ws():
-                        if ws.closed:
-                            continue
-                        # An admin who is also a player already got their
-                        # per-player tick above — don't double-send.
-                        if is_admin and any(p.ws is ws for p in players):
-                            continue
-                        sends.append(self._conn.send(ws, {
-                            "type": "timer_tick",
-                            "remaining": round(min_remaining, 1),
-                        }))
+                    dash_shown = math.ceil(max(0.0, min_remaining))
+                    if dash_shown != last_dashboard_shown:
+                        last_dashboard_shown = dash_shown
+                        sends.append(
+                            self._conn.broadcast_to_admins_and_dashboards({
+                                "type": "timer_tick",
+                                "remaining": round(min_remaining, 1),
+                            })
+                        )
                     if sends:
                         await asyncio.gather(*sends)
                     await asyncio.sleep(TICK_INTERVAL)
@@ -2218,6 +2313,30 @@ class QuizifyWebSocketHandler:
     # Disconnect handling
     # ------------------------------------------------------------------
 
+    def _maybe_evaluate_after_dropout(self, game_state: QuizifyGameState) -> bool:
+        """Auto-evaluate the live round if a dropout left everyone submitted (#412).
+
+        ``all_submitted()`` is normally only consulted inside
+        submit_answer/submit_guess. When the last unanswered player disconnects
+        (or is removed after the grace timeout) mid-question, that check never
+        re-runs, so a room where everyone else already answered would sit idle
+        until the timer expired. Re-test it here: during QUESTION_ACTIVE, if the
+        registry now reports all active participants submitted, stop the
+        countdown and evaluate. ``evaluate_round`` fires the
+        ``round_evaluated`` state event, which drives the reveal broadcast (same
+        as the timer-expiry and admin-skip paths); it is guarded against double
+        evaluation, so racing with the tick loop is safe.
+
+        Returns True when it triggered an evaluation.
+        """
+        if game_state.phase != GamePhase.QUESTION_ACTIVE:
+            return False
+        if not game_state.all_submitted():
+            return False
+        self._cancel_timer_tick()
+        game_state.evaluate_round()
+        return True
+
     async def _handle_disconnect(
         self, ws: web.WebSocketResponse, was_admin: bool | None = None
     ) -> None:
@@ -2253,6 +2372,18 @@ class QuizifyWebSocketHandler:
 
         player.connected = False
         _LOGGER.info("Player disconnected: %s", player.name)
+
+        # #412: if the last unanswered player just dropped mid-question and
+        # everyone still in the room has already submitted, nothing else would
+        # re-check ``all_submitted()`` — the room would wait out the full timer.
+        # Evaluate now (same path submit_answer/timer-expiry use) so the reveal
+        # fires immediately. Done BEFORE the admin-pause scheduling below so a
+        # completed round doesn't also arm a spurious pause.
+        if self._maybe_evaluate_after_dropout(game_state):
+            _LOGGER.info(
+                "Round auto-evaluated after last unanswered player %s dropped",
+                player.name,
+            )
 
         # Host-disconnect graceful recovery: if the admin-as-player tab
         # drops mid-question, pause the game instead of letting the timer
@@ -2308,6 +2439,15 @@ class QuizifyWebSocketHandler:
                     _LOGGER.info(
                         "Removed disconnected player after grace period: %s", name
                     )
+                    # #412: removing the last unanswered player can complete the
+                    # round — re-check all-submitted and evaluate if so, same as
+                    # the immediate-disconnect path above.
+                    if self._maybe_evaluate_after_dropout(gs):
+                        _LOGGER.info(
+                            "Round auto-evaluated after removing last "
+                            "unanswered player %s",
+                            name,
+                        )
 
         self._conn.schedule_player_removal(player.name, grace, remove_after_timeout)
 
@@ -2537,14 +2677,31 @@ class QuizifyWebSocketHandler:
     # ------------------------------------------------------------------
 
     async def _broadcast_finale(self, game_state: QuizifyGameState) -> None:
-        """Build and broadcast the finale message (podium + superlatives)."""
-        from custom_components.quizify.game.scoring import (
-            calculate_podium,  # noqa: PLC0415
-        )
+        """Build and broadcast the finale message (podium + superlatives).
 
-        podium = calculate_podium(game_state.get_players())
+        ``end_game`` already computed and cached the podium + superlatives, so
+        reuse them here instead of recomputing ``calculate_podium`` +
+        ``compute_superlatives`` from scratch (#415). Falls back to a fresh
+        compute only if this is ever reached without a populated cache (e.g. a
+        direct call in a test) so behaviour is unchanged in that edge case.
+        """
         all_players = game_state.get_players()
-        awards = [s.to_dict() for s in compute_superlatives(all_players)]
+
+        podium = game_state.get_finale_podium()
+        if podium is None:
+            from custom_components.quizify.game.scoring import (
+                calculate_podium,  # noqa: PLC0415
+            )
+
+            podium = calculate_podium(all_players)
+
+        cached_superlatives = game_state.get_finale_superlatives()
+        superlatives = (
+            cached_superlatives
+            if cached_superlatives is not None
+            else compute_superlatives(all_players)
+        )
+        awards = [s.to_dict() for s in superlatives]
         finale_msg = serialize_finale(podium, all_players, superlatives=awards)
         await self._conn.broadcast(finale_msg)
 

--- a/tests/test_perf_wasted_work_304.py
+++ b/tests/test_perf_wasted_work_304.py
@@ -236,6 +236,10 @@ class TestReactionCoalescing:
         bob_before = gs.get_player_by_ws(b).score
         await h._handle_reaction(a, {"emoji": "🎉"}, gs)
 
-        # Bonus fires synchronously inside _handle_reaction.
+        # The point award still fires synchronously inside _handle_reaction.
         assert gs.get_player_by_ws(b).score == bob_before + 1
+        # The reaction_bonus BROADCAST is now coalesced into the ~150ms flush
+        # window (#416) rather than emitted inline — drain the flush task.
+        if h._reaction_flush_task is not None:
+            await h._reaction_flush_task
         assert any(m.get("type") == "reaction_bonus" for m in sent)

--- a/tests/test_ws_state_batch_w2.py
+++ b/tests/test_ws_state_batch_w2.py
@@ -1,0 +1,377 @@
+"""Regression tests for the ws/state bug+perf batch (#407,#410,#412,#413,
+#414,#415,#416).
+
+Each concern gets a focused test so a future edit can't silently regress:
+
+  * #407 — an explicit start / play-again out of LOBBY cancels the lightning
+    loop AND the deferred admin-pause, not just the timer tick.
+  * #410 — a non-dict JSON frame (``[1,2]``, ``"x"``, ``5``) is rejected with a
+    clean error instead of tearing down the connection with an AttributeError.
+  * #412 — when the last unanswered player drops (or is removed after grace)
+    mid-question and everyone else has submitted, the round evaluates now
+    instead of waiting out the timer.
+  * #413 — the normal-round tick loop coalesces frames to one per displayed
+    second (``ceil(remaining)``), like the lightning loop.
+  * #414 — ``build_round_summary`` is memoized per (game_id, round) and
+    invalidated on the next round / reset.
+  * #415 — ``serialize_finale`` builds the leaderboard once; ``_broadcast_finale``
+    consumes the cached podium/superlatives instead of recomputing.
+  * #416 — reveal reaction bonuses are coalesced into one ``reaction_bonus`` per
+    flush window carrying a single leaderboard.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game import scoring  # noqa: E402
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+from custom_components.quizify.server import WS_PATH  # noqa: E402
+from custom_components.quizify.server import websocket as ws_mod  # noqa: E402
+from custom_components.quizify.server.round_message_builder import (  # noqa: E402
+    RoundMessageBuilder,
+)
+from custom_components.quizify.server.serializers import serialize_finale  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _Runtime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+    def create_task(self, coro):  # noqa: ANN001
+        return asyncio.ensure_future(coro)
+
+
+def _fake_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    return ws
+
+
+def _handler(tmp_path: Path, game: QuizifyGameState) -> QuizifyWebSocketHandler:
+    return QuizifyWebSocketHandler(
+        runtime=_Runtime(tmp_path), game_state_provider=lambda: game
+    )
+
+
+def _started_game(tmp_path: Path, names: list[str]) -> QuizifyGameState:
+    gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+    for n in names:
+        gs.add_player(n, _fake_ws())
+    gs.start_game(language="de", num_rounds=3, lightning_enabled=False)
+    gs.start_next_question()
+    return gs
+
+
+# ---------------------------------------------------------------------------
+# #407 — start / play-again cancels lightning loop + admin pause
+# ---------------------------------------------------------------------------
+
+
+class TestStartResetCancels407:
+    @pytest.mark.asyncio
+    async def test_start_game_out_of_lobby_cancels_lightning_and_admin_pause(
+        self, tmp_path: Path
+    ) -> None:
+        gs = _started_game(tmp_path, ["Alice", "Bob"])
+        assert gs.phase == GamePhase.QUESTION_ACTIVE
+
+        h = _handler(tmp_path, gs)
+        h.START_REDIRECT_GRACE = 0.0  # don't wait the redirect grace
+        # Pre-arm the two tasks the old code left dangling.
+        h._lightning_task = asyncio.ensure_future(asyncio.sleep(100))
+        h._admin_pause_task = asyncio.ensure_future(asyncio.sleep(100))
+
+        await h._handle_start_game(
+            _fake_ws(),
+            {"language": "de", "num_rounds": 3, "lightning_enabled": False},
+            gs,
+        )
+
+        # Both must have been cancelled (the cancel helpers null them out).
+        assert h._lightning_task is None
+        assert h._admin_pause_task is None
+        h._cancel_timer_tick()
+
+    @pytest.mark.asyncio
+    async def test_play_again_cancels_lightning_and_admin_pause(
+        self, tmp_path: Path
+    ) -> None:
+        gs = _started_game(tmp_path, ["Alice", "Bob"])
+        # last_settings is populated by start_game, so play_again won't fall
+        # back to reset.
+        assert gs.last_settings
+
+        h = _handler(tmp_path, gs)
+        h.START_REDIRECT_GRACE = 0.0
+        h._lightning_task = asyncio.ensure_future(asyncio.sleep(100))
+        h._admin_pause_task = asyncio.ensure_future(asyncio.sleep(100))
+
+        await h._handle_play_again(_fake_ws(), gs)
+
+        assert h._lightning_task is None
+        assert h._admin_pause_task is None
+        h._cancel_timer_tick()
+
+
+# ---------------------------------------------------------------------------
+# #410 — non-dict JSON frame is rejected, connection survives
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedFrameGuard410:
+    async def _make_client(self, handler: QuizifyWebSocketHandler) -> TestClient:
+        app = web.Application()
+        app.router.add_get(WS_PATH, handler.handle)
+        client = TestClient(TestServer(app))
+        await client.start_server()
+        return client
+
+    @pytest.mark.parametrize("payload", [[1, 2], "x", 5, True])
+    @pytest.mark.asyncio
+    async def test_non_dict_json_gets_error_not_teardown(
+        self, tmp_path: Path, payload: object
+    ) -> None:
+        gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+        handler = _handler(tmp_path, gs)
+        client = await self._make_client(handler)
+        try:
+            ws = await client.ws_connect(WS_PATH)
+            await ws.send_json(payload)
+            err = await ws.receive_json(timeout=2)
+            assert err["type"] == "error"
+            # The socket must still be alive: a follow-up valid message gets a
+            # real response instead of a closed connection.
+            await ws.send_json({"type": "get_state"})
+            follow = await ws.receive_json(timeout=2)
+            assert follow["type"] in ("game_state", "error")
+            await ws.close()
+        finally:
+            await client.close()
+
+
+# ---------------------------------------------------------------------------
+# #412 — last unanswered player dropping completes the round
+# ---------------------------------------------------------------------------
+
+
+class TestLastPlayerDropoutEval412:
+    @pytest.mark.asyncio
+    async def test_disconnect_of_last_unanswered_evaluates_round(
+        self, tmp_path: Path
+    ) -> None:
+        gs = _started_game(tmp_path, ["Alice", "Bob"])
+        bob = gs.get_player("Bob")
+        q = gs.get_current_question()
+        correct = next(i for i, a in enumerate(q.answers) if a.correct)
+        gs.submit_answer("Bob", correct)
+        assert gs.phase == GamePhase.QUESTION_ACTIVE  # Alice hasn't answered
+
+        h = _handler(tmp_path, gs)
+        h._conn.broadcast = AsyncMock()  # type: ignore[method-assign]
+
+        alice_ws = gs.get_player("Alice").ws
+        await h._handle_disconnect(alice_ws, was_admin=False)
+
+        # Alice (the last unanswered) is gone → registry now reports all
+        # submitted → round auto-evaluated into the reveal.
+        assert gs.phase == GamePhase.ANSWER_REVEAL
+        assert bob.score > 0
+        await h._conn.cleanup()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_when_others_unanswered_does_not_evaluate(
+        self, tmp_path: Path
+    ) -> None:
+        gs = _started_game(tmp_path, ["Alice", "Bob"])
+        # Nobody has answered. Alice dropping still leaves Bob unanswered, so
+        # the round must NOT evaluate early.
+        h = _handler(tmp_path, gs)
+        h._conn.broadcast = AsyncMock()  # type: ignore[method-assign]
+
+        alice_ws = gs.get_player("Alice").ws
+        await h._handle_disconnect(alice_ws, was_admin=False)
+
+        assert gs.phase == GamePhase.QUESTION_ACTIVE
+        await h._conn.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# #413 — tick loop coalesces to one frame per displayed second
+# ---------------------------------------------------------------------------
+
+
+class TestTickCoalescing413:
+    @pytest.mark.asyncio
+    async def test_no_duplicate_frames_within_one_displayed_second(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Fast poll cadence, long timer → many poll iterations but the displayed
+        # second (ceil) never changes across the test window.
+        monkeypatch.setattr(ws_mod, "TICK_INTERVAL", 0.02)
+        gs = _started_game(tmp_path, ["Alice"])
+        assert gs.phase == GamePhase.QUESTION_ACTIVE
+
+        h = _handler(tmp_path, gs)
+        player_sends: list[dict] = []
+        admin_broadcasts: list[dict] = []
+
+        async def _send(ws, msg):  # noqa: ANN001
+            player_sends.append(msg)
+
+        async def _admin_bcast(msg):  # noqa: ANN001
+            admin_broadcasts.append(msg)
+
+        h._conn.send = _send  # type: ignore[assignment]
+        h._conn.broadcast_to_admins_and_dashboards = _admin_bcast  # type: ignore[assignment]
+
+        h._start_timer_tick(gs)
+        # ~7 poll iterations at 0.02s; the 30s-ish timer barely moves so
+        # ceil(remaining) stays constant the whole time.
+        await asyncio.sleep(0.15)
+        h._cancel_timer_tick()
+
+        tick_frames = [m for m in player_sends if m.get("type") == "timer_tick"]
+        # Before the fix: one frame per poll (~7). After: exactly one, because
+        # the displayed second never changed.
+        assert len(tick_frames) == 1
+        assert len(admin_broadcasts) == 1
+
+
+# ---------------------------------------------------------------------------
+# #414 — build_round_summary is memoized per round
+# ---------------------------------------------------------------------------
+
+
+class TestRoundSummaryMemo414:
+    def _to_reveal(self, gs: QuizifyGameState) -> None:
+        q = gs.get_current_question()
+        correct = next(i for i, a in enumerate(q.answers) if a.correct)
+        gs.submit_answer(gs.get_players()[0].name, correct)
+        gs.evaluate_round()
+
+    def test_memoized_within_round_and_invalidated_next_round(
+        self, tmp_path: Path
+    ) -> None:
+        gs = _started_game(tmp_path, ["Alice", "Bob"])
+        self._to_reveal(gs)
+        assert gs.phase == GamePhase.ANSWER_REVEAL
+
+        builder = RoundMessageBuilder()
+        msg1 = builder.build_round_summary(gs)
+        msg2 = builder.build_round_summary(gs)
+        # Same cached object, not a fresh rebuild.
+        assert msg1 is msg2
+        key = (gs.game_id, gs.round)
+        assert gs.get_cached_round_summary_msg(key) is msg1
+
+        # Next round invalidates the cache.
+        gs.start_next_question()
+        assert gs.get_cached_round_summary_msg(key) is None
+
+    def test_reset_to_lobby_clears_cache(self, tmp_path: Path) -> None:
+        gs = _started_game(tmp_path, ["Alice", "Bob"])
+        self._to_reveal(gs)
+        key = (gs.game_id, gs.round)
+        RoundMessageBuilder().build_round_summary(gs)
+        assert gs.get_cached_round_summary_msg(key) is not None
+        gs.reset_to_lobby()
+        assert gs.get_cached_round_summary_msg(key) is None
+
+
+# ---------------------------------------------------------------------------
+# #415 — finale serialization dedup + cached-data consumption
+# ---------------------------------------------------------------------------
+
+
+class TestFinaleEfficiency415:
+    def test_serialize_finale_reuses_one_leaderboard(self, tmp_path: Path) -> None:
+        gs = _started_game(tmp_path, ["Alice", "Bob"])
+        players = gs.get_players()
+        podium = scoring.calculate_podium(players)
+        msg = serialize_finale(podium, players)
+        # Same list object powers both keys — serialized once.
+        assert msg["leaderboard"] is msg["all_players"]
+
+    @pytest.mark.asyncio
+    async def test_broadcast_finale_consumes_cache_without_recompute(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        gs = _started_game(tmp_path, ["Alice", "Bob"])
+        gs.end_game()  # populates _finale_podium / _finale_superlatives
+        assert gs.get_finale_podium() is not None
+
+        h = _handler(tmp_path, gs)
+        captured: list[dict] = []
+        h._conn.broadcast = lambda m: captured.append(m) or asyncio.sleep(0)  # type: ignore[assignment,return-value]
+
+        # If _broadcast_finale recomputes instead of using the cache, these blow
+        # up — proving the cache is consumed.
+        def _boom(*_a, **_k):  # noqa: ANN002, ANN003
+            raise AssertionError("podium recomputed despite cached finale data")
+
+        monkeypatch.setattr(scoring, "calculate_podium", _boom)
+        monkeypatch.setattr(ws_mod, "compute_superlatives", _boom)
+
+        await h._broadcast_finale(gs)
+        assert captured and captured[-1]["type"] == "finale"
+
+
+# ---------------------------------------------------------------------------
+# #416 — reaction bonuses coalesced into one flush frame
+# ---------------------------------------------------------------------------
+
+
+class TestReactionBonusCoalescing416:
+    @pytest.mark.asyncio
+    async def test_two_reactors_produce_one_bonus_frame(
+        self, tmp_path: Path
+    ) -> None:
+        gs = _started_game(tmp_path, ["Bob", "Alice", "Carol"])
+        q = gs.get_current_question()
+        correct = next(i for i, a in enumerate(q.answers) if a.correct)
+        gs.submit_answer("Bob", correct)
+        gs.evaluate_round()
+        assert gs.phase == GamePhase.ANSWER_REVEAL
+
+        h = _handler(tmp_path, gs)
+        sent: list[dict] = []
+        h._conn.broadcast = lambda m: sent.append(m) or asyncio.sleep(0)  # type: ignore[assignment,return-value]
+
+        bob_before = gs.get_player("Bob").score
+        await h._handle_reaction(gs.get_player("Alice").ws, {"emoji": "🎉"}, gs)
+        await h._handle_reaction(gs.get_player("Carol").ws, {"emoji": "👏"}, gs)
+
+        # Points settle synchronously: Bob tipped +1 by each of two reactors.
+        assert gs.get_player("Bob").score == bob_before + 2
+
+        # Drain the flush window.
+        if h._reaction_flush_task is not None:
+            await h._reaction_flush_task
+
+        bonus_frames = [m for m in sent if m.get("type") == "reaction_bonus"]
+        assert len(bonus_frames) == 1
+        frame = bonus_frames[0]
+        assert frame["to_players"] == ["Bob"]
+        assert set(frame["from_players"]) == {"Alice", "Carol"}
+        assert frame["leaderboard"], "coalesced bonus must carry a leaderboard"


### PR DESCRIPTION
Fixes #407
Fixes #410
Fixes #412
Fixes #413
Fixes #414
Fixes #415
Fixes #416

Seven related backend bug + perf items clustered on `server/websocket.py`, `game/state.py`, `server/round_message_builder.py` and `server/serializers.py`, bundled into one branch to avoid conflicts.

### Bugs
- **#407** `_handle_start_game` (non-LOBBY branch) and `_handle_play_again` now also call `_cancel_lightning_loop()` + `_cancel_admin_pause()` before `reset_to_lobby()`, matching `_handle_reset_game`. Prevents a stale admin-pause from pausing round 1 of a new game and a lingering lightning task from broadcasting stale frames into the rematch.
- **#410** A non-dict JSON frame (`[1,2]`, `"x"`, `5`) is now rejected with `ERR_INVALID_ACTION` immediately after parsing. Previously `data.get("type")` (admin_auth / join checks) raised `AttributeError` outside the `_handle_message` try/except and tore down the connection with a traceback.
- **#412** `_handle_disconnect` (and the post-grace `remove_after_timeout` removal) now re-check `all_submitted()` during QUESTION_ACTIVE: if the last unanswered player drops while everyone else has answered, the round evaluates immediately (same path submit/timer-expiry use) instead of waiting out the full timer.

### Perf
- **#413** The normal-round tick loop now coalesces to one `timer_tick` per displayed second (`ceil(remaining)`), mirroring the lightning loop, and fans the shared admin/dashboard frame out via the pre-serialized broadcast string path instead of per-socket `send_json`. Sleep cadence unchanged, so accuracy and auto-evaluate timing are preserved.
- **#414** `build_round_summary()` is memoized per `(game_id, round)` on `QuizifyGameState`, invalidated in `start_next_question`/`reset_to_lobby`. The recipient-independent summary is no longer rebuilt for every join/reconnect/get_state during ANSWER_REVEAL (was O(P) each, O(P²) under a reconnect storm). Callers copy before mutating.
- **#415** `serialize_finale` serializes the leaderboard once for both `leaderboard` and `all_players`; `_broadcast_finale` consumes the podium/superlatives `end_game` already cached instead of recomputing `calculate_podium` + `compute_superlatives`.
- **#416** Reveal reaction bonuses are coalesced into the existing ~150ms flush window — one `reaction_bonus` with a single batch leaderboard — and the drained broadcasts are awaited via a single `asyncio.gather`. Point awards stay synchronous; the #354 drain-until-empty behaviour is preserved.

### Tests
- New `tests/test_ws_state_batch_w2.py` covers all seven items (start/play-again cancels, malformed-frame guard over a live WS, last-player dropout eval, tick coalescing, summary memoization + invalidation, finale dedup + cache consumption, reaction-bonus coalescing).
- Updated `tests/test_perf_wasted_work_304.py` for the now-deferred reaction-bonus broadcast.
- Full suite: 931 passed, 5 skipped. `ruff check custom_components/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)