### PR TITLE
fix: invalidate round-summary memo on reaction bonus + add leaderboardMore i18n (#449, #461)

### DIFF
--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -1918,6 +1918,20 @@ class QuizifyGameState:
         self._round_summary_msg_key = key
         self._round_summary_msg = msg
 
+    def invalidate_round_summary_msg(self) -> None:
+        """Drop the memoized round-summary message (#449).
+
+        The #414 memo caches the full round-summary msg (incl. the serialized
+        leaderboard) keyed on ``(game_id, round)``. A reveal-time reaction
+        bonus (#416) mutates recipient scores via ``add_reaction_bonus`` while
+        that memo is still live, so any join/reconnect/get_state during the
+        same ANSWER_REVEAL would otherwise serve a STALE pre-bonus leaderboard.
+        Call this after applying reaction bonuses so the next build
+        re-serializes the fresh scores.
+        """
+        self._round_summary_msg = None
+        self._round_summary_msg_key = None
+
     def get_finale_podium(self) -> list | None:
         """Return the finale podium cached by ``end_game`` (#415), or None."""
         return self._finale_podium

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -1081,6 +1081,14 @@ class QuizifyWebSocketHandler:
             bonus_recipients.append(recipient.name)
 
         if bonus_recipients:
+            # #449: the bonus above mutated recipient scores, but the #414
+            # round-summary memo (built for the reveal broadcast) still holds
+            # the pre-bonus leaderboard. Invalidate it so any join/reconnect/
+            # get_state during this same ANSWER_REVEAL re-serializes the fresh,
+            # post-bonus leaderboard instead of serving the stale cache.
+            invalidate = getattr(game_state, "invalidate_round_summary_msg", None)
+            if invalidate is not None:
+                invalidate()
             # #416: defer + coalesce the leaderboard broadcast into the shared
             # ~150ms flush window instead of emitting a full-leaderboard frame
             # per reactor right here. The points are already awarded above; the

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -453,7 +453,8 @@
     "questionCounter": "Frage {current} / {total}",
     "pointsShort": "Pkt.",
     "awards": "Auszeichnungen",
-    "runnersUp": "Außerdem dabei"
+    "runnersUp": "Außerdem dabei",
+    "leaderboardMore": "+{count} weitere"
   },
   "connection": {
     "connected": "Verbunden",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -453,7 +453,8 @@
     "questionCounter": "Question {current} / {total}",
     "pointsShort": "pts",
     "awards": "Awards",
-    "runnersUp": "Also playing"
+    "runnersUp": "Also playing",
+    "leaderboardMore": "+{count} more"
   },
   "connection": {
     "connected": "Connected",

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -438,7 +438,8 @@
     "questionCounter": "Pregunta {current} / {total}",
     "pointsShort": "pts",
     "awards": "Premios",
-    "runnersUp": "También juegan"
+    "runnersUp": "También juegan",
+    "leaderboardMore": "+{count} más"
   },
   "connection": {
     "connected": "Conectado",

--- a/tests/test_ws_state_batch_w2.py
+++ b/tests/test_ws_state_batch_w2.py
@@ -375,3 +375,49 @@ class TestReactionBonusCoalescing416:
         assert frame["to_players"] == ["Bob"]
         assert set(frame["from_players"]) == {"Alice", "Carol"}
         assert frame["leaderboard"], "coalesced bonus must carry a leaderboard"
+
+
+# ---------------------------------------------------------------------------
+# #449 — a reveal-time reaction bonus invalidates the #414 round-summary memo
+# so a join/reconnect/get_state during the same reveal sees the fresh score
+# ---------------------------------------------------------------------------
+
+
+class TestReactionBonusInvalidatesSummaryMemo449:
+    @staticmethod
+    def _bob_score(msg: dict) -> int:
+        entry = next(e for e in msg["leaderboard"] if e["name"] == "Bob")
+        return entry["score"]
+
+    @pytest.mark.asyncio
+    async def test_reveal_reaction_bonus_busts_stale_leaderboard_cache(
+        self, tmp_path: Path
+    ) -> None:
+        gs = _started_game(tmp_path, ["Bob", "Alice"])
+        q = gs.get_current_question()
+        correct = next(i for i, a in enumerate(q.answers) if a.correct)
+        gs.submit_answer("Bob", correct)
+        gs.evaluate_round()
+        assert gs.phase == GamePhase.ANSWER_REVEAL
+
+        builder = RoundMessageBuilder()
+        # First build during the reveal broadcast memoizes the PRE-bonus board.
+        pre = builder.build_round_summary(gs)
+        bob_before = self._bob_score(pre)
+
+        h = _handler(tmp_path, gs)
+        sent: list[dict] = []
+        h._conn.broadcast = lambda m: sent.append(m) or asyncio.sleep(0)  # type: ignore[assignment,return-value]
+
+        # Alice reacts → Bob gets +1 while the memo still holds the old board.
+        await h._handle_reaction(gs.get_player("Alice").ws, {"emoji": "🎉"}, gs)
+        assert gs.get_player("Bob").score == bob_before + 1
+
+        # A join/reconnect/get_state during THIS reveal rebuilds the summary.
+        # Without invalidation it would serve the cached pre-bonus board.
+        post = builder.build_round_summary(gs)
+        assert self._bob_score(post) == bob_before + 1, (
+            "reconnect during reveal must see the post-bonus leaderboard, "
+            "not the stale memoized one"
+        )
+        assert post is not pre, "memo must have been invalidated + rebuilt"


### PR DESCRIPTION
Fixes #449
Fixes #461

Two same-day regressions from the #414/#416 and #429 merges.

**#449** (regression from #414 memoization × #416 reaction batching): `build_round_summary` memoizes the summary msg (incl. serialized leaderboard) keyed on `(game_id, round)`. But `_handle_reaction` applied the reveal reaction bonus via `add_reaction_bonus` without invalidating that memo, so a join/reconnect/get_state during the same `ANSWER_REVEAL` served a stale pre-bonus leaderboard (`project_snapshot_for_player`'s `out.update(merged)` overwrote the fresh snapshot board with the cached one). Added `QuizifyGameState.invalidate_round_summary_msg()` and call it in `_handle_reaction` after the bonus-recipients loop. Regression test proves a reconnect during reveal now sees the post-bonus board.

**#461** (regression from #429): `www/dashboard.html` calls `t('dashboard.leaderboardMore', ...)` for the "+N more" row, but the key existed in none of `www/i18n/{en,de,es}.json`. Added `leaderboardMore` to the `dashboard` section of all three locales; the `{count}` token matches the `.replace()` in dashboard.html.

Full suite (952 passed, 5 skipped) + ruff + drift all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)