### PR TITLE
fix(ux): round-4 batch — submission chips, finale scroll, timer reset, a11y aria, hero relabel, wager slider, danger buttons, image alt (#458,#459,#460,#462,#463,#464,#465,#466,#467)

### DIFF
--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -56,7 +56,7 @@
          the Share → Add to Home Screen flow that Apple requires. -->
     <div class="pwa-ios-hint hidden" id="pwa-ios-hint" role="dialog" aria-modal="true" aria-labelledby="pwa-ios-hint-title">
         <div class="pwa-ios-hint-content">
-            <button type="button" class="pwa-ios-hint-close" id="pwa-ios-hint-close" aria-label="Close">&times;</button>
+            <button type="button" class="pwa-ios-hint-close" id="pwa-ios-hint-close" data-i18n-aria-label="common.close" aria-label="Close">&times;</button>
             <p id="pwa-ios-hint-title"><strong data-i18n="pwa.iosHintTitle">Install Quizify</strong></p>
             <p data-i18n="pwa.iosHintBody">Tap <span aria-hidden="true">⬆️</span> Share, then <strong>"Add to Home Screen"</strong></p>
         </div>
@@ -109,7 +109,7 @@
                 </div>
                 <button type="button" id="start-game-btn" class="btn btn-primary btn-lg btn-block">
                     <span aria-hidden="true">▶︎</span>
-                    <span data-i18n="admin.startGame">Start Game</span>
+                    <span data-i18n="admin.openLobby">Open lobby</span>
                 </button>
                 <button type="button" id="setup-tweak-btn" class="setup-tweak-link"
                         data-i18n="setup.tweak">
@@ -195,22 +195,22 @@
 
                         <!-- Phase 2: Theme-Tabs. Always visible. Filter visible sub-pack
                              chips. The "Alle" tab keeps all chips visible (current default). -->
-                        <div class="theme-tabs" id="theme-tabs" role="tablist" data-i18n-aria-label="admin.themes" aria-label="Themes">
+                        <div class="theme-tabs" id="theme-tabs" role="group" data-i18n-aria-label="admin.themes" aria-label="Themes">
                             <!-- "Alle" stays text-only (no theme icon). Themed tabs carry an
                                  SVG line icon (filled by admin.js paintThemeTabIcons via the
                                  shared QuizifyIcons set) + a text-only i18n label span. The
                                  data-i18n attr lives on the inner .theme-tab-label so i18n's
                                  textContent write never clobbers the sibling SVG. -->
-                            <button type="button" class="theme-tab active" data-theme="all"><span class="theme-tab-label" data-i18n="admin.themeAll">Alle</span></button>
-                            <button type="button" class="theme-tab" data-theme="geography"><span class="qz-icon qz-icon--coral"></span><span class="theme-tab-label" data-i18n="theme.geography">Geo</span></button>
-                            <button type="button" class="theme-tab" data-theme="nature"><span class="qz-icon qz-icon--sage"></span><span class="theme-tab-label" data-i18n="theme.nature">Natur</span></button>
-                            <button type="button" class="theme-tab" data-theme="popculture"><span class="qz-icon qz-icon--sky"></span><span class="theme-tab-label" data-i18n="theme.popculture">Pop</span></button>
-                            <button type="button" class="theme-tab" data-theme="sport"><span class="qz-icon qz-icon--sun"></span><span class="theme-tab-label" data-i18n="theme.sport">Sport</span></button>
-                            <button type="button" class="theme-tab" data-theme="music"><span class="qz-icon qz-icon--coral"></span><span class="theme-tab-label" data-i18n="theme.music">Musik</span></button>
-                            <button type="button" class="theme-tab" data-theme="science"><span class="qz-icon qz-icon--sage"></span><span class="theme-tab-label" data-i18n="theme.science">Wissen</span></button>
-                            <button type="button" class="theme-tab" data-theme="history"><span class="qz-icon qz-icon--sky"></span><span class="theme-tab-label" data-i18n="theme.history">Historie</span></button>
-                            <button type="button" class="theme-tab" data-theme="food"><span class="qz-icon qz-icon--sun"></span><span class="theme-tab-label" data-i18n="theme.food">Essen</span></button>
-                            <button type="button" class="theme-tab" data-theme="tech"><span class="qz-icon qz-icon--coral"></span><span class="theme-tab-label" data-i18n="theme.tech">Tech</span></button>
+                            <button type="button" class="theme-tab active" data-theme="all" aria-pressed="true"><span class="theme-tab-label" data-i18n="admin.themeAll">Alle</span></button>
+                            <button type="button" class="theme-tab" aria-pressed="false" data-theme="geography"><span class="qz-icon qz-icon--coral"></span><span class="theme-tab-label" data-i18n="theme.geography">Geo</span></button>
+                            <button type="button" class="theme-tab" aria-pressed="false" data-theme="nature"><span class="qz-icon qz-icon--sage"></span><span class="theme-tab-label" data-i18n="theme.nature">Natur</span></button>
+                            <button type="button" class="theme-tab" aria-pressed="false" data-theme="popculture"><span class="qz-icon qz-icon--sky"></span><span class="theme-tab-label" data-i18n="theme.popculture">Pop</span></button>
+                            <button type="button" class="theme-tab" aria-pressed="false" data-theme="sport"><span class="qz-icon qz-icon--sun"></span><span class="theme-tab-label" data-i18n="theme.sport">Sport</span></button>
+                            <button type="button" class="theme-tab" aria-pressed="false" data-theme="music"><span class="qz-icon qz-icon--coral"></span><span class="theme-tab-label" data-i18n="theme.music">Musik</span></button>
+                            <button type="button" class="theme-tab" aria-pressed="false" data-theme="science"><span class="qz-icon qz-icon--sage"></span><span class="theme-tab-label" data-i18n="theme.science">Wissen</span></button>
+                            <button type="button" class="theme-tab" aria-pressed="false" data-theme="history"><span class="qz-icon qz-icon--sky"></span><span class="theme-tab-label" data-i18n="theme.history">Historie</span></button>
+                            <button type="button" class="theme-tab" aria-pressed="false" data-theme="food"><span class="qz-icon qz-icon--sun"></span><span class="theme-tab-label" data-i18n="theme.food">Essen</span></button>
+                            <button type="button" class="theme-tab" aria-pressed="false" data-theme="tech"><span class="qz-icon qz-icon--coral"></span><span class="theme-tab-label" data-i18n="theme.tech">Tech</span></button>
                         </div>
 
                         <!-- Pack-Cards (was: flat chip-row). The chip-group--cards modifier
@@ -644,7 +644,7 @@
             <h2 id="end-game-modal-title" data-i18n="admin.endGameConfirm">End game?</h2>
             <p data-i18n="admin.endGameWarning">All players will be disconnected.</p>
             <div class="modal-actions">
-                <button type="button" id="end-game-confirm-btn" class="btn btn-primary" data-i18n="admin.endGame">End Game</button>
+                <button type="button" id="end-game-confirm-btn" class="btn btn-danger" data-i18n="admin.endGame">End Game</button>
                 <button type="button" id="end-game-cancel-btn" class="btn btn-secondary" data-i18n="common.cancel">Cancel</button>
             </div>
         </div>
@@ -657,7 +657,7 @@
             <h2 id="reset-game-modal-title" data-i18n="admin.resetGameConfirm">Reset game?</h2>
             <p data-i18n="admin.resetGameWarning">The current round and all players will be cleared. You'll return to the setup screen.</p>
             <div class="modal-actions">
-                <button type="button" id="reset-game-confirm-btn" class="btn btn-primary" data-i18n="admin.resetGame">Reset game</button>
+                <button type="button" id="reset-game-confirm-btn" class="btn btn-danger" data-i18n="admin.resetGame">Reset game</button>
                 <button type="button" id="reset-game-cancel-btn" class="btn btn-secondary" data-i18n="common.cancel">Cancel</button>
             </div>
         </div>

--- a/custom_components/quizify/www/css/src/07-player.css
+++ b/custom_components/quizify/www/css/src/07-player.css
@@ -703,6 +703,9 @@
 }
 
 .submitted-players {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
     color: var(--color-text-neon-muted);
     font-size: 0.75rem;
 }
@@ -736,23 +739,56 @@
     margin: var(--space-xs) 0;
 }
 
-/* Player indicator dot */
+/* Player submission chip (issue #458): avatar circle + name pill in a flex row.
+   Previously .player-indicator was an 8x8 dot while the JS emitted an avatar +
+   initials + name, so initials/names spilled out unstyled. */
 .player-indicator {
-    width: 8px;
-    height: 8px;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xs);
+    max-width: 100%;
+    padding: 2px 8px 2px 2px;
     border-radius: var(--radius-full);
-    background: var(--color-text-neon-muted);
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
     flex-shrink: 0;
 }
 
-.player-indicator.is-submitted {
+.player-indicator .player-avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: var(--radius-full);
+    background: var(--color-text-neon-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.player-indicator .player-initials {
+    font-size: 0.65rem;
+    font-weight: 600;
+    line-height: 1;
+    color: #fff;
+}
+
+.player-indicator .player-name {
+    font-size: 0.75rem;
+    line-height: 1.2;
+    color: var(--color-text-neon-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 8rem;
+}
+
+.player-indicator.is-submitted .player-avatar {
     background: var(--color-success-neon);
     box-shadow: 0 0 6px var(--color-success-neon);
 }
 
-.is-current-player {
-    background: rgba(232, 138, 127, 0.08);
-    border-radius: var(--radius-md);
+.player-indicator.is-current-player {
+    background: rgba(232, 138, 127, 0.12);
 }
 
 /* ==========================================
@@ -3324,7 +3360,10 @@ body.is-admin .reaction-bar {
 .estimate-slider-wrap {
     margin: 28px 4px 0;
 }
-.estimate-slider {
+/* #465: #wager-slider shares the estimate-slider treatment (34px thumb,
+   gradient track, focus-visible ring) instead of a bare native range. */
+.estimate-slider,
+#wager-slider {
     width: 100%;
     height: 28px;
     margin: 0;
@@ -3333,22 +3372,26 @@ body.is-admin .reaction-bar {
     background: transparent;
     cursor: pointer;
 }
-.estimate-slider:focus-visible {
+.estimate-slider:focus-visible,
+#wager-slider:focus-visible {
     outline: 2px solid var(--color-accent-primary);
     outline-offset: 4px;
     border-radius: var(--radius-full);
 }
-.estimate-slider::-webkit-slider-runnable-track {
+.estimate-slider::-webkit-slider-runnable-track,
+#wager-slider::-webkit-slider-runnable-track {
     height: 14px;
     border-radius: var(--radius-full);
     background: linear-gradient(90deg, var(--color-accent-secondary), var(--color-accent-primary));
 }
-.estimate-slider::-moz-range-track {
+.estimate-slider::-moz-range-track,
+#wager-slider::-moz-range-track {
     height: 14px;
     border-radius: var(--radius-full);
     background: linear-gradient(90deg, var(--color-accent-secondary), var(--color-accent-primary));
 }
-.estimate-slider::-webkit-slider-thumb {
+.estimate-slider::-webkit-slider-thumb,
+#wager-slider::-webkit-slider-thumb {
     -webkit-appearance: none;
     appearance: none;
     width: 34px;
@@ -3359,7 +3402,8 @@ body.is-admin .reaction-bar {
     border: 3px solid var(--color-accent-primary);
     box-shadow: 0 4px 12px rgba(232, 138, 127, 0.30);
 }
-.estimate-slider::-moz-range-thumb {
+.estimate-slider::-moz-range-thumb,
+#wager-slider::-moz-range-thumb {
     width: 34px;
     height: 34px;
     border-radius: 50%;
@@ -3367,7 +3411,8 @@ body.is-admin .reaction-bar {
     border: 3px solid var(--color-accent-primary);
     box-shadow: 0 4px 12px rgba(232, 138, 127, 0.30);
 }
-.estimate-slider:disabled {
+.estimate-slider:disabled,
+#wager-slider:disabled {
     opacity: 0.7;
     cursor: default;
 }

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -3663,6 +3663,9 @@ footer {
 }
 
 .submitted-players {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
     color: var(--color-text-neon-muted);
     font-size: 0.75rem;
 }
@@ -3696,23 +3699,56 @@ footer {
     margin: var(--space-xs) 0;
 }
 
-/* Player indicator dot */
+/* Player submission chip (issue #458): avatar circle + name pill in a flex row.
+   Previously .player-indicator was an 8x8 dot while the JS emitted an avatar +
+   initials + name, so initials/names spilled out unstyled. */
 .player-indicator {
-    width: 8px;
-    height: 8px;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xs);
+    max-width: 100%;
+    padding: 2px 8px 2px 2px;
     border-radius: var(--radius-full);
-    background: var(--color-text-neon-muted);
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
     flex-shrink: 0;
 }
 
-.player-indicator.is-submitted {
+.player-indicator .player-avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: var(--radius-full);
+    background: var(--color-text-neon-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.player-indicator .player-initials {
+    font-size: 0.65rem;
+    font-weight: 600;
+    line-height: 1;
+    color: #fff;
+}
+
+.player-indicator .player-name {
+    font-size: 0.75rem;
+    line-height: 1.2;
+    color: var(--color-text-neon-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 8rem;
+}
+
+.player-indicator.is-submitted .player-avatar {
     background: var(--color-success-neon);
     box-shadow: 0 0 6px var(--color-success-neon);
 }
 
-.is-current-player {
-    background: rgba(232, 138, 127, 0.08);
-    border-radius: var(--radius-md);
+.player-indicator.is-current-player {
+    background: rgba(232, 138, 127, 0.12);
 }
 
 /* ==========================================
@@ -6284,7 +6320,10 @@ body.is-admin .reaction-bar {
 .estimate-slider-wrap {
     margin: 28px 4px 0;
 }
-.estimate-slider {
+/* #465: #wager-slider shares the estimate-slider treatment (34px thumb,
+   gradient track, focus-visible ring) instead of a bare native range. */
+.estimate-slider,
+#wager-slider {
     width: 100%;
     height: 28px;
     margin: 0;
@@ -6293,22 +6332,26 @@ body.is-admin .reaction-bar {
     background: transparent;
     cursor: pointer;
 }
-.estimate-slider:focus-visible {
+.estimate-slider:focus-visible,
+#wager-slider:focus-visible {
     outline: 2px solid var(--color-accent-primary);
     outline-offset: 4px;
     border-radius: var(--radius-full);
 }
-.estimate-slider::-webkit-slider-runnable-track {
+.estimate-slider::-webkit-slider-runnable-track,
+#wager-slider::-webkit-slider-runnable-track {
     height: 14px;
     border-radius: var(--radius-full);
     background: linear-gradient(90deg, var(--color-accent-secondary), var(--color-accent-primary));
 }
-.estimate-slider::-moz-range-track {
+.estimate-slider::-moz-range-track,
+#wager-slider::-moz-range-track {
     height: 14px;
     border-radius: var(--radius-full);
     background: linear-gradient(90deg, var(--color-accent-secondary), var(--color-accent-primary));
 }
-.estimate-slider::-webkit-slider-thumb {
+.estimate-slider::-webkit-slider-thumb,
+#wager-slider::-webkit-slider-thumb {
     -webkit-appearance: none;
     appearance: none;
     width: 34px;
@@ -6319,7 +6362,8 @@ body.is-admin .reaction-bar {
     border: 3px solid var(--color-accent-primary);
     box-shadow: 0 4px 12px rgba(232, 138, 127, 0.30);
 }
-.estimate-slider::-moz-range-thumb {
+.estimate-slider::-moz-range-thumb,
+#wager-slider::-moz-range-thumb {
     width: 34px;
     height: 34px;
     border-radius: 50%;
@@ -6327,7 +6371,8 @@ body.is-admin .reaction-bar {
     border: 3px solid var(--color-accent-primary);
     box-shadow: 0 4px 12px rgba(232, 138, 127, 0.30);
 }
-.estimate-slider:disabled {
+.estimate-slider:disabled,
+#wager-slider:disabled {
     opacity: 0.7;
     cursor: default;
 }

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -1150,6 +1150,12 @@
             overflow: hidden;
             position: relative;
             z-index: 1;
+            /* #459: make the card a flex column with min-height:0 so the inner
+               .dashboard-leaderboard (flex:1; overflow-y:auto) actually scrolls
+               with 8+ players instead of clipping under overflow:hidden. */
+            display: flex;
+            flex-direction: column;
+            min-height: 0;
         }
 
         .finale-leaderboard-card .card-header {
@@ -1513,10 +1519,15 @@
                 setImageLayout(false);
             };
             if (safe) {
+                // #467: localized generic alt so the TV image question isn't
+                // an unlabelled graphic for assistive tech.
+                var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
                 img.src = safe;
+                img.alt = t('game.questionImageAlt');
                 setImageLayout(true);
             } else {
                 img.removeAttribute('src');
+                img.alt = '';
                 setImageLayout(false);
             }
         }
@@ -1886,6 +1897,14 @@
 
         function handleRoundSummary(msg) {
             var summary = msg.round_summary || msg;
+
+            // #460: reset the timer bar at reveal. A skipped/timed-out question
+            // otherwise leaves a stalled red/pulsing bar during the summary.
+            // Mirror renderRevealFromSnapshot: width 0% + clean className.
+            if (els.timerFill) {
+                els.timerFill.style.width = '0%';
+                els.timerFill.className = 'dashboard-timer-fill';
+            }
 
             // #275: estimate rounds render a number line instead of the MC
             // answer-tile highlight + distribution.

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -74,6 +74,7 @@
     "joinAsPlayer": "Als Spieler beitreten",
     "joinedAs": "Du spielst als {name}",
     "startGame": "Spiel starten",
+    "openLobby": "Zur Lobby →",
     "startGameHint": "Du gibst deinen Namen im nächsten Schritt ein",
     "startGameplay": "Spiel starten",
     "startGameplayHint": "Spielt mit den Spielern in der Lobby. Du bleibst als Host.",
@@ -143,6 +144,7 @@
   },
   "game": {
     "question": "Frage",
+    "questionImageAlt": "Fragebild",
     "zoomImage": "Bild vergrößern",
     "soundMute": "Soundeffekte stummschalten",
     "soundUnmute": "Soundeffekte einschalten",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -74,6 +74,7 @@
     "joinAsPlayer": "Join as Player",
     "joinedAs": "You're playing as {name}",
     "startGame": "Start Game",
+    "openLobby": "Open lobby →",
     "startGameHint": "You'll enter your name in the next step",
     "startGameplay": "Start Game",
     "startGameplayHint": "Plays with everyone in the lobby. You stay as host.",
@@ -143,6 +144,7 @@
   },
   "game": {
     "question": "Question",
+    "questionImageAlt": "Question image",
     "zoomImage": "Zoom image",
     "soundMute": "Mute sound effects",
     "soundUnmute": "Unmute sound effects",

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -74,6 +74,7 @@
     "joinAsPlayer": "Unirse como jugador",
     "joinedAs": "Estás jugando como {name}",
     "startGame": "Empezar partida",
+    "openLobby": "Abrir sala →",
     "startGameHint": "Escribirás tu nombre en el siguiente paso",
     "startGameplay": "Empezar partida",
     "startGameplayHint": "Juega con todos los de la sala. Tú sigues siendo el anfitrión.",
@@ -143,6 +144,7 @@
   },
   "game": {
     "question": "Pregunta",
+    "questionImageAlt": "Imagen de la pregunta",
     "zoomImage": "Ampliar imagen",
     "soundMute": "Silenciar efectos de sonido",
     "soundUnmute": "Activar efectos de sonido",

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -542,7 +542,11 @@
         if (!els.categoryChips) return;
         if (els.themeTabs) {
             els.themeTabs.querySelectorAll('.theme-tab').forEach(function (t) {
-                t.classList.toggle('active', t.dataset.theme === theme);
+                var isActive = t.dataset.theme === theme;
+                t.classList.toggle('active', isActive);
+                // #463: these filter buttons expose aria-pressed (role="group",
+                // not a tablist) so screen readers announce the active filter.
+                t.setAttribute('aria-pressed', isActive ? 'true' : 'false');
             });
         }
         els.categoryChips.querySelectorAll('.chip[data-theme]').forEach(function (chip) {

--- a/custom_components/quizify/www/js/player-game.js
+++ b/custom_components/quizify/www/js/player-game.js
@@ -246,10 +246,15 @@
             media.hidden = true;
         };
         if (safeImg) {
+            // #467: populate a localized generic alt so the image question
+            // isn't announced as an unlabelled graphic.
+            var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
             img.src = safeImg;
+            img.alt = t('game.questionImageAlt');
             media.hidden = false;
         } else {
             img.removeAttribute('src');
+            img.alt = '';
             media.hidden = true;
         }
     }

--- a/custom_components/quizify/www/js/player-lightning.js
+++ b/custom_components/quizify/www/js/player-lightning.js
@@ -72,8 +72,14 @@
             // before they reach img.src.
             var safeImg = (typeof msg.image_url === 'string' && /^https?:\/\//i.test(msg.image_url))
                 ? msg.image_url : '';
-            if (safeImg) { img.src = safeImg; img.hidden = false; }
-            else { img.hidden = true; img.removeAttribute('src'); }
+            if (safeImg) {
+                // #467: localized generic alt for the lightning image question.
+                var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
+                img.src = safeImg;
+                img.alt = t('game.questionImageAlt');
+                img.hidden = false;
+            }
+            else { img.hidden = true; img.alt = ''; img.removeAttribute('src'); }
         }
 
         var qtext = document.getElementById('lightning-question-text');

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -2781,8 +2781,14 @@
             // before they reach img.src.
             var safeImg = (typeof msg.image_url === 'string' && /^https?:\/\//i.test(msg.image_url))
                 ? msg.image_url : '';
-            if (safeImg) { img.src = safeImg; img.hidden = false; }
-            else { img.hidden = true; img.removeAttribute('src'); }
+            if (safeImg) {
+                // #467: localized generic alt for the lightning image question.
+                var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
+                img.src = safeImg;
+                img.alt = t('game.questionImageAlt');
+                img.hidden = false;
+            }
+            else { img.hidden = true; img.alt = ''; img.removeAttribute('src'); }
         }
 
         var qtext = document.getElementById('lightning-question-text');
@@ -3216,10 +3222,15 @@
             media.hidden = true;
         };
         if (safeImg) {
+            // #467: populate a localized generic alt so the image question
+            // isn't announced as an unlabelled graphic.
+            var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
             img.src = safeImg;
+            img.alt = t('game.questionImageAlt');
             media.hidden = false;
         } else {
             img.removeAttribute('src');
+            img.alt = '';
             media.hidden = true;
         }
     }

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -786,7 +786,7 @@
             </div>
             <p class="qr-modal-label" data-i18n="lobby.scanToJoin">Scan to join the game</p>
             <button id="qr-modal-close" class="btn btn-secondary qr-modal-close"
-                    aria-label="Close QR code" data-i18n="common.close">Close</button>
+                    data-i18n="common.close">Close</button>
         </div>
     </div>
 
@@ -827,7 +827,7 @@
             </div>
             <p id="invite-copy-feedback" class="invite-copy-feedback hidden" data-i18n="lobby.copied">Copied!</p>
             <button id="invite-modal-close" class="btn btn-secondary invite-modal-close"
-                    aria-label="Close invite popup" data-i18n="common.close">Close</button>
+                    data-i18n="common.close">Close</button>
         </div>
     </div>
 

--- a/tests/test_fe_ux_r4.py
+++ b/tests/test_fe_ux_r4.py
@@ -1,0 +1,136 @@
+"""Guard tests for the round-4 frontend UX batch.
+
+Text-level assertions over the *built* assets (styles.css, player.bundle.js)
+plus the HTML/i18n source so a later edit can't silently regress any of:
+
+  #458 submission chips        #463 theme filter group + aria-pressed
+  #459 finale card flex        #464 hero CTA relabelled (Open lobby)
+  #460 timer reset at reveal   #465 wager slider styled
+  #462 localized close aria     #466 destructive confirm buttons btn-danger
+  #467 image alt i18n wired
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+WWW = REPO / "custom_components" / "quizify" / "www"
+
+STYLES = (WWW / "css" / "styles.css").read_text("utf-8")
+PLAYER_CSS = (WWW / "css" / "src" / "07-player.css").read_text("utf-8")
+BUNDLE = (WWW / "js" / "player.bundle.js").read_text("utf-8")
+ADMIN_HTML = (WWW / "admin.html").read_text("utf-8")
+PLAYER_HTML = (WWW / "player.html").read_text("utf-8")
+DASH_HTML = (WWW / "dashboard.html").read_text("utf-8")
+ADMIN_JS = (WWW / "js" / "admin.js").read_text("utf-8")
+LIGHTNING_JS = (WWW / "js" / "player-lightning.js").read_text("utf-8")
+I18N = {
+    lang: json.loads((WWW / "i18n" / f"{lang}.json").read_text("utf-8"))
+    for lang in ("en", "de", "es")
+}
+
+
+# -- #458 submission chips -------------------------------------------------
+def test_458_submission_chip_styled() -> None:
+    # The avatar circle must actually be styled (>=24px), and the chip row a flex.
+    assert ".player-indicator .player-avatar" in STYLES
+    assert "width: 24px" in STYLES and "height: 24px" in STYLES
+    # Container lays chips out in a wrapping flex row.
+    assert ".submitted-players" in STYLES
+    tracker = STYLES[STYLES.index(".submitted-players {"):]
+    block = tracker[: tracker.index("}")]
+    assert "flex" in block and "wrap" in block
+    # The old bare-dot rule (8x8) must be gone.
+    assert "width: 8px" not in PLAYER_CSS or ".player-name" in PLAYER_CSS
+
+
+# -- #459 finale card flex -------------------------------------------------
+def test_459_finale_card_is_flex_column() -> None:
+    # Locate the base .finale-leaderboard-card rule (the one with width:100%).
+    search = 0
+    block = ""
+    while True:
+        idx = DASH_HTML.index(".finale-leaderboard-card {", search)
+        blk = DASH_HTML[idx: DASH_HTML.index("}", idx)]
+        if "width: 100%" in blk:
+            block = blk
+            break
+        search = idx + 1
+    assert "display: flex" in block
+    assert "flex-direction: column" in block
+    assert "min-height: 0" in block
+
+
+# -- #460 timer reset at round_summary -------------------------------------
+def test_460_round_summary_resets_timer() -> None:
+    idx = DASH_HTML.index("function handleRoundSummary(")
+    body = DASH_HTML[idx: idx + 800]
+    assert "timerFill.style.width = '0%'" in body
+    assert "timerFill.className = 'dashboard-timer-fill'" in body
+
+
+# -- #462 localized close aria ---------------------------------------------
+def test_462_close_buttons_localized() -> None:
+    # The icon-only iOS hint close gets a localized aria-label key.
+    assert 'id="pwa-ios-hint-close"' in ADMIN_HTML
+    hint = ADMIN_HTML[ADMIN_HTML.index('id="pwa-ios-hint-close"') - 120:
+                      ADMIN_HTML.index('id="pwa-ios-hint-close"') + 120]
+    assert 'data-i18n-aria-label="common.close"' in hint
+    # The text-labelled modal close buttons no longer carry a hardcoded English aria.
+    for anchor in ('id="qr-modal-close"', 'id="invite-modal-close"'):
+        seg = PLAYER_HTML[PLAYER_HTML.index(anchor): PLAYER_HTML.index(anchor) + 160]
+        assert "aria-label=" not in seg, f"{anchor} should drop the hardcoded aria-label"
+        assert 'data-i18n="common.close"' in seg
+
+
+# -- #463 theme filter group + aria-pressed --------------------------------
+def test_463_theme_tabs_group_semantics() -> None:
+    tabs = ADMIN_HTML[ADMIN_HTML.index('id="theme-tabs"'):]
+    header = tabs[: tabs.index(">") + 1]
+    assert 'role="group"' in header
+    assert 'role="tablist"' not in header
+    # Every theme-tab button exposes aria-pressed in the markup.
+    block = tabs[: tabs.index("</div>")]
+    assert block.count("aria-pressed=") >= 10
+    # JS keeps aria-pressed in sync with .active.
+    assert "setAttribute('aria-pressed'" in ADMIN_JS
+
+
+# -- #464 hero CTA relabelled ----------------------------------------------
+def test_464_hero_cta_relabelled() -> None:
+    seg = ADMIN_HTML[ADMIN_HTML.index('id="start-game-btn"'):
+                     ADMIN_HTML.index('id="start-game-btn"') + 260]
+    assert 'data-i18n="admin.openLobby"' in seg
+    assert 'data-i18n="admin.startGame"' not in seg
+    for lang in ("en", "de", "es"):
+        assert "openLobby" in I18N[lang]["admin"]
+
+
+# -- #465 wager slider styled ----------------------------------------------
+def test_465_wager_slider_styled() -> None:
+    assert "#wager-slider::-webkit-slider-thumb" in STYLES
+    assert "#wager-slider::-moz-range-thumb" in STYLES
+    assert "#wager-slider:focus-visible" in STYLES
+    # Shares the 34px thumb treatment.
+    thumb = STYLES[STYLES.index("#wager-slider::-webkit-slider-thumb"):]
+    assert "34px" in thumb[: thumb.index("}")]
+
+
+# -- #466 destructive confirm buttons --------------------------------------
+def test_466_confirm_buttons_danger() -> None:
+    for anchor in ('id="end-game-confirm-btn"', 'id="reset-game-confirm-btn"'):
+        seg = ADMIN_HTML[ADMIN_HTML.index(anchor) - 90: ADMIN_HTML.index(anchor) + 60]
+        assert "btn-danger" in seg
+        assert "btn-primary" not in seg
+
+
+# -- #467 image alt i18n wired ---------------------------------------------
+def test_467_image_alt_i18n() -> None:
+    for lang in ("en", "de", "es"):
+        assert I18N[lang]["game"].get("questionImageAlt")
+    # Player (bundled), lightning, and dashboard renderers all set the alt.
+    assert "game.questionImageAlt" in BUNDLE
+    assert "game.questionImageAlt" in LIGHTNING_JS
+    assert "game.questionImageAlt" in DASH_HTML


### PR DESCRIPTION
Fixes #458
Fixes #459
Fixes #460
Fixes #462
Fixes #463
Fixes #464
Fixes #465
Fixes #466
Fixes #467

Round-4 frontend UX batch — bundled into one branch to avoid same-file conflicts across www/player.html, www/admin.html, www/dashboard.html, www/css/src/*, www/js/player-*.js and www/i18n/*.json.

## Changes
- **#458 submission chips** — `renderSubmissionTracker()` emitted avatar + initials + name but CSS only styled `.player-indicator` as an 8x8 dot. Added real chip styling: a 24px avatar circle with initials and a name pill in a wrapping flex row on `#submitted-players`.
- **#459 finale scroll** — `.finale-leaderboard-card` was a block parent with `overflow:hidden`, so the inner `.dashboard-leaderboard` (`flex:1; overflow-y:auto`) never engaged and final standings clipped with 8+ players. Made the card `display:flex; flex-direction:column; min-height:0`.
- **#460 timer reset** — `handleRoundSummary()` now resets `timerFill` to width 0% + clean className (mirrors `renderRevealFromSnapshot`), so a skipped/timed-out question no longer leaves a stalled red/pulsing bar during reveal.
- **#462 a11y close aria** — icon-only iOS install-hint close now uses `data-i18n-aria-label="common.close"`; the text-labelled QR/invite modal close buttons drop their hardcoded English `aria-label` (the visible translated "Close" already labels them).
- **#463 a11y theme filters** — `#theme-tabs` switched from `role="tablist"` (no tab semantics, no keyboard nav) to `role="group"`, with each button exposing `aria-pressed` kept in sync with `.active` in admin.js.
- **#464 hero relabel** — the hero CTA (which only opens the lobby) is relabelled `admin.openLobby` (Open lobby → / Zur Lobby → / Abrir sala →) so it no longer duplicates the real "Start Game" button in the lobby.
- **#465 wager slider** — `#wager-slider` now shares the `.estimate-slider` treatment (34px thumb, gradient track, `focus-visible` ring) instead of a bare native range.
- **#466 danger buttons** — `#end-game-confirm-btn` and `#reset-game-confirm-btn` switched from `btn-primary` to `btn-danger`; Cancel stays neutral.
- **#467 image alt** — image questions now set a localized generic alt (`game.questionImageAlt`) on the player, lightning, and dashboard renderers when `image_url` is present.

New i18n keys (`admin.openLobby`, `game.questionImageAlt`) added to en/de/es. CSS rebuilt via `build_css.py`, player bundle via `build_bundle.py`.

## Tests
Guard tests in `tests/test_fe_ux_r4.py` read the built assets/HTML/i18n as text and lock in every fix. Full suite (961 passed, 5 skipped), ruff, and the generated-artifacts drift checks all green.

## Mobile/TV-verify needed before merge
CSS/layout changes (submission chips at 390x844, finale-card scroll with 8+ players on the TV dashboard, wager-slider thumb, danger buttons) still need a live mobile + TV browser-harness pass before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)