### PR TITLE
fix+perf: join reclaim, steal round_score, roster coalesce, lightning-recap cache (#448,#450,#453,#455)

### DIFF
--- a/custom_components/quizify/game/lightning.py
+++ b/custom_components/quizify/game/lightning.py
@@ -116,6 +116,16 @@ class LightningRound:
         self.scores: dict[str, int] = dict.fromkeys(self._players, 0)
         self._recaps: list[LightningQuestionRecap] = []
 
+        # Memoized end-screen payload (#455). Once the round is finished the
+        # recap is immutable, but get_state_snapshot() rebuilds it on EVERY
+        # join / reconnect / get_state while the phase is LIGHTNING_RECAP.
+        # Cache the built dict the first time build_recap() runs post-finish
+        # and reuse it thereafter. A fresh LightningRound instance (each detour
+        # makes a new one; resume/reset drop the old) starts with an empty
+        # cache, so no cross-round staleness is possible; start() also clears
+        # it defensively for a reused instance.
+        self._recap_cache: dict[str, Any] | None = None
+
         # Per-question answer matrix: index -> {player_name -> LightningAnswer}.
         self._answers: dict[int, dict[str, LightningAnswer]] = {}
         # Per-player shuffle for the CURRENT question (name -> shuffled->orig).
@@ -189,6 +199,7 @@ class LightningRound:
         self.num_questions = len(self._questions)
         self.active = True
         self.finished = False
+        self._recap_cache = None  # #455: fresh round → drop any stale recap
         self.index = 0
         self._arm_current()
         _LOGGER.info(
@@ -389,8 +400,19 @@ class LightningRound:
         ]
 
     def build_recap(self) -> dict[str, Any]:
-        """Full end-screen payload: per-player totals + per-question grid."""
-        return {
+        """Full end-screen payload: per-player totals + per-question grid.
+
+        Memoized once the round is finished (#455): the recap is immutable
+        after ``advance()`` sets ``self.finished``, so the every-join/reconnect
+        rebuild during LIGHTNING_RECAP is pure wasted work. Build once, cache,
+        and hand back the same dict thereafter. A pre-finish call (shouldn't
+        happen — build_recap is only read at LIGHTNING_RECAP) is left
+        uncached so a mid-round change can't be frozen in.
+        """
+        if self.finished and self._recap_cache is not None:
+            return self._recap_cache
+
+        recap = {
             "num_questions": self.num_questions,
             "points_per_correct": self.points_per_correct,
             "leaderboard": self.leaderboard(),
@@ -405,3 +427,7 @@ class LightningRound:
                 for r in self._recaps
             ],
         }
+
+        if self.finished:
+            self._recap_cache = recap
+        return recap

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -781,7 +781,18 @@ class QuizifyGameState:
             player.streak_milestone_bonus_total += milestone_bonus
             player.streak_milestones_hit += 1
 
-        player.round_score = points
+        # #450: accumulate, don't assign. A STEAL (or reaction bonus) can land
+        # BEFORE the source submits, adding to round_score while round_score was
+        # zeroed by reset_round at round start. A plain `= points` here wiped
+        # those pre-submit deltas from round_score even though `score` kept
+        # them, so the reveal breakdown, round_scores history, the Top Score
+        # superlative, and a later STEAL against this player (which halves
+        # round_score) all under-counted. `+= points` folds this round's earned
+        # points on top of any pre-submit steal/bonus delta. Submit is guarded
+        # by the `player.submitted` early-return above, so this runs exactly
+        # once per round — no double-count. (The estimate path can't hit this:
+        # STEAL is rejected on estimate rounds, #406.)
+        player.round_score += points
         player.round_score_breakdown = computation.breakdown
         player.score += points
         if player.score < 0:

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -241,6 +241,21 @@ class QuizifyWebSocketHandler:
         # union of reactors/recipients keeps first-seen order.
         self._reaction_bonus_from: dict[str, None] = {}
         self._reaction_bonus_to: dict[str, None] = {}
+        # Roster-broadcast coalescing (#453). Every join / reconnect / kick /
+        # disconnect / grace-removal used to fan a FULL serialize_player_list
+        # roster out to every socket immediately. A room-wide wifi blip (all P
+        # players reconnecting at once) turned that into O(P²) frames. The
+        # roster is now marked dirty and a single ``player_joined`` /
+        # ``player_left`` message carrying the CURRENT list is broadcast once
+        # per flush window — same wire shape, one frame per window instead of
+        # one per event. ``_roster_last_type`` records the direction of the
+        # last event in the window so the client still gets the right
+        # join/leave animation; the ``players`` list is always authoritative,
+        # re-serialized from live game state at flush time (correctness: the
+        # final roster is always sent).
+        self._roster_dirty: bool = False
+        self._roster_last_type: str = "player_joined"
+        self._roster_flush_task: asyncio.Task | None = None
 
     # Coalescing window for visual reactions (#304), seconds.
     _REACTION_FLUSH_WINDOW = 0.15
@@ -613,9 +628,19 @@ class QuizifyWebSocketHandler:
             return
 
         # Auto-append number if name is taken
+        #
+        # #448: gate on ``is_active`` (connected AND ws open), not the raw
+        # ``connected`` flag. After a reload the old slot can linger with
+        # ``connected = True`` but a CLOSED WebSocket — the "stale connected
+        # flag, old WS closed" case that PlayerRegistry.add_player treats as a
+        # legitimate rejoin/reclaim. Renaming to "Name 2" here (before
+        # add_player ever sees the original name) made that reclaim branch
+        # unreachable, spawning a duplicate ghost with score 0. Falling through
+        # on a stale slot lets add_player reclaim the original name; genuinely
+        # live duplicates (ws still open) still get the "Name 2" suffix.
         original_name = name
         counter = 2
-        while (existing := game_state.get_player(name)) and existing.connected:
+        while (existing := game_state.get_player(name)) and existing.is_active:
             name = f"{original_name} {counter}"
             counter += 1
 
@@ -789,12 +814,8 @@ class QuizifyWebSocketHandler:
             state["type"] = "game_state"
             await self._conn.send(ws, state)
 
-            # Broadcast player list to everyone
-            players = game_state.get_players()
-            await self._conn.broadcast({
-                "type": "player_joined",
-                "players": serialize_player_list(players),
-            })
+            # Broadcast player list to everyone — coalesced (#453).
+            self._mark_roster_dirty("player_joined")
 
             # Narrate the join (#281). The host's own admin-as-player tab is
             # skipped inside the announcer so the room doesn't hear the host
@@ -901,12 +922,8 @@ class QuizifyWebSocketHandler:
         state["type"] = "game_state"
         await self._conn.send(ws, state)
 
-        # Broadcast updated player list
-        players = game_state.get_players()
-        await self._conn.broadcast({
-            "type": "player_joined",
-            "players": serialize_player_list(players),
-        })
+        # Broadcast updated player list — coalesced (#453).
+        self._mark_roster_dirty("player_joined")
 
     # ------------------------------------------------------------------
     # Submit answer
@@ -1196,6 +1213,69 @@ class QuizifyWebSocketHandler:
         self._reaction_buffer.clear()
         self._reaction_bonus_from.clear()
         self._reaction_bonus_to.clear()
+
+    def _mark_roster_dirty(self, event_type: str) -> None:
+        """Flag the roster as changed and (re)arm the coalescing flush (#453).
+
+        ``event_type`` is ``"player_joined"`` or ``"player_left"`` and only
+        determines the wire ``type`` of the coalesced message (the join/leave
+        animation the client plays); the ``players`` list itself is always the
+        live roster serialized at flush time. Mixed joins+leaves in one window
+        collapse to a single frame typed by the LAST event.
+        """
+        self._roster_dirty = True
+        self._roster_last_type = event_type
+        self._ensure_roster_flush()
+
+    def _ensure_roster_flush(self) -> None:
+        """(Re)arm the roster-coalescing flush task if none is pending."""
+        if self._roster_flush_task is None or self._roster_flush_task.done():
+            # Stored on self (no GC risk), matching the timer-tick / lightning /
+            # admin-pause fire-and-forget pattern in this handler.
+            self._roster_flush_task = asyncio.ensure_future(
+                self._flush_roster_after_window()
+            )
+
+    async def _flush_roster_after_window(self) -> None:
+        """Wait one window, then broadcast ONE roster frame (#453).
+
+        Mirrors ``_flush_reactions_after_window``: coalesces a burst of roster
+        changes into a single ``player_joined`` / ``player_left`` carrying the
+        current player list. Re-arms itself if more changes landed during the
+        broadcast so the final roster always reaches every client.
+        """
+        try:
+            await asyncio.sleep(self._REACTION_FLUSH_WINDOW)
+        except asyncio.CancelledError:
+            self._roster_dirty = False
+            raise
+
+        if not self._roster_dirty:
+            return
+
+        event_type = self._roster_last_type
+        self._roster_dirty = False
+        gs = self._get_game_state()
+        if gs is not None:
+            await self._conn.broadcast({
+                "type": event_type,
+                "players": serialize_player_list(gs.get_players()),
+            })
+
+        # A roster change that landed DURING the broadcast set _roster_dirty
+        # again; _ensure_roster_flush won't start a new task while this one is
+        # running, so re-arm here to drain the tail (mirrors #354).
+        if self._roster_dirty:
+            self._roster_flush_task = asyncio.ensure_future(
+                self._flush_roster_after_window()
+            )
+
+    def _cancel_roster_flush(self) -> None:
+        """Cancel any pending roster-flush task (called on cleanup)."""
+        if self._roster_flush_task is not None:
+            self._roster_flush_task.cancel()
+            self._roster_flush_task = None
+        self._roster_dirty = False
 
     # ------------------------------------------------------------------
     # Wager (gameplay idea #3 — Jeopardy-style final round)
@@ -1738,10 +1818,8 @@ class QuizifyWebSocketHandler:
 
         _LOGGER.info("Admin kicked player: %s", target.name)
 
-        await self._conn.broadcast({
-            "type": "player_left",
-            "players": serialize_player_list(game_state.get_players()),
-        })
+        # Coalesced roster broadcast (#453).
+        self._mark_roster_dirty("player_left")
 
     # ------------------------------------------------------------------
     # Lightning Round (issue #42)
@@ -2416,12 +2494,8 @@ class QuizifyWebSocketHandler:
         ):
             self._schedule_admin_pause(player.name)
 
-        # Broadcast updated player list
-        players = game_state.get_players()
-        await self._conn.broadcast({
-            "type": "player_left",
-            "players": serialize_player_list(players),
-        })
+        # Broadcast updated player list — coalesced (#453).
+        self._mark_roster_dirty("player_left")
 
         # Schedule removal after grace period
         grace = (
@@ -2439,11 +2513,8 @@ class QuizifyWebSocketHandler:
                     gs.remove_player(name)
                     # Clean up session tokens for this player
                     self._conn.clear_player_tokens(name)
-                    remaining = gs.get_players()
-                    await self._conn.broadcast({
-                        "type": "player_left",
-                        "players": serialize_player_list(remaining),
-                    })
+                    # Coalesced roster broadcast (#453).
+                    self._mark_roster_dirty("player_left")
                     _LOGGER.info(
                         "Removed disconnected player after grace period: %s", name
                     )
@@ -2754,6 +2825,7 @@ class QuizifyWebSocketHandler:
         self._cancel_timer_tick()
         self._cancel_lightning_loop()
         self._cancel_reaction_flush()
+        self._cancel_roster_flush()
         # Also cancel the deferred admin-disconnect pause (#362): a game
         # teardown/reset that leaves it pending would fire a spurious pause
         # (or hold a reference) after the game is already gone.

--- a/tests/test_be_a_ws_state_r4.py
+++ b/tests/test_be_a_ws_state_r4.py
@@ -1,0 +1,376 @@
+"""Regression tests for the be-a-ws-state-r4 backend batch.
+
+Four independent fixes, bundled here because they share the
+server/websocket.py + game/state.py + game/lightning.py surface:
+
+* #448 — _handle_join's auto-rename loop gated on the raw ``connected`` flag
+         renamed a rejoiner to "Name 2" even when the old slot was a stale
+         connected-but-closed ghost, making PlayerRegistry.add_player's
+         same-name reclaim unreachable (duplicate ghost, score 0). Fixed by
+         gating on ``is_active`` (connected AND ws open).
+* #450 — submit_answer overwrote ``round_score`` with a plain assignment,
+         wiping any pre-submit STEAL / reaction-bonus delta from round_score
+         while ``score`` kept it. Fixed by accumulating (``+= points``).
+* #453 — every join/leave broadcast a full roster to every socket (O(N²) on a
+         room-wide blip). Now coalesced through a ~150ms flush window into one
+         ``player_joined`` / ``player_left`` per window.
+* #455 — get_state_snapshot rebuilt the immutable lightning recap on every
+         join/reconnect during LIGHTNING_RECAP. Now memoized behind
+         ``LightningRound.finished``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.lightning import LightningRound  # noqa: E402
+from custom_components.quizify.game.powerups import (  # noqa: E402
+    PowerUpEffect,
+    PowerUpType,
+)
+from custom_components.quizify.game.questions import QuestionBank  # noqa: E402
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    def create_task(self, coro):
+        return asyncio.ensure_future(coro)
+
+    async def run_in_executor(self, func, *args):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func, *args)
+
+
+def _ws(closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    ws.send_json = AsyncMock()
+    return ws
+
+
+def _correct_index(game: QuizifyGameState) -> int:
+    q = game._current_question
+    assert q is not None
+    return next(i for i, a in enumerate(q.answers) if a.correct)
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+@pytest.fixture
+def handler(game: QuizifyGameState) -> QuizifyWebSocketHandler:
+    runtime = _FakeRuntime(game._runtime.data_dir)  # type: ignore[attr-defined]
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    h._conn = ConnectionManager(runtime, lambda: game)
+    h._conn.broadcast = AsyncMock()
+    h._conn.send = AsyncMock()
+    h._conn.send_error = AsyncMock()
+    # Fast coalescing window so the roster tests don't crawl.
+    h._REACTION_FLUSH_WINDOW = 0.02
+    return h
+
+
+async def _drain_roster(handler: QuizifyWebSocketHandler) -> None:
+    """Let the coalescing flush window elapse and the task finish."""
+    task = handler._roster_flush_task
+    if task is not None:
+        await asyncio.wait_for(asyncio.shield(task), timeout=2.0)
+    # A tiny extra beat for any re-armed tail pass to settle.
+    await asyncio.sleep(handler._REACTION_FLUSH_WINDOW * 2)
+
+
+# ---------------------------------------------------------------------------
+# #448 — stale connected slot must be reclaimed, not renamed
+# ---------------------------------------------------------------------------
+
+
+class TestJoinReclaimStaleSlot:
+    @pytest.mark.asyncio
+    async def test_stale_ghost_reclaimed_not_duplicated(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        """A reload leaves the old slot connected=True with a CLOSED ws. A
+        rejoin under the SAME name must reclaim that slot (keeping score), not
+        rename to "Alice 2" and spawn a score-0 ghost."""
+        alice_ws = _ws()
+        bob_ws = _ws()
+        game.add_player("Alice", alice_ws)
+        game.add_player("Bob", bob_ws)
+        game.start_game(num_rounds=3, language="de")
+        game.start_next_question()
+
+        # Alice answers correctly → she has a real score.
+        game.submit_answer("Alice", _correct_index(game))
+        alice = game.get_player("Alice")
+        assert alice is not None
+        assert alice.score > 0
+        earned = alice.score
+
+        # Simulate the reload: her tab's ws dies but _handle_disconnect hasn't
+        # fired yet → stale connected flag with a closed ws.
+        alice_ws.closed = True
+        assert alice.connected is True
+        assert not alice.is_active  # the case the fix keys on
+
+        # Alice rejoins with a fresh ws under the same name.
+        fresh_ws = _ws()
+        await handler._handle_join(fresh_ws, {"name": "Alice"}, game)
+
+        # No ghost: still exactly one Alice, no "Alice 2", score preserved.
+        names = [p.name for p in game.get_players()]
+        assert names.count("Alice") == 1
+        assert "Alice 2" not in names
+        reclaimed = game.get_player("Alice")
+        assert reclaimed is not None
+        assert reclaimed.score == earned
+        assert reclaimed.ws is fresh_ws
+        assert reclaimed.is_active
+
+    @pytest.mark.asyncio
+    async def test_live_duplicate_still_renamed(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        """A genuinely LIVE duplicate (old ws still open) must still get the
+        "Name 2" suffix — the fix must not collapse two real players."""
+        first_ws = _ws()
+        game.add_player("Charlie", first_ws)
+        assert game.get_player("Charlie").is_active
+
+        second_ws = _ws()
+        await handler._handle_join(second_ws, {"name": "Charlie"}, game)
+
+        names = [p.name for p in game.get_players()]
+        assert "Charlie" in names
+        assert "Charlie 2" in names
+
+
+# ---------------------------------------------------------------------------
+# #450 — pre-submit STEAL delta must survive the thief's own submit
+# ---------------------------------------------------------------------------
+
+
+class TestStealRoundScoreAccumulates:
+    def test_steal_before_submit_not_wiped_by_submit(
+        self, game: QuizifyGameState
+    ) -> None:
+        thief_ws, victim_ws = _ws(), _ws()
+        game.add_player("Thief", thief_ws)
+        game.add_player("Victim", victim_ws)
+        game.start_game(num_rounds=3, language="de")
+        game.start_next_question()
+
+        # Victim submits correctly → has a round_score worth stealing.
+        game.submit_answer("Victim", _correct_index(game))
+        victim = game.get_player("Victim")
+        assert victim.round_score > 1
+
+        # Thief steals from the (submitted) victim BEFORE answering.
+        game._powerup_manager._inventory["Thief"] = PowerUpType.STEAL
+        effect = game.use_powerup("Thief", "Victim")
+        assert isinstance(effect, PowerUpEffect)
+        thief = game.get_player("Thief")
+        stolen = thief.round_score
+        assert stolen > 0
+
+        # Thief now answers correctly. round_score must ACCUMULATE the earned
+        # points on top of the stolen delta — not overwrite it.
+        result = game.submit_answer("Thief", _correct_index(game))
+        points = result.points_earned
+
+        assert thief.round_score == stolen + points
+        # The actual bug symptom: a plain assignment left round_score == points.
+        assert thief.round_score > points
+        # round_score stays consistent with score (thief started at 0).
+        assert thief.round_score == thief.score
+
+    def test_no_steal_round_score_equals_points(
+        self, game: QuizifyGameState
+    ) -> None:
+        """Sanity: with no pre-submit delta, ``+= points`` from a zeroed
+        round_score is identical to the old behaviour."""
+        a_ws = _ws()
+        game.add_player("Solo", a_ws)
+        game.start_game(num_rounds=3, language="de")
+        game.start_next_question()
+
+        result = game.submit_answer("Solo", _correct_index(game))
+        solo = game.get_player("Solo")
+        assert solo.round_score == result.points_earned
+
+
+# ---------------------------------------------------------------------------
+# #453 — roster broadcasts coalesced through the flush window
+# ---------------------------------------------------------------------------
+
+
+class TestRosterCoalescing:
+    @pytest.mark.asyncio
+    async def test_burst_of_joins_collapses_to_one_broadcast(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        game.add_player("A", _ws())
+        game.add_player("B", _ws())
+        game.add_player("C", _ws())
+
+        # Three roster changes inside one window.
+        handler._mark_roster_dirty("player_joined")
+        handler._mark_roster_dirty("player_joined")
+        handler._mark_roster_dirty("player_joined")
+
+        await _drain_roster(handler)
+
+        # ONE broadcast, not three — carrying the full current roster.
+        handler._conn.broadcast.assert_awaited_once()
+        msg = handler._conn.broadcast.await_args.args[0]
+        assert msg["type"] == "player_joined"
+        assert {p["name"] for p in msg["players"]} == {"A", "B", "C"}
+
+    @pytest.mark.asyncio
+    async def test_mixed_window_types_by_last_event_list_authoritative(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        """A join then a leave in one window collapse to a single frame typed
+        by the LAST event, but the players list is always the live roster."""
+        game.add_player("A", _ws())
+        game.add_player("B", _ws())
+        handler._mark_roster_dirty("player_joined")
+        handler._mark_roster_dirty("player_left")
+
+        await _drain_roster(handler)
+
+        handler._conn.broadcast.assert_awaited_once()
+        msg = handler._conn.broadcast.await_args.args[0]
+        assert msg["type"] == "player_left"
+        assert {p["name"] for p in msg["players"]} == {"A", "B"}
+
+    @pytest.mark.asyncio
+    async def test_join_handler_defers_roster_broadcast(
+        self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
+    ) -> None:
+        """_handle_join no longer broadcasts the roster synchronously — the
+        joining player still gets their game_state, the roster goes out once
+        the window flushes."""
+        await handler._handle_join(_ws(), {"name": "Zoe"}, game)
+        # Nothing broadcast yet (still inside the window / task pending).
+        handler._conn.broadcast.assert_not_awaited()
+
+        await _drain_roster(handler)
+
+        handler._conn.broadcast.assert_awaited_once()
+        msg = handler._conn.broadcast.await_args.args[0]
+        assert msg["type"] == "player_joined"
+        assert any(p["name"] == "Zoe" for p in msg["players"])
+
+
+# ---------------------------------------------------------------------------
+# #455 — lightning recap memoized once finished
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bank() -> QuestionBank:
+    qb = QuestionBank()
+    qb.load_all_categories()
+    return qb
+
+
+def _run_to_finish(lr: LightningRound) -> None:
+    steps = 0
+    while True:
+        q = lr.current_question
+        if q is not None:
+            correct_orig = next(i for i, a in enumerate(q.answers) if a.correct)
+            order = lr._shuffles["A"]
+            lr.record_answer("A", order.index(correct_orig))
+        if not lr.advance():
+            break
+        steps += 1
+        assert steps < 50
+
+
+class TestLightningRecapCache:
+    def test_recap_memoized_after_finish(self, bank: QuestionBank) -> None:
+        lr = LightningRound(bank, ["A"], language="de", num_questions=3)
+        assert lr.start() is True
+        _run_to_finish(lr)
+        assert lr.finished is True
+
+        first = lr.build_recap()
+        second = lr.build_recap()
+        # Same dict object handed back — no rebuild per join/reconnect.
+        assert first is second
+
+    def test_cached_recap_immune_to_later_mutation(
+        self, bank: QuestionBank
+    ) -> None:
+        """Once cached, a stray score mutation can't leak into the payload —
+        the recap is immutable post-finish by contract."""
+        lr = LightningRound(bank, ["A"], language="de", num_questions=3)
+        lr.start()
+        _run_to_finish(lr)
+        first = lr.build_recap()
+        first_scores = {row["name"]: row["score"] for row in first["leaderboard"]}
+
+        lr.scores["A"] = 9999  # would change leaderboard on a fresh build
+        again = lr.build_recap()
+        again_scores = {row["name"]: row["score"] for row in again["leaderboard"]}
+        assert again_scores == first_scores
+
+    def test_prefinish_recap_not_cached(self, bank: QuestionBank) -> None:
+        """A build before the round finishes must NOT be frozen in — the
+        cache only arms once ``finished`` is set."""
+        lr = LightningRound(bank, ["A"], language="de", num_questions=3)
+        lr.start()
+        # Mid-round build (unusual, but must stay live).
+        lr.build_recap()
+        assert lr._recap_cache is None
+        assert lr.finished is False
+
+    def test_start_invalidates_stale_cache(self, bank: QuestionBank) -> None:
+        """A reused instance's start() drops any prior recap cache."""
+        lr = LightningRound(bank, ["A"], language="de", num_questions=3)
+        lr.start()
+        _run_to_finish(lr)
+        lr.build_recap()
+        assert lr._recap_cache is not None
+
+        # Re-arm the same instance for a new round.
+        assert lr.start() is True
+        assert lr._recap_cache is None
+
+    def test_snapshot_reuses_cached_recap(self, tmp_path: Path) -> None:
+        """get_state_snapshot at LIGHTNING_RECAP reuses the cached recap dict
+        rather than rebuilding it each call."""
+        state = QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+        state.add_player("A", _ws())
+        state.start_game(num_rounds=3, language="de", lightning_enabled=True)
+        # Drive a standalone lightning round to its recap.
+        lr = LightningRound(state._question_bank, ["A"], language="de", num_questions=3)
+        assert lr.start() is True
+        _run_to_finish(lr)
+        state._lightning = lr
+        state.phase = GamePhase.LIGHTNING_RECAP
+
+        snap1 = state.get_state_snapshot()
+        snap2 = state.get_state_snapshot()
+        assert snap1["lightning_recap"] is snap2["lightning_recap"]


### PR DESCRIPTION
Fixes #448
Fixes #450
Fixes #453
Fixes #455

Four backend items on the `server/websocket.py` + `game/state.py` + `game/lightning.py` surface, bundled into one branch.

**#448 (P2 bug) — join reclaim.** `_handle_join`'s auto-rename loop gated on the raw `connected` flag. After a reload the old slot still shows `connected=True` with a CLOSED ws (the "stale connected flag, old WS closed — allowing rejoin" case in `PlayerRegistry.add_player`). The handler renamed the rejoiner to "Name 2" before `add_player` ever saw the original name, so the reclaim branch was unreachable → a duplicate ghost with score 0. Now the loop gates on `existing.is_active` (connected AND ws open): a stale-flag slot falls through to the same-name reclaim, while genuinely live duplicates still get the "Name 2" suffix.

**#450 (P2 bug) — steal round_score.** A STEAL landing before the thief submits does `source_player.round_score += stolen`. `submit_answer` then did `player.round_score = points` (plain assignment), wiping that pre-submit delta from `round_score` even though `score` kept it — so the reveal breakdown, `round_scores` history, the Top Score superlative, and a later STEAL against the thief all under-counted. Now `submit_answer` accumulates (`player.round_score += points`); `round_score` is zeroed in `reset_round`, so any pre-submit content is exactly steal/bonus deltas. The estimate path (`submit_guess`) is unaffected — it never sets `round_score` at submit time, and STEAL is rejected on estimate rounds (#406), so the eval-time assignment stays consistent.

**#453 (P3 perf) — roster coalesce.** Every join/reconnect/disconnect/grace-removal/kick broadcast a full `serialize_player_list` roster to all sockets → O(N²) during a room-wide wifi blip. Roster updates are now coalesced through the existing ~150ms flush-window pattern (mirroring the reaction flush, #354/#416): each event marks the roster dirty and arms one flush task, which broadcasts a single `player_joined`/`player_left` carrying the live list per window. `_roster_last_type` picks the wire `type` (join/leave animation); the `players` list is always re-serialized from live game state at flush time, so the final roster is always sent. Wire shape unchanged.

**#455 (P3 perf) — lightning-recap cache.** `get_state_snapshot()` called `LightningRound.build_recap()` on every join/reconnect/get_state while phase == `LIGHTNING_RECAP`, though the recap is immutable once `advance()` sets `finished`. `build_recap()` now memoizes the built dict behind `self.finished`; a fresh `LightningRound` (each detour makes a new one; resume/reset drop the old) starts with an empty cache, and `start()` clears it defensively for a reused instance.

**Tests:** `tests/test_be_a_ws_state_r4.py` adds regressions per item (stale-ghost reclaim vs live-duplicate rename, steal-then-submit accumulation, roster burst coalescing + mixed-window typing, recap memoization + invalidation + snapshot reuse). Verified they fail on the pre-fix code. Full suite: 964 passed, 5 skipped. Ruff clean on `custom_components/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)