### PR TITLE
fix: preserve steal on timeout + expire analytics metrics memo (#472, #473)

### DIFF
--- a/custom_components/quizify/analytics.py
+++ b/custom_components/quizify/analytics.py
@@ -80,7 +80,7 @@ class QuizifyAnalytics:
         # full O(n) passes over up to 1000 records. Cache value is
         # ``(fingerprint, result)`` where fingerprint = (total_games,
         # last ended_at); a mismatch (append or prune) recomputes.
-        self._metrics_cache: dict[str, tuple[tuple[int, int], dict[str, Any]]] = {}
+        self._metrics_cache: dict[str, tuple[tuple[int, int, int], dict[str, Any]]] = {}
 
     def _empty_data(self) -> AnalyticsData:
         """Return empty analytics data structure."""

--- a/custom_components/quizify/analytics.py
+++ b/custom_components/quizify/analytics.py
@@ -342,9 +342,21 @@ class QuizifyAnalytics:
         last ended_at)`` lets repeated reads reuse the last result instead of
         re-scanning every record. ``add_game`` clears the cache; a prune shifts
         the fingerprint, so both paths recompute.
+
+        #473: the fingerprint also carries a coarse hourly wall-clock bucket
+        (``int(time.time()) // 3600``). The underlying compute is wall-clock
+        relative — the window is ``now - days*86400`` and the chart buckets are
+        relative to ``now`` — so with no new game the games-only fingerprint
+        would never change and the 7d/30d results plus chart would freeze on the
+        cache-write day (aged-out games still counted). The hourly bucket makes
+        the windowed metrics expire as wall-clock advances.
         """
         games = self._data["games"]
-        fingerprint = (len(games), games[-1]["ended_at"] if games else 0)
+        fingerprint = (
+            len(games),
+            games[-1]["ended_at"] if games else 0,
+            int(time.time()) // 3600,
+        )
         cached = self._metrics_cache.get(period)
         if cached is not None and cached[0] == fingerprint:
             return cached[1]

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -923,7 +923,14 @@ class QuizifyGameState:
                 # (i18n wager.timeoutNote). Do NOT add a wager deduction here.
                 player.streak = 0
                 player.record_round_result("timeout")
-                player.round_scores.append(0)
+                # Record round_score, not a literal 0 (#472). For a genuine
+                # timeout this is 0 (reset_round zeroed it and the player never
+                # submitted), but a pre-submit STEAL can have folded points into
+                # this player's round_score before they timed out. The reveal's
+                # AnswerResult below already reports points_earned=round_score,
+                # so the round_scores history and Top-Score aggregation must
+                # match — appending 0 here under-counted that stolen amount.
+                player.round_scores.append(player.round_score)
                 player_correct[player.name] = False
             else:
                 is_correct = player.last_answer_correct

--- a/tests/test_be_a_ws_state_r4.py
+++ b/tests/test_be_a_ws_state_r4.py
@@ -219,6 +219,66 @@ class TestStealRoundScoreAccumulates:
 
 
 # ---------------------------------------------------------------------------
+# #472 — a pre-submit STEAL by a player who then times out must be recorded
+#        in round_scores history (gap left by #450)
+# ---------------------------------------------------------------------------
+
+
+class TestStealThenTimeoutRecordsHistory:
+    def test_timeout_after_steal_records_stolen_round_score(
+        self, game: QuizifyGameState
+    ) -> None:
+        """A thief who steals then never submits must have the stolen amount
+        recorded in ``round_scores`` — the timeout branch used to append a
+        literal 0 while the AnswerResult reported ``points_earned=round_score``,
+        under-counting the Top-Score / history aggregation."""
+        thief_ws, victim_ws = _ws(), _ws()
+        game.add_player("Thief", thief_ws)
+        game.add_player("Victim", victim_ws)
+        game.start_game(num_rounds=3, language="de")
+        game.start_next_question()
+
+        # Victim submits correctly → has a round_score worth stealing.
+        game.submit_answer("Victim", _correct_index(game))
+        victim = game.get_player("Victim")
+        assert victim.round_score > 1
+
+        # Thief steals BEFORE answering, then never submits (timeout).
+        game._powerup_manager._inventory["Thief"] = PowerUpType.STEAL
+        effect = game.use_powerup("Thief", "Victim")
+        assert isinstance(effect, PowerUpEffect)
+        thief = game.get_player("Thief")
+        stolen = thief.round_score
+        assert stolen > 0
+        assert not thief.submitted
+
+        # Timer expires → round evaluated with the thief still unsubmitted.
+        summary = game.evaluate_round()
+        assert summary is not None
+
+        # History must carry the stolen delta, not a literal 0.
+        assert thief.round_scores[-1] == stolen
+        # And it must agree with the reveal's AnswerResult (which reports
+        # points_earned=round_score) for the same player.
+        thief_result = next(r for r in summary.results if r.player_id == "Thief")
+        assert thief_result.points_earned == stolen
+        assert thief.round_scores[-1] == thief_result.points_earned
+
+    def test_genuine_timeout_records_zero(self, game: QuizifyGameState) -> None:
+        """Sanity: a plain timeout with no pre-submit delta still records 0,
+        since reset_round zeroed round_score."""
+        game.add_player("Idle", _ws())
+        game.start_game(num_rounds=3, language="de")
+        game.start_next_question()
+
+        idle = game.get_player("Idle")
+        assert not idle.submitted
+
+        game.evaluate_round()
+        assert idle.round_scores[-1] == 0
+
+
+# ---------------------------------------------------------------------------
 # #453 — roster broadcasts coalesced through the flush window
 # ---------------------------------------------------------------------------
 

--- a/tests/test_perf_views_analytics_417_418.py
+++ b/tests/test_perf_views_analytics_417_418.py
@@ -176,6 +176,44 @@ def test_compute_metrics_returns_cached_result_until_add_game(tmp_path) -> None:
     assert fresh["avg_players_per_game"] == round((99 + 3 + 3) / 3, 1)
 
 
+def test_compute_metrics_expires_on_hourly_bucket_rollover(
+    tmp_path, monkeypatch
+) -> None:
+    """#473: with no new game, advancing wall-clock past an hourly bucket
+    boundary must recompute so the windowed metrics don't freeze on the
+    cache-write hour (aged-out games would otherwise keep counting)."""
+    import custom_components.quizify.analytics as analytics_mod
+
+    analytics = _make_analytics(tmp_path)
+    analytics.schedule_save = lambda: None  # type: ignore[assignment]
+
+    # Pin the clock to a bucket boundary for deterministic arithmetic.
+    base = (int(time.time()) // 3600) * 3600
+    clock = {"now": base}
+    monkeypatch.setattr(analytics_mod.time, "time", lambda: clock["now"])
+
+    day = 86400
+    # Two games: one comfortably inside the 7d window, one that will age out
+    # of it once the clock advances by ~1 day past the 7-day cutoff.
+    fresh_game = _game("fresh", base - day)  # ~1 day old
+    edge_game = _game("edge", base - 6 * day)  # ~6 days old, inside 7d
+    analytics._data["games"] = [edge_game, fresh_game]
+
+    first = analytics.compute_metrics("7d")
+    assert first["total_games"] == 2
+    # Same hour → cached object reused (no recompute).
+    assert analytics.compute_metrics("7d") is first
+
+    # Advance the wall clock by 2 days: crosses the hourly bucket boundary AND
+    # pushes edge_game (now ~8 days old) out of the 7d window. Fingerprint's
+    # hourly bucket changes even though games (len + last ended_at) did not.
+    clock["now"] = base + 2 * day
+    fresh = analytics.compute_metrics("7d")
+
+    assert fresh is not first  # recomputed, not frozen
+    assert fresh["total_games"] == 1  # aged-out edge_game no longer counted
+
+
 def test_compute_metrics_cache_is_per_period(tmp_path) -> None:
     """Distinct periods are cached independently and stay correct."""
     analytics = _make_analytics(tmp_path)


### PR DESCRIPTION
Fixes #472
Fixes #473

## #472 — steal-then-timeout under-counts history (gap in #450)
In `game/state.py` `_do_evaluate_round`, the not-submitted (timeout) branch appended a literal `0` to `round_scores`, but the AnswerResult reports `points_earned=player.round_score`. A pre-submit STEAL can leave `round_score` non-zero for a player who never submits, so the round-history and Top-Score aggregation under-counted the stolen amount. Now appends `player.round_score` (still 0 for genuine timeouts since `reset_round` zeroes it).

## #473 — windowed analytics metrics freeze (regression from #418)
In `analytics.py`, `compute_metrics` memoized per period keyed only on `(len(games), games[-1].ended_at)`, but the underlying compute is wall-clock relative (window = `now - days*86400`, chart buckets relative to `now`). With no new game the fingerprint never changed, so 7d/30d results and the chart froze on the cache-write day while aged-out games kept counting. Now adds a coarse hourly bucket `int(time.time())//3600` to the fingerprint so windowed metrics expire hourly as wall-clock advances.

Regression tests added for both. Full suite green (984 passed, 5 skipped), `ruff check custom_components/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)