### PR TITLE
fix: roster-flush exception callback + drop loop-side path.exists (#474, #475)

### DIFF
--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -324,13 +324,18 @@ def _read_template_cached(path: Path) -> str:
 async def _serve_html(request: web.Request, filename: str) -> web.Response:
     """Read a file from www/, substitute {{VERSION}}, return as HTML."""
     html_path = _WWW_DIR / filename
-    if not html_path.exists():
-        _LOGGER.error("Page not found: %s", html_path)
-        return web.Response(text=f"{filename} not found", status=500)
-
     ctx = _get_ctx(request)
     version = _get_live_version(ctx.version)
-    html_content = await ctx.runtime.run_in_executor(_read_template_cached, html_path)
+    # The missing-file ``stat`` happens once, off-loop, inside
+    # ``_read_template_cached`` (which raises ``OSError`` on a missing file) —
+    # no redundant loop-thread ``path.exists()`` stat on the request path (#475).
+    try:
+        html_content = await ctx.runtime.run_in_executor(
+            _read_template_cached, html_path
+        )
+    except OSError:
+        _LOGGER.error("Page not found: %s", html_path)
+        return web.Response(text=f"{filename} not found", status=500)
     html_content = _apply_version(html_content, version)
     asset_version = await _get_asset_version_async(ctx, version)
     html_content = html_content.replace(_ASSET_VER_TOKEN, asset_version)
@@ -376,12 +381,15 @@ async def sw_view(request: web.Request) -> web.Response:
     asset caches.
     """
     sw_path = _WWW_DIR / "sw.js"
-    if not sw_path.exists():
-        return web.Response(text="sw.js not found", status=404)
-
     ctx = _get_ctx(request)
     version = _get_live_version(ctx.version)
-    body = await ctx.runtime.run_in_executor(_read_template_cached, sw_path)
+    # The missing-file ``stat`` happens once, off-loop, inside
+    # ``_read_template_cached`` (raises ``OSError``) — no loop-thread
+    # ``path.exists()`` stat on the request path (#475).
+    try:
+        body = await ctx.runtime.run_in_executor(_read_template_cached, sw_path)
+    except OSError:
+        return web.Response(text="sw.js not found", status=404)
     body = _apply_version(body, version)
     body = body.replace(_ASSET_VER_TOKEN, await _get_asset_version_async(ctx, version))
     # The SW is served from /quizify/static/sw.js but must control /quizify/*

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -1235,6 +1235,7 @@ class QuizifyWebSocketHandler:
             self._roster_flush_task = asyncio.ensure_future(
                 self._flush_roster_after_window()
             )
+            self._roster_flush_task.add_done_callback(self._log_task_exception)
 
     async def _flush_roster_after_window(self) -> None:
         """Wait one window, then broadcast ONE roster frame (#453).
@@ -1269,6 +1270,7 @@ class QuizifyWebSocketHandler:
             self._roster_flush_task = asyncio.ensure_future(
                 self._flush_roster_after_window()
             )
+            self._roster_flush_task.add_done_callback(self._log_task_exception)
 
     def _cancel_roster_flush(self) -> None:
         """Cancel any pending roster-flush task (called on cleanup)."""

--- a/tests/test_be_a_ws_state_r4.py
+++ b/tests/test_be_a_ws_state_r4.py
@@ -264,6 +264,39 @@ class TestRosterCoalescing:
         assert {p["name"] for p in msg["players"]} == {"A", "B"}
 
     @pytest.mark.asyncio
+    async def test_raising_flush_is_logged_not_swallowed(
+        self,
+        handler: QuizifyWebSocketHandler,
+        game: QuizifyGameState,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """#474: the roster-flush task carries the same _log_task_exception
+        done-callback as every other fire-and-forget task here. If broadcast
+        raises inside the flush (after _roster_dirty was cleared), the crash is
+        surfaced in the log instead of only appearing at GC time."""
+        game.add_player("A", _ws())
+        handler._conn.broadcast = AsyncMock(side_effect=RuntimeError("boom"))
+
+        handler._mark_roster_dirty("player_joined")
+        task = handler._roster_flush_task
+        assert task is not None
+        # The done-callback must be attached (mirrors lightning/timer/pause).
+        assert handler._log_task_exception in [
+            cb for cb, _ctx in task._callbacks  # type: ignore[attr-defined]
+        ]
+
+        with caplog.at_level("ERROR"):
+            with pytest.raises(RuntimeError):
+                await asyncio.wait_for(asyncio.shield(task), timeout=2.0)
+            # Let the done-callback run.
+            await asyncio.sleep(0)
+
+        assert any(
+            "Unhandled exception in background task" in r.message
+            for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
     async def test_join_handler_defers_roster_broadcast(
         self, handler: QuizifyWebSocketHandler, game: QuizifyGameState
     ) -> None:

--- a/tests/test_be_b_isolated_r4.py
+++ b/tests/test_be_b_isolated_r4.py
@@ -20,6 +20,8 @@ import sys
 import time
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT))
 
@@ -110,6 +112,15 @@ class TestTemplateMtimeCache:
         # Re-stat returns the same mtime_ns, so the cached branch is taken.
         assert views._read_template_cached(page) == "cached"
         assert views._TEMPLATE_TEXT_CACHE[str(page)] == cached_entry
+
+    def test_missing_file_raises_oserror(self, tmp_path: Path) -> None:
+        """#475: _serve_html / sw_view dropped their loop-side path.exists()
+        stat and now rely on the off-loop stat inside _read_template_cached to
+        signal a missing file via OSError (so the view can map it to 404/500)."""
+        views._TEMPLATE_TEXT_CACHE.clear()
+        missing = tmp_path / "does-not-exist.html"
+        with pytest.raises(OSError):
+            views._read_template_cached(missing)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #474
Fixes #475

## #474 — roster-flush tasks now carry the exception done-callback (P2)
The roster-coalescing flush tasks in `server/websocket.py` were created with bare `asyncio.ensure_future(self._flush_roster_after_window())` (initial arm + tail re-arm) without `add_done_callback(self._log_task_exception)`, unlike every other fire-and-forget task here (lightning/timer/admin-pause). If broadcast raised inside the flush after `_roster_dirty` was cleared, the final roster frame was lost and the exception surfaced only at GC. Both `ensure_future` sites now attach the log-callback.

## #475 — drop loop-side `path.exists()` on the request path (P3 perf)
`_serve_html` and `sw_view` in `server/views.py` ran `path.exists()` on the event loop on every request before the executor-offloaded `_read_template_cached` — the only remaining loop-thread FS stat on the request path (HA flags it) and redundant with the stat `_read_template_cached` already does. The loop-side checks are dropped; the executor call is wrapped in `try/except OSError` mapping to 500 (`_serve_html`) / 404 (`sw_view`). `_read_template_cached` already raises `OSError` (via `os.stat`) on a missing file, so the missing-file stat now happens once, off-loop.

## Tests
- `test_raising_flush_is_logged_not_swallowed` — a raising flush is logged and the done-callback is attached (#474).
- `test_missing_file_raises_oserror` — `_read_template_cached` raises `OSError` on a missing file, the contract the view now relies on (#475).
- Full suite: 983 passed, 5 skipped. Ruff clean on `custom_components/` and the touched test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)