### PR TITLE
fix(ux): round-5 — disconnected chip, chip contrast, wager aria, dialog focus, styled kick modal (#476,#477,#478,#479,#480)

### DIFF
--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -663,6 +663,19 @@
         </div>
     </div>
 
+    <!-- Kick player confirmation modal (#480) -->
+    <div id="kick-player-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="kick-player-modal-title">
+        <div class="modal-backdrop"></div>
+        <div class="modal-content">
+            <h2 id="kick-player-modal-title" data-i18n="admin.kickModalTitle">Remove player?</h2>
+            <p id="kick-player-modal-text" data-i18n="admin.kickConfirm">Remove this player from the lobby?</p>
+            <div class="modal-actions">
+                <button type="button" id="kick-player-confirm-btn" class="btn btn-danger" data-i18n="admin.kickConfirmBtn">Remove</button>
+                <button type="button" id="kick-player-cancel-btn" class="btn btn-secondary" data-i18n="common.cancel">Cancel</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Error toast -->
     <div id="error-toast" class="toast hidden" role="alert" aria-live="assertive"></div>
 

--- a/custom_components/quizify/www/css/src/07-player.css
+++ b/custom_components/quizify/www/css/src/07-player.css
@@ -705,6 +705,7 @@
 .submitted-players {
     display: flex;
     flex-wrap: wrap;
+    justify-content: center;
     gap: var(--space-xs);
     color: var(--color-text-neon-muted);
     font-size: 0.75rem;
@@ -749,8 +750,11 @@
     max-width: 100%;
     padding: 2px 8px 2px 2px;
     border-radius: var(--radius-full);
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    /* #477: ink-based alphas so the chip is visible on the cream (#FAF6EC)
+       light surface. The old white alphas (rgba(255,255,255,.04)/.08) were a
+       dark-theme carry-over and rendered near-invisible on the paper bg. */
+    background: rgba(42, 40, 32, 0.05);
+    border: 1px solid rgba(42, 40, 32, 0.14);
     flex-shrink: 0;
 }
 
@@ -769,7 +773,10 @@
     font-size: 0.65rem;
     font-weight: 600;
     line-height: 1;
-    color: #fff;
+    /* #477: warm ink instead of #fff. White on the sage success avatar
+       (#7FA897) was ~2.2:1; ink (#2A2820) clears 3:1 on both the sage
+       submitted fill (~6.4:1) and the muted default fill (~3.1:1). */
+    color: var(--color-text-primary);
 }
 
 .player-indicator .player-name {
@@ -789,6 +796,16 @@
 
 .player-indicator.is-current-player {
     background: rgba(232, 138, 127, 0.12);
+}
+
+/* #476: a dropped player's submission chip must read as distinct. player-game.js
+   already emits `player-indicator--disconnected` (player.connected === false) but
+   no rule existed, so a disconnected player looked identical to a connected one.
+   Matches the lobby's disconnected treatment: dimmed + dashed muted border. */
+.player-indicator--disconnected {
+    opacity: 0.45;
+    border-style: dashed;
+    border-color: var(--color-text-neon-muted);
 }
 
 /* ==========================================

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -3665,6 +3665,7 @@ footer {
 .submitted-players {
     display: flex;
     flex-wrap: wrap;
+    justify-content: center;
     gap: var(--space-xs);
     color: var(--color-text-neon-muted);
     font-size: 0.75rem;
@@ -3709,8 +3710,11 @@ footer {
     max-width: 100%;
     padding: 2px 8px 2px 2px;
     border-radius: var(--radius-full);
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    /* #477: ink-based alphas so the chip is visible on the cream (#FAF6EC)
+       light surface. The old white alphas (rgba(255,255,255,.04)/.08) were a
+       dark-theme carry-over and rendered near-invisible on the paper bg. */
+    background: rgba(42, 40, 32, 0.05);
+    border: 1px solid rgba(42, 40, 32, 0.14);
     flex-shrink: 0;
 }
 
@@ -3729,7 +3733,10 @@ footer {
     font-size: 0.65rem;
     font-weight: 600;
     line-height: 1;
-    color: #fff;
+    /* #477: warm ink instead of #fff. White on the sage success avatar
+       (#7FA897) was ~2.2:1; ink (#2A2820) clears 3:1 on both the sage
+       submitted fill (~6.4:1) and the muted default fill (~3.1:1). */
+    color: var(--color-text-primary);
 }
 
 .player-indicator .player-name {
@@ -3749,6 +3756,16 @@ footer {
 
 .player-indicator.is-current-player {
     background: rgba(232, 138, 127, 0.12);
+}
+
+/* #476: a dropped player's submission chip must read as distinct. player-game.js
+   already emits `player-indicator--disconnected` (player.connected === false) but
+   no rule existed, so a disconnected player looked identical to a connected one.
+   Matches the lobby's disconnected treatment: dimmed + dashed muted border. */
+.player-indicator--disconnected {
+    opacity: 0.45;
+    border-style: dashed;
+    border-color: var(--color-text-neon-muted);
 }
 
 /* ==========================================

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -96,6 +96,8 @@
     "hostBadge": "Host",
     "kickPlayer": "Spieler entfernen",
     "kickConfirm": "{name} aus der Lobby entfernen?",
+    "kickModalTitle": "Spieler entfernen?",
+    "kickConfirmBtn": "Entfernen",
     "continueBtn": "Weiter",
     "newGame": "Neues Spiel",
     "startNewGame": "Neues Spiel starten",
@@ -404,6 +406,7 @@
     "timeoutNote": "Der Einsatz zählt nur, wenn du antwortest. Keine Antwort = deine Punkte bleiben (kein Gewinn, kein Verlust).",
     "bank": "Punktestand",
     "submit": "Einsatz festlegen",
+    "sliderAria": "Einsatz in Prozent",
     "valueFmt": "{pct}% ({pts} Pkt.)",
     "locked": "Eingesetzt: {pct}%",
     "bonusFromReaction": "+1 von {from}"

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -96,6 +96,8 @@
     "hostBadge": "Host",
     "kickPlayer": "Remove player",
     "kickConfirm": "Remove {name} from the lobby?",
+    "kickModalTitle": "Remove player?",
+    "kickConfirmBtn": "Remove",
     "continueBtn": "Continue",
     "newGame": "New Game",
     "startNewGame": "Start New Game",
@@ -404,6 +406,7 @@
     "timeoutNote": "The wager only counts if you answer. No answer = you keep your points (no win, no loss).",
     "bank": "Current points",
     "submit": "Lock in wager",
+    "sliderAria": "Wager percent",
     "valueFmt": "{pct}% ({pts} pts)",
     "locked": "Wagered: {pct}%",
     "bonusFromReaction": "+1 from {from}"

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -96,6 +96,8 @@
     "hostBadge": "Anfitrión",
     "kickPlayer": "Expulsar jugador",
     "kickConfirm": "¿Expulsar a {name} de la sala?",
+    "kickModalTitle": "¿Expulsar jugador?",
+    "kickConfirmBtn": "Expulsar",
     "continueBtn": "Continuar",
     "newGame": "Nueva partida",
     "startNewGame": "Empezar nueva partida",
@@ -389,6 +391,7 @@
     "timeoutNote": "La apuesta solo cuenta si respondes. Sin respuesta = conservas tus puntos (ni ganas ni pierdes).",
     "bank": "Puntos actuales",
     "submit": "Confirmar apuesta",
+    "sliderAria": "Porcentaje de apuesta",
     "valueFmt": "{pct}% ({pts} pts)",
     "locked": "Apostado: {pct}%",
     "bonusFromReaction": "+1 de {from}"

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -1436,10 +1436,8 @@
                     ev.stopPropagation();
                     var name = btn.getAttribute('data-kick-name');
                     if (!name) return;
-                    var confirmMsg = _t('admin.kickConfirm') || ('Remove ' + name + ' from the lobby?');
-                    if (window.confirm(confirmMsg.replace('{name}', name))) {
-                        send('kick_player', { player_name: name });
-                    }
+                    // #480: themed confirm modal instead of window.confirm().
+                    openKickModal(name, btn);
                 });
             });
         }
@@ -1930,24 +1928,47 @@
     }
     on(els.nextQuestionBtn, 'click', function () { _debouncedSend(els.nextQuestionBtn, 'next_question'); });
 
+    // #479: focus management for the destructive confirm dialogs. Opening one
+    // by toggling .hidden left keyboard focus behind the backdrop; on close it
+    // was never returned to the trigger. openConfirmModal moves focus to the
+    // Cancel button (safe default for a destructive action) and remembers the
+    // element that opened it; closeConfirmModal restores focus to that trigger.
+    var _confirmModalTrigger = null;
+
+    function openConfirmModal(modalId, cancelBtnId, triggerEl) {
+        var modal = document.getElementById(modalId);
+        if (!modal) return;
+        _confirmModalTrigger = triggerEl
+            || (document.activeElement && document.activeElement !== document.body
+                ? document.activeElement
+                : null);
+        modal.classList.remove('hidden');
+        var cancelBtn = document.getElementById(cancelBtnId);
+        if (cancelBtn) setTimeout(function () { cancelBtn.focus(); }, 0);
+    }
+
+    function closeConfirmModal(modalId) {
+        var modal = document.getElementById(modalId);
+        if (modal) modal.classList.add('hidden');
+        var trigger = _confirmModalTrigger;
+        _confirmModalTrigger = null;
+        if (trigger && typeof trigger.focus === 'function') trigger.focus();
+    }
+
     on(els.endGameBtn, 'click', function () {
-        var modal = document.getElementById('end-game-modal');
-        if (modal) modal.classList.remove('hidden');
+        openConfirmModal('end-game-modal', 'end-game-cancel-btn', els.endGameBtn);
     });
 
     on('end-game-confirm-btn', 'click', function () {
         send('end_game', {});
-        var modal = document.getElementById('end-game-modal');
-        if (modal) modal.classList.add('hidden');
+        closeConfirmModal('end-game-modal');
     });
     on('end-game-cancel-btn', 'click', function () {
-        var modal = document.getElementById('end-game-modal');
-        if (modal) modal.classList.add('hidden');
+        closeConfirmModal('end-game-modal');
     });
     var endBackdrop = document.querySelector('#end-game-modal .modal-backdrop');
     if (endBackdrop) on(endBackdrop, 'click', function () {
-        var modal = document.getElementById('end-game-modal');
-        if (modal) modal.classList.add('hidden');
+        closeConfirmModal('end-game-modal');
     });
 
     on(els.newGameBtn, 'click', function () { send('reset_game', {}); });
@@ -1960,31 +1981,70 @@
 
     // ---- Reset Game button (header) ----
     on(els.resetGameBtn, 'click', function () {
-        var modal = document.getElementById('reset-game-modal');
-        if (modal) modal.classList.remove('hidden');
+        openConfirmModal('reset-game-modal', 'reset-game-cancel-btn', els.resetGameBtn);
     });
     on('reset-game-confirm-btn', 'click', function () {
         send('reset_game', {});
-        var modal = document.getElementById('reset-game-modal');
-        if (modal) modal.classList.add('hidden');
+        closeConfirmModal('reset-game-modal');
     });
     on('reset-game-cancel-btn', 'click', function () {
-        var modal = document.getElementById('reset-game-modal');
-        if (modal) modal.classList.add('hidden');
+        closeConfirmModal('reset-game-modal');
     });
     var resetBackdrop = document.querySelector('#reset-game-modal .modal-backdrop');
     if (resetBackdrop) on(resetBackdrop, 'click', function () {
-        var modal = document.getElementById('reset-game-modal');
-        if (modal) modal.classList.add('hidden');
+        closeConfirmModal('reset-game-modal');
+    });
+
+    // ---- Kick player confirmation modal (#480) ----
+    // Replaces the raw window.confirm() with the themed btn-danger modal used by
+    // end/reset. The kick action itself is unchanged (send('kick_player', ...)).
+    var _pendingKickName = null;
+
+    function openKickModal(name, triggerEl) {
+        _pendingKickName = name;
+        var textEl = document.getElementById('kick-player-modal-text');
+        if (textEl) {
+            var tmpl = _t('admin.kickConfirm') || 'Remove {name} from the lobby?';
+            textEl.textContent = tmpl.replace('{name}', name);
+        }
+        var modal = document.getElementById('kick-player-modal');
+        if (!modal) {
+            // Fallback: markup missing → keep the old confirm() so kicks still work.
+            var msg = (_t('admin.kickConfirm') || ('Remove ' + name + ' from the lobby?')).replace('{name}', name);
+            if (window.confirm(msg)) send('kick_player', { player_name: name });
+            _pendingKickName = null;
+            return;
+        }
+        openConfirmModal('kick-player-modal', 'kick-player-cancel-btn', triggerEl);
+    }
+
+    on('kick-player-confirm-btn', 'click', function () {
+        if (_pendingKickName) send('kick_player', { player_name: _pendingKickName });
+        _pendingKickName = null;
+        closeConfirmModal('kick-player-modal');
+    });
+    on('kick-player-cancel-btn', 'click', function () {
+        _pendingKickName = null;
+        closeConfirmModal('kick-player-modal');
+    });
+    var kickBackdrop = document.querySelector('#kick-player-modal .modal-backdrop');
+    if (kickBackdrop) on(kickBackdrop, 'click', function () {
+        _pendingKickName = null;
+        closeConfirmModal('kick-player-modal');
     });
 
     document.addEventListener('keydown', function (e) {
         if (e.key === 'Escape') {
             closeAdminJoinModal();
-            var endModal = document.getElementById('end-game-modal');
-            if (endModal) endModal.classList.add('hidden');
-            var resetModal = document.getElementById('reset-game-modal');
-            if (resetModal) resetModal.classList.add('hidden');
+            // Restore focus to the trigger for whichever confirm dialog is open.
+            var confirmIds = ['end-game-modal', 'reset-game-modal', 'kick-player-modal'];
+            for (var i = 0; i < confirmIds.length; i++) {
+                var m = document.getElementById(confirmIds[i]);
+                if (m && !m.classList.contains('hidden')) {
+                    _pendingKickName = null;
+                    closeConfirmModal(confirmIds[i]);
+                }
+            }
         }
     });
 

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -271,8 +271,9 @@
                     <p id="wager-panel-timeout-note" class="wager-panel-hint wager-panel-timeout-note"></p>
                     <div class="wager-slider-row">
                         <input type="range" id="wager-slider" min="0" max="100" step="5" value="25"
+                               data-i18n-aria-label="wager.sliderAria"
                                aria-label="Wager percent">
-                        <output id="wager-value" class="wager-value">25%</output>
+                        <output id="wager-value" class="wager-value" for="wager-slider">25%</output>
                     </div>
                     <p class="wager-bank-line">
                         <span data-i18n="wager.bank">Current points</span>:

--- a/tests/test_r5_fe_ux.py
+++ b/tests/test_r5_fe_ux.py
@@ -1,0 +1,158 @@
+"""Guard tests for the round-5 frontend UX fixes (#476–#480).
+
+#476 — player-game.js emits `player-indicator--disconnected` on the submission
+tracker but no CSS rule existed, so a dropped player looked identical to a
+connected one. A dimmed + dashed rule now exists.
+
+#477 — the submission chips used dark-theme white alphas on the cream light
+theme (near-invisible) and white initials on the sage success avatar (~2.2:1).
+Now ink-based alphas + ink initials.
+
+#478 — #wager-slider carried a hardcoded aria-label with no data-i18n-aria-label
+(unlike #estimate-slider) and #wager-value lacked for="wager-slider".
+
+#479 — the end/reset confirm dialogs toggled .hidden with no focus management.
+admin.js now moves focus to Cancel on open and restores it on close.
+
+#480 — kick_player used window.confirm(); it now uses a themed btn-danger modal.
+"""
+
+import json
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WWW = _REPO_ROOT / "custom_components" / "quizify" / "www"
+_I18N = _WWW / "i18n"
+_LANGS = ("en", "de", "es")
+
+
+def _load(lang: str) -> dict:
+    return json.loads((_I18N / f"{lang}.json").read_text(encoding="utf-8"))
+
+
+def _get(obj: dict, dotted: str):
+    cur = obj
+    for part in dotted.split("."):
+        assert isinstance(cur, dict), f"{dotted}: {part} parent not a dict"
+        assert part in cur, f"missing key: {dotted}"
+        cur = cur[part]
+    return cur
+
+
+# --- #476: disconnected chip rule present -------------------------------------
+
+def test_disconnected_chip_rule_present() -> None:
+    css = (_WWW / "css" / "src" / "07-player.css").read_text(encoding="utf-8")
+    assert ".player-indicator--disconnected" in css, (
+        "no CSS rule for the disconnected submission chip (#476)"
+    )
+    # Distinct visual treatment: dimmed and/or dashed muted border.
+    block = css.split(".player-indicator--disconnected", 1)[1].split("}", 1)[0]
+    assert "opacity" in block, "disconnected chip should be dimmed (#476)"
+    assert "dashed" in block, "disconnected chip should use a dashed border (#476)"
+    # And it must survive into the generated stylesheet.
+    styles = (_WWW / "css" / "styles.css").read_text(encoding="utf-8")
+    assert ".player-indicator--disconnected" in styles, (
+        "styles.css is stale — disconnected chip rule missing (#476)"
+    )
+
+
+# --- #477: chip ink-alpha + initials contrast ---------------------------------
+
+def test_chip_uses_ink_alpha_not_white() -> None:
+    css = (_WWW / "css" / "src" / "07-player.css").read_text(encoding="utf-8")
+    block = css.split(".player-indicator {", 1)[1].split("}", 1)[0]
+    assert "rgba(255, 255, 255" not in block, (
+        "player-indicator still uses white alphas on the cream light theme (#477)"
+    )
+    assert "rgba(42, 40, 32" in block, (
+        "player-indicator should use ink-based alphas (#477)"
+    )
+
+
+def test_initials_not_pure_white() -> None:
+    css = (_WWW / "css" / "src" / "07-player.css").read_text(encoding="utf-8")
+    block = css.split(".player-indicator .player-initials {", 1)[1].split("}", 1)[0]
+    # Ignore comment prose; assert the color *declaration* is no longer white.
+    decls = [ln.split("/*", 1)[0].strip() for ln in block.splitlines()]
+    color_decls = [d for d in decls if d.startswith("color")]
+    assert color_decls, "player-initials has no color declaration"
+    assert not any("#fff" in d.lower() for d in color_decls), (
+        "player-initials still #fff (~2.2:1 on the sage avatar) — should be ink (#477)"
+    )
+    assert "var(--color-text-primary)" in block, (
+        "player-initials should use the ink token for >=3:1 contrast (#477)"
+    )
+
+
+def test_submitted_players_centered() -> None:
+    css = (_WWW / "css" / "src" / "07-player.css").read_text(encoding="utf-8")
+    block = css.split(".submitted-players {", 1)[1].split("}", 1)[0]
+    assert "justify-content: center" in block, (
+        "submitted-players should center the chips (#477)"
+    )
+
+
+# --- #478: wager slider aria + for --------------------------------------------
+
+def test_wager_slider_aria_and_for() -> None:
+    html = (_WWW / "player.html").read_text(encoding="utf-8")
+    slider = html.split('id="wager-slider"', 1)[1].split(">", 1)[0]
+    assert 'data-i18n-aria-label="wager.sliderAria"' in slider, (
+        "#wager-slider missing data-i18n-aria-label (#478)"
+    )
+    output = html.split('id="wager-value"', 1)[1].split(">", 1)[0]
+    assert 'for="wager-slider"' in output, (
+        '#wager-value <output> missing for="wager-slider" (#478)'
+    )
+
+
+def test_wager_slider_aria_i18n_key() -> None:
+    for lang in _LANGS:
+        val = _get(_load(lang), "wager.sliderAria")
+        assert isinstance(val, str) and val.strip(), (
+            f"{lang}: wager.sliderAria empty/non-string (#478)"
+        )
+
+
+# --- #479: confirm-dialog focus management ------------------------------------
+
+def test_confirm_dialog_focus_code_present() -> None:
+    js = (_WWW / "js" / "admin.js").read_text(encoding="utf-8")
+    assert "openConfirmModal" in js and "closeConfirmModal" in js, (
+        "confirm-modal focus helpers missing (#479)"
+    )
+    # Focus moves to the Cancel button on open and is restored on close.
+    assert "cancelBtn.focus()" in js, "open should focus the Cancel button (#479)"
+    assert "trigger.focus()" in js, "close should restore focus to the trigger (#479)"
+    # End/reset now route through the helpers.
+    assert "openConfirmModal('end-game-modal'" in js
+    assert "openConfirmModal('reset-game-modal'" in js
+
+
+# --- #480: styled kick modal --------------------------------------------------
+
+def test_kick_modal_markup_present() -> None:
+    html = (_WWW / "admin.html").read_text(encoding="utf-8")
+    assert 'id="kick-player-modal"' in html, "kick modal markup missing (#480)"
+    assert 'id="kick-player-confirm-btn"' in html and "btn-danger" in html.split(
+        'id="kick-player-confirm-btn"', 1
+    )[1].split(">", 1)[0], "kick confirm must be a btn-danger (#480)"
+    assert 'id="kick-player-cancel-btn"' in html
+
+
+def test_kick_uses_modal_not_confirm() -> None:
+    js = (_WWW / "js" / "admin.js").read_text(encoding="utf-8")
+    assert "openKickModal(" in js, "kick should open the themed modal (#480)"
+    # The kick action is unchanged.
+    assert "send('kick_player'" in js
+
+
+def test_kick_modal_i18n_keys() -> None:
+    for lang in _LANGS:
+        data = _load(lang)
+        for key in ("admin.kickModalTitle", "admin.kickConfirmBtn"):
+            val = _get(data, key)
+            assert isinstance(val, str) and val.strip(), (
+                f"{lang}: {key} empty/non-string (#480)"
+            )


### PR DESCRIPTION
Fixes #476
Fixes #477
Fixes #478
Fixes #479
Fixes #480

Round-5 frontend UX batch (player.html / admin.html / css / admin.js / i18n).

- **#476** — add `.player-indicator--disconnected` CSS (opacity .45 + dashed muted border) so a dropped player's submission chip is visually distinct. `player-game.js` already emitted the class; no rule existed.
- **#477** — replace dark-theme white alphas with ink-based alphas (`rgba(42,40,32,.05)` bg / `.14` border) so the chip is visible on the cream (`#FAF6EC`) surface; darken initials from `#fff` to ink (`var(--color-text-primary)`) for ≥3:1 contrast on both the sage submitted fill (~6.4:1) and the muted default fill (~3.1:1); center the chip row.
- **#478** — `#wager-slider` gets `data-i18n-aria-label="wager.sliderAria"` (new key en/de/es) and `#wager-value` `<output>` gets `for="wager-slider"`, matching the estimate slider.
- **#479** — end/reset confirm dialogs move focus to Cancel on open and restore focus to the trigger on close (incl. Escape).
- **#480** — `kick_player` now uses a themed `btn-danger` modal (mirrors `#end-game-modal`) instead of `window.confirm()`, with i18n keys; kick action unchanged, falls back to `confirm()` if markup is absent.

Adds `tests/test_r5_fe_ux.py`. `styles.css` rebuilt. Full suite (991 passed, 5 skipped) + ruff + artifact-drift green.

## Mobile-verify needed before merge
CSS/HTML changes affect the player submission tracker and the admin confirm dialogs — please run the CLAUDE.md mobile (390x844) verify + cut-off audit on the player game screen and the admin lobby before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)