### PR TITLE
fix(ux): admin toggle contrast + focus-visible + confirm-dialog focus trap (#485,#486,#487)

### DIFF
--- a/custom_components/quizify/www/css/src/02-shared.css
+++ b/custom_components/quizify/www/css/src/02-shared.css
@@ -793,10 +793,16 @@ button, .btn {
 .toggle-switch-compact {
     width: 36px;
     height: 20px;
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(42, 40, 32, 0.10);
+    border: 1px solid rgba(42, 40, 32, 0.18);
     border-radius: 10px;
     position: relative;
     transition: background 0.2s ease;
+}
+
+.toggle-compact input:focus-visible + .toggle-switch-compact {
+    outline: 2px solid var(--color-accent-primary);
+    outline-offset: 2px;
 }
 
 .toggle-switch-compact::after {

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -1499,10 +1499,16 @@ button, .btn {
 .toggle-switch-compact {
     width: 36px;
     height: 20px;
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(42, 40, 32, 0.10);
+    border: 1px solid rgba(42, 40, 32, 0.18);
     border-radius: 10px;
     position: relative;
     transition: background 0.2s ease;
+}
+
+.toggle-compact input:focus-visible + .toggle-switch-compact {
+    outline: 2px solid var(--color-accent-primary);
+    outline-offset: 2px;
 }
 
 .toggle-switch-compact::after {

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -1934,6 +1934,26 @@
     // Cancel button (safe default for a destructive action) and remembers the
     // element that opened it; closeConfirmModal restores focus to that trigger.
     var _confirmModalTrigger = null;
+    // #487: Tab-trap so keyboard focus stays inside the open aria-modal dialog.
+    // Without this, Tab/Shift+Tab escaped behind the backdrop. We install a
+    // keydown handler when a modal opens and remove it on close.
+    var _confirmTrapHandler = null;
+
+    function _getModalFocusable(modal) {
+        var content = modal.querySelector('.modal-content') || modal;
+        var nodes = content.querySelectorAll(
+            'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        var out = [];
+        for (var i = 0; i < nodes.length; i++) {
+            var el = nodes[i];
+            if (!el.disabled && el.getAttribute('tabindex') !== '-1'
+                && (el.offsetWidth > 0 || el.offsetHeight > 0 || el === document.activeElement)) {
+                out.push(el);
+            }
+        }
+        return out;
+    }
 
     function openConfirmModal(modalId, cancelBtnId, triggerEl) {
         var modal = document.getElementById(modalId);
@@ -1945,11 +1965,41 @@
         modal.classList.remove('hidden');
         var cancelBtn = document.getElementById(cancelBtnId);
         if (cancelBtn) setTimeout(function () { cancelBtn.focus(); }, 0);
+
+        // Remove any stale trap before installing a fresh one.
+        if (_confirmTrapHandler) {
+            document.removeEventListener('keydown', _confirmTrapHandler, true);
+            _confirmTrapHandler = null;
+        }
+        _confirmTrapHandler = function (e) {
+            if (e.key !== 'Tab') return;
+            var focusable = _getModalFocusable(modal);
+            if (!focusable.length) return;
+            var first = focusable[0];
+            var last = focusable[focusable.length - 1];
+            var active = document.activeElement;
+            if (e.shiftKey) {
+                if (active === first || !modal.contains(active)) {
+                    e.preventDefault();
+                    last.focus();
+                }
+            } else {
+                if (active === last || !modal.contains(active)) {
+                    e.preventDefault();
+                    first.focus();
+                }
+            }
+        };
+        document.addEventListener('keydown', _confirmTrapHandler, true);
     }
 
     function closeConfirmModal(modalId) {
         var modal = document.getElementById(modalId);
         if (modal) modal.classList.add('hidden');
+        if (_confirmTrapHandler) {
+            document.removeEventListener('keydown', _confirmTrapHandler, true);
+            _confirmTrapHandler = null;
+        }
         var trigger = _confirmModalTrigger;
         _confirmModalTrigger = null;
         if (trigger && typeof trigger.focus === 'function') trigger.focus();

--- a/tests/test_r6_admin_ux.py
+++ b/tests/test_r6_admin_ux.py
@@ -1,0 +1,77 @@
+"""Guard tests for the round-6 admin UX/a11y fixes (#485–#487).
+
+#485 — .toggle-switch-compact used a dark-theme white-alpha OFF track
+(rgba(255,255,255,0.1)) that is invisible on the Soft Parlor cream cards
+(lightning + TTS toggles). It now uses an ink-based alpha fill + border so
+the unchecked switch reads on the light surface.
+
+#486 — .toggle-compact input hid the native checkbox (opacity:0; width/height:0)
+with no visible keyboard focus. A :focus-visible outline now renders on the
+adjacent .toggle-switch-compact track when the input is keyboard-focused.
+
+#487 — admin.js openConfirmModal managed initial/restore focus (#479) but did
+not contain Tab, so Tab/Shift+Tab escaped behind the aria-modal backdrop of the
+end/reset/kick dialogs. It now installs a keydown Tab-trap on open and removes
+it on close.
+"""
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WWW = _REPO_ROOT / "custom_components" / "quizify" / "www"
+
+
+# --- #485: toggle OFF track uses ink alpha, not white -------------------------
+
+def test_toggle_track_ink_alpha_in_built_css() -> None:
+    styles = (_WWW / "css" / "styles.css").read_text(encoding="utf-8")
+    block = styles.split(".toggle-switch-compact {", 1)[1].split("}", 1)[0]
+    assert "rgba(42, 40, 32" in block, (
+        "toggle OFF track should use an ink-based alpha on the cream card (#485)"
+    )
+    assert "rgba(255, 255, 255" not in block, (
+        "toggle OFF track still uses invisible dark-theme white alpha (#485)"
+    )
+    # Border gives the switch an edge on the light surface.
+    assert "border" in block, "toggle OFF track should carry a border (#485)"
+
+
+# --- #486: keyboard focus-visible outline on the toggle -----------------------
+
+def test_toggle_focus_visible_rule_present() -> None:
+    src = (_WWW / "css" / "src" / "02-shared.css").read_text(encoding="utf-8")
+    assert ".toggle-compact input:focus-visible + .toggle-switch-compact" in src, (
+        "no :focus-visible rule for the setup toggles (#486)"
+    )
+    styles = (_WWW / "css" / "styles.css").read_text(encoding="utf-8")
+    assert ".toggle-compact input:focus-visible + .toggle-switch-compact" in styles, (
+        "styles.css is stale — toggle focus-visible rule missing (#486)"
+    )
+    block = styles.split(
+        ".toggle-compact input:focus-visible + .toggle-switch-compact", 1
+    )[1].split("}", 1)[0]
+    assert "outline" in block, "toggle focus-visible rule must draw an outline (#486)"
+
+
+# --- #487: confirm-dialog Tab-trap installed ----------------------------------
+
+def test_confirm_modal_tab_trap_present() -> None:
+    js = (_WWW / "js" / "admin.js").read_text(encoding="utf-8")
+    open_block = js.split("function openConfirmModal", 1)[1].split(
+        "function closeConfirmModal", 1
+    )[0]
+    # A keydown handler that reacts to Tab is installed on open.
+    assert "addEventListener('keydown'" in open_block, (
+        "openConfirmModal must install a keydown handler for the Tab-trap (#487)"
+    )
+    assert "'Tab'" in open_block, (
+        "openConfirmModal Tab-trap must key off the Tab key (#487)"
+    )
+    assert "shiftKey" in open_block, (
+        "openConfirmModal must handle Shift+Tab backwards wrap (#487)"
+    )
+    # And the handler is removed again on close so it does not leak.
+    close_block = js.split("function closeConfirmModal", 1)[1].split("}", 1)[0]
+    assert "removeEventListener('keydown'" in close_block, (
+        "closeConfirmModal must remove the Tab-trap handler (#487)"
+    )


### PR DESCRIPTION
Fixes #485
Fixes #486
Fixes #487

Three admin UX/a11y fixes, one branch:

- **#485** — `.toggle-switch-compact` OFF track used a dark-theme white alpha (`rgba(255,255,255,0.1)`), invisible on the Soft Parlor cream cards (lightning + TTS toggles). Now an ink fill `rgba(42,40,32,0.10)` + `1px rgba(42,40,32,0.18)` border. ON/checked state untouched.
- **#486** — the setup toggles hid the native checkbox with no visible keyboard focus. Added `.toggle-compact input:focus-visible + .toggle-switch-compact` accent outline.
- **#487** — `openConfirmModal` (gap in #479) had focus set/restore but no Tab containment; Tab escaped behind the aria-modal backdrop of the end/reset/kick dialogs. Now installs a keydown Tab/Shift+Tab trap between the first and last focusable controls on open and removes it on close. Escape close already existed.

Guard tests: `tests/test_r6_admin_ux.py` (toggle track ink-alpha in built styles.css, focus-visible rule present, openConfirmModal Tab-trap handler installed + removed on close). Full suite 999 passed / 5 skipped, ruff clean, generated-artifacts drift green (styles.css rebuilt).

## Mobile-verify needed before merge
CSS touches the visible toggle tracks — verify the lightning + TTS toggles at 390x844 (OFF track visible on cream, focus outline on Tab) before shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)