### PR TITLE
fix(ux): keep compact toggle knob centered — inset shadow not border (#490)

### DIFF
--- a/custom_components/quizify/www/css/src/02-shared.css
+++ b/custom_components/quizify/www/css/src/02-shared.css
@@ -794,7 +794,9 @@ button, .btn {
     width: 36px;
     height: 20px;
     background: rgba(42, 40, 32, 0.10);
-    border: 1px solid rgba(42, 40, 32, 0.18);
+    /* #490: inset box-shadow instead of border so box-sizing:border-box
+       doesn't shrink the padding box + off-center the ::after knob. */
+    box-shadow: inset 0 0 0 1px rgba(42, 40, 32, 0.18);
     border-radius: 10px;
     position: relative;
     transition: background 0.2s ease;

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -1500,7 +1500,9 @@ button, .btn {
     width: 36px;
     height: 20px;
     background: rgba(42, 40, 32, 0.10);
-    border: 1px solid rgba(42, 40, 32, 0.18);
+    /* #490: inset box-shadow instead of border so box-sizing:border-box
+       doesn't shrink the padding box + off-center the ::after knob. */
+    box-shadow: inset 0 0 0 1px rgba(42, 40, 32, 0.18);
     border-radius: 10px;
     position: relative;
     transition: background 0.2s ease;


### PR DESCRIPTION
Fixes #490

The #485 border shrank the padding box under box-sizing:border-box, off-centering the toggle knob. Swapped to an inset box-shadow (same visual, no layout shrink). styles.css rebuilt; drift green.

## Mobile-verify needed before merge
Lightning + TTS toggles: knob centered in OFF/ON on the admin setup card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)