### PR TITLE
feat: complete Spanish support — i18n parity + 3 native Spanish packs (#373)

### DIFF
--- a/custom_components/quizify/questions/ciencia-es.json
+++ b/custom_components/quizify/questions/ciencia-es.json
@@ -1,0 +1,3158 @@
+{
+  "name": "Ciencia",
+  "language": "es",
+  "version": "1.0",
+  "theme": "science",
+  "questions": [
+    {
+      "id": "cie_es_001",
+      "question": "¿Qué velocidad tiene la luz en el vacío (aproximada)?",
+      "answers": [
+        {
+          "text": "300.000 km/s",
+          "correct": true
+        },
+        {
+          "text": "150.000 km/s",
+          "correct": false
+        },
+        {
+          "text": "1.000 km/s",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La velocidad de la luz es exactamente 299.792.458 metros por segundo.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_002",
+      "question": "¿Cuál es el símbolo químico del oro?",
+      "answers": [
+        {
+          "text": "Or",
+          "correct": false
+        },
+        {
+          "text": "Au",
+          "correct": true
+        },
+        {
+          "text": "Go",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El símbolo Au proviene del latín 'aurum', que significa 'brillo del amanecer'.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_003",
+      "question": "¿Qué planeta gira 'de lado', con su eje casi horizontal?",
+      "answers": [
+        {
+          "text": "Neptuno",
+          "correct": false
+        },
+        {
+          "text": "Saturno",
+          "correct": false
+        },
+        {
+          "text": "Urano",
+          "correct": true
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Urano tiene una inclinación axial de unos 98 grados respecto a su órbita.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_004",
+      "question": "¿Qué tipo de energía produce el Sol?",
+      "answers": [
+        {
+          "text": "Nuclear (fusión)",
+          "correct": true
+        },
+        {
+          "text": "Química",
+          "correct": false
+        },
+        {
+          "text": "Eólica",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El Sol fusiona hidrógeno en helio, liberando enormes cantidades de energía.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_005",
+      "question": "¿Qué planeta es conocido como el planeta rojo?",
+      "answers": [
+        {
+          "text": "Júpiter",
+          "correct": false
+        },
+        {
+          "text": "Venus",
+          "correct": false
+        },
+        {
+          "text": "Marte",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Marte debe su color al óxido de hierro (herrumbre) que cubre su superficie.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_006",
+      "question": "¿Qué científico descubrió la penicilina?",
+      "answers": [
+        {
+          "text": "Robert Koch",
+          "correct": false
+        },
+        {
+          "text": "Alexander Fleming",
+          "correct": true
+        },
+        {
+          "text": "Edward Jenner",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Fleming descubrió la penicilina por accidente en 1928 al observar un moho.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_007",
+      "question": "¿Cuál es el metal más ligero conocido?",
+      "answers": [
+        {
+          "text": "Litio",
+          "correct": true
+        },
+        {
+          "text": "Aluminio",
+          "correct": false
+        },
+        {
+          "text": "Titanio",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El litio es tan ligero que flota sobre el agua y el aceite.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_008",
+      "question": "¿Cuál es el gas más abundante en la atmósfera terrestre?",
+      "answers": [
+        {
+          "text": "Oxígeno",
+          "correct": false
+        },
+        {
+          "text": "Nitrógeno",
+          "correct": true
+        },
+        {
+          "text": "Dióxido de carbono",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El nitrógeno constituye aproximadamente el 78 % del aire que respiramos.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_009",
+      "question": "¿Qué unidad mide la fuerza en el Sistema Internacional?",
+      "answers": [
+        {
+          "text": "El julio",
+          "correct": false
+        },
+        {
+          "text": "El vatio",
+          "correct": false
+        },
+        {
+          "text": "El newton",
+          "correct": true
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El newton se define como la fuerza que da 1 m/s² a una masa de 1 kg.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_010",
+      "question": "¿Cuál es el elemento más abundante en la corteza terrestre?",
+      "answers": [
+        {
+          "text": "Oxígeno",
+          "correct": true
+        },
+        {
+          "text": "Silicio",
+          "correct": false
+        },
+        {
+          "text": "Hierro",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El oxígeno representa cerca del 46 % de la masa de la corteza terrestre.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_011",
+      "question": "¿Qué científico formuló la teoría de la relatividad?",
+      "answers": [
+        {
+          "text": "Isaac Newton",
+          "correct": false
+        },
+        {
+          "text": "Nikola Tesla",
+          "correct": false
+        },
+        {
+          "text": "Albert Einstein",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Einstein publicó la teoría de la relatividad especial en 1905, su 'año milagroso'.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_012",
+      "question": "¿Qué científica contribuyó con la imagen del ADN mediante rayos X?",
+      "answers": [
+        {
+          "text": "Marie Curie",
+          "correct": false
+        },
+        {
+          "text": "Rosalind Franklin",
+          "correct": true
+        },
+        {
+          "text": "Barbara McClintock",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La 'Fotografía 51' de Franklin fue clave para describir la doble hélice.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_013",
+      "question": "¿Qué gas produce el efecto invernadero más asociado al cambio climático?",
+      "answers": [
+        {
+          "text": "Dióxido de carbono",
+          "correct": true
+        },
+        {
+          "text": "Oxígeno",
+          "correct": false
+        },
+        {
+          "text": "Argón",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La concentración de CO₂ ha superado las 420 partes por millón.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_014",
+      "question": "¿Cuántos planetas tiene el sistema solar?",
+      "answers": [
+        {
+          "text": "Nueve",
+          "correct": false
+        },
+        {
+          "text": "Ocho",
+          "correct": true
+        },
+        {
+          "text": "Siete",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Plutón fue reclasificado como planeta enano en 2006, dejando ocho planetas.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_015",
+      "question": "¿Cuántos cromosomas tiene una célula humana típica?",
+      "answers": [
+        {
+          "text": "23",
+          "correct": false
+        },
+        {
+          "text": "48",
+          "correct": false
+        },
+        {
+          "text": "46",
+          "correct": true
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los humanos tenemos 23 pares de cromosomas, 46 en total.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_016",
+      "question": "¿Qué planeta tiene la mayor cantidad de lunas conocidas?",
+      "answers": [
+        {
+          "text": "Saturno",
+          "correct": true
+        },
+        {
+          "text": "Júpiter",
+          "correct": false
+        },
+        {
+          "text": "Neptuno",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Saturno superó a Júpiter con más de 140 lunas confirmadas.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_017",
+      "question": "¿Qué órgano del cuerpo humano bombea la sangre?",
+      "answers": [
+        {
+          "text": "El hígado",
+          "correct": false
+        },
+        {
+          "text": "Los pulmones",
+          "correct": false
+        },
+        {
+          "text": "El corazón",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El corazón humano late unas 100.000 veces al día.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_018",
+      "question": "¿Qué elemento químico tiene el símbolo Na?",
+      "answers": [
+        {
+          "text": "Nitrógeno",
+          "correct": false
+        },
+        {
+          "text": "Sodio",
+          "correct": true
+        },
+        {
+          "text": "Níquel",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El símbolo Na proviene del latín 'natrium'.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_019",
+      "question": "¿Qué científico desarrolló la tabla periódica moderna?",
+      "answers": [
+        {
+          "text": "Dmitri Mendeléyev",
+          "correct": true
+        },
+        {
+          "text": "John Dalton",
+          "correct": false
+        },
+        {
+          "text": "Antoine Lavoisier",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Mendeléyev dejó huecos en su tabla de 1869 prediciendo elementos aún no descubiertos.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_020",
+      "question": "¿Cuál es el símbolo químico del agua?",
+      "answers": [
+        {
+          "text": "CO₂",
+          "correct": false
+        },
+        {
+          "text": "H₂O",
+          "correct": true
+        },
+        {
+          "text": "O₂",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Cada molécula de agua tiene dos átomos de hidrógeno y uno de oxígeno.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_021",
+      "question": "¿Qué científico desarrolló la teoría atómica moderna a inicios del siglo XIX?",
+      "answers": [
+        {
+          "text": "Ernest Rutherford",
+          "correct": false
+        },
+        {
+          "text": "Niels Bohr",
+          "correct": false
+        },
+        {
+          "text": "John Dalton",
+          "correct": true
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Dalton propuso en 1808 que la materia está formada por átomos indivisibles.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_022",
+      "question": "¿Qué instrumento inventó Galileo para observar el cielo?",
+      "answers": [
+        {
+          "text": "El telescopio",
+          "correct": true
+        },
+        {
+          "text": "El microscopio",
+          "correct": false
+        },
+        {
+          "text": "El barómetro",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Galileo perfeccionó el telescopio y descubrió cuatro lunas de Júpiter en 1610.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_023",
+      "question": "¿Qué fuerza nos mantiene pegados al suelo?",
+      "answers": [
+        {
+          "text": "El magnetismo",
+          "correct": false
+        },
+        {
+          "text": "La fricción",
+          "correct": false
+        },
+        {
+          "text": "La gravedad",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Isaac Newton describió la ley de gravitación universal en 1687.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_024",
+      "question": "¿Qué unidad mide la energía en el Sistema Internacional?",
+      "answers": [
+        {
+          "text": "El newton",
+          "correct": false
+        },
+        {
+          "text": "El julio",
+          "correct": true
+        },
+        {
+          "text": "El pascal",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El julio recibe su nombre del físico británico James Prescott Joule.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_025",
+      "question": "¿Qué científico describió la estructura del átomo con núcleo central?",
+      "answers": [
+        {
+          "text": "Ernest Rutherford",
+          "correct": true
+        },
+        {
+          "text": "J.J. Thomson",
+          "correct": false
+        },
+        {
+          "text": "Max Planck",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Rutherford dedujo el núcleo atómico en su experimento con láminas de oro (1911).",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_026",
+      "question": "¿Cuál es la estrella más cercana a la Tierra?",
+      "answers": [
+        {
+          "text": "Sirio",
+          "correct": false
+        },
+        {
+          "text": "El Sol",
+          "correct": true
+        },
+        {
+          "text": "Alfa Centauri",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La luz del Sol tarda unos 8 minutos y 20 segundos en llegar a la Tierra.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_027",
+      "question": "¿Qué tipo de sangre es el donante universal?",
+      "answers": [
+        {
+          "text": "AB positivo",
+          "correct": false
+        },
+        {
+          "text": "A positivo",
+          "correct": false
+        },
+        {
+          "text": "O negativo",
+          "correct": true
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La sangre O negativo puede transfundirse a personas de cualquier grupo sanguíneo.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_028",
+      "question": "¿Qué fenómeno provoca los arcoíris?",
+      "answers": [
+        {
+          "text": "La refracción de la luz",
+          "correct": true
+        },
+        {
+          "text": "La reflexión del sonido",
+          "correct": false
+        },
+        {
+          "text": "La ionización del aire",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La luz blanca se descompone en colores al atravesar las gotas de agua.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_029",
+      "question": "¿Qué animal es el mamífero más grande del mundo?",
+      "answers": [
+        {
+          "text": "El elefante africano",
+          "correct": false
+        },
+        {
+          "text": "El tiburón ballena",
+          "correct": false
+        },
+        {
+          "text": "La ballena azul",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La ballena azul puede medir hasta 30 metros y pesar más de 170 toneladas.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_030",
+      "question": "¿Qué parte del cerebro controla el equilibrio y la coordinación?",
+      "answers": [
+        {
+          "text": "El hipotálamo",
+          "correct": false
+        },
+        {
+          "text": "El cerebelo",
+          "correct": true
+        },
+        {
+          "text": "El bulbo raquídeo",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El cerebelo contiene más de la mitad de las neuronas del cerebro.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_031",
+      "question": "¿Qué órgano del cuerpo humano es el más grande?",
+      "answers": [
+        {
+          "text": "La piel",
+          "correct": true
+        },
+        {
+          "text": "El hígado",
+          "correct": false
+        },
+        {
+          "text": "El cerebro",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La piel de un adulto puede cubrir unos 2 metros cuadrados.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_032",
+      "question": "¿Cuál es el metal líquido a temperatura ambiente?",
+      "answers": [
+        {
+          "text": "Plomo",
+          "correct": false
+        },
+        {
+          "text": "Mercurio",
+          "correct": true
+        },
+        {
+          "text": "Hierro",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El mercurio fue el único metal usado durante siglos en los termómetros.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_033",
+      "question": "¿Qué científico creó la primera vacuna, contra la viruela?",
+      "answers": [
+        {
+          "text": "Louis Pasteur",
+          "correct": false
+        },
+        {
+          "text": "Jonas Salk",
+          "correct": false
+        },
+        {
+          "text": "Edward Jenner",
+          "correct": true
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Jenner usó la viruela bovina en 1796; 'vacuna' viene del latín 'vacca'.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_034",
+      "question": "¿Cuántos grados tiene el cero absoluto en la escala Celsius?",
+      "answers": [
+        {
+          "text": "-273,15 °C",
+          "correct": true
+        },
+        {
+          "text": "0 °C",
+          "correct": false
+        },
+        {
+          "text": "-100 °C",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El cero absoluto es la temperatura más baja teóricamente posible.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_035",
+      "question": "¿Qué instrumento se usa para medir la temperatura?",
+      "answers": [
+        {
+          "text": "El barómetro",
+          "correct": false
+        },
+        {
+          "text": "El higrómetro",
+          "correct": false
+        },
+        {
+          "text": "El termómetro",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El barómetro mide la presión atmosférica, no la temperatura.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_036",
+      "question": "¿Cuál es el planeta más caliente del sistema solar?",
+      "answers": [
+        {
+          "text": "Mercurio",
+          "correct": false
+        },
+        {
+          "text": "Venus",
+          "correct": true
+        },
+        {
+          "text": "Marte",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Venus alcanza unos 465 °C por su densa atmósfera de CO₂ y efecto invernadero.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_037",
+      "question": "¿Qué mide la escala de Richter?",
+      "answers": [
+        {
+          "text": "La magnitud de los terremotos",
+          "correct": true
+        },
+        {
+          "text": "La velocidad del viento",
+          "correct": false
+        },
+        {
+          "text": "La presión del aire",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La escala de Richter fue desarrollada por Charles Richter en 1935.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_038",
+      "question": "¿Cuál es el hueso más largo del cuerpo humano?",
+      "answers": [
+        {
+          "text": "La tibia",
+          "correct": false
+        },
+        {
+          "text": "El fémur",
+          "correct": true
+        },
+        {
+          "text": "El húmero",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El fémur, en el muslo, puede soportar hasta 30 veces el peso del cuerpo.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_039",
+      "question": "¿Qué científica es pionera de la programación informática?",
+      "answers": [
+        {
+          "text": "Grace Hopper",
+          "correct": false
+        },
+        {
+          "text": "Hedy Lamarr",
+          "correct": false
+        },
+        {
+          "text": "Ada Lovelace",
+          "correct": true
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Ada Lovelace escribió el primer algoritmo pensado para una máquina en 1843.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_040",
+      "question": "¿Qué gas noble se usa en los letreros luminosos rojos?",
+      "answers": [
+        {
+          "text": "Neón",
+          "correct": true
+        },
+        {
+          "text": "Helio",
+          "correct": false
+        },
+        {
+          "text": "Argón",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El neón emite una característica luz rojo-anaranjada al aplicarle electricidad.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_041",
+      "question": "¿Qué gas necesitan las plantas para la fotosíntesis?",
+      "answers": [
+        {
+          "text": "Oxígeno",
+          "correct": false
+        },
+        {
+          "text": "Nitrógeno",
+          "correct": false
+        },
+        {
+          "text": "Dióxido de carbono",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Durante la fotosíntesis las plantas absorben CO₂ y liberan oxígeno.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_042",
+      "question": "¿Cuál es la partícula de carga positiva del núcleo atómico?",
+      "answers": [
+        {
+          "text": "El electrón",
+          "correct": false
+        },
+        {
+          "text": "El protón",
+          "correct": true
+        },
+        {
+          "text": "El fotón",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El número de protones determina de qué elemento químico se trata.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_043",
+      "question": "¿Qué planeta tarda unos 165 años en dar una vuelta al Sol?",
+      "answers": [
+        {
+          "text": "Neptuno",
+          "correct": true
+        },
+        {
+          "text": "Urano",
+          "correct": false
+        },
+        {
+          "text": "Saturno",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Neptuno completó su primera órbita conocida desde su descubrimiento en 2011.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_044",
+      "question": "¿Cuál es el planeta más grande del sistema solar?",
+      "answers": [
+        {
+          "text": "Saturno",
+          "correct": false
+        },
+        {
+          "text": "Júpiter",
+          "correct": true
+        },
+        {
+          "text": "Neptuno",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Júpiter es tan grande que en su interior cabrían más de 1.300 Tierras.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_045",
+      "question": "¿Qué científico descubrió la ley de la flotabilidad?",
+      "answers": [
+        {
+          "text": "Pitágoras",
+          "correct": false
+        },
+        {
+          "text": "Aristóteles",
+          "correct": false
+        },
+        {
+          "text": "Arquímedes",
+          "correct": true
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Se dice que Arquímedes gritó '¡Eureka!' al descubrir su principio en el baño.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_046",
+      "question": "¿Qué vitamina produce el cuerpo con la luz solar?",
+      "answers": [
+        {
+          "text": "Vitamina D",
+          "correct": true
+        },
+        {
+          "text": "Vitamina C",
+          "correct": false
+        },
+        {
+          "text": "Vitamina A",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La piel sintetiza vitamina D al exponerse a la radiación ultravioleta B.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_047",
+      "question": "¿Qué científica ganó dos premios Nobel en ciencias distintas?",
+      "answers": [
+        {
+          "text": "Rosalind Franklin",
+          "correct": false
+        },
+        {
+          "text": "Ada Lovelace",
+          "correct": false
+        },
+        {
+          "text": "Marie Curie",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Marie Curie ganó el Nobel de Física en 1903 y el de Química en 1911.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_048",
+      "question": "¿Qué científico descubrió la radiactividad de forma pionera?",
+      "answers": [
+        {
+          "text": "Wilhelm Röntgen",
+          "correct": false
+        },
+        {
+          "text": "Henri Becquerel",
+          "correct": true
+        },
+        {
+          "text": "Enrico Fermi",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Becquerel descubrió la radiactividad natural del uranio en 1896.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_049",
+      "question": "¿Qué unidad se usa para medir la resistencia eléctrica?",
+      "answers": [
+        {
+          "text": "El ohmio",
+          "correct": true
+        },
+        {
+          "text": "El voltio",
+          "correct": false
+        },
+        {
+          "text": "El amperio",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El ohmio recibe su nombre del físico alemán Georg Ohm.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_050",
+      "question": "¿Cuál es el símbolo químico del oxígeno?",
+      "answers": [
+        {
+          "text": "Ox",
+          "correct": false
+        },
+        {
+          "text": "O",
+          "correct": true
+        },
+        {
+          "text": "O₂",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El oxígeno fue descubierto de forma independiente por Scheele y Priestley.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_051",
+      "question": "¿Qué proceso libera energía en el interior de una estrella?",
+      "answers": [
+        {
+          "text": "La fisión nuclear",
+          "correct": false
+        },
+        {
+          "text": "La combustión",
+          "correct": false
+        },
+        {
+          "text": "La fusión nuclear",
+          "correct": true
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "En las estrellas, los núcleos de hidrógeno se fusionan para formar helio.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_052",
+      "question": "¿Qué científico descubrió los rayos X?",
+      "answers": [
+        {
+          "text": "Wilhelm Röntgen",
+          "correct": true
+        },
+        {
+          "text": "Marie Curie",
+          "correct": false
+        },
+        {
+          "text": "Ernest Rutherford",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Röntgen recibió el primer premio Nobel de Física en 1901 por este hallazgo.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_053",
+      "question": "¿Qué planeta es el más cercano al Sol?",
+      "answers": [
+        {
+          "text": "Venus",
+          "correct": false
+        },
+        {
+          "text": "La Tierra",
+          "correct": false
+        },
+        {
+          "text": "Mercurio",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Mercurio completa una vuelta alrededor del Sol en solo 88 días terrestres.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_054",
+      "question": "¿Cuál es el símbolo químico del potasio?",
+      "answers": [
+        {
+          "text": "Po",
+          "correct": false
+        },
+        {
+          "text": "K",
+          "correct": true
+        },
+        {
+          "text": "Pt",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El símbolo K proviene del latín 'kalium'.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_055",
+      "question": "¿Qué científico es considerado el padre de la genética?",
+      "answers": [
+        {
+          "text": "Gregor Mendel",
+          "correct": true
+        },
+        {
+          "text": "Charles Darwin",
+          "correct": false
+        },
+        {
+          "text": "James Watson",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Mendel estudió la herencia usando plantas de guisantes en el siglo XIX.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_056",
+      "question": "¿Cuántos estados de la materia son los clásicos?",
+      "answers": [
+        {
+          "text": "Dos",
+          "correct": false
+        },
+        {
+          "text": "Tres",
+          "correct": true
+        },
+        {
+          "text": "Cinco",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Sólido, líquido y gaseoso son los tres estados clásicos; el plasma es el cuarto.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_057",
+      "question": "¿Qué científico ideó la escala de temperatura absoluta?",
+      "answers": [
+        {
+          "text": "Anders Celsius",
+          "correct": false
+        },
+        {
+          "text": "Daniel Fahrenheit",
+          "correct": false
+        },
+        {
+          "text": "Lord Kelvin",
+          "correct": true
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La escala Kelvin comienza en el cero absoluto, -273,15 °C.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_058",
+      "question": "¿Qué tipo de onda es el sonido?",
+      "answers": [
+        {
+          "text": "Una onda mecánica",
+          "correct": true
+        },
+        {
+          "text": "Una onda electromagnética",
+          "correct": false
+        },
+        {
+          "text": "Una onda gravitacional",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El sonido necesita un medio material para propagarse; no viaja en el vacío.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_059",
+      "question": "¿Qué parte de la célula contiene el ADN?",
+      "answers": [
+        {
+          "text": "La membrana",
+          "correct": false
+        },
+        {
+          "text": "El citoplasma",
+          "correct": false
+        },
+        {
+          "text": "El núcleo",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El ADN humano contiene unos 3.000 millones de pares de bases.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_060",
+      "question": "¿Cuál es la unidad de medida de la corriente eléctrica?",
+      "answers": [
+        {
+          "text": "El voltio",
+          "correct": false
+        },
+        {
+          "text": "El amperio",
+          "correct": true
+        },
+        {
+          "text": "El vatio",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El amperio se llama así en honor a André-Marie Ampère.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_061",
+      "question": "¿Qué científico enunció el principio de incertidumbre?",
+      "answers": [
+        {
+          "text": "Werner Heisenberg",
+          "correct": true
+        },
+        {
+          "text": "Erwin Schrödinger",
+          "correct": false
+        },
+        {
+          "text": "Paul Dirac",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El principio de Heisenberg dice que no se puede conocer a la vez posición y velocidad exactas.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_062",
+      "question": "¿Qué elemento químico tiene el número atómico 1?",
+      "answers": [
+        {
+          "text": "Helio",
+          "correct": false
+        },
+        {
+          "text": "Hidrógeno",
+          "correct": true
+        },
+        {
+          "text": "Oxígeno",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El hidrógeno es el elemento más abundante del universo.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_063",
+      "question": "¿Qué elemento químico tiene el símbolo Ag?",
+      "answers": [
+        {
+          "text": "Argón",
+          "correct": false
+        },
+        {
+          "text": "Oro",
+          "correct": false
+        },
+        {
+          "text": "Plata",
+          "correct": true
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El símbolo Ag proviene del latín 'argentum'.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_064",
+      "question": "¿Qué planeta enano orbita más allá de Neptuno y fue planeta hasta 2006?",
+      "answers": [
+        {
+          "text": "Plutón",
+          "correct": true
+        },
+        {
+          "text": "Ceres",
+          "correct": false
+        },
+        {
+          "text": "Eris",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Plutón fue descubierto en 1930 por Clyde Tombaugh.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_065",
+      "question": "¿Cómo se llama la galaxia en la que vivimos?",
+      "answers": [
+        {
+          "text": "Andrómeda",
+          "correct": false
+        },
+        {
+          "text": "El Triángulo",
+          "correct": false
+        },
+        {
+          "text": "La Vía Láctea",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La Vía Láctea contiene entre 100.000 y 400.000 millones de estrellas.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_066",
+      "question": "¿Qué científico formuló las leyes del movimiento planetario?",
+      "answers": [
+        {
+          "text": "Galileo Galilei",
+          "correct": false
+        },
+        {
+          "text": "Johannes Kepler",
+          "correct": true
+        },
+        {
+          "text": "Isaac Newton",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Kepler descubrió que las órbitas de los planetas son elipses, no círculos.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_067",
+      "question": "¿Cuál es la constante que relaciona la circunferencia con su diámetro?",
+      "answers": [
+        {
+          "text": "Pi (π)",
+          "correct": true
+        },
+        {
+          "text": "El número de Euler (e)",
+          "correct": false
+        },
+        {
+          "text": "La razón áurea (φ)",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El valor de pi es aproximadamente 3,14159 y es un número irracional.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_068",
+      "question": "¿Qué científico propuso la teoría de la evolución por selección natural?",
+      "answers": [
+        {
+          "text": "Gregor Mendel",
+          "correct": false
+        },
+        {
+          "text": "Charles Darwin",
+          "correct": true
+        },
+        {
+          "text": "Louis Pasteur",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Darwin publicó 'El origen de las especies' en 1859.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_069",
+      "question": "¿Qué tipo de roca se forma al enfriarse el magma?",
+      "answers": [
+        {
+          "text": "Sedimentaria",
+          "correct": false
+        },
+        {
+          "text": "Metamórfica",
+          "correct": false
+        },
+        {
+          "text": "Ígnea",
+          "correct": true
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El granito y el basalto son ejemplos de rocas ígneas.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_070",
+      "question": "¿Qué gas noble es el segundo elemento más abundante del universo?",
+      "answers": [
+        {
+          "text": "Helio",
+          "correct": true
+        },
+        {
+          "text": "Neón",
+          "correct": false
+        },
+        {
+          "text": "Kriptón",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El helio se formó en gran parte durante el Big Bang.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_071",
+      "question": "¿Cuál es el planeta con anillos más visibles?",
+      "answers": [
+        {
+          "text": "Júpiter",
+          "correct": false
+        },
+        {
+          "text": "Urano",
+          "correct": false
+        },
+        {
+          "text": "Saturno",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Los anillos de Saturno están formados principalmente por hielo y roca.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_072",
+      "question": "¿Qué unidad mide la potencia eléctrica?",
+      "answers": [
+        {
+          "text": "El julio",
+          "correct": false
+        },
+        {
+          "text": "El vatio",
+          "correct": true
+        },
+        {
+          "text": "El ohmio",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El vatio recibe su nombre del ingeniero James Watt.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_073",
+      "question": "¿Qué científico propuso el modelo heliocéntrico del sistema solar?",
+      "answers": [
+        {
+          "text": "Nicolás Copérnico",
+          "correct": true
+        },
+        {
+          "text": "Ptolomeo",
+          "correct": false
+        },
+        {
+          "text": "Tycho Brahe",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Copérnico situó al Sol en el centro en su obra publicada en 1543.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_074",
+      "question": "¿Qué órgano permite la respiración en los humanos?",
+      "answers": [
+        {
+          "text": "El estómago",
+          "correct": false
+        },
+        {
+          "text": "Los pulmones",
+          "correct": true
+        },
+        {
+          "text": "Los riñones",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Un adulto respira en reposo unas 12 a 20 veces por minuto.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_075",
+      "question": "¿Qué unidad mide la presión en el Sistema Internacional?",
+      "answers": [
+        {
+          "text": "El newton",
+          "correct": false
+        },
+        {
+          "text": "El julio",
+          "correct": false
+        },
+        {
+          "text": "El pascal",
+          "correct": true
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El pascal recibe su nombre del matemático y físico Blaise Pascal.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_076",
+      "question": "¿Qué fenómeno óptico separa la luz blanca en colores con un prisma?",
+      "answers": [
+        {
+          "text": "La dispersión",
+          "correct": true
+        },
+        {
+          "text": "La difusión",
+          "correct": false
+        },
+        {
+          "text": "La polarización",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Newton demostró con un prisma que la luz blanca contiene todos los colores.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_077",
+      "question": "¿Cuál es el símbolo químico del hierro?",
+      "answers": [
+        {
+          "text": "Hi",
+          "correct": false
+        },
+        {
+          "text": "Ir",
+          "correct": false
+        },
+        {
+          "text": "Fe",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El símbolo Fe proviene del latín 'ferrum'.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_078",
+      "question": "¿Qué elemento químico tiene el símbolo Pb?",
+      "answers": [
+        {
+          "text": "Potasio",
+          "correct": false
+        },
+        {
+          "text": "Plomo",
+          "correct": true
+        },
+        {
+          "text": "Paladio",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El símbolo Pb proviene del latín 'plumbum'.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_079",
+      "question": "¿Qué científico propuso el modelo atómico con electrones en órbitas?",
+      "answers": [
+        {
+          "text": "Niels Bohr",
+          "correct": true
+        },
+        {
+          "text": "John Dalton",
+          "correct": false
+        },
+        {
+          "text": "James Chadwick",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El modelo de Bohr de 1913 explicó los niveles de energía del hidrógeno.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_080",
+      "question": "¿Qué satélite natural tiene la Tierra?",
+      "answers": [
+        {
+          "text": "Titán",
+          "correct": false
+        },
+        {
+          "text": "La Luna",
+          "correct": true
+        },
+        {
+          "text": "Fobos",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La Luna se aleja de la Tierra unos 3,8 centímetros cada año.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_081",
+      "question": "¿Qué instrumento mide la presión atmosférica?",
+      "answers": [
+        {
+          "text": "El termómetro",
+          "correct": false
+        },
+        {
+          "text": "El anemómetro",
+          "correct": false
+        },
+        {
+          "text": "El barómetro",
+          "correct": true
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Evangelista Torricelli inventó el barómetro de mercurio en 1643.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_082",
+      "question": "¿Qué tipo de célula transporta el oxígeno en la sangre?",
+      "answers": [
+        {
+          "text": "Los glóbulos rojos",
+          "correct": true
+        },
+        {
+          "text": "Los glóbulos blancos",
+          "correct": false
+        },
+        {
+          "text": "Las plaquetas",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los glóbulos rojos contienen hemoglobina, que se une al oxígeno.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_083",
+      "question": "¿Cuál es el sentido asociado a la retina?",
+      "answers": [
+        {
+          "text": "El oído",
+          "correct": false
+        },
+        {
+          "text": "El olfato",
+          "correct": false
+        },
+        {
+          "text": "La vista",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La retina contiene células llamadas conos y bastones que detectan la luz.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_084",
+      "question": "¿Cuál es la galaxia grande más cercana a la Vía Láctea?",
+      "answers": [
+        {
+          "text": "El Triángulo",
+          "correct": false
+        },
+        {
+          "text": "Andrómeda",
+          "correct": true
+        },
+        {
+          "text": "Las Nubes de Magallanes",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Andrómeda se acerca a la Vía Láctea y ambas chocarán en unos 4.500 millones de años.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_085",
+      "question": "¿Qué reacción química ocurre cuando algo se oxida con el oxígeno?",
+      "answers": [
+        {
+          "text": "La oxidación",
+          "correct": true
+        },
+        {
+          "text": "La reducción",
+          "correct": false
+        },
+        {
+          "text": "La sublimación",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El herrumbre del hierro es un ejemplo cotidiano de oxidación.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_086",
+      "question": "¿Qué científico enunció las tres leyes del movimiento?",
+      "answers": [
+        {
+          "text": "Galileo Galilei",
+          "correct": false
+        },
+        {
+          "text": "Isaac Newton",
+          "correct": true
+        },
+        {
+          "text": "Johannes Kepler",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Newton publicó sus leyes del movimiento en los 'Principia' de 1687.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_087",
+      "question": "¿Qué unidad mide la frecuencia?",
+      "answers": [
+        {
+          "text": "El decibelio",
+          "correct": false
+        },
+        {
+          "text": "El nudo",
+          "correct": false
+        },
+        {
+          "text": "El hercio",
+          "correct": true
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Un hercio equivale a un ciclo por segundo; su nombre honra a Heinrich Hertz.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_088",
+      "question": "¿Qué elemento químico tiene el símbolo Sn?",
+      "answers": [
+        {
+          "text": "Estaño",
+          "correct": true
+        },
+        {
+          "text": "Azufre",
+          "correct": false
+        },
+        {
+          "text": "Selenio",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El símbolo Sn proviene del latín 'stannum'.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_089",
+      "question": "¿Qué partícula subatómica tiene carga negativa?",
+      "answers": [
+        {
+          "text": "El protón",
+          "correct": false
+        },
+        {
+          "text": "El neutrón",
+          "correct": false
+        },
+        {
+          "text": "El electrón",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El electrón fue descubierto por J.J. Thomson en 1897.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_090",
+      "question": "¿Qué tipo de energía tiene un objeto por estar en movimiento?",
+      "answers": [
+        {
+          "text": "Energía potencial",
+          "correct": false
+        },
+        {
+          "text": "Energía cinética",
+          "correct": true
+        },
+        {
+          "text": "Energía térmica",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La energía cinética depende de la masa y del cuadrado de la velocidad.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_091",
+      "question": "¿Qué gas hace que el pan y los pasteles suban al hornearse?",
+      "answers": [
+        {
+          "text": "Dióxido de carbono",
+          "correct": true
+        },
+        {
+          "text": "Oxígeno",
+          "correct": false
+        },
+        {
+          "text": "Metano",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La levadura y el bicarbonato liberan CO₂, que forma burbujas en la masa.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_092",
+      "question": "¿Cuál es la unidad básica de la vida?",
+      "answers": [
+        {
+          "text": "El átomo",
+          "correct": false
+        },
+        {
+          "text": "La célula",
+          "correct": true
+        },
+        {
+          "text": "El tejido",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El término 'célula' fue acuñado por Robert Hooke en 1665.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_093",
+      "question": "¿Qué científico desarrolló la pila eléctrica?",
+      "answers": [
+        {
+          "text": "Michael Faraday",
+          "correct": false
+        },
+        {
+          "text": "Georg Ohm",
+          "correct": false
+        },
+        {
+          "text": "Alessandro Volta",
+          "correct": true
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Volta presentó su pila en 1800; el voltio lleva su nombre.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_094",
+      "question": "¿Cuál es la capa de gas que protege la Tierra de la radiación ultravioleta?",
+      "answers": [
+        {
+          "text": "La capa de ozono",
+          "correct": true
+        },
+        {
+          "text": "La troposfera",
+          "correct": false
+        },
+        {
+          "text": "La ionosfera",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La capa de ozono se encuentra en la estratosfera.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_095",
+      "question": "¿Qué proceso convierte el agua líquida en vapor?",
+      "answers": [
+        {
+          "text": "Condensación",
+          "correct": false
+        },
+        {
+          "text": "Solidificación",
+          "correct": false
+        },
+        {
+          "text": "Evaporación",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La evaporación ocurre en la superficie del líquido a cualquier temperatura.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_096",
+      "question": "¿Qué elemento químico tiene el símbolo Cu?",
+      "answers": [
+        {
+          "text": "Cobalto",
+          "correct": false
+        },
+        {
+          "text": "Cobre",
+          "correct": true
+        },
+        {
+          "text": "Curio",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El símbolo Cu proviene del latín 'cuprum', asociado a la isla de Chipre.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_097",
+      "question": "¿Qué tipo de reacción libera calor al entorno?",
+      "answers": [
+        {
+          "text": "Exotérmica",
+          "correct": true
+        },
+        {
+          "text": "Endotérmica",
+          "correct": false
+        },
+        {
+          "text": "Isotérmica",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La combustión es un ejemplo clásico de reacción exotérmica.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_098",
+      "question": "¿Cuál es la temperatura de congelación del agua a nivel del mar?",
+      "answers": [
+        {
+          "text": "10 °C",
+          "correct": false
+        },
+        {
+          "text": "0 °C",
+          "correct": true
+        },
+        {
+          "text": "-10 °C",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El agua hierve a 100 °C y se congela a 0 °C a presión atmosférica normal.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_099",
+      "question": "¿Cuál es el elemento químico más ligero de todos?",
+      "answers": [
+        {
+          "text": "Helio",
+          "correct": false
+        },
+        {
+          "text": "Litio",
+          "correct": false
+        },
+        {
+          "text": "Hidrógeno",
+          "correct": true
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El hidrógeno tiene un solo protón y es el átomo más simple.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_100",
+      "question": "¿Qué mineral es el más duro según la escala de Mohs?",
+      "answers": [
+        {
+          "text": "El diamante",
+          "correct": true
+        },
+        {
+          "text": "El cuarzo",
+          "correct": false
+        },
+        {
+          "text": "El corindón",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El diamante alcanza el valor 10, el máximo de la escala de Mohs.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_101",
+      "question": "¿Qué científico formuló la ley de la gravitación universal?",
+      "answers": [
+        {
+          "text": "Albert Einstein",
+          "correct": false
+        },
+        {
+          "text": "Nikola Tesla",
+          "correct": false
+        },
+        {
+          "text": "Isaac Newton",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Cuenta la leyenda que una manzana cayendo inspiró a Newton.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_102",
+      "question": "¿Qué científico descubrió el neutrón?",
+      "answers": [
+        {
+          "text": "Ernest Rutherford",
+          "correct": false
+        },
+        {
+          "text": "James Chadwick",
+          "correct": true
+        },
+        {
+          "text": "J.J. Thomson",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Chadwick descubrió el neutrón en 1932, partícula sin carga del núcleo.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_103",
+      "question": "¿Qué órgano produce la insulina en el cuerpo humano?",
+      "answers": [
+        {
+          "text": "El páncreas",
+          "correct": true
+        },
+        {
+          "text": "El hígado",
+          "correct": false
+        },
+        {
+          "text": "La tiroides",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La falta de insulina o su mal uso causa la diabetes.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_104",
+      "question": "¿Cuál es el símbolo químico del carbono?",
+      "answers": [
+        {
+          "text": "Ca",
+          "correct": false
+        },
+        {
+          "text": "C",
+          "correct": true
+        },
+        {
+          "text": "Co",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El carbono es la base de toda la química orgánica y de la vida.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_105",
+      "question": "¿Qué unidad mide la cantidad de sustancia en química?",
+      "answers": [
+        {
+          "text": "El gramo",
+          "correct": false
+        },
+        {
+          "text": "El litro",
+          "correct": false
+        },
+        {
+          "text": "El mol",
+          "correct": true
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Un mol contiene el número de Avogadro: unos 6,022 × 10²³ partículas.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_106",
+      "question": "¿Qué tipo de sangre es el receptor universal?",
+      "answers": [
+        {
+          "text": "AB positivo",
+          "correct": true
+        },
+        {
+          "text": "O negativo",
+          "correct": false
+        },
+        {
+          "text": "A negativo",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Las personas con sangre AB positivo pueden recibir de cualquier grupo.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_107",
+      "question": "¿Qué elemento químico es esencial para respirar?",
+      "answers": [
+        {
+          "text": "Helio",
+          "correct": false
+        },
+        {
+          "text": "Neón",
+          "correct": false
+        },
+        {
+          "text": "Oxígeno",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El oxígeno representa cerca del 21 % del aire atmosférico.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_108",
+      "question": "¿Qué planeta tiene una gran mancha roja que es una tormenta gigante?",
+      "answers": [
+        {
+          "text": "Marte",
+          "correct": false
+        },
+        {
+          "text": "Júpiter",
+          "correct": true
+        },
+        {
+          "text": "Saturno",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La Gran Mancha Roja de Júpiter es más grande que toda la Tierra.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_109",
+      "question": "¿Qué tipo de electricidad genera un rayo?",
+      "answers": [
+        {
+          "text": "Estática",
+          "correct": true
+        },
+        {
+          "text": "Continua de baja tensión",
+          "correct": false
+        },
+        {
+          "text": "Química",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Un rayo puede alcanzar temperaturas cinco veces mayores que la superficie del Sol.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_110",
+      "question": "¿Qué órgano filtra la sangre y produce orina?",
+      "answers": [
+        {
+          "text": "El hígado",
+          "correct": false
+        },
+        {
+          "text": "Los riñones",
+          "correct": true
+        },
+        {
+          "text": "El páncreas",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Los riñones filtran unos 180 litros de sangre al día.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_111",
+      "question": "¿Qué científico describió la circulación de la sangre?",
+      "answers": [
+        {
+          "text": "Andrés Vesalio",
+          "correct": false
+        },
+        {
+          "text": "Claudio Galeno",
+          "correct": false
+        },
+        {
+          "text": "William Harvey",
+          "correct": true
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Harvey demostró en 1628 que el corazón bombea la sangre en circuito cerrado.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_112",
+      "question": "¿Qué científica descubrió los elementos polonio y radio?",
+      "answers": [
+        {
+          "text": "Marie Curie",
+          "correct": true
+        },
+        {
+          "text": "Lise Meitner",
+          "correct": false
+        },
+        {
+          "text": "Irène Joliot-Curie",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Marie Curie nombró el polonio en honor a su Polonia natal.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_113",
+      "question": "¿Qué gas se libera al respirar los seres humanos?",
+      "answers": [
+        {
+          "text": "Oxígeno",
+          "correct": false
+        },
+        {
+          "text": "Hidrógeno",
+          "correct": false
+        },
+        {
+          "text": "Dióxido de carbono",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Exhalamos CO₂ como producto de la respiración celular.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_114",
+      "question": "¿Qué proceso divide una célula en dos idénticas?",
+      "answers": [
+        {
+          "text": "La meiosis",
+          "correct": false
+        },
+        {
+          "text": "La mitosis",
+          "correct": true
+        },
+        {
+          "text": "La fecundación",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La mitosis permite el crecimiento y la reparación de los tejidos.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_115",
+      "question": "¿Cuál es el planeta menos denso del sistema solar?",
+      "answers": [
+        {
+          "text": "Saturno",
+          "correct": true
+        },
+        {
+          "text": "Júpiter",
+          "correct": false
+        },
+        {
+          "text": "Urano",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Saturno es tan poco denso que flotaría en un océano lo bastante grande.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_116",
+      "question": "¿Cuál es el símbolo químico del helio?",
+      "answers": [
+        {
+          "text": "Hi",
+          "correct": false
+        },
+        {
+          "text": "He",
+          "correct": true
+        },
+        {
+          "text": "Hl",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El helio fue detectado primero en el Sol antes que en la Tierra.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_117",
+      "question": "¿Qué tipo de energía almacena una batería cargada?",
+      "answers": [
+        {
+          "text": "Energía nuclear",
+          "correct": false
+        },
+        {
+          "text": "Energía sonora",
+          "correct": false
+        },
+        {
+          "text": "Energía química",
+          "correct": true
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Al usarla, la batería convierte la energía química en energía eléctrica.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_118",
+      "question": "¿Cuál es el símbolo químico del cloro?",
+      "answers": [
+        {
+          "text": "Cl",
+          "correct": true
+        },
+        {
+          "text": "Cr",
+          "correct": false
+        },
+        {
+          "text": "Co",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El cloro se usa para desinfectar el agua potable.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_119",
+      "question": "¿Cuál es la molécula que porta la información genética?",
+      "answers": [
+        {
+          "text": "El ARN mensajero",
+          "correct": false
+        },
+        {
+          "text": "La proteína",
+          "correct": false
+        },
+        {
+          "text": "El ADN",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El ADN tiene forma de doble hélice, descrita por Watson y Crick en 1953.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_120",
+      "question": "¿Qué partícula de luz transporta energía electromagnética?",
+      "answers": [
+        {
+          "text": "El electrón",
+          "correct": false
+        },
+        {
+          "text": "El fotón",
+          "correct": true
+        },
+        {
+          "text": "El neutrino",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El fotón no tiene masa y siempre viaja a la velocidad de la luz.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_121",
+      "question": "¿Qué científico es conocido por sus experimentos con la electricidad y la cometa?",
+      "answers": [
+        {
+          "text": "Benjamin Franklin",
+          "correct": true
+        },
+        {
+          "text": "Thomas Edison",
+          "correct": false
+        },
+        {
+          "text": "Nikola Tesla",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Franklin demostró que los rayos son electricidad e inventó el pararrayos.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_122",
+      "question": "¿Cuál es el símbolo químico del calcio?",
+      "answers": [
+        {
+          "text": "Cl",
+          "correct": false
+        },
+        {
+          "text": "Ca",
+          "correct": true
+        },
+        {
+          "text": "Cu",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El calcio es esencial para huesos y dientes fuertes.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_123",
+      "question": "¿Qué órgano del cuerpo genera la bilis?",
+      "answers": [
+        {
+          "text": "El estómago",
+          "correct": false
+        },
+        {
+          "text": "El bazo",
+          "correct": false
+        },
+        {
+          "text": "El hígado",
+          "correct": true
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El hígado realiza más de 500 funciones distintas en el organismo.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_124",
+      "question": "¿Qué unidad mide la temperatura en el Sistema Internacional?",
+      "answers": [
+        {
+          "text": "El kelvin",
+          "correct": true
+        },
+        {
+          "text": "El grado Celsius",
+          "correct": false
+        },
+        {
+          "text": "El grado Fahrenheit",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El kelvin es la única escala del SI y no usa el símbolo de grados.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_125",
+      "question": "¿Qué astro se encuentra en el centro del sistema solar?",
+      "answers": [
+        {
+          "text": "La Tierra",
+          "correct": false
+        },
+        {
+          "text": "Júpiter",
+          "correct": false
+        },
+        {
+          "text": "El Sol",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El Sol contiene más del 99 % de toda la masa del sistema solar.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_126",
+      "question": "¿Qué planeta es conocido como 'la estrella de la mañana'?",
+      "answers": [
+        {
+          "text": "Mercurio",
+          "correct": false
+        },
+        {
+          "text": "Venus",
+          "correct": true
+        },
+        {
+          "text": "Marte",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Venus es el objeto más brillante del cielo tras el Sol y la Luna.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_127",
+      "question": "¿Qué científico inventó la bombilla incandescente práctica?",
+      "answers": [
+        {
+          "text": "Thomas Edison",
+          "correct": true
+        },
+        {
+          "text": "Nikola Tesla",
+          "correct": false
+        },
+        {
+          "text": "Alexander Graham Bell",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Edison patentó su bombilla en 1879 tras probar miles de filamentos.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_128",
+      "question": "¿Cuál es la fuerza que se opone al movimiento entre superficies?",
+      "answers": [
+        {
+          "text": "La gravedad",
+          "correct": false
+        },
+        {
+          "text": "La fricción",
+          "correct": true
+        },
+        {
+          "text": "La inercia",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La fricción convierte parte de la energía del movimiento en calor.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_129",
+      "question": "¿Qué científico propuso la teoría de la deriva continental?",
+      "answers": [
+        {
+          "text": "Charles Lyell",
+          "correct": false
+        },
+        {
+          "text": "James Hutton",
+          "correct": false
+        },
+        {
+          "text": "Alfred Wegener",
+          "correct": true
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Wegener planteó en 1912 que los continentes fueron un solo bloque, Pangea.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_130",
+      "question": "¿Qué elemento es el principal componente del diamante y el grafito?",
+      "answers": [
+        {
+          "text": "Carbono",
+          "correct": true
+        },
+        {
+          "text": "Silicio",
+          "correct": false
+        },
+        {
+          "text": "Boro",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El diamante y el grafito son formas distintas (alótropos) del mismo carbono.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_131",
+      "question": "¿Qué proceso realizan las plantas para producir su alimento?",
+      "answers": [
+        {
+          "text": "La respiración",
+          "correct": false
+        },
+        {
+          "text": "La digestión",
+          "correct": false
+        },
+        {
+          "text": "La fotosíntesis",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La fotosíntesis convierte luz, agua y CO₂ en glucosa y oxígeno.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_132",
+      "question": "¿Qué fenómeno hace que se vean las fases de la Luna?",
+      "answers": [
+        {
+          "text": "Las nubes terrestres",
+          "correct": false
+        },
+        {
+          "text": "La posición relativa Sol-Tierra-Luna",
+          "correct": true
+        },
+        {
+          "text": "La rotación de la Luna sobre sí misma",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Vemos distintas porciones iluminadas de la Luna según su posición en la órbita.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_133",
+      "question": "¿Qué molécula transporta el oxígeno dentro de los glóbulos rojos?",
+      "answers": [
+        {
+          "text": "La hemoglobina",
+          "correct": true
+        },
+        {
+          "text": "La insulina",
+          "correct": false
+        },
+        {
+          "text": "El colágeno",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La hemoglobina contiene hierro, que le da su color rojo a la sangre.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_134",
+      "question": "¿Cuál es el símbolo químico del nitrógeno?",
+      "answers": [
+        {
+          "text": "Ni",
+          "correct": false
+        },
+        {
+          "text": "N",
+          "correct": true
+        },
+        {
+          "text": "Na",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El nitrógeno líquido hierve a unos -196 °C.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_135",
+      "question": "¿Qué unidad mide el voltaje o diferencia de potencial?",
+      "answers": [
+        {
+          "text": "El amperio",
+          "correct": false
+        },
+        {
+          "text": "El ohmio",
+          "correct": false
+        },
+        {
+          "text": "El voltio",
+          "correct": true
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El voltio recibe su nombre de Alessandro Volta.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_136",
+      "question": "¿Qué elemento químico tiene el número atómico 6?",
+      "answers": [
+        {
+          "text": "Carbono",
+          "correct": true
+        },
+        {
+          "text": "Oxígeno",
+          "correct": false
+        },
+        {
+          "text": "Nitrógeno",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El carbono forma la columna vertebral de las moléculas de la vida.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_137",
+      "question": "¿Qué instrumento se usa para observar objetos muy pequeños?",
+      "answers": [
+        {
+          "text": "El telescopio",
+          "correct": false
+        },
+        {
+          "text": "El periscopio",
+          "correct": false
+        },
+        {
+          "text": "El microscopio",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Antonie van Leeuwenhoek fue de los primeros en ver microorganismos con un microscopio.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_138",
+      "question": "¿Qué científico desarrolló la teoría cuántica al estudiar la radiación?",
+      "answers": [
+        {
+          "text": "Albert Einstein",
+          "correct": false
+        },
+        {
+          "text": "Max Planck",
+          "correct": true
+        },
+        {
+          "text": "Louis de Broglie",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Planck introdujo la idea de los 'cuantos' de energía en el año 1900.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_139",
+      "question": "¿Qué tipo de energía tiene un objeto elevado a cierta altura?",
+      "answers": [
+        {
+          "text": "Energía potencial gravitatoria",
+          "correct": true
+        },
+        {
+          "text": "Energía cinética",
+          "correct": false
+        },
+        {
+          "text": "Energía sonora",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Al caer, esa energía potencial se transforma en energía cinética.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_140",
+      "question": "¿Qué parte de la planta absorbe el agua del suelo?",
+      "answers": [
+        {
+          "text": "Las hojas",
+          "correct": false
+        },
+        {
+          "text": "Las raíces",
+          "correct": true
+        },
+        {
+          "text": "Las flores",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Las raíces también anclan la planta al suelo.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_141",
+      "question": "¿Qué científico es el padre de la microbiología y la pasteurización?",
+      "answers": [
+        {
+          "text": "Robert Koch",
+          "correct": false
+        },
+        {
+          "text": "Alexander Fleming",
+          "correct": false
+        },
+        {
+          "text": "Louis Pasteur",
+          "correct": true
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Pasteur demostró que los microbios causan enfermedades y desarrolló vacunas.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_142",
+      "question": "¿Qué elemento químico es el más abundante en el cuerpo humano por masa?",
+      "answers": [
+        {
+          "text": "Oxígeno",
+          "correct": true
+        },
+        {
+          "text": "Carbono",
+          "correct": false
+        },
+        {
+          "text": "Hidrógeno",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El oxígeno representa cerca del 65 % de la masa del cuerpo humano.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_143",
+      "question": "¿Qué unidad se usa para medir distancias astronómicas grandes?",
+      "answers": [
+        {
+          "text": "El kilómetro",
+          "correct": false
+        },
+        {
+          "text": "La milla náutica",
+          "correct": false
+        },
+        {
+          "text": "El año luz",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Un año luz equivale a unos 9,46 billones de kilómetros.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_144",
+      "question": "¿Qué gas forma la mayor parte del Sol?",
+      "answers": [
+        {
+          "text": "Oxígeno",
+          "correct": false
+        },
+        {
+          "text": "Hidrógeno",
+          "correct": true
+        },
+        {
+          "text": "Carbono",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El Sol es aproximadamente 74 % hidrógeno por masa.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_145",
+      "question": "¿Cuál es el símbolo químico del azufre?",
+      "answers": [
+        {
+          "text": "S",
+          "correct": true
+        },
+        {
+          "text": "Az",
+          "correct": false
+        },
+        {
+          "text": "Su",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El azufre puro es un sólido amarillo conocido desde la antigüedad.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_146",
+      "question": "¿Qué órgano del cuerpo humano procesa el pensamiento y la memoria?",
+      "answers": [
+        {
+          "text": "El corazón",
+          "correct": false
+        },
+        {
+          "text": "El cerebro",
+          "correct": true
+        },
+        {
+          "text": "El estómago",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El cerebro humano tiene unos 86.000 millones de neuronas.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_147",
+      "question": "¿Qué científico descubrió que la Tierra no es el centro del universo, apoyando el heliocentrismo con su telescopio?",
+      "answers": [
+        {
+          "text": "Nicolás Copérnico",
+          "correct": false
+        },
+        {
+          "text": "Isaac Newton",
+          "correct": false
+        },
+        {
+          "text": "Galileo Galilei",
+          "correct": true
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Galileo fue juzgado por la Inquisición por defender el heliocentrismo.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_148",
+      "question": "¿Qué proceso convierte el vapor de agua en líquido?",
+      "answers": [
+        {
+          "text": "La condensación",
+          "correct": true
+        },
+        {
+          "text": "La evaporación",
+          "correct": false
+        },
+        {
+          "text": "La sublimación",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El rocío de la mañana es un ejemplo de condensación.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_149",
+      "question": "¿Qué elemento químico tiene el símbolo He y llena los globos que flotan?",
+      "answers": [
+        {
+          "text": "Hidrógeno",
+          "correct": false
+        },
+        {
+          "text": "Neón",
+          "correct": false
+        },
+        {
+          "text": "Helio",
+          "correct": true
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El helio es más ligero que el aire, por eso los globos suben.",
+      "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_150",
+      "question": "¿Qué tipo de onda es la luz visible?",
+      "answers": [
+        {
+          "text": "Mecánica",
+          "correct": false
+        },
+        {
+          "text": "Electromagnética",
+          "correct": true
+        },
+        {
+          "text": "Sonora",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La luz visible es una pequeña parte del espectro electromagnético.",
+      "category": "Ciencia"
+    }
+  ]
+}

--- a/custom_components/quizify/questions/ciencia-es.json
+++ b/custom_components/quizify/questions/ciencia-es.json
@@ -447,7 +447,7 @@
     },
     {
       "id": "cie_es_022",
-      "question": "¿Qué instrumento inventó Galileo para observar el cielo?",
+      "question": "¿Qué instrumento perfeccionó Galileo para observar el cielo?",
       "answers": [
         {
           "text": "El telescopio",

--- a/custom_components/quizify/questions/historia-es.json
+++ b/custom_components/quizify/questions/historia-es.json
@@ -1938,7 +1938,7 @@
     },
     {
       "id": "his_es_093",
-      "question": "¿Qué civilización mesoamericana es considerada la 'cultura madre' por los olmecas y otros pueblos?",
+      "question": "¿Qué civilización es considerada la 'cultura madre' de Mesoamérica, origen de culturas posteriores?",
       "answers": [
         {
           "text": "Los olmecas",
@@ -2106,7 +2106,7 @@
     },
     {
       "id": "his_es_101",
-      "question": "¿En qué década estalló la Revolución mexicana?",
+      "question": "¿En qué año estalló la Revolución mexicana?",
       "answers": [
         {
           "text": "En 1910",

--- a/custom_components/quizify/questions/historia-es.json
+++ b/custom_components/quizify/questions/historia-es.json
@@ -1,0 +1,3158 @@
+{
+  "name": "Historia",
+  "language": "es",
+  "version": "1.0",
+  "theme": "history",
+  "questions": [
+    {
+      "id": "his_es_001",
+      "question": "¿En qué año llegó Cristóbal Colón por primera vez a América?",
+      "answers": [
+        {
+          "text": "1492",
+          "correct": true
+        },
+        {
+          "text": "1512",
+          "correct": false
+        },
+        {
+          "text": "1453",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Colón desembarcó el 12 de octubre de 1492 en la isla de Guanahaní, en las actuales Bahamas, creyendo haber llegado a las Indias.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_002",
+      "question": "¿Qué civilización antigua construyó las pirámides de Guiza?",
+      "answers": [
+        {
+          "text": "Los egipcios",
+          "correct": true
+        },
+        {
+          "text": "Los romanos",
+          "correct": false
+        },
+        {
+          "text": "Los griegos",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La Gran Pirámide de Guiza, construida hacia el 2560 a. C., fue la estructura más alta hecha por el hombre durante casi 4000 años.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_003",
+      "question": "¿Qué imperio precolombino tenía su capital en Tenochtitlan?",
+      "answers": [
+        {
+          "text": "El Imperio azteca",
+          "correct": true
+        },
+        {
+          "text": "El Imperio inca",
+          "correct": false
+        },
+        {
+          "text": "La civilización maya",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Tenochtitlan fue fundada en 1325 sobre un islote del lago Texcoco; hoy sus ruinas se encuentran bajo la Ciudad de México.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_004",
+      "question": "¿Quién fue el primer emperador del Imperio romano?",
+      "answers": [
+        {
+          "text": "Augusto",
+          "correct": true
+        },
+        {
+          "text": "Julio César",
+          "correct": false
+        },
+        {
+          "text": "Nerón",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Octavio recibió el título de Augusto en el año 27 a. C., marcando el inicio del Imperio romano tras siglos de república.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_005",
+      "question": "¿En qué año cayó el Muro de Berlín?",
+      "answers": [
+        {
+          "text": "1989",
+          "correct": true
+        },
+        {
+          "text": "1991",
+          "correct": false
+        },
+        {
+          "text": "1985",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La caída del Muro de Berlín el 9 de noviembre de 1989 simbolizó el fin de la Guerra Fría y aceleró la reunificación alemana.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_006",
+      "question": "¿Qué conquistador español derrotó al Imperio azteca?",
+      "answers": [
+        {
+          "text": "Hernán Cortés",
+          "correct": true
+        },
+        {
+          "text": "Francisco Pizarro",
+          "correct": false
+        },
+        {
+          "text": "Vasco Núñez de Balboa",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Hernán Cortés tomó Tenochtitlan en 1521 tras aliarse con pueblos enemigos de los aztecas, como los tlaxcaltecas.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_007",
+      "question": "¿Qué conquistador español conquistó el Imperio inca?",
+      "answers": [
+        {
+          "text": "Francisco Pizarro",
+          "correct": true
+        },
+        {
+          "text": "Hernán Cortés",
+          "correct": false
+        },
+        {
+          "text": "Diego de Almagro",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Pizarro capturó al inca Atahualpa en Cajamarca en 1532 y lo ejecutó al año siguiente, pese al pago de un cuantioso rescate en oro.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_008",
+      "question": "¿En qué año comenzó la Primera Guerra Mundial?",
+      "answers": [
+        {
+          "text": "1914",
+          "correct": true
+        },
+        {
+          "text": "1918",
+          "correct": false
+        },
+        {
+          "text": "1912",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La Primera Guerra Mundial estalló tras el asesinato del archiduque Francisco Fernando de Austria en Sarajevo en junio de 1914.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_009",
+      "question": "¿En qué año terminó la Segunda Guerra Mundial?",
+      "answers": [
+        {
+          "text": "1945",
+          "correct": true
+        },
+        {
+          "text": "1943",
+          "correct": false
+        },
+        {
+          "text": "1947",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La guerra terminó en Europa en mayo de 1945 y en el Pacífico en septiembre, tras las bombas atómicas de Hiroshima y Nagasaki.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_010",
+      "question": "¿Qué famoso general cartaginés cruzó los Alpes con elefantes?",
+      "answers": [
+        {
+          "text": "Aníbal",
+          "correct": true
+        },
+        {
+          "text": "Escipión",
+          "correct": false
+        },
+        {
+          "text": "Espartaco",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Aníbal cruzó los Alpes en el 218 a. C. durante la Segunda Guerra Púnica para atacar Roma desde el norte de Italia.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_011",
+      "question": "¿Qué reina egipcia mantuvo relaciones con Julio César y Marco Antonio?",
+      "answers": [
+        {
+          "text": "Cleopatra",
+          "correct": true
+        },
+        {
+          "text": "Nefertiti",
+          "correct": false
+        },
+        {
+          "text": "Hatshepsut",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Cleopatra VII fue la última faraona de Egipto; con su muerte en el 30 a. C. el país quedó bajo dominio romano.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_012",
+      "question": "¿Qué documento firmó el rey Juan de Inglaterra en 1215?",
+      "answers": [
+        {
+          "text": "La Carta Magna",
+          "correct": true
+        },
+        {
+          "text": "La Declaración de Independencia",
+          "correct": false
+        },
+        {
+          "text": "El Tratado de Versalles",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La Carta Magna limitó el poder del rey y es considerada un precedente fundamental de las libertades constitucionales modernas.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_013",
+      "question": "¿Quiénes fueron los Reyes Católicos que financiaron el viaje de Colón?",
+      "answers": [
+        {
+          "text": "Isabel de Castilla y Fernando de Aragón",
+          "correct": true
+        },
+        {
+          "text": "Carlos I y Juana de Castilla",
+          "correct": false
+        },
+        {
+          "text": "Felipe II y María Tudor",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "En 1492 los Reyes Católicos culminaron la Reconquista con la toma de Granada y patrocinaron el primer viaje de Colón.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_014",
+      "question": "¿En qué año se produjo la Revolución francesa?",
+      "answers": [
+        {
+          "text": "1789",
+          "correct": true
+        },
+        {
+          "text": "1776",
+          "correct": false
+        },
+        {
+          "text": "1804",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La toma de la Bastilla el 14 de julio de 1789 se considera el inicio simbólico de la Revolución francesa.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_015",
+      "question": "¿Quién lideró el Imperio francés y fue derrotado en Waterloo?",
+      "answers": [
+        {
+          "text": "Napoleón Bonaparte",
+          "correct": true
+        },
+        {
+          "text": "Luis XIV",
+          "correct": false
+        },
+        {
+          "text": "Robespierre",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La batalla de Waterloo, en 1815, marcó la derrota definitiva de Napoleón, que fue desterrado a la isla de Santa Elena.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_016",
+      "question": "¿Qué civilización desarrolló un avanzado calendario y escritura en la selva de Mesoamérica?",
+      "answers": [
+        {
+          "text": "Los mayas",
+          "correct": true
+        },
+        {
+          "text": "Los incas",
+          "correct": false
+        },
+        {
+          "text": "Los olmecas",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los mayas desarrollaron un sistema de escritura jeroglífica completo y calendarios de gran precisión astronómica.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_017",
+      "question": "¿Cuál era la capital del Imperio inca?",
+      "answers": [
+        {
+          "text": "Cusco",
+          "correct": true
+        },
+        {
+          "text": "Lima",
+          "correct": false
+        },
+        {
+          "text": "Quito",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Cusco, en el actual Perú, era considerada por los incas el ombligo del mundo y centro de su vasto imperio andino.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_018",
+      "question": "¿Qué emperador romano legalizó el cristianismo con el Edicto de Milán?",
+      "answers": [
+        {
+          "text": "Constantino",
+          "correct": true
+        },
+        {
+          "text": "Trajano",
+          "correct": false
+        },
+        {
+          "text": "Diocleciano",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El Edicto de Milán, del año 313, concedió libertad de culto a los cristianos tras siglos de persecuciones en el Imperio.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_019",
+      "question": "¿En qué año cayó el Imperio romano de Occidente?",
+      "answers": [
+        {
+          "text": "476 d. C.",
+          "correct": true
+        },
+        {
+          "text": "410 d. C.",
+          "correct": false
+        },
+        {
+          "text": "532 d. C.",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "En el 476 el caudillo germano Odoacro depuso a Rómulo Augústulo, considerado el último emperador romano de Occidente.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_020",
+      "question": "¿Qué explorador portugués dio la primera vuelta al mundo, completada tras su muerte?",
+      "answers": [
+        {
+          "text": "Fernando de Magallanes",
+          "correct": true
+        },
+        {
+          "text": "Vasco de Gama",
+          "correct": false
+        },
+        {
+          "text": "Bartolomé Díaz",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Magallanes murió en Filipinas en 1521; Juan Sebastián Elcano completó la primera circunnavegación en 1522.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_021",
+      "question": "¿Qué guerra enfrentó a Atenas y Esparta en la antigua Grecia?",
+      "answers": [
+        {
+          "text": "La Guerra del Peloponeso",
+          "correct": true
+        },
+        {
+          "text": "Las Guerras Púnicas",
+          "correct": false
+        },
+        {
+          "text": "Las Guerras Médicas",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La Guerra del Peloponeso (431-404 a. C.) terminó con la victoria de Esparta y el declive de la hegemonía ateniense.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_022",
+      "question": "¿Quién fue el conquistador macedonio que creó un vasto imperio en el siglo IV a. C.?",
+      "answers": [
+        {
+          "text": "Alejandro Magno",
+          "correct": true
+        },
+        {
+          "text": "Pericles",
+          "correct": false
+        },
+        {
+          "text": "Leónidas",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Alejandro Magno llegó hasta la India y difundió la cultura helenística; murió a los 32 años en Babilonia en el 323 a. C.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_023",
+      "question": "¿Qué rey español encargó la construcción del Monasterio de El Escorial?",
+      "answers": [
+        {
+          "text": "Felipe II",
+          "correct": true
+        },
+        {
+          "text": "Carlos III",
+          "correct": false
+        },
+        {
+          "text": "Fernando VII",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Felipe II mandó construir El Escorial en el siglo XVI como palacio, monasterio y panteón de los reyes de España.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_024",
+      "question": "¿Qué peste diezmó a Europa en el siglo XIV?",
+      "answers": [
+        {
+          "text": "La peste negra",
+          "correct": true
+        },
+        {
+          "text": "La gripe española",
+          "correct": false
+        },
+        {
+          "text": "El cólera",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La peste negra mató entre un tercio y la mitad de la población europea entre 1347 y 1351.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_025",
+      "question": "¿En qué año declararon su independencia las Trece Colonias de Estados Unidos?",
+      "answers": [
+        {
+          "text": "1776",
+          "correct": true
+        },
+        {
+          "text": "1789",
+          "correct": false
+        },
+        {
+          "text": "1783",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La Declaración de Independencia se firmó el 4 de julio de 1776, fecha que se celebra como fiesta nacional en EE. UU.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_026",
+      "question": "¿Quién fue el primer presidente de los Estados Unidos?",
+      "answers": [
+        {
+          "text": "George Washington",
+          "correct": true
+        },
+        {
+          "text": "Thomas Jefferson",
+          "correct": false
+        },
+        {
+          "text": "Abraham Lincoln",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "George Washington asumió la presidencia en 1789 tras liderar el ejército continental en la Guerra de Independencia.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_027",
+      "question": "¿Qué líder de la independencia es conocido como 'El Libertador' en Sudamérica?",
+      "answers": [
+        {
+          "text": "Simón Bolívar",
+          "correct": true
+        },
+        {
+          "text": "José de San Martín",
+          "correct": false
+        },
+        {
+          "text": "Bernardo O'Higgins",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Simón Bolívar contribuyó a la independencia de Venezuela, Colombia, Ecuador, Perú y Bolivia, país que lleva su nombre.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_028",
+      "question": "¿Qué imperio dominó gran parte del Mediterráneo oriental con capital en Constantinopla?",
+      "answers": [
+        {
+          "text": "El Imperio bizantino",
+          "correct": true
+        },
+        {
+          "text": "El Imperio otomano",
+          "correct": false
+        },
+        {
+          "text": "El Imperio persa",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El Imperio bizantino fue la continuación del Imperio romano de Oriente y sobrevivió mil años, hasta 1453.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_029",
+      "question": "¿En qué año conquistaron los otomanos Constantinopla?",
+      "answers": [
+        {
+          "text": "1453",
+          "correct": true
+        },
+        {
+          "text": "1492",
+          "correct": false
+        },
+        {
+          "text": "1204",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La caída de Constantinopla en 1453 ante Mehmed II puso fin al Imperio bizantino y se toma como fin de la Edad Media.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_030",
+      "question": "¿Qué artista italiano pintó la Capilla Sixtina?",
+      "answers": [
+        {
+          "text": "Miguel Ángel",
+          "correct": true
+        },
+        {
+          "text": "Leonardo da Vinci",
+          "correct": false
+        },
+        {
+          "text": "Rafael",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Miguel Ángel pintó la bóveda de la Capilla Sixtina entre 1508 y 1512, una obra cumbre del Renacimiento.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_031",
+      "question": "¿Quién pintó 'La Mona Lisa'?",
+      "answers": [
+        {
+          "text": "Leonardo da Vinci",
+          "correct": true
+        },
+        {
+          "text": "Sandro Botticelli",
+          "correct": false
+        },
+        {
+          "text": "Tiziano",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Leonardo da Vinci pintó 'La Gioconda' hacia 1503; hoy se exhibe en el Museo del Louvre de París.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_032",
+      "question": "¿Qué monje inició la Reforma protestante en 1517?",
+      "answers": [
+        {
+          "text": "Martín Lutero",
+          "correct": true
+        },
+        {
+          "text": "Juan Calvino",
+          "correct": false
+        },
+        {
+          "text": "Enrique VIII",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Martín Lutero clavó sus 95 tesis en Wittenberg criticando la venta de indulgencias por la Iglesia católica.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_033",
+      "question": "¿Qué guerra civil española comenzó en 1936?",
+      "answers": [
+        {
+          "text": "La Guerra Civil española",
+          "correct": true
+        },
+        {
+          "text": "La Guerra de la Independencia",
+          "correct": false
+        },
+        {
+          "text": "Las Guerras Carlistas",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La Guerra Civil española (1936-1939) terminó con la victoria del bando de Franco, que gobernó España hasta 1975.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_034",
+      "question": "¿Quién gobernó España como dictador entre 1939 y 1975?",
+      "answers": [
+        {
+          "text": "Francisco Franco",
+          "correct": true
+        },
+        {
+          "text": "Miguel Primo de Rivera",
+          "correct": false
+        },
+        {
+          "text": "Manuel Azaña",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Tras la muerte de Franco en 1975, España inició una transición hacia la democracia con el rey Juan Carlos I.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_035",
+      "question": "¿En qué guerra ocurrió el desembarco de Normandía?",
+      "answers": [
+        {
+          "text": "La Segunda Guerra Mundial",
+          "correct": true
+        },
+        {
+          "text": "La Primera Guerra Mundial",
+          "correct": false
+        },
+        {
+          "text": "La Guerra de Corea",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El Día D, 6 de junio de 1944, los Aliados desembarcaron en Normandía para liberar Europa occidental de los nazis.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_036",
+      "question": "¿Qué líder alemán encabezó el régimen nazi durante la Segunda Guerra Mundial?",
+      "answers": [
+        {
+          "text": "Adolf Hitler",
+          "correct": true
+        },
+        {
+          "text": "Otto von Bismarck",
+          "correct": false
+        },
+        {
+          "text": "Heinrich Himmler",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Hitler llegó al poder en 1933 como canciller de Alemania y se suicidó en Berlín en abril de 1945.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_037",
+      "question": "¿Qué antiguo pueblo desarrolló la democracia en la ciudad de Atenas?",
+      "answers": [
+        {
+          "text": "Los griegos",
+          "correct": true
+        },
+        {
+          "text": "Los romanos",
+          "correct": false
+        },
+        {
+          "text": "Los fenicios",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La democracia ateniense, desarrollada en el siglo V a. C., permitía a los ciudadanos varones libres votar en la asamblea.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_038",
+      "question": "¿Qué muralla se construyó para proteger China de invasiones del norte?",
+      "answers": [
+        {
+          "text": "La Gran Muralla China",
+          "correct": true
+        },
+        {
+          "text": "El Muro de Adriano",
+          "correct": false
+        },
+        {
+          "text": "La Línea Maginot",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La Gran Muralla China se construyó a lo largo de siglos y se extiende por miles de kilómetros a través del norte de China.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_039",
+      "question": "¿Qué explorador portugués fue el primero en llegar a la India por mar rodeando África?",
+      "answers": [
+        {
+          "text": "Vasco de Gama",
+          "correct": true
+        },
+        {
+          "text": "Fernando de Magallanes",
+          "correct": false
+        },
+        {
+          "text": "Cristóbal Colón",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Vasco de Gama alcanzó Calicut, en la India, en 1498, abriendo la ruta marítima de las especias para Portugal.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_040",
+      "question": "¿Qué tratado de 1494 repartió el Nuevo Mundo entre España y Portugal?",
+      "answers": [
+        {
+          "text": "El Tratado de Tordesillas",
+          "correct": true
+        },
+        {
+          "text": "La Paz de Westfalia",
+          "correct": false
+        },
+        {
+          "text": "El Tratado de Utrecht",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El Tratado de Tordesillas trazó una línea de reparto que explica por qué Brasil quedó bajo dominio portugués.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_041",
+      "question": "¿Quién fue el líder no violento de la independencia de la India?",
+      "answers": [
+        {
+          "text": "Mahatma Gandhi",
+          "correct": true
+        },
+        {
+          "text": "Jawaharlal Nehru",
+          "correct": false
+        },
+        {
+          "text": "Nelson Mandela",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Gandhi promovió la resistencia pacífica y la desobediencia civil; la India logró su independencia del Reino Unido en 1947.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_042",
+      "question": "¿Qué líder sudafricano luchó contra el apartheid y llegó a ser presidente?",
+      "answers": [
+        {
+          "text": "Nelson Mandela",
+          "correct": true
+        },
+        {
+          "text": "Desmond Tutu",
+          "correct": false
+        },
+        {
+          "text": "Kwame Nkrumah",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Mandela pasó 27 años en prisión y en 1994 se convirtió en el primer presidente negro de Sudáfrica.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_043",
+      "question": "¿Qué acontecimiento marcó el inicio de la Edad Contemporánea según muchos historiadores?",
+      "answers": [
+        {
+          "text": "La Revolución francesa",
+          "correct": true
+        },
+        {
+          "text": "La caída de Constantinopla",
+          "correct": false
+        },
+        {
+          "text": "El descubrimiento de América",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La Revolución francesa de 1789 suele tomarse como frontera entre la Edad Moderna y la Edad Contemporánea.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_044",
+      "question": "¿Qué presidente estadounidense abolió la esclavitud durante la Guerra de Secesión?",
+      "answers": [
+        {
+          "text": "Abraham Lincoln",
+          "correct": true
+        },
+        {
+          "text": "George Washington",
+          "correct": false
+        },
+        {
+          "text": "Franklin D. Roosevelt",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Lincoln emitió la Proclamación de Emancipación en 1863; la esclavitud quedó abolida con la Decimotercera Enmienda en 1865.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_045",
+      "question": "¿En qué años tuvo lugar la Guerra de Secesión estadounidense?",
+      "answers": [
+        {
+          "text": "1861-1865",
+          "correct": true
+        },
+        {
+          "text": "1775-1783",
+          "correct": false
+        },
+        {
+          "text": "1846-1848",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La Guerra Civil de Estados Unidos enfrentó a los estados del Norte y del Sur, principalmente por la esclavitud y la unión.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_046",
+      "question": "¿Qué imperio fue gobernado por los zares hasta 1917?",
+      "answers": [
+        {
+          "text": "El Imperio ruso",
+          "correct": true
+        },
+        {
+          "text": "El Imperio austrohúngaro",
+          "correct": false
+        },
+        {
+          "text": "El Imperio otomano",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La Revolución rusa de 1917 derrocó al zar Nicolás II y dio paso a la creación de la Unión Soviética en 1922.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_047",
+      "question": "¿Quién lideró la Revolución bolchevique de 1917 en Rusia?",
+      "answers": [
+        {
+          "text": "Vladimir Lenin",
+          "correct": true
+        },
+        {
+          "text": "Iósif Stalin",
+          "correct": false
+        },
+        {
+          "text": "León Trotski",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Lenin encabezó a los bolcheviques en la Revolución de Octubre, que instauró el primer estado socialista del mundo.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_048",
+      "question": "¿Qué revolucionario argentino luchó junto a Fidel Castro en Cuba?",
+      "answers": [
+        {
+          "text": "Ernesto 'Che' Guevara",
+          "correct": true
+        },
+        {
+          "text": "Emiliano Zapata",
+          "correct": false
+        },
+        {
+          "text": "Pancho Villa",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El Che Guevara participó en la Revolución cubana de 1959 y murió en Bolivia en 1967 intentando extender la guerrilla.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_049",
+      "question": "¿En qué año triunfó la Revolución cubana liderada por Fidel Castro?",
+      "answers": [
+        {
+          "text": "1959",
+          "correct": true
+        },
+        {
+          "text": "1953",
+          "correct": false
+        },
+        {
+          "text": "1967",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El 1 de enero de 1959, Fidel Castro derrocó al dictador Fulgencio Batista tras años de lucha guerrillera en Sierra Maestra.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_050",
+      "question": "¿Qué cura mexicano dio el 'Grito de Dolores' en 1810?",
+      "answers": [
+        {
+          "text": "Miguel Hidalgo",
+          "correct": true
+        },
+        {
+          "text": "Benito Juárez",
+          "correct": false
+        },
+        {
+          "text": "Emiliano Zapata",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El Grito de Dolores del padre Hidalgo inició la guerra de independencia de México, que culminó en 1821.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_051",
+      "question": "¿Qué antigua ciudad romana fue sepultada por la erupción del Vesubio en el año 79?",
+      "answers": [
+        {
+          "text": "Pompeya",
+          "correct": true
+        },
+        {
+          "text": "Cartago",
+          "correct": false
+        },
+        {
+          "text": "Éfeso",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Las cenizas del Vesubio conservaron Pompeya casi intacta, ofreciendo una imagen única de la vida en la antigua Roma.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_052",
+      "question": "¿Qué esclavo lideró una gran rebelión contra la República romana?",
+      "answers": [
+        {
+          "text": "Espartaco",
+          "correct": true
+        },
+        {
+          "text": "Aníbal",
+          "correct": false
+        },
+        {
+          "text": "Vercingétorix",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La rebelión de Espartaco entre el 73 y el 71 a. C. llegó a reunir decenas de miles de esclavos antes de ser aplastada.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_053",
+      "question": "¿Qué dinastía construyó gran parte de la Alhambra de Granada?",
+      "answers": [
+        {
+          "text": "La dinastía nazarí",
+          "correct": true
+        },
+        {
+          "text": "La dinastía Habsburgo",
+          "correct": false
+        },
+        {
+          "text": "La dinastía Borbón",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La Alhambra fue el palacio del reino nazarí de Granada, último bastión musulmán de la península ibérica hasta 1492.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_054",
+      "question": "¿Cómo se llama el periodo de dominio musulmán en la península ibérica?",
+      "answers": [
+        {
+          "text": "Al-Ándalus",
+          "correct": true
+        },
+        {
+          "text": "La Hispania romana",
+          "correct": false
+        },
+        {
+          "text": "El Reino visigodo",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Al-Ándalus se inició con la invasión musulmana de 711 y duró casi ocho siglos, hasta la caída de Granada en 1492.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_055",
+      "question": "¿Qué proceso histórico buscó recuperar la península ibérica del dominio musulmán?",
+      "answers": [
+        {
+          "text": "La Reconquista",
+          "correct": true
+        },
+        {
+          "text": "Las Cruzadas",
+          "correct": false
+        },
+        {
+          "text": "La Contrarreforma",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La Reconquista se extendió durante casi ocho siglos y concluyó con la toma de Granada por los Reyes Católicos en 1492.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_056",
+      "question": "¿Qué expediciones militares cristianas medievales buscaron controlar Tierra Santa?",
+      "answers": [
+        {
+          "text": "Las Cruzadas",
+          "correct": true
+        },
+        {
+          "text": "Las Guerras Púnicas",
+          "correct": false
+        },
+        {
+          "text": "La Guerra de los Cien Años",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La Primera Cruzada comenzó en 1096 y en 1099 los cruzados tomaron Jerusalén tras un largo asedio.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_057",
+      "question": "¿Qué guerra entre Inglaterra y Francia duró más de un siglo?",
+      "answers": [
+        {
+          "text": "La Guerra de los Cien Años",
+          "correct": true
+        },
+        {
+          "text": "La Guerra de los Treinta Años",
+          "correct": false
+        },
+        {
+          "text": "La Guerra de las Dos Rosas",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La Guerra de los Cien Años (1337-1453) enfrentó a Inglaterra y Francia por el trono francés y territorios continentales.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_058",
+      "question": "¿Qué joven francesa lideró tropas en la Guerra de los Cien Años y fue quemada en la hoguera?",
+      "answers": [
+        {
+          "text": "Juana de Arco",
+          "correct": true
+        },
+        {
+          "text": "María Antonieta",
+          "correct": false
+        },
+        {
+          "text": "Leonor de Aquitania",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Juana de Arco fue ejecutada en 1431 y canonizada como santa por la Iglesia católica casi cinco siglos después, en 1920.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_059",
+      "question": "¿Qué flota española fue derrotada al intentar invadir Inglaterra en 1588?",
+      "answers": [
+        {
+          "text": "La Armada Invencible",
+          "correct": true
+        },
+        {
+          "text": "La flota de Lepanto",
+          "correct": false
+        },
+        {
+          "text": "La Grande Armée",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La Armada Invencible de Felipe II fracasó en 1588 por tormentas y por la resistencia de la flota inglesa de Isabel I.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_060",
+      "question": "¿En qué batalla naval de 1571 fue derrotada la flota otomana por una coalición cristiana?",
+      "answers": [
+        {
+          "text": "La batalla de Lepanto",
+          "correct": true
+        },
+        {
+          "text": "La batalla de Trafalgar",
+          "correct": false
+        },
+        {
+          "text": "La batalla de Actium",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "En Lepanto participó Miguel de Cervantes, autor del Quijote, que perdió el uso de la mano izquierda en el combate.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_061",
+      "question": "¿Quién escribió 'Don Quijote de la Mancha'?",
+      "answers": [
+        {
+          "text": "Miguel de Cervantes",
+          "correct": true
+        },
+        {
+          "text": "Lope de Vega",
+          "correct": false
+        },
+        {
+          "text": "Francisco de Quevedo",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La primera parte del Quijote se publicó en 1605 y está considerada la primera novela moderna de la literatura universal.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_062",
+      "question": "¿Qué imperio precolombino construyó la ciudadela de Machu Picchu?",
+      "answers": [
+        {
+          "text": "El Imperio inca",
+          "correct": true
+        },
+        {
+          "text": "El Imperio azteca",
+          "correct": false
+        },
+        {
+          "text": "La civilización maya",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Machu Picchu fue construida en el siglo XV en los Andes peruanos y el explorador Hiram Bingham la dio a conocer en 1911.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_063",
+      "question": "¿Qué explorador español avistó por primera vez el océano Pacífico desde América?",
+      "answers": [
+        {
+          "text": "Vasco Núñez de Balboa",
+          "correct": true
+        },
+        {
+          "text": "Juan Ponce de León",
+          "correct": false
+        },
+        {
+          "text": "Hernando de Soto",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "En 1513, Balboa cruzó el istmo de Panamá y fue el primer europeo en ver el Pacífico desde el continente americano.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_064",
+      "question": "¿Qué rey francés fue conocido como el 'Rey Sol'?",
+      "answers": [
+        {
+          "text": "Luis XIV",
+          "correct": true
+        },
+        {
+          "text": "Luis XVI",
+          "correct": false
+        },
+        {
+          "text": "Francisco I",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Luis XIV reinó más de 70 años y construyó el suntuoso Palacio de Versalles, símbolo del absolutismo francés.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_065",
+      "question": "¿Qué rey y reina de Francia fueron guillotinados durante la Revolución francesa?",
+      "answers": [
+        {
+          "text": "Luis XVI y María Antonieta",
+          "correct": true
+        },
+        {
+          "text": "Luis XIV y María Teresa",
+          "correct": false
+        },
+        {
+          "text": "Carlos X y María Amelia",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Luis XVI fue ejecutado en enero de 1793 y María Antonieta en octubre del mismo año, en plena Revolución francesa.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_066",
+      "question": "¿Qué invención de Gutenberg revolucionó la difusión del conocimiento hacia 1450?",
+      "answers": [
+        {
+          "text": "La imprenta de tipos móviles",
+          "correct": true
+        },
+        {
+          "text": "El papel",
+          "correct": false
+        },
+        {
+          "text": "El telégrafo",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La imprenta de Gutenberg permitió producir libros en masa; la Biblia fue una de sus primeras obras impresas.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_067",
+      "question": "¿En qué país comenzó la Revolución Industrial en el siglo XVIII?",
+      "answers": [
+        {
+          "text": "El Reino Unido",
+          "correct": true
+        },
+        {
+          "text": "Alemania",
+          "correct": false
+        },
+        {
+          "text": "Estados Unidos",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La Revolución Industrial arrancó en Gran Bretaña con la máquina de vapor y la mecanización de la industria textil.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_068",
+      "question": "¿Quién perfeccionó la máquina de vapor impulsando la Revolución Industrial?",
+      "answers": [
+        {
+          "text": "James Watt",
+          "correct": true
+        },
+        {
+          "text": "Thomas Edison",
+          "correct": false
+        },
+        {
+          "text": "Alexander Graham Bell",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "James Watt mejoró notablemente la eficiencia de la máquina de vapor en la década de 1760; la unidad de potencia, el vatio, lleva su nombre.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_069",
+      "question": "¿Qué muro dividió Alemania durante la Guerra Fría?",
+      "answers": [
+        {
+          "text": "El Muro de Berlín",
+          "correct": true
+        },
+        {
+          "text": "El Telón de Acero",
+          "correct": false
+        },
+        {
+          "text": "La Línea Maginot",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El Muro de Berlín se levantó en 1961 y separó la ciudad en dos hasta su caída en 1989.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_070",
+      "question": "¿Entre qué dos superpotencias se desarrolló la Guerra Fría?",
+      "answers": [
+        {
+          "text": "Estados Unidos y la Unión Soviética",
+          "correct": true
+        },
+        {
+          "text": "Estados Unidos y China",
+          "correct": false
+        },
+        {
+          "text": "El Reino Unido y Alemania",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La Guerra Fría fue un enfrentamiento ideológico y político sin combate directo entre ambas potencias, desde 1947 hasta 1991.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_071",
+      "question": "¿En qué año llegó el ser humano a la Luna por primera vez?",
+      "answers": [
+        {
+          "text": "1969",
+          "correct": true
+        },
+        {
+          "text": "1961",
+          "correct": false
+        },
+        {
+          "text": "1972",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El 20 de julio de 1969, Neil Armstrong se convirtió en el primer ser humano en pisar la Luna con la misión Apolo 11.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_072",
+      "question": "¿Quién fue el primer ser humano en viajar al espacio?",
+      "answers": [
+        {
+          "text": "Yuri Gagarin",
+          "correct": true
+        },
+        {
+          "text": "Neil Armstrong",
+          "correct": false
+        },
+        {
+          "text": "John Glenn",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El soviético Yuri Gagarin orbitó la Tierra el 12 de abril de 1961 a bordo de la nave Vostok 1.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_073",
+      "question": "¿Qué antigua civilización mesopotámica creó el Código de Hammurabi?",
+      "answers": [
+        {
+          "text": "Babilonia",
+          "correct": true
+        },
+        {
+          "text": "Egipto",
+          "correct": false
+        },
+        {
+          "text": "Persia",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El Código de Hammurabi, del siglo XVIII a. C., es uno de los conjuntos de leyes escritas más antiguos que se conservan.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_074",
+      "question": "¿Qué escritura desarrollaron los antiguos egipcios?",
+      "answers": [
+        {
+          "text": "Los jeroglíficos",
+          "correct": true
+        },
+        {
+          "text": "El cuneiforme",
+          "correct": false
+        },
+        {
+          "text": "El alfabeto latino",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La Piedra de Rosetta permitió a Champollion descifrar los jeroglíficos egipcios en 1822.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_075",
+      "question": "¿Qué pueblo antiguo fue famoso por su comercio marítimo y por difundir el alfabeto?",
+      "answers": [
+        {
+          "text": "Los fenicios",
+          "correct": true
+        },
+        {
+          "text": "Los espartanos",
+          "correct": false
+        },
+        {
+          "text": "Los etruscos",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Los fenicios fundaron colonias por todo el Mediterráneo, como Cartago, y su alfabeto influyó en el griego y el latino.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_076",
+      "question": "¿Qué general romano cruzó el Rubicón y provocó una guerra civil?",
+      "answers": [
+        {
+          "text": "Julio César",
+          "correct": true
+        },
+        {
+          "text": "Pompeyo",
+          "correct": false
+        },
+        {
+          "text": "Marco Aurelio",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Al cruzar el Rubicón en el 49 a. C., César desafió al Senado; de ahí la expresión 'la suerte está echada'.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_077",
+      "question": "¿En qué año fue asesinado Julio César?",
+      "answers": [
+        {
+          "text": "44 a. C.",
+          "correct": true
+        },
+        {
+          "text": "27 a. C.",
+          "correct": false
+        },
+        {
+          "text": "14 d. C.",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Julio César fue apuñalado en el Senado el 15 de marzo del 44 a. C., los famosos idus de marzo.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_078",
+      "question": "¿Qué rey visigodo se convirtió al catolicismo unificando religiosamente Hispania?",
+      "answers": [
+        {
+          "text": "Recaredo",
+          "correct": true
+        },
+        {
+          "text": "Pelayo",
+          "correct": false
+        },
+        {
+          "text": "Wamba",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El rey Recaredo se convirtió del arrianismo al catolicismo en el III Concilio de Toledo, en el año 589.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_079",
+      "question": "¿Qué emperador unió gran parte de Europa occidental y fue coronado en el año 800?",
+      "answers": [
+        {
+          "text": "Carlomagno",
+          "correct": true
+        },
+        {
+          "text": "Otón I",
+          "correct": false
+        },
+        {
+          "text": "Federico Barbarroja",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Carlomagno fue coronado emperador por el papa León III en el año 800, reviviendo la idea de un imperio en Occidente.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_080",
+      "question": "¿Qué sistema social medieval se basaba en la relación entre señores y vasallos?",
+      "answers": [
+        {
+          "text": "El feudalismo",
+          "correct": true
+        },
+        {
+          "text": "El capitalismo",
+          "correct": false
+        },
+        {
+          "text": "El absolutismo",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "En el feudalismo, los señores concedían tierras a cambio de fidelidad y servicio militar de sus vasallos.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_081",
+      "question": "¿Qué guerrero y estadista fundó el Imperio mongol en el siglo XIII?",
+      "answers": [
+        {
+          "text": "Gengis Kan",
+          "correct": true
+        },
+        {
+          "text": "Atila",
+          "correct": false
+        },
+        {
+          "text": "Tamerlán",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Gengis Kan unificó las tribus mongolas y creó el mayor imperio terrestre contiguo de la historia.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_082",
+      "question": "¿Qué emperador español heredó también el trono del Sacro Imperio Romano Germánico?",
+      "answers": [
+        {
+          "text": "Carlos I de España y V de Alemania",
+          "correct": true
+        },
+        {
+          "text": "Felipe II",
+          "correct": false
+        },
+        {
+          "text": "Fernando VI",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Carlos I gobernó un vasto imperio 'donde nunca se ponía el sol' y abdicó en 1556, retirándose al monasterio de Yuste.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_083",
+      "question": "¿Qué dinastía real gobierna España en la actualidad?",
+      "answers": [
+        {
+          "text": "Los Borbones",
+          "correct": true
+        },
+        {
+          "text": "Los Habsburgo",
+          "correct": false
+        },
+        {
+          "text": "Los Trastámara",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La dinastía de los Borbones reina en España desde Felipe V, a comienzos del siglo XVIII, con algunas interrupciones.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_084",
+      "question": "¿Qué guerra española de principios del siglo XIX enfrentó a España contra la ocupación napoleónica?",
+      "answers": [
+        {
+          "text": "La Guerra de la Independencia",
+          "correct": true
+        },
+        {
+          "text": "La Guerra de Sucesión",
+          "correct": false
+        },
+        {
+          "text": "La Guerra Civil",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La Guerra de la Independencia española (1808-1814) inspiró a Goya obras como 'Los fusilamientos del 3 de mayo'.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_085",
+      "question": "¿Qué pintor español retrató los horrores de la Guerra de la Independencia?",
+      "answers": [
+        {
+          "text": "Francisco de Goya",
+          "correct": true
+        },
+        {
+          "text": "Diego Velázquez",
+          "correct": false
+        },
+        {
+          "text": "El Greco",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Goya plasmó la invasión napoleónica en pinturas como 'El 2 de mayo de 1808' y 'Los fusilamientos del 3 de mayo'.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_086",
+      "question": "¿Qué pintor español creó la obra 'Las meninas'?",
+      "answers": [
+        {
+          "text": "Diego Velázquez",
+          "correct": true
+        },
+        {
+          "text": "Bartolomé Esteban Murillo",
+          "correct": false
+        },
+        {
+          "text": "Francisco de Zurbarán",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "'Las meninas', pintada por Velázquez en 1656, es una de las obras maestras del Museo del Prado en Madrid.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_087",
+      "question": "¿Qué constitución española de 1812 es conocida popularmente como 'La Pepa'?",
+      "answers": [
+        {
+          "text": "La Constitución de Cádiz",
+          "correct": true
+        },
+        {
+          "text": "La Constitución de 1978",
+          "correct": false
+        },
+        {
+          "text": "La Constitución de 1931",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Se promulgó el 19 de marzo de 1812, día de San José, de ahí el apodo 'La Pepa'; fue una de las primeras constituciones liberales.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_088",
+      "question": "¿En qué año se aprobó la actual Constitución democrática de España?",
+      "answers": [
+        {
+          "text": "1978",
+          "correct": true
+        },
+        {
+          "text": "1975",
+          "correct": false
+        },
+        {
+          "text": "1981",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La Constitución de 1978 consolidó la democracia tras la dictadura franquista y estableció una monarquía parlamentaria.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_089",
+      "question": "¿Qué rey de España reinó durante la Transición a la democracia tras la muerte de Franco?",
+      "answers": [
+        {
+          "text": "Juan Carlos I",
+          "correct": true
+        },
+        {
+          "text": "Alfonso XIII",
+          "correct": false
+        },
+        {
+          "text": "Felipe VI",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Juan Carlos I fue clave en la Transición y en frenar el intento de golpe de Estado del 23 de febrero de 1981.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_090",
+      "question": "¿Qué antigua ciudad rival de Roma fue destruida en las Guerras Púnicas?",
+      "answers": [
+        {
+          "text": "Cartago",
+          "correct": true
+        },
+        {
+          "text": "Atenas",
+          "correct": false
+        },
+        {
+          "text": "Alejandría",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Roma arrasó Cartago en el 146 a. C. al final de la Tercera Guerra Púnica, poniendo fin a su gran rival mediterráneo.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_091",
+      "question": "¿Qué famosa batalla enfrentó a 300 espartanos contra el ejército persa?",
+      "answers": [
+        {
+          "text": "La batalla de las Termópilas",
+          "correct": true
+        },
+        {
+          "text": "La batalla de Maratón",
+          "correct": false
+        },
+        {
+          "text": "La batalla de Salamina",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "En las Termópilas, en el 480 a. C., el rey Leónidas y sus espartanos resistieron heroicamente al ejército de Jerjes.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_092",
+      "question": "¿Qué imperio construyó una red de calzadas famosas por su frase 'todos los caminos llevan a Roma'?",
+      "answers": [
+        {
+          "text": "El Imperio romano",
+          "correct": true
+        },
+        {
+          "text": "El Imperio persa",
+          "correct": false
+        },
+        {
+          "text": "El Imperio chino",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Los romanos construyeron miles de kilómetros de calzadas para comunicar y controlar su extenso imperio.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_093",
+      "question": "¿Qué civilización mesoamericana es considerada la 'cultura madre' por los olmecas y otros pueblos?",
+      "answers": [
+        {
+          "text": "Los olmecas",
+          "correct": true
+        },
+        {
+          "text": "Los toltecas",
+          "correct": false
+        },
+        {
+          "text": "Los zapotecas",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Los olmecas florecieron hacia el 1200 a. C. y son célebres por sus colosales cabezas de piedra en el golfo de México.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_094",
+      "question": "¿Qué emperador azteca gobernaba a la llegada de Hernán Cortés?",
+      "answers": [
+        {
+          "text": "Moctezuma II",
+          "correct": true
+        },
+        {
+          "text": "Cuauhtémoc",
+          "correct": false
+        },
+        {
+          "text": "Atahualpa",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Moctezuma II recibió a Cortés en 1519 y murió al año siguiente durante la ocupación española de Tenochtitlan.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_095",
+      "question": "¿Qué metal precioso buscaban ansiosamente los conquistadores españoles en América?",
+      "answers": [
+        {
+          "text": "El oro",
+          "correct": true
+        },
+        {
+          "text": "El hierro",
+          "correct": false
+        },
+        {
+          "text": "El estaño",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La leyenda de 'El Dorado', una ciudad de oro, impulsó numerosas expediciones españolas por el interior de Sudamérica.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_096",
+      "question": "¿Qué virreinato español tenía su capital en Lima?",
+      "answers": [
+        {
+          "text": "El Virreinato del Perú",
+          "correct": true
+        },
+        {
+          "text": "El Virreinato de Nueva España",
+          "correct": false
+        },
+        {
+          "text": "El Virreinato del Río de la Plata",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El Virreinato del Perú, creado en 1542, fue uno de los territorios más ricos del imperio español en América.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_097",
+      "question": "¿Qué virreinato español tenía su capital en la Ciudad de México?",
+      "answers": [
+        {
+          "text": "El Virreinato de Nueva España",
+          "correct": true
+        },
+        {
+          "text": "El Virreinato del Perú",
+          "correct": false
+        },
+        {
+          "text": "El Virreinato de Nueva Granada",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El Virreinato de Nueva España abarcaba México, América Central y territorios que hoy pertenecen al sur de Estados Unidos.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_098",
+      "question": "¿Qué general argentino cruzó los Andes para liberar Chile y Perú?",
+      "answers": [
+        {
+          "text": "José de San Martín",
+          "correct": true
+        },
+        {
+          "text": "Simón Bolívar",
+          "correct": false
+        },
+        {
+          "text": "Manuel Belgrano",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "San Martín cruzó la cordillera de los Andes en 1817 con su Ejército de los Andes para independizar Chile del dominio español.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_099",
+      "question": "¿Qué país sudamericano lleva el nombre de Simón Bolívar?",
+      "answers": [
+        {
+          "text": "Bolivia",
+          "correct": true
+        },
+        {
+          "text": "Colombia",
+          "correct": false
+        },
+        {
+          "text": "Venezuela",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Bolivia adoptó su nombre en honor a Simón Bolívar tras declarar su independencia en 1825.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_100",
+      "question": "¿Qué presidente indígena mexicano promovió las Leyes de Reforma en el siglo XIX?",
+      "answers": [
+        {
+          "text": "Benito Juárez",
+          "correct": true
+        },
+        {
+          "text": "Porfirio Díaz",
+          "correct": false
+        },
+        {
+          "text": "Antonio López de Santa Anna",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Benito Juárez, de origen zapoteco, es célebre por su frase 'el respeto al derecho ajeno es la paz'.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_101",
+      "question": "¿En qué década estalló la Revolución mexicana?",
+      "answers": [
+        {
+          "text": "En 1910",
+          "correct": true
+        },
+        {
+          "text": "En 1810",
+          "correct": false
+        },
+        {
+          "text": "En 1940",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La Revolución mexicana comenzó en 1910 contra el largo gobierno de Porfirio Díaz y transformó el país durante una década.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_102",
+      "question": "¿Qué líder revolucionario mexicano defendió el lema 'Tierra y Libertad'?",
+      "answers": [
+        {
+          "text": "Emiliano Zapata",
+          "correct": true
+        },
+        {
+          "text": "Venustiano Carranza",
+          "correct": false
+        },
+        {
+          "text": "Francisco Madero",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Emiliano Zapata lideró a los campesinos del sur de México reclamando el reparto de tierras durante la Revolución.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_103",
+      "question": "¿Qué tratado puso fin a la Primera Guerra Mundial en 1919?",
+      "answers": [
+        {
+          "text": "El Tratado de Versalles",
+          "correct": true
+        },
+        {
+          "text": "El Tratado de Tordesillas",
+          "correct": false
+        },
+        {
+          "text": "La Paz de Westfalia",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El Tratado de Versalles impuso duras condiciones a Alemania, que muchos consideran una de las causas de la Segunda Guerra Mundial.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_104",
+      "question": "¿Qué organización internacional se creó en 1945 para preservar la paz mundial?",
+      "answers": [
+        {
+          "text": "La Organización de las Naciones Unidas",
+          "correct": true
+        },
+        {
+          "text": "La Sociedad de Naciones",
+          "correct": false
+        },
+        {
+          "text": "La OTAN",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La ONU se fundó tras la Segunda Guerra Mundial y hoy reúne a casi todos los países del mundo con sede en Nueva York.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_105",
+      "question": "¿Qué país lanzó las bombas atómicas sobre Hiroshima y Nagasaki?",
+      "answers": [
+        {
+          "text": "Estados Unidos",
+          "correct": true
+        },
+        {
+          "text": "La Unión Soviética",
+          "correct": false
+        },
+        {
+          "text": "El Reino Unido",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Las bombas atómicas se lanzaron en agosto de 1945 y precipitaron la rendición de Japón, fin de la Segunda Guerra Mundial.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_106",
+      "question": "¿Qué dictador soviético gobernó la URSS desde los años 1920 hasta 1953?",
+      "answers": [
+        {
+          "text": "Iósif Stalin",
+          "correct": true
+        },
+        {
+          "text": "Nikita Jrushchov",
+          "correct": false
+        },
+        {
+          "text": "Mijaíl Gorbachov",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Stalin industrializó la URSS a costa de millones de muertes por hambrunas, purgas y campos de trabajo forzado.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_107",
+      "question": "¿Qué líder soviético impulsó las reformas de la 'perestroika' y la 'glásnost'?",
+      "answers": [
+        {
+          "text": "Mijaíl Gorbachov",
+          "correct": true
+        },
+        {
+          "text": "Leonid Brézhnev",
+          "correct": false
+        },
+        {
+          "text": "Boris Yeltsin",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Las reformas de Gorbachov en los años 80 contribuyeron al fin de la Guerra Fría y a la disolución de la URSS en 1991.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_108",
+      "question": "¿En qué año se disolvió la Unión Soviética?",
+      "answers": [
+        {
+          "text": "1991",
+          "correct": true
+        },
+        {
+          "text": "1989",
+          "correct": false
+        },
+        {
+          "text": "1985",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La disolución de la URSS en diciembre de 1991 dio lugar a quince repúblicas independientes, entre ellas Rusia.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_109",
+      "question": "¿Qué líder chino proclamó la República Popular China en 1949?",
+      "answers": [
+        {
+          "text": "Mao Zedong",
+          "correct": true
+        },
+        {
+          "text": "Deng Xiaoping",
+          "correct": false
+        },
+        {
+          "text": "Chiang Kai-shek",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Mao Zedong lideró a los comunistas a la victoria en la guerra civil china y fundó la República Popular el 1 de octubre de 1949.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_110",
+      "question": "¿Qué científico publicó la teoría de la evolución por selección natural en 1859?",
+      "answers": [
+        {
+          "text": "Charles Darwin",
+          "correct": true
+        },
+        {
+          "text": "Gregor Mendel",
+          "correct": false
+        },
+        {
+          "text": "Louis Pasteur",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Darwin publicó 'El origen de las especies' en 1859 tras su viaje por las islas Galápagos a bordo del Beagle.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_111",
+      "question": "¿Qué antigua ciudad griega fue famosa por su disciplina militar y sus guerreros?",
+      "answers": [
+        {
+          "text": "Esparta",
+          "correct": true
+        },
+        {
+          "text": "Corinto",
+          "correct": false
+        },
+        {
+          "text": "Tebas",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "En Esparta, los niños se entrenaban desde pequeños en la agogé, un severo sistema educativo orientado a la guerra.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_112",
+      "question": "¿Qué famoso filósofo griego fue maestro de Alejandro Magno?",
+      "answers": [
+        {
+          "text": "Aristóteles",
+          "correct": true
+        },
+        {
+          "text": "Platón",
+          "correct": false
+        },
+        {
+          "text": "Sócrates",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Aristóteles, discípulo de Platón, fundó su propia escuela, el Liceo, y fue tutor del joven Alejandro Magno.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_113",
+      "question": "¿Qué filósofo griego fue condenado a beber cicuta en Atenas?",
+      "answers": [
+        {
+          "text": "Sócrates",
+          "correct": true
+        },
+        {
+          "text": "Pitágoras",
+          "correct": false
+        },
+        {
+          "text": "Diógenes",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Sócrates fue condenado a muerte en el 399 a. C. acusado de corromper a la juventud y no reconocer a los dioses de la ciudad.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_114",
+      "question": "¿En qué ciudad griega se celebraron los primeros Juegos Olímpicos de la Antigüedad?",
+      "answers": [
+        {
+          "text": "Olimpia",
+          "correct": true
+        },
+        {
+          "text": "Atenas",
+          "correct": false
+        },
+        {
+          "text": "Delfos",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los primeros Juegos Olímpicos se celebraron en Olimpia en el 776 a. C. en honor al dios Zeus.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_115",
+      "question": "¿Qué faraona egipcia gobernó Egipto como una de sus pocas mujeres al frente del trono?",
+      "answers": [
+        {
+          "text": "Hatshepsut",
+          "correct": true
+        },
+        {
+          "text": "Cleopatra I",
+          "correct": false
+        },
+        {
+          "text": "Nefertari",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Hatshepsut gobernó Egipto en el siglo XV a. C. y a menudo se la representaba con los atributos masculinos del faraón.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_116",
+      "question": "¿Qué río fue esencial para el desarrollo de la civilización del antiguo Egipto?",
+      "answers": [
+        {
+          "text": "El Nilo",
+          "correct": true
+        },
+        {
+          "text": "El Éufrates",
+          "correct": false
+        },
+        {
+          "text": "El Tigris",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Las crecidas anuales del Nilo fertilizaban las tierras de cultivo, lo que hizo posible la prosperidad del antiguo Egipto.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_117",
+      "question": "¿Entre qué dos ríos surgió la civilización de Mesopotamia?",
+      "answers": [
+        {
+          "text": "El Tigris y el Éufrates",
+          "correct": true
+        },
+        {
+          "text": "El Nilo y el Congo",
+          "correct": false
+        },
+        {
+          "text": "El Indo y el Ganges",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Mesopotamia significa 'tierra entre ríos' y en ella nacieron algunas de las primeras ciudades de la humanidad.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_118",
+      "question": "¿Qué imperio antiguo fue gobernado por Darío y Jerjes?",
+      "answers": [
+        {
+          "text": "El Imperio persa",
+          "correct": true
+        },
+        {
+          "text": "El Imperio babilónico",
+          "correct": false
+        },
+        {
+          "text": "El Imperio egipcio",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El Imperio persa aqueménida fue uno de los mayores de la Antigüedad hasta ser conquistado por Alejandro Magno.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_119",
+      "question": "¿Qué monumento megalítico prehistórico se encuentra en el sur de Inglaterra?",
+      "answers": [
+        {
+          "text": "Stonehenge",
+          "correct": true
+        },
+        {
+          "text": "El Coliseo",
+          "correct": false
+        },
+        {
+          "text": "La Acrópolis",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Stonehenge se construyó hace unos 5000 años y su función exacta sigue siendo objeto de estudio y debate.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_120",
+      "question": "¿Qué imperio precolombino se extendía a lo largo de la cordillera de los Andes?",
+      "answers": [
+        {
+          "text": "El Imperio inca",
+          "correct": true
+        },
+        {
+          "text": "El Imperio azteca",
+          "correct": false
+        },
+        {
+          "text": "El Imperio maya",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El Imperio inca, llamado Tahuantinsuyo, se extendía por el actual Perú, Ecuador, Bolivia, Chile y Argentina.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_121",
+      "question": "¿Qué sistema de nudos usaban los incas para llevar registros?",
+      "answers": [
+        {
+          "text": "El quipu",
+          "correct": true
+        },
+        {
+          "text": "El ábaco",
+          "correct": false
+        },
+        {
+          "text": "El jeroglífico",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El quipu era un conjunto de cuerdas anudadas que los incas empleaban para registrar cifras y datos administrativos.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_122",
+      "question": "¿Qué reino cristiano inició la Reconquista en el norte de la península ibérica?",
+      "answers": [
+        {
+          "text": "El Reino de Asturias",
+          "correct": true
+        },
+        {
+          "text": "El Reino de Granada",
+          "correct": false
+        },
+        {
+          "text": "El Reino de Portugal",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Se considera que la Reconquista comenzó con la victoria de Don Pelayo en Covadonga, hacia el año 722.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_123",
+      "question": "¿Qué caballero castellano medieval es el protagonista del 'Cantar de mio Cid'?",
+      "answers": [
+        {
+          "text": "Rodrigo Díaz de Vivar",
+          "correct": true
+        },
+        {
+          "text": "Don Pelayo",
+          "correct": false
+        },
+        {
+          "text": "Guzmán el Bueno",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El Cid conquistó Valencia en 1094 y su figura es protagonista del cantar de gesta más importante de la literatura española.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_124",
+      "question": "¿Qué periodo cultural europeo revalorizó el arte y el saber de la Antigüedad clásica?",
+      "answers": [
+        {
+          "text": "El Renacimiento",
+          "correct": true
+        },
+        {
+          "text": "El Romanticismo",
+          "correct": false
+        },
+        {
+          "text": "La Ilustración",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El Renacimiento surgió en Italia en el siglo XV y dio figuras como Leonardo da Vinci, Miguel Ángel y Rafael.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_125",
+      "question": "¿Qué movimiento intelectual del siglo XVIII defendió la razón y el progreso?",
+      "answers": [
+        {
+          "text": "La Ilustración",
+          "correct": true
+        },
+        {
+          "text": "El Renacimiento",
+          "correct": false
+        },
+        {
+          "text": "La Reforma",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La Ilustración, con pensadores como Voltaire y Rousseau, influyó en las revoluciones francesa y estadounidense.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_126",
+      "question": "¿Qué astrónomo defendió que la Tierra gira alrededor del Sol enfrentándose a la Iglesia?",
+      "answers": [
+        {
+          "text": "Galileo Galilei",
+          "correct": true
+        },
+        {
+          "text": "Isaac Newton",
+          "correct": false
+        },
+        {
+          "text": "Johannes Kepler",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Galileo fue procesado por la Inquisición en 1633 por defender el modelo heliocéntrico propuesto por Copérnico.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_127",
+      "question": "¿Qué astrónomo polaco propuso el modelo heliocéntrico en el siglo XVI?",
+      "answers": [
+        {
+          "text": "Nicolás Copérnico",
+          "correct": true
+        },
+        {
+          "text": "Tycho Brahe",
+          "correct": false
+        },
+        {
+          "text": "Ptolomeo",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Copérnico publicó su obra sobre el movimiento de los planetas alrededor del Sol en 1543, el año de su muerte.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_128",
+      "question": "¿Qué conflicto religioso y político asoló Europa central entre 1618 y 1648?",
+      "answers": [
+        {
+          "text": "La Guerra de los Treinta Años",
+          "correct": true
+        },
+        {
+          "text": "La Guerra de los Cien Años",
+          "correct": false
+        },
+        {
+          "text": "La Guerra de Sucesión española",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La Guerra de los Treinta Años terminó con la Paz de Westfalia en 1648, base del moderno sistema de estados soberanos.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_129",
+      "question": "¿Qué reina inglesa dio nombre a una época dorada de expansión y cultura en el siglo XVI?",
+      "answers": [
+        {
+          "text": "Isabel I",
+          "correct": true
+        },
+        {
+          "text": "Victoria",
+          "correct": false
+        },
+        {
+          "text": "María I",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Durante el reinado de Isabel I florecieron autores como Shakespeare y se consolidó el poder naval de Inglaterra.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_130",
+      "question": "¿Qué rey inglés fundó la Iglesia anglicana al romper con Roma?",
+      "answers": [
+        {
+          "text": "Enrique VIII",
+          "correct": true
+        },
+        {
+          "text": "Ricardo Corazón de León",
+          "correct": false
+        },
+        {
+          "text": "Jorge III",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Enrique VIII rompió con el papado en la década de 1530 para poder divorciarse, dando origen a la Iglesia de Inglaterra.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_131",
+      "question": "¿Qué reina británica gobernó durante gran parte del siglo XIX en la cumbre del imperio?",
+      "answers": [
+        {
+          "text": "La reina Victoria",
+          "correct": true
+        },
+        {
+          "text": "La reina Ana",
+          "correct": false
+        },
+        {
+          "text": "La reina Isabel II",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La reina Victoria reinó más de 63 años y dio nombre a la época victoriana, apogeo del Imperio británico.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_132",
+      "question": "¿Qué canciller unificó Alemania en 1871?",
+      "answers": [
+        {
+          "text": "Otto von Bismarck",
+          "correct": true
+        },
+        {
+          "text": "Guillermo II",
+          "correct": false
+        },
+        {
+          "text": "Konrad Adenauer",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Bismarck, apodado el 'Canciller de Hierro', logró la unificación alemana mediante una hábil política de guerras y alianzas.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_133",
+      "question": "¿Qué líder italiano encabezó el régimen fascista en el siglo XX?",
+      "answers": [
+        {
+          "text": "Benito Mussolini",
+          "correct": true
+        },
+        {
+          "text": "Giuseppe Garibaldi",
+          "correct": false
+        },
+        {
+          "text": "Victor Manuel II",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Mussolini gobernó Italia desde 1922 y su régimen fascista sirvió de modelo a otros movimientos autoritarios europeos.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_134",
+      "question": "¿Qué patriota lideró la unificación de Italia con sus 'Camisas Rojas'?",
+      "answers": [
+        {
+          "text": "Giuseppe Garibaldi",
+          "correct": true
+        },
+        {
+          "text": "Camillo Cavour",
+          "correct": false
+        },
+        {
+          "text": "Giuseppe Mazzini",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Garibaldi fue una figura clave del Risorgimento, el proceso que culminó en la unificación de Italia en 1861.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_135",
+      "question": "¿Qué conflicto enfrentó a Estados Unidos con Vietnam del Norte entre los años 50 y 70?",
+      "answers": [
+        {
+          "text": "La Guerra de Vietnam",
+          "correct": true
+        },
+        {
+          "text": "La Guerra de Corea",
+          "correct": false
+        },
+        {
+          "text": "La Guerra del Golfo",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La Guerra de Vietnam terminó en 1975 con la caída de Saigón y la reunificación del país bajo el gobierno comunista.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_136",
+      "question": "¿Qué crisis de 1962 llevó al mundo al borde de una guerra nuclear?",
+      "answers": [
+        {
+          "text": "La crisis de los misiles en Cuba",
+          "correct": true
+        },
+        {
+          "text": "La crisis del canal de Suez",
+          "correct": false
+        },
+        {
+          "text": "El bloqueo de Berlín",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La crisis de los misiles enfrentó a Kennedy y Jrushchov cuando la URSS instaló misiles nucleares en Cuba en 1962.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_137",
+      "question": "¿Qué presidente estadounidense fue asesinado en Dallas en 1963?",
+      "answers": [
+        {
+          "text": "John F. Kennedy",
+          "correct": true
+        },
+        {
+          "text": "Franklin D. Roosevelt",
+          "correct": false
+        },
+        {
+          "text": "Richard Nixon",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "John F. Kennedy fue asesinado el 22 de noviembre de 1963 mientras recorría Dallas en un coche descubierto.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_138",
+      "question": "¿Qué líder estadounidense luchó por los derechos civiles con su discurso 'I have a dream'?",
+      "answers": [
+        {
+          "text": "Martin Luther King",
+          "correct": true
+        },
+        {
+          "text": "Malcolm X",
+          "correct": false
+        },
+        {
+          "text": "Rosa Parks",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Martin Luther King pronunció su famoso discurso en Washington en 1963 y recibió el Premio Nobel de la Paz en 1964.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_139",
+      "question": "¿En qué año se produjeron los atentados contra las Torres Gemelas de Nueva York?",
+      "answers": [
+        {
+          "text": "2001",
+          "correct": true
+        },
+        {
+          "text": "1999",
+          "correct": false
+        },
+        {
+          "text": "2005",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Los atentados del 11 de septiembre de 2001 marcaron un antes y un después en la política internacional del siglo XXI.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_140",
+      "question": "¿Qué moneda única europea entró en circulación física en 2002?",
+      "answers": [
+        {
+          "text": "El euro",
+          "correct": true
+        },
+        {
+          "text": "El ecu",
+          "correct": false
+        },
+        {
+          "text": "El florín",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El euro entró en circulación como billetes y monedas el 1 de enero de 2002 en doce países de la Unión Europea.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_141",
+      "question": "¿Qué imperio precolombino practicaba sacrificios en el Templo Mayor de Tenochtitlan?",
+      "answers": [
+        {
+          "text": "El Imperio azteca",
+          "correct": true
+        },
+        {
+          "text": "El Imperio inca",
+          "correct": false
+        },
+        {
+          "text": "La cultura chavín",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El Templo Mayor era el centro religioso de Tenochtitlan, dedicado a los dioses Huitzilopochtli y Tláloc.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_142",
+      "question": "¿Qué escritura utilizaban los sumerios de Mesopotamia?",
+      "answers": [
+        {
+          "text": "La escritura cuneiforme",
+          "correct": true
+        },
+        {
+          "text": "Los jeroglíficos",
+          "correct": false
+        },
+        {
+          "text": "El alfabeto fenicio",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La escritura cuneiforme, hecha con cuñas sobre tablillas de arcilla, es uno de los sistemas de escritura más antiguos conocidos.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_143",
+      "question": "¿Qué gran anfiteatro romano se usaba para combates de gladiadores?",
+      "answers": [
+        {
+          "text": "El Coliseo",
+          "correct": true
+        },
+        {
+          "text": "El Partenón",
+          "correct": false
+        },
+        {
+          "text": "El Panteón",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El Coliseo de Roma, inaugurado en el año 80, podía albergar a decenas de miles de espectadores.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_144",
+      "question": "¿Qué templo dedicado a la diosa Atenea corona la Acrópolis de Atenas?",
+      "answers": [
+        {
+          "text": "El Partenón",
+          "correct": true
+        },
+        {
+          "text": "El Coliseo",
+          "correct": false
+        },
+        {
+          "text": "El Ágora",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El Partenón se construyó en el siglo V a. C. durante la época de Pericles, apogeo de la Atenas clásica.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_145",
+      "question": "¿Qué antigua ruta comercial conectaba China con Europa a través de Asia?",
+      "answers": [
+        {
+          "text": "La Ruta de la Seda",
+          "correct": true
+        },
+        {
+          "text": "La Ruta de las Especias",
+          "correct": false
+        },
+        {
+          "text": "El Camino Real",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Por la Ruta de la Seda circularon durante siglos mercancías, ideas y religiones entre Oriente y Occidente.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_146",
+      "question": "¿Qué explorador italiano relató sus viajes por Asia y la corte de Kublai Kan?",
+      "answers": [
+        {
+          "text": "Marco Polo",
+          "correct": true
+        },
+        {
+          "text": "Américo Vespucio",
+          "correct": false
+        },
+        {
+          "text": "Juan Caboto",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Marco Polo viajó a China en el siglo XIII y su libro de viajes despertó en Europa gran interés por Oriente.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_147",
+      "question": "¿De qué navegante deriva el nombre del continente americano?",
+      "answers": [
+        {
+          "text": "Américo Vespucio",
+          "correct": true
+        },
+        {
+          "text": "Cristóbal Colón",
+          "correct": false
+        },
+        {
+          "text": "Fernando de Magallanes",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El nombre 'América' proviene de Américo Vespucio, quien comprendió que las nuevas tierras eran un continente desconocido.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_148",
+      "question": "¿Qué acontecimiento de 1929 marcó el inicio de la Gran Depresión?",
+      "answers": [
+        {
+          "text": "El crac de la Bolsa de Nueva York",
+          "correct": true
+        },
+        {
+          "text": "La caída del Muro de Berlín",
+          "correct": false
+        },
+        {
+          "text": "El estallido de la Segunda Guerra Mundial",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El desplome bursátil del 'jueves negro' de octubre de 1929 arrastró a la economía mundial a una profunda crisis.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_149",
+      "question": "¿Qué canal marítimo inauguró Panamá en 1914 para unir dos océanos?",
+      "answers": [
+        {
+          "text": "El Canal de Panamá",
+          "correct": true
+        },
+        {
+          "text": "El Canal de Suez",
+          "correct": false
+        },
+        {
+          "text": "El Canal de Corinto",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El Canal de Panamá conecta el océano Atlántico con el Pacífico y revolucionó el comercio marítimo mundial.",
+      "category": "Historia"
+    },
+    {
+      "id": "his_es_150",
+      "question": "¿Qué canal egipcio, inaugurado en 1869, une el Mediterráneo con el mar Rojo?",
+      "answers": [
+        {
+          "text": "El Canal de Suez",
+          "correct": true
+        },
+        {
+          "text": "El Canal de Panamá",
+          "correct": false
+        },
+        {
+          "text": "El Canal de la Mancha",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El Canal de Suez acortó enormemente la ruta marítima entre Europa y Asia al evitar rodear todo el continente africano.",
+      "category": "Historia"
+    }
+  ]
+}

--- a/custom_components/quizify/questions/naturaleza-es.json
+++ b/custom_components/quizify/questions/naturaleza-es.json
@@ -1917,18 +1917,18 @@
     },
     {
       "id": "nat_es_092",
-      "question": "¿Qué animal es el único que no puede saltar?",
+      "question": "¿Cuál de estos animales no puede saltar?",
       "answers": [
         {
           "text": "El elefante",
           "correct": true
         },
         {
-          "text": "El hipopótamo",
+          "text": "El canguro",
           "correct": false
         },
         {
-          "text": "El rinoceronte",
+          "text": "La rana",
           "correct": false
         }
       ],
@@ -2610,7 +2610,7 @@
     },
     {
       "id": "nat_es_125",
-      "question": "¿Qué animal posee el genoma con más pares de bases conocido, muy superior al humano?",
+      "question": "¿Cuál de estos animales tiene un genoma mucho más grande que el del ser humano?",
       "answers": [
         {
           "text": "El ajolote",

--- a/custom_components/quizify/questions/naturaleza-es.json
+++ b/custom_components/quizify/questions/naturaleza-es.json
@@ -1,0 +1,3158 @@
+{
+  "name": "Naturaleza",
+  "language": "es",
+  "version": "1.0",
+  "theme": "nature",
+  "questions": [
+    {
+      "id": "nat_es_001",
+      "question": "¿Cuál es el animal terrestre más grande del mundo?",
+      "answers": [
+        {
+          "text": "El elefante africano",
+          "correct": true
+        },
+        {
+          "text": "La jirafa",
+          "correct": false
+        },
+        {
+          "text": "El rinoceronte blanco",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Un elefante africano adulto puede pesar más de 6 toneladas.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_002",
+      "question": "¿Qué animal es conocido como el 'rey de la selva'?",
+      "answers": [
+        {
+          "text": "El tigre",
+          "correct": false
+        },
+        {
+          "text": "El león",
+          "correct": true
+        },
+        {
+          "text": "El leopardo",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "En realidad los leones viven en sabanas y praderas, no en selvas.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_003",
+      "question": "¿Cuántas patas tiene una araña?",
+      "answers": [
+        {
+          "text": "Seis",
+          "correct": false
+        },
+        {
+          "text": "Ocho",
+          "correct": true
+        },
+        {
+          "text": "Diez",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Las arañas son arácnidos, no insectos; los insectos tienen seis patas.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_004",
+      "question": "¿Qué gas absorben las plantas del aire durante la fotosíntesis?",
+      "answers": [
+        {
+          "text": "Oxígeno",
+          "correct": false
+        },
+        {
+          "text": "Nitrógeno",
+          "correct": false
+        },
+        {
+          "text": "Dióxido de carbono",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Las plantas liberan oxígeno como subproducto de la fotosíntesis.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_005",
+      "question": "¿Cuál es el ave más grande del mundo?",
+      "answers": [
+        {
+          "text": "El avestruz",
+          "correct": true
+        },
+        {
+          "text": "El águila real",
+          "correct": false
+        },
+        {
+          "text": "El cóndor andino",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El avestruz no puede volar, pero corre a más de 70 km/h.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_006",
+      "question": "¿Qué animal marino es un mamífero?",
+      "answers": [
+        {
+          "text": "El tiburón",
+          "correct": false
+        },
+        {
+          "text": "La ballena",
+          "correct": true
+        },
+        {
+          "text": "El atún",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Las ballenas respiran aire por pulmones y amamantan a sus crías.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_007",
+      "question": "¿De qué color es la clorofila que da su color a las hojas?",
+      "answers": [
+        {
+          "text": "Roja",
+          "correct": false
+        },
+        {
+          "text": "Verde",
+          "correct": true
+        },
+        {
+          "text": "Azul",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La clorofila absorbe la luz roja y azul y refleja la verde.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_008",
+      "question": "¿Qué insecto produce miel?",
+      "answers": [
+        {
+          "text": "La avispa",
+          "correct": false
+        },
+        {
+          "text": "La hormiga",
+          "correct": false
+        },
+        {
+          "text": "La abeja",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Una abeja produce apenas una doceava parte de cucharadita de miel en toda su vida.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_009",
+      "question": "¿Cuál es el felino más rápido del mundo?",
+      "answers": [
+        {
+          "text": "El leopardo",
+          "correct": false
+        },
+        {
+          "text": "El guepardo",
+          "correct": true
+        },
+        {
+          "text": "El jaguar",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El guepardo puede alcanzar los 100 km/h en pocos segundos.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_010",
+      "question": "¿Qué animal es famoso por cambiar de color para camuflarse?",
+      "answers": [
+        {
+          "text": "El camaleón",
+          "correct": true
+        },
+        {
+          "text": "La rana",
+          "correct": false
+        },
+        {
+          "text": "La serpiente",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Los camaleones también cambian de color para comunicarse y regular su temperatura.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_011",
+      "question": "¿Cuál es el planeta en el que vivimos?",
+      "answers": [
+        {
+          "text": "Marte",
+          "correct": false
+        },
+        {
+          "text": "La Tierra",
+          "correct": true
+        },
+        {
+          "text": "Venus",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La Tierra es el único planeta conocido con vida.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_012",
+      "question": "¿Qué necesitan las plantas, además de agua y aire, para crecer?",
+      "answers": [
+        {
+          "text": "Luz solar",
+          "correct": true
+        },
+        {
+          "text": "Oscuridad total",
+          "correct": false
+        },
+        {
+          "text": "Sal",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La luz solar aporta la energía necesaria para la fotosíntesis.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_013",
+      "question": "¿Qué animal tiene una trompa larga?",
+      "answers": [
+        {
+          "text": "El hipopótamo",
+          "correct": false
+        },
+        {
+          "text": "El elefante",
+          "correct": true
+        },
+        {
+          "text": "El búfalo",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La trompa de un elefante tiene unos 40.000 músculos.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_014",
+      "question": "¿Cuál de estos animales es un anfibio?",
+      "answers": [
+        {
+          "text": "La rana",
+          "correct": true
+        },
+        {
+          "text": "El lagarto",
+          "correct": false
+        },
+        {
+          "text": "El pez",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Los anfibios viven parte de su vida en el agua y parte en tierra.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_015",
+      "question": "¿Qué árbol produce bellotas?",
+      "answers": [
+        {
+          "text": "El pino",
+          "correct": false
+        },
+        {
+          "text": "El roble",
+          "correct": true
+        },
+        {
+          "text": "El abedul",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Un solo roble puede producir miles de bellotas al año.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_016",
+      "question": "¿Qué animal es el mejor amigo del hombre?",
+      "answers": [
+        {
+          "text": "El gato",
+          "correct": false
+        },
+        {
+          "text": "El perro",
+          "correct": true
+        },
+        {
+          "text": "El caballo",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El perro fue el primer animal domesticado por el ser humano.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_017",
+      "question": "¿Cuántas alas tiene una mariposa?",
+      "answers": [
+        {
+          "text": "Dos",
+          "correct": false
+        },
+        {
+          "text": "Cuatro",
+          "correct": true
+        },
+        {
+          "text": "Seis",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Las mariposas tienen cuatro alas cubiertas de diminutas escamas.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_018",
+      "question": "¿Qué comen principalmente los pandas gigantes?",
+      "answers": [
+        {
+          "text": "Carne",
+          "correct": false
+        },
+        {
+          "text": "Bambú",
+          "correct": true
+        },
+        {
+          "text": "Pescado",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Un panda gigante puede comer hasta 38 kg de bambú al día.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_019",
+      "question": "¿Qué fenómeno se produce cuando el agua cae del cielo en forma líquida?",
+      "answers": [
+        {
+          "text": "Nieve",
+          "correct": false
+        },
+        {
+          "text": "Lluvia",
+          "correct": true
+        },
+        {
+          "text": "Granizo",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La lluvia forma parte del ciclo del agua en la naturaleza.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_020",
+      "question": "¿Cuál es el animal más alto del mundo?",
+      "answers": [
+        {
+          "text": "El elefante",
+          "correct": false
+        },
+        {
+          "text": "La jirafa",
+          "correct": true
+        },
+        {
+          "text": "El camello",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La jirafa puede medir hasta 5,5 metros de altura.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_021",
+      "question": "¿Qué le sale a los árboles en otoño en muchos climas templados?",
+      "answers": [
+        {
+          "text": "Se les caen las hojas",
+          "correct": true
+        },
+        {
+          "text": "Les crecen raíces nuevas",
+          "correct": false
+        },
+        {
+          "text": "Cambian de tronco",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Los árboles de hoja caduca pierden las hojas para ahorrar agua en invierno.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_022",
+      "question": "¿Qué animal pone huevos y también da leche a sus crías?",
+      "answers": [
+        {
+          "text": "El ornitorrinco",
+          "correct": true
+        },
+        {
+          "text": "El delfín",
+          "correct": false
+        },
+        {
+          "text": "El koala",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El ornitorrinco es uno de los pocos mamíferos que pone huevos.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_023",
+      "question": "¿Cuál de estos es un reptil?",
+      "answers": [
+        {
+          "text": "La tortuga",
+          "correct": true
+        },
+        {
+          "text": "El salmón",
+          "correct": false
+        },
+        {
+          "text": "El murciélago",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Las tortugas existen desde hace más de 200 millones de años.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_024",
+      "question": "¿Qué órgano bombea la sangre en el cuerpo humano?",
+      "answers": [
+        {
+          "text": "El hígado",
+          "correct": false
+        },
+        {
+          "text": "El corazón",
+          "correct": true
+        },
+        {
+          "text": "El pulmón",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El corazón late unas 100.000 veces al día.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_025",
+      "question": "¿De qué se alimentan las vacas?",
+      "answers": [
+        {
+          "text": "Carne",
+          "correct": false
+        },
+        {
+          "text": "Hierba",
+          "correct": true
+        },
+        {
+          "text": "Insectos",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Las vacas tienen un estómago con cuatro compartimentos para digerir la hierba.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_026",
+      "question": "¿Qué animal es conocido por su larga hibernación en invierno?",
+      "answers": [
+        {
+          "text": "El oso",
+          "correct": true
+        },
+        {
+          "text": "El lobo",
+          "correct": false
+        },
+        {
+          "text": "El zorro",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Durante la hibernación, el ritmo cardíaco del oso baja mucho para ahorrar energía.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_027",
+      "question": "¿Qué parte de la planta absorbe el agua del suelo?",
+      "answers": [
+        {
+          "text": "Las flores",
+          "correct": false
+        },
+        {
+          "text": "Las hojas",
+          "correct": false
+        },
+        {
+          "text": "Las raíces",
+          "correct": true
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Las raíces también anclan la planta al suelo.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_028",
+      "question": "¿Cuál es el animal marino con ocho brazos?",
+      "answers": [
+        {
+          "text": "El calamar",
+          "correct": false
+        },
+        {
+          "text": "El pulpo",
+          "correct": true
+        },
+        {
+          "text": "La medusa",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El pulpo tiene tres corazones y sangre azul.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_029",
+      "question": "¿Qué insecto es famoso por vivir en colonias muy organizadas y cargar objetos pesados?",
+      "answers": [
+        {
+          "text": "La mosca",
+          "correct": false
+        },
+        {
+          "text": "La hormiga",
+          "correct": true
+        },
+        {
+          "text": "El mosquito",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Una hormiga puede cargar hasta 50 veces su propio peso.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_030",
+      "question": "¿Qué tipo de animal es el tiburón?",
+      "answers": [
+        {
+          "text": "Un mamífero",
+          "correct": false
+        },
+        {
+          "text": "Un pez",
+          "correct": true
+        },
+        {
+          "text": "Un anfibio",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El esqueleto de los tiburones está hecho de cartílago, no de hueso.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_031",
+      "question": "¿Qué estación del año viene después del invierno?",
+      "answers": [
+        {
+          "text": "El verano",
+          "correct": false
+        },
+        {
+          "text": "La primavera",
+          "correct": true
+        },
+        {
+          "text": "El otoño",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "En primavera muchas plantas florecen y los animales tienen crías.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_032",
+      "question": "¿Cuál es el mamífero más grande del planeta?",
+      "answers": [
+        {
+          "text": "El elefante africano",
+          "correct": false
+        },
+        {
+          "text": "La ballena azul",
+          "correct": true
+        },
+        {
+          "text": "El cachalote",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La ballena azul puede medir más de 30 metros y pesar unas 150 toneladas.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_033",
+      "question": "¿Qué animal nocturno puede girar la cabeza casi por completo?",
+      "answers": [
+        {
+          "text": "El búho",
+          "correct": true
+        },
+        {
+          "text": "El águila",
+          "correct": false
+        },
+        {
+          "text": "El loro",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Los búhos pueden girar la cabeza hasta unos 270 grados.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_034",
+      "question": "¿Qué produce un árbol para respirar y limpiar el aire?",
+      "answers": [
+        {
+          "text": "Dióxido de carbono",
+          "correct": false
+        },
+        {
+          "text": "Oxígeno",
+          "correct": true
+        },
+        {
+          "text": "Humo",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Un árbol adulto puede liberar oxígeno suficiente para varias personas al año.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_035",
+      "question": "¿Qué animal tiene rayas negras y blancas?",
+      "answers": [
+        {
+          "text": "El leopardo",
+          "correct": false
+        },
+        {
+          "text": "La cebra",
+          "correct": true
+        },
+        {
+          "text": "El puma",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El patrón de rayas de cada cebra es único, como una huella dactilar.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_036",
+      "question": "¿En qué lugar viven los peces?",
+      "answers": [
+        {
+          "text": "En el agua",
+          "correct": true
+        },
+        {
+          "text": "En los árboles",
+          "correct": false
+        },
+        {
+          "text": "Bajo tierra",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Los peces obtienen oxígeno del agua a través de sus branquias.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_037",
+      "question": "¿Qué animal es conocido por su caparazón duro donde se esconde?",
+      "answers": [
+        {
+          "text": "La tortuga",
+          "correct": true
+        },
+        {
+          "text": "El conejo",
+          "correct": false
+        },
+        {
+          "text": "El erizo",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El caparazón de la tortuga forma parte de su esqueleto.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_038",
+      "question": "¿Qué se forma en el cielo tras la lluvia cuando sale el sol?",
+      "answers": [
+        {
+          "text": "Un arcoíris",
+          "correct": true
+        },
+        {
+          "text": "Un eclipse",
+          "correct": false
+        },
+        {
+          "text": "Una aurora",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El arcoíris se forma cuando la luz se refracta en las gotas de agua.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_039",
+      "question": "¿Cuál de estos animales vuela?",
+      "answers": [
+        {
+          "text": "El pingüino",
+          "correct": false
+        },
+        {
+          "text": "El murciélago",
+          "correct": true
+        },
+        {
+          "text": "El avestruz",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El murciélago es el único mamífero capaz de volar de verdad.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_040",
+      "question": "¿Qué animal es famoso por su cuello largo para comer hojas de los árboles altos?",
+      "answers": [
+        {
+          "text": "La jirafa",
+          "correct": true
+        },
+        {
+          "text": "El caballo",
+          "correct": false
+        },
+        {
+          "text": "El camello",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La lengua de la jirafa puede medir hasta 50 centímetros.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_041",
+      "question": "¿Qué comen las mariposas adultas principalmente?",
+      "answers": [
+        {
+          "text": "Néctar de las flores",
+          "correct": true
+        },
+        {
+          "text": "Hojas",
+          "correct": false
+        },
+        {
+          "text": "Otros insectos",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Las mariposas saborean con las patas antes de posarse a comer.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_042",
+      "question": "¿Cuál es el color del cielo despejado durante el día?",
+      "answers": [
+        {
+          "text": "Verde",
+          "correct": false
+        },
+        {
+          "text": "Azul",
+          "correct": true
+        },
+        {
+          "text": "Rojo",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El cielo se ve azul porque la atmósfera dispersa más la luz azul del Sol.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_043",
+      "question": "¿Qué animal salta y guarda a sus crías en una bolsa?",
+      "answers": [
+        {
+          "text": "El koala",
+          "correct": false
+        },
+        {
+          "text": "El canguro",
+          "correct": true
+        },
+        {
+          "text": "El mono",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Una cría de canguro recién nacida es del tamaño de una uva.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_044",
+      "question": "¿Qué necesitamos los seres humanos para respirar?",
+      "answers": [
+        {
+          "text": "Oxígeno",
+          "correct": true
+        },
+        {
+          "text": "Helio",
+          "correct": false
+        },
+        {
+          "text": "Dióxido de carbono",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El oxígeno que respiramos proviene en gran parte de las plantas y las algas.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_045",
+      "question": "¿Cuál de estos es un mamífero que vive en el mar y es muy inteligente?",
+      "answers": [
+        {
+          "text": "El delfín",
+          "correct": true
+        },
+        {
+          "text": "El pulpo",
+          "correct": false
+        },
+        {
+          "text": "La sardina",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Los delfines duermen con la mitad del cerebro despierta para seguir respirando.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_046",
+      "question": "¿Qué animal construye presas en los ríos con ramas y troncos?",
+      "answers": [
+        {
+          "text": "La nutria",
+          "correct": false
+        },
+        {
+          "text": "El castor",
+          "correct": true
+        },
+        {
+          "text": "La rata",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Las presas de los castores crean estanques que benefician a otros animales.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_047",
+      "question": "¿Qué le pasa al agua cuando se congela?",
+      "answers": [
+        {
+          "text": "Se convierte en hielo",
+          "correct": true
+        },
+        {
+          "text": "Se convierte en vapor",
+          "correct": false
+        },
+        {
+          "text": "Desaparece",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El agua se congela a 0 grados Celsius a nivel del mar.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_048",
+      "question": "¿Qué animal es conocido por su melena y su fuerte rugido?",
+      "answers": [
+        {
+          "text": "El león",
+          "correct": true
+        },
+        {
+          "text": "El tigre",
+          "correct": false
+        },
+        {
+          "text": "La pantera",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El rugido de un león puede oírse hasta a 8 kilómetros de distancia.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_049",
+      "question": "¿Cuál es el órgano más grande del cuerpo humano?",
+      "answers": [
+        {
+          "text": "El hígado",
+          "correct": false
+        },
+        {
+          "text": "La piel",
+          "correct": true
+        },
+        {
+          "text": "El intestino",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La piel de un adulto puede pesar alrededor de 4 kilogramos.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_050",
+      "question": "¿Qué proceso permite a las plantas convertir la luz en energía química?",
+      "answers": [
+        {
+          "text": "La respiración",
+          "correct": false
+        },
+        {
+          "text": "La fotosíntesis",
+          "correct": true
+        },
+        {
+          "text": "La transpiración",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La fotosíntesis produce glucosa, que la planta usa como alimento.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_051",
+      "question": "¿Cuál es el hueso más largo del cuerpo humano?",
+      "answers": [
+        {
+          "text": "El fémur",
+          "correct": true
+        },
+        {
+          "text": "El húmero",
+          "correct": false
+        },
+        {
+          "text": "La tibia",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El fémur, en el muslo, puede soportar hasta 30 veces el peso del cuerpo.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_052",
+      "question": "¿Qué animal tiene el corazón más grande de todo el reino animal?",
+      "answers": [
+        {
+          "text": "El elefante",
+          "correct": false
+        },
+        {
+          "text": "La ballena azul",
+          "correct": true
+        },
+        {
+          "text": "La jirafa",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El corazón de la ballena azul puede pesar unos 180 kilogramos.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_053",
+      "question": "¿Cómo se llama el fenómeno por el que algunos animales pasan el invierno en un letargo profundo?",
+      "answers": [
+        {
+          "text": "Migración",
+          "correct": false
+        },
+        {
+          "text": "Hibernación",
+          "correct": true
+        },
+        {
+          "text": "Muda",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Durante la hibernación el metabolismo del animal se reduce drásticamente.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_054",
+      "question": "¿Qué tipo de raíz es la de la zanahoria?",
+      "answers": [
+        {
+          "text": "Fasciculada",
+          "correct": false
+        },
+        {
+          "text": "Napiforme",
+          "correct": true
+        },
+        {
+          "text": "Aérea",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La raíz napiforme almacena nutrientes de reserva para la planta.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_055",
+      "question": "¿Cuál es el pájaro que vuela hacia atrás?",
+      "answers": [
+        {
+          "text": "El gorrión",
+          "correct": false
+        },
+        {
+          "text": "El colibrí",
+          "correct": true
+        },
+        {
+          "text": "La golondrina",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El colibrí puede batir sus alas más de 50 veces por segundo.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_056",
+      "question": "¿Qué gas es el más abundante en la atmósfera terrestre?",
+      "answers": [
+        {
+          "text": "Oxígeno",
+          "correct": false
+        },
+        {
+          "text": "Nitrógeno",
+          "correct": true
+        },
+        {
+          "text": "Argón",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El nitrógeno constituye cerca del 78 % del aire que respiramos.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_057",
+      "question": "¿Cómo se llama el conjunto de seres vivos que interactúan en un mismo lugar junto con su entorno?",
+      "answers": [
+        {
+          "text": "Ecosistema",
+          "correct": true
+        },
+        {
+          "text": "Biosfera",
+          "correct": false
+        },
+        {
+          "text": "Población",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Un ecosistema incluye tanto factores vivos como el clima y el suelo.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_058",
+      "question": "¿Qué animal es el que muda su piel de una sola pieza?",
+      "answers": [
+        {
+          "text": "La serpiente",
+          "correct": true
+        },
+        {
+          "text": "El lagarto",
+          "correct": false
+        },
+        {
+          "text": "La tortuga",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Al mudar, la serpiente incluso renueva la piel transparente de sus ojos.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_059",
+      "question": "¿Cuántas cámaras tiene el corazón humano?",
+      "answers": [
+        {
+          "text": "Dos",
+          "correct": false
+        },
+        {
+          "text": "Cuatro",
+          "correct": true
+        },
+        {
+          "text": "Tres",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El corazón humano tiene dos aurículas y dos ventrículos.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_060",
+      "question": "¿Qué insecto experimenta una metamorfosis completa: huevo, larva, pupa y adulto?",
+      "answers": [
+        {
+          "text": "El saltamontes",
+          "correct": false
+        },
+        {
+          "text": "La mariposa",
+          "correct": true
+        },
+        {
+          "text": "La libélula",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La fase de pupa de la mariposa se llama crisálida.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_061",
+      "question": "¿Qué animal es el mamífero terrestre más rápido?",
+      "answers": [
+        {
+          "text": "El antílope",
+          "correct": false
+        },
+        {
+          "text": "El guepardo",
+          "correct": true
+        },
+        {
+          "text": "El caballo",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El guepardo solo puede mantener su velocidad máxima durante unos segundos.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_062",
+      "question": "¿Qué parte de la flor produce el polen?",
+      "answers": [
+        {
+          "text": "El pistilo",
+          "correct": false
+        },
+        {
+          "text": "El estambre",
+          "correct": true
+        },
+        {
+          "text": "El pétalo",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El estambre es la parte masculina de la flor.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_063",
+      "question": "¿Cómo se llama el desplazamiento estacional de animales de una región a otra?",
+      "answers": [
+        {
+          "text": "Migración",
+          "correct": true
+        },
+        {
+          "text": "Hibernación",
+          "correct": false
+        },
+        {
+          "text": "Depredación",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El charrán ártico realiza una de las migraciones más largas: de polo a polo.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_064",
+      "question": "¿Qué animal es venenoso y tiene ocho patas, con un aguijón en la cola?",
+      "answers": [
+        {
+          "text": "La araña",
+          "correct": false
+        },
+        {
+          "text": "El escorpión",
+          "correct": true
+        },
+        {
+          "text": "El ciempiés",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Algunos escorpiones brillan con luz ultravioleta.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_065",
+      "question": "¿Qué bioma se caracteriza por escasas precipitaciones y temperaturas extremas?",
+      "answers": [
+        {
+          "text": "La tundra",
+          "correct": false
+        },
+        {
+          "text": "El desierto",
+          "correct": true
+        },
+        {
+          "text": "La selva",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Algunos desiertos pueden pasar años sin recibir lluvia.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_066",
+      "question": "¿Cuál de estas aves no puede volar?",
+      "answers": [
+        {
+          "text": "El pingüino",
+          "correct": true
+        },
+        {
+          "text": "El halcón",
+          "correct": false
+        },
+        {
+          "text": "La paloma",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los pingüinos usan sus alas como aletas para nadar.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_067",
+      "question": "¿Qué proceso libera energía en las células a partir del oxígeno y los nutrientes?",
+      "answers": [
+        {
+          "text": "La fotosíntesis",
+          "correct": false
+        },
+        {
+          "text": "La respiración celular",
+          "correct": true
+        },
+        {
+          "text": "La fermentación",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La respiración celular ocurre principalmente en las mitocondrias.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_068",
+      "question": "¿Qué animal marino es capaz de regenerar sus brazos si los pierde?",
+      "answers": [
+        {
+          "text": "La estrella de mar",
+          "correct": true
+        },
+        {
+          "text": "El cangrejo",
+          "correct": false
+        },
+        {
+          "text": "La medusa",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Algunas estrellas de mar pueden regenerar un cuerpo entero a partir de un solo brazo.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_069",
+      "question": "¿Cuál es el árbol más alto del mundo?",
+      "answers": [
+        {
+          "text": "El eucalipto",
+          "correct": false
+        },
+        {
+          "text": "La secuoya roja",
+          "correct": true
+        },
+        {
+          "text": "El baobab",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La secuoya roja de California puede superar los 100 metros de altura.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_070",
+      "question": "¿Qué tipo de animal es la abeja?",
+      "answers": [
+        {
+          "text": "Un arácnido",
+          "correct": false
+        },
+        {
+          "text": "Un insecto",
+          "correct": true
+        },
+        {
+          "text": "Un crustáceo",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Las abejas se comunican con una 'danza' para indicar dónde hay flores.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_071",
+      "question": "¿Qué órgano permite a los peces obtener oxígeno del agua?",
+      "answers": [
+        {
+          "text": "Los pulmones",
+          "correct": false
+        },
+        {
+          "text": "Las branquias",
+          "correct": true
+        },
+        {
+          "text": "La vejiga natatoria",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El agua pasa por las branquias, donde la sangre absorbe el oxígeno.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_072",
+      "question": "¿Qué animal es conocido por producir seda?",
+      "answers": [
+        {
+          "text": "La araña",
+          "correct": true
+        },
+        {
+          "text": "La abeja",
+          "correct": false
+        },
+        {
+          "text": "La hormiga",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El gusano de seda, la larva de una mariposa, también produce seda para su capullo.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_073",
+      "question": "¿Cómo se llama la capa gaseosa que protege la Tierra de los rayos ultravioleta?",
+      "answers": [
+        {
+          "text": "La ionosfera",
+          "correct": false
+        },
+        {
+          "text": "La capa de ozono",
+          "correct": true
+        },
+        {
+          "text": "La troposfera",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La capa de ozono se encuentra en la estratósfera.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_074",
+      "question": "¿Qué mamífero pone huevos además del ornitorrinco?",
+      "answers": [
+        {
+          "text": "El equidna",
+          "correct": true
+        },
+        {
+          "text": "El armadillo",
+          "correct": false
+        },
+        {
+          "text": "El erizo",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El equidna y el ornitorrinco son los únicos mamíferos que ponen huevos, los monotremas.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_075",
+      "question": "¿Qué se mide con la escala de Richter?",
+      "answers": [
+        {
+          "text": "La velocidad del viento",
+          "correct": false
+        },
+        {
+          "text": "La magnitud de los terremotos",
+          "correct": true
+        },
+        {
+          "text": "La cantidad de lluvia",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La escala de Richter es logarítmica: cada punto multiplica la energía liberada.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_076",
+      "question": "¿Qué animal tiene el veneno más letal de todos los del planeta según su toxina?",
+      "answers": [
+        {
+          "text": "La cobra real",
+          "correct": false
+        },
+        {
+          "text": "La rana dardo dorada",
+          "correct": true
+        },
+        {
+          "text": "La viuda negra",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La rana dardo dorada de Colombia contiene suficiente veneno para matar a varias personas.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_077",
+      "question": "¿Qué gas producen los seres vivos al respirar y las plantas absorben?",
+      "answers": [
+        {
+          "text": "Oxígeno",
+          "correct": false
+        },
+        {
+          "text": "Dióxido de carbono",
+          "correct": true
+        },
+        {
+          "text": "Hidrógeno",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Este intercambio de gases mantiene el equilibrio del ciclo del carbono.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_078",
+      "question": "¿Cuál es el felino más grande del mundo?",
+      "answers": [
+        {
+          "text": "El león",
+          "correct": false
+        },
+        {
+          "text": "El tigre",
+          "correct": true
+        },
+        {
+          "text": "El jaguar",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El tigre siberiano puede pesar más de 300 kilogramos.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_079",
+      "question": "¿Qué tipo de nube suele anunciar tormentas y tiene forma de yunque?",
+      "answers": [
+        {
+          "text": "Cirro",
+          "correct": false
+        },
+        {
+          "text": "Cumulonimbo",
+          "correct": true
+        },
+        {
+          "text": "Estrato",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los cumulonimbos pueden alcanzar varios kilómetros de altura.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_080",
+      "question": "¿Qué animal es un marsupial de Australia que se alimenta de hojas de eucalipto?",
+      "answers": [
+        {
+          "text": "El wombat",
+          "correct": false
+        },
+        {
+          "text": "El koala",
+          "correct": true
+        },
+        {
+          "text": "El demonio de Tasmania",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El koala duerme hasta 20 horas al día para digerir el eucalipto.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_081",
+      "question": "¿Cómo se llama la relación en la que dos especies se benefician mutuamente?",
+      "answers": [
+        {
+          "text": "Parasitismo",
+          "correct": false
+        },
+        {
+          "text": "Mutualismo",
+          "correct": true
+        },
+        {
+          "text": "Depredación",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Un ejemplo es el pez payaso y la anémona de mar.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_082",
+      "question": "¿Qué órgano del cuerpo humano se encarga de filtrar la sangre y producir orina?",
+      "answers": [
+        {
+          "text": "El hígado",
+          "correct": false
+        },
+        {
+          "text": "El riñón",
+          "correct": true
+        },
+        {
+          "text": "El páncreas",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los riñones filtran alrededor de 180 litros de sangre al día.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_083",
+      "question": "¿Qué animal es capaz de sobrevivir en el espacio, la radiación y temperaturas extremas?",
+      "answers": [
+        {
+          "text": "La cucaracha",
+          "correct": false
+        },
+        {
+          "text": "El tardígrado",
+          "correct": true
+        },
+        {
+          "text": "El escarabajo",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El tardígrado, u 'oso de agua', mide menos de un milímetro.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_084",
+      "question": "¿Cuál es la unidad básica de la vida?",
+      "answers": [
+        {
+          "text": "El átomo",
+          "correct": false
+        },
+        {
+          "text": "La célula",
+          "correct": true
+        },
+        {
+          "text": "El tejido",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Todos los seres vivos están formados por una o más células.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_085",
+      "question": "¿Qué animal produce el sonido más fuerte del reino animal bajo el agua?",
+      "answers": [
+        {
+          "text": "El delfín",
+          "correct": false
+        },
+        {
+          "text": "La ballena azul",
+          "correct": true
+        },
+        {
+          "text": "La foca",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los cantos de la ballena azul pueden recorrer cientos de kilómetros en el océano.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_086",
+      "question": "¿Qué árbol es famoso por su tronco muy grueso que almacena agua en la sabana africana?",
+      "answers": [
+        {
+          "text": "El baobab",
+          "correct": true
+        },
+        {
+          "text": "La acacia",
+          "correct": false
+        },
+        {
+          "text": "El sauce",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Un baobab puede almacenar miles de litros de agua en su tronco.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_087",
+      "question": "¿Qué animal cambia su pelaje a blanco en invierno para camuflarse en la nieve?",
+      "answers": [
+        {
+          "text": "La liebre ártica",
+          "correct": true
+        },
+        {
+          "text": "El lobo gris",
+          "correct": false
+        },
+        {
+          "text": "El reno",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Este cambio de color estacional ayuda a la liebre a esconderse de los depredadores.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_088",
+      "question": "¿Qué fenómeno atmosférico produce los relámpagos?",
+      "answers": [
+        {
+          "text": "La condensación",
+          "correct": false
+        },
+        {
+          "text": "La descarga eléctrica",
+          "correct": true
+        },
+        {
+          "text": "La evaporación",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Un rayo puede alcanzar temperaturas cinco veces más altas que la superficie del Sol.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_089",
+      "question": "¿Qué grupo de animales tiene sangre fría y su temperatura depende del ambiente?",
+      "answers": [
+        {
+          "text": "Los mamíferos",
+          "correct": false
+        },
+        {
+          "text": "Los reptiles",
+          "correct": true
+        },
+        {
+          "text": "Las aves",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Por eso muchos reptiles toman el sol para calentarse.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_090",
+      "question": "¿Cuál es el ave que realiza la migración más larga del planeta?",
+      "answers": [
+        {
+          "text": "La cigüeña",
+          "correct": false
+        },
+        {
+          "text": "El charrán ártico",
+          "correct": true
+        },
+        {
+          "text": "El águila",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El charrán ártico viaja del Ártico a la Antártida y de vuelta cada año.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_091",
+      "question": "¿Qué parte de la planta es la encargada de la reproducción?",
+      "answers": [
+        {
+          "text": "La flor",
+          "correct": true
+        },
+        {
+          "text": "El tallo",
+          "correct": false
+        },
+        {
+          "text": "La raíz",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Tras la polinización, la flor da lugar al fruto y las semillas.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_092",
+      "question": "¿Qué animal es el único que no puede saltar?",
+      "answers": [
+        {
+          "text": "El elefante",
+          "correct": true
+        },
+        {
+          "text": "El hipopótamo",
+          "correct": false
+        },
+        {
+          "text": "El rinoceronte",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Debido a su peso y a la estructura de sus patas, el elefante nunca despega del suelo.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_093",
+      "question": "¿Qué tipo de dieta tiene un animal carnívoro?",
+      "answers": [
+        {
+          "text": "Se alimenta de plantas",
+          "correct": false
+        },
+        {
+          "text": "Se alimenta de otros animales",
+          "correct": true
+        },
+        {
+          "text": "Se alimenta de todo",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los carnívoros suelen tener dientes afilados para desgarrar la carne.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_094",
+      "question": "¿Cuál es el mamífero más pequeño del mundo?",
+      "answers": [
+        {
+          "text": "El musgaño enano",
+          "correct": true
+        },
+        {
+          "text": "El ratón común",
+          "correct": false
+        },
+        {
+          "text": "El topo",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El musgaño etrusco pesa menos de 2 gramos.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_095",
+      "question": "¿Qué animal marino tiene la mayor cantidad de dientes en filas que se reemplazan?",
+      "answers": [
+        {
+          "text": "El tiburón",
+          "correct": true
+        },
+        {
+          "text": "La orca",
+          "correct": false
+        },
+        {
+          "text": "El pez espada",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Un tiburón puede perder y reemplazar miles de dientes a lo largo de su vida.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_096",
+      "question": "¿Qué tipo de árbol conserva sus hojas verdes durante todo el año?",
+      "answers": [
+        {
+          "text": "Caduco",
+          "correct": false
+        },
+        {
+          "text": "Perenne",
+          "correct": true
+        },
+        {
+          "text": "Frutal",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los pinos y abetos son ejemplos de árboles de hoja perenne.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_097",
+      "question": "¿Qué animal es conocido por regenerar extremidades completas, incluso partes del corazón?",
+      "answers": [
+        {
+          "text": "La salamandra",
+          "correct": false
+        },
+        {
+          "text": "El ajolote",
+          "correct": true
+        },
+        {
+          "text": "El geco",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El ajolote mexicano puede regenerar patas, cola y hasta partes del cerebro.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_098",
+      "question": "¿Cómo se llama el proceso por el que el agua líquida pasa a estado gaseoso?",
+      "answers": [
+        {
+          "text": "Condensación",
+          "correct": false
+        },
+        {
+          "text": "Evaporación",
+          "correct": true
+        },
+        {
+          "text": "Sublimación",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La evaporación es un paso clave en el ciclo del agua.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_099",
+      "question": "¿Qué órgano controla todo el sistema nervioso del cuerpo humano?",
+      "answers": [
+        {
+          "text": "El corazón",
+          "correct": false
+        },
+        {
+          "text": "El cerebro",
+          "correct": true
+        },
+        {
+          "text": "El hígado",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El cerebro humano tiene unos 86.000 millones de neuronas.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_100",
+      "question": "¿Qué animal utiliza la ecolocalización para orientarse en la oscuridad?",
+      "answers": [
+        {
+          "text": "El murciélago",
+          "correct": true
+        },
+        {
+          "text": "El búho",
+          "correct": false
+        },
+        {
+          "text": "El gato",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El murciélago emite sonidos y escucha su eco para 'ver' en la oscuridad.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_101",
+      "question": "¿Qué tipo de organismo es un hongo, como el champiñón?",
+      "answers": [
+        {
+          "text": "Una planta",
+          "correct": false
+        },
+        {
+          "text": "Ni planta ni animal, un reino aparte",
+          "correct": true
+        },
+        {
+          "text": "Un animal",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los hongos forman su propio reino y muchos se alimentan de materia en descomposición.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_102",
+      "question": "¿Qué provoca las mareas en los océanos?",
+      "answers": [
+        {
+          "text": "El viento",
+          "correct": false
+        },
+        {
+          "text": "La gravedad de la Luna",
+          "correct": true
+        },
+        {
+          "text": "La rotación de las nubes",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El Sol también influye en las mareas, aunque menos que la Luna.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_103",
+      "question": "¿Qué animal terrestre tiene la mordida más potente?",
+      "answers": [
+        {
+          "text": "El león",
+          "correct": false
+        },
+        {
+          "text": "El cocodrilo",
+          "correct": true
+        },
+        {
+          "text": "El tiburón",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La mordida del cocodrilo marino es una de las más fuertes jamás medidas.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_104",
+      "question": "¿Qué insecto es fundamental para la polinización de muchos cultivos?",
+      "answers": [
+        {
+          "text": "La mosca",
+          "correct": false
+        },
+        {
+          "text": "La abeja",
+          "correct": true
+        },
+        {
+          "text": "La cucaracha",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Cerca de un tercio de los alimentos que consumimos dependen de la polinización.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_105",
+      "question": "¿Cómo se llama la sustancia roja de la sangre que transporta oxígeno?",
+      "answers": [
+        {
+          "text": "La hemoglobina",
+          "correct": true
+        },
+        {
+          "text": "El plasma",
+          "correct": false
+        },
+        {
+          "text": "La insulina",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La hemoglobina contiene hierro, que le da su color rojo.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_106",
+      "question": "¿Qué animal marino es en realidad una colonia de organismos que forma arrecifes?",
+      "answers": [
+        {
+          "text": "El coral",
+          "correct": true
+        },
+        {
+          "text": "La esponja",
+          "correct": false
+        },
+        {
+          "text": "La almeja",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los arrecifes de coral albergan una cuarta parte de la vida marina.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_107",
+      "question": "¿Qué elemento químico es esencial en la molécula de clorofila de las plantas?",
+      "answers": [
+        {
+          "text": "El hierro",
+          "correct": false
+        },
+        {
+          "text": "El magnesio",
+          "correct": true
+        },
+        {
+          "text": "El calcio",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El magnesio ocupa el centro de la molécula de clorofila.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_108",
+      "question": "¿Qué fenómeno da lugar a las auroras boreales?",
+      "answers": [
+        {
+          "text": "La lluvia de meteoros",
+          "correct": false
+        },
+        {
+          "text": "Las partículas solares chocando con la atmósfera",
+          "correct": true
+        },
+        {
+          "text": "Los rayos de las tormentas",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El campo magnético de la Tierra guía las partículas hacia los polos.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_109",
+      "question": "¿Qué animal es el reptil vivo más grande del mundo?",
+      "answers": [
+        {
+          "text": "La anaconda",
+          "correct": false
+        },
+        {
+          "text": "El cocodrilo marino",
+          "correct": true
+        },
+        {
+          "text": "El dragón de Komodo",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El cocodrilo marino puede superar los 6 metros de longitud.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_110",
+      "question": "¿Qué tipo de suelo es más adecuado para retener agua para las plantas?",
+      "answers": [
+        {
+          "text": "Arenoso",
+          "correct": false
+        },
+        {
+          "text": "Arcilloso",
+          "correct": true
+        },
+        {
+          "text": "Rocoso",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El suelo arcilloso retiene el agua, aunque puede compactarse fácilmente.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_111",
+      "question": "¿Cuál es el animal más venenoso del mar?",
+      "answers": [
+        {
+          "text": "El pulpo de anillos azules",
+          "correct": false
+        },
+        {
+          "text": "La avispa de mar (medusa)",
+          "correct": true
+        },
+        {
+          "text": "La raya",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La avispa de mar es una de las medusas más mortales que existen.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_112",
+      "question": "¿Qué órgano almacena la bilis producida por el hígado?",
+      "answers": [
+        {
+          "text": "El bazo",
+          "correct": false
+        },
+        {
+          "text": "La vesícula biliar",
+          "correct": true
+        },
+        {
+          "text": "El apéndice",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La bilis ayuda a digerir las grasas de los alimentos.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_113",
+      "question": "¿Qué tipo de animal es el caracol?",
+      "answers": [
+        {
+          "text": "Un insecto",
+          "correct": false
+        },
+        {
+          "text": "Un molusco",
+          "correct": true
+        },
+        {
+          "text": "Un crustáceo",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El caracol se desplaza sobre una capa de baba que reduce el rozamiento.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_114",
+      "question": "¿Qué proceso natural convierte la roca en suelo con el paso del tiempo?",
+      "answers": [
+        {
+          "text": "La erosión y meteorización",
+          "correct": true
+        },
+        {
+          "text": "La condensación",
+          "correct": false
+        },
+        {
+          "text": "La fotosíntesis",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La meteorización puede tardar miles de años en formar suelo fértil.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_115",
+      "question": "¿Qué estructura celular contiene el ADN en las células eucariotas?",
+      "answers": [
+        {
+          "text": "El ribosoma",
+          "correct": false
+        },
+        {
+          "text": "El núcleo",
+          "correct": true
+        },
+        {
+          "text": "La mitocondria",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El núcleo protege el material genético y coordina la actividad celular.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_116",
+      "question": "¿Cómo se llama el bioma frío y sin árboles con suelo permanentemente helado?",
+      "answers": [
+        {
+          "text": "La taiga",
+          "correct": false
+        },
+        {
+          "text": "La tundra",
+          "correct": true
+        },
+        {
+          "text": "La estepa",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El suelo helado de la tundra se conoce como permafrost.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_117",
+      "question": "¿Qué científico propuso la teoría de la evolución por selección natural?",
+      "answers": [
+        {
+          "text": "Gregor Mendel",
+          "correct": false
+        },
+        {
+          "text": "Charles Darwin",
+          "correct": true
+        },
+        {
+          "text": "Louis Pasteur",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Darwin publicó sus ideas en 'El origen de las especies' en 1859.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_118",
+      "question": "¿Cómo se denomina el pigmento que da color rojo o amarillo a muchas hojas en otoño?",
+      "answers": [
+        {
+          "text": "La clorofila",
+          "correct": false
+        },
+        {
+          "text": "Los carotenoides",
+          "correct": true
+        },
+        {
+          "text": "La melanina",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Los carotenoides quedan visibles cuando la clorofila se degrada en otoño.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_119",
+      "question": "¿Qué tipo de simbiosis forman los hongos y las algas en un liquen?",
+      "answers": [
+        {
+          "text": "Parasitismo",
+          "correct": false
+        },
+        {
+          "text": "Mutualismo",
+          "correct": true
+        },
+        {
+          "text": "Comensalismo",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El alga aporta alimento por fotosíntesis y el hongo, protección y humedad.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_120",
+      "question": "¿Qué gas de efecto invernadero es liberado principalmente por la ganadería y los humedales?",
+      "answers": [
+        {
+          "text": "Dióxido de carbono",
+          "correct": false
+        },
+        {
+          "text": "Metano",
+          "correct": true
+        },
+        {
+          "text": "Ozono",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El metano atrapa mucho más calor que el CO2, aunque dura menos en la atmósfera.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_121",
+      "question": "¿Cómo se llama el fenómeno por el que una especie imita a otra peligrosa para protegerse?",
+      "answers": [
+        {
+          "text": "Mimetismo batesiano",
+          "correct": true
+        },
+        {
+          "text": "Camuflaje críptico",
+          "correct": false
+        },
+        {
+          "text": "Homeostasis",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Algunas moscas inofensivas imitan los colores de las avispas para ahuyentar depredadores.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_122",
+      "question": "¿Qué parte del cerebro coordina el equilibrio y los movimientos musculares?",
+      "answers": [
+        {
+          "text": "El bulbo raquídeo",
+          "correct": false
+        },
+        {
+          "text": "El cerebelo",
+          "correct": true
+        },
+        {
+          "text": "El hipotálamo",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El cerebelo contiene más de la mitad de todas las neuronas del cerebro.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_123",
+      "question": "¿Cómo se llama el proceso de división celular que produce células sexuales?",
+      "answers": [
+        {
+          "text": "La mitosis",
+          "correct": false
+        },
+        {
+          "text": "La meiosis",
+          "correct": true
+        },
+        {
+          "text": "La gemación",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La meiosis reduce a la mitad el número de cromosomas en gametos.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_124",
+      "question": "¿Qué corriente oceánica influye en el clima cálido del noroeste de Europa?",
+      "answers": [
+        {
+          "text": "La corriente de Humboldt",
+          "correct": false
+        },
+        {
+          "text": "La corriente del Golfo",
+          "correct": true
+        },
+        {
+          "text": "La corriente de California",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La corriente del Golfo transporta agua cálida desde el Caribe hacia el Atlántico Norte.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_125",
+      "question": "¿Qué animal posee el genoma con más pares de bases conocido, muy superior al humano?",
+      "answers": [
+        {
+          "text": "El ajolote",
+          "correct": true
+        },
+        {
+          "text": "El chimpancé",
+          "correct": false
+        },
+        {
+          "text": "El ratón",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El genoma del ajolote es unas diez veces mayor que el humano.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_126",
+      "question": "¿Cómo se llama la teoría que explica el movimiento de los continentes?",
+      "answers": [
+        {
+          "text": "La deriva genética",
+          "correct": false
+        },
+        {
+          "text": "La tectónica de placas",
+          "correct": true
+        },
+        {
+          "text": "La subducción glacial",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Alfred Wegener propuso la idea de la deriva continental a principios del siglo XX.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_127",
+      "question": "¿Qué estructura de la planta regula la entrada de CO2 y la salida de vapor de agua?",
+      "answers": [
+        {
+          "text": "Los estomas",
+          "correct": true
+        },
+        {
+          "text": "El xilema",
+          "correct": false
+        },
+        {
+          "text": "El floema",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Los estomas se abren y cierran según la luz y la humedad disponibles.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_128",
+      "question": "¿Qué organismo fue clave para producir el oxígeno de la atmósfera primitiva?",
+      "answers": [
+        {
+          "text": "Los helechos",
+          "correct": false
+        },
+        {
+          "text": "Las cianobacterias",
+          "correct": true
+        },
+        {
+          "text": "Los musgos",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Las cianobacterias iniciaron la 'Gran Oxidación' hace unos 2.400 millones de años.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_129",
+      "question": "¿Cómo se llama la relación en la que una especie se beneficia y la otra no se ve afectada?",
+      "answers": [
+        {
+          "text": "Mutualismo",
+          "correct": false
+        },
+        {
+          "text": "Comensalismo",
+          "correct": true
+        },
+        {
+          "text": "Depredación",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Las rémoras que viajan pegadas a los tiburones son un ejemplo de comensalismo.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_130",
+      "question": "¿Qué molécula transporta la energía en las células, conocida como 'moneda energética'?",
+      "answers": [
+        {
+          "text": "El ADN",
+          "correct": false
+        },
+        {
+          "text": "El ATP",
+          "correct": true
+        },
+        {
+          "text": "La glucosa",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El ATP libera energía al romperse uno de sus enlaces de fosfato.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_131",
+      "question": "¿Qué extinción masiva acabó con los dinosaurios no aviares hace unos 66 millones de años?",
+      "answers": [
+        {
+          "text": "La extinción del Pérmico",
+          "correct": false
+        },
+        {
+          "text": "La extinción del Cretácico-Paleógeno",
+          "correct": true
+        },
+        {
+          "text": "La extinción del Ordovícico",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Se asocia al impacto de un asteroide en la actual península de Yucatán.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_132",
+      "question": "¿Qué vaso sanguíneo lleva la sangre desde el corazón hacia el resto del cuerpo?",
+      "answers": [
+        {
+          "text": "La vena cava",
+          "correct": false
+        },
+        {
+          "text": "La arteria aorta",
+          "correct": true
+        },
+        {
+          "text": "La vena porta",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La aorta es la arteria más grande del cuerpo humano.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_133",
+      "question": "¿Qué tipo de bioma es la selva amazónica?",
+      "answers": [
+        {
+          "text": "Bosque templado",
+          "correct": false
+        },
+        {
+          "text": "Selva tropical húmeda",
+          "correct": true
+        },
+        {
+          "text": "Sabana",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La selva amazónica alberga cerca del 10 % de las especies conocidas del planeta.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_134",
+      "question": "¿Cómo se llama el pigmento responsable de la fotosíntesis que absorbe la luz roja y azul?",
+      "answers": [
+        {
+          "text": "La antocianina",
+          "correct": false
+        },
+        {
+          "text": "La clorofila",
+          "correct": true
+        },
+        {
+          "text": "La xantofila",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Existen varios tipos de clorofila, siendo la 'a' la más común en plantas.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_135",
+      "question": "¿Qué grupo de animales invertebrados incluye a insectos, arácnidos y crustáceos?",
+      "answers": [
+        {
+          "text": "Los moluscos",
+          "correct": false
+        },
+        {
+          "text": "Los artrópodos",
+          "correct": true
+        },
+        {
+          "text": "Los cnidarios",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Los artrópodos son el grupo animal más numeroso de la Tierra.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_136",
+      "question": "¿Qué proceso realizan ciertas bacterias para convertir el nitrógeno del aire en compuestos aprovechables?",
+      "answers": [
+        {
+          "text": "La fijación de nitrógeno",
+          "correct": true
+        },
+        {
+          "text": "La fotosíntesis",
+          "correct": false
+        },
+        {
+          "text": "La fermentación",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Muchas de estas bacterias viven en las raíces de las leguminosas.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_137",
+      "question": "¿Cómo se llama la capa de la atmósfera donde ocurren la mayoría de los fenómenos meteorológicos?",
+      "answers": [
+        {
+          "text": "La estratósfera",
+          "correct": false
+        },
+        {
+          "text": "La troposfera",
+          "correct": true
+        },
+        {
+          "text": "La mesosfera",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La troposfera es la capa más cercana a la superficie terrestre.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_138",
+      "question": "¿Qué animal presenta bioluminiscencia gracias a bacterias simbióticas en las profundidades marinas?",
+      "answers": [
+        {
+          "text": "El pez linterna",
+          "correct": true
+        },
+        {
+          "text": "El atún",
+          "correct": false
+        },
+        {
+          "text": "La caballa",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "En la oscuridad del fondo marino, la luz sirve para atraer presas o comunicarse.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_139",
+      "question": "¿Qué científico estableció las leyes de la herencia estudiando plantas de guisante?",
+      "answers": [
+        {
+          "text": "Charles Darwin",
+          "correct": false
+        },
+        {
+          "text": "Gregor Mendel",
+          "correct": true
+        },
+        {
+          "text": "Carl Linneo",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Mendel es considerado el padre de la genética moderna.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_140",
+      "question": "¿Cómo se llama el conjunto de todos los ecosistemas de la Tierra donde existe vida?",
+      "answers": [
+        {
+          "text": "La litosfera",
+          "correct": false
+        },
+        {
+          "text": "La biosfera",
+          "correct": true
+        },
+        {
+          "text": "La hidrosfera",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La biosfera abarca desde las profundidades oceánicas hasta la atmósfera baja.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_141",
+      "question": "¿Qué tejido vegetal transporta la savia elaborada con azúcares desde las hojas?",
+      "answers": [
+        {
+          "text": "El xilema",
+          "correct": false
+        },
+        {
+          "text": "El floema",
+          "correct": true
+        },
+        {
+          "text": "La epidermis",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El xilema, en cambio, transporta agua y minerales desde las raíces.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_142",
+      "question": "¿Qué fenómeno climático periódico calienta las aguas del Pacífico y altera el clima global?",
+      "answers": [
+        {
+          "text": "El monzón",
+          "correct": false
+        },
+        {
+          "text": "El Niño",
+          "correct": true
+        },
+        {
+          "text": "El ciclón polar",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El Niño puede provocar sequías e inundaciones en distintas regiones del mundo.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_143",
+      "question": "¿Qué clase de animales fueron los primeros vertebrados en colonizar la tierra firme?",
+      "answers": [
+        {
+          "text": "Los reptiles",
+          "correct": false
+        },
+        {
+          "text": "Los anfibios",
+          "correct": true
+        },
+        {
+          "text": "Las aves",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Los anfibios evolucionaron a partir de peces con aletas lobuladas.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_144",
+      "question": "¿Cómo se denomina el número máximo de individuos que un ecosistema puede mantener?",
+      "answers": [
+        {
+          "text": "Densidad relativa",
+          "correct": false
+        },
+        {
+          "text": "Capacidad de carga",
+          "correct": true
+        },
+        {
+          "text": "Biomasa neta",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Superar la capacidad de carga suele provocar escasez de recursos y caída de la población.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_145",
+      "question": "¿Qué órgano de las aves les ayuda a triturar los alimentos que no pueden masticar?",
+      "answers": [
+        {
+          "text": "El buche",
+          "correct": false
+        },
+        {
+          "text": "La molleja",
+          "correct": true
+        },
+        {
+          "text": "El hígado",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Muchas aves tragan pequeñas piedras que ayudan a la molleja a moler la comida.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_146",
+      "question": "¿Qué tipo de roca se forma por el enfriamiento del magma?",
+      "answers": [
+        {
+          "text": "Sedimentaria",
+          "correct": false
+        },
+        {
+          "text": "Ígnea",
+          "correct": true
+        },
+        {
+          "text": "Metamórfica",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El granito y el basalto son ejemplos de rocas ígneas.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_147",
+      "question": "¿Cómo se llama la fase de la mitosis en la que los cromosomas se alinean en el centro de la célula?",
+      "answers": [
+        {
+          "text": "Profase",
+          "correct": false
+        },
+        {
+          "text": "Metafase",
+          "correct": true
+        },
+        {
+          "text": "Telofase",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Tras la metafase, las cromátidas se separan hacia los polos en la anafase.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_148",
+      "question": "¿Qué reino agrupa a organismos unicelulares como las amebas y los paramecios?",
+      "answers": [
+        {
+          "text": "Reino fungi",
+          "correct": false
+        },
+        {
+          "text": "Reino protista",
+          "correct": true
+        },
+        {
+          "text": "Reino monera",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Los protistas son en su mayoría microscópicos y muy diversos.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_149",
+      "question": "¿Qué proceso permite a algunas plantas del desierto abrir sus estomas de noche para ahorrar agua?",
+      "answers": [
+        {
+          "text": "Fotosíntesis C3",
+          "correct": false
+        },
+        {
+          "text": "Metabolismo ácido de las crasuláceas (CAM)",
+          "correct": true
+        },
+        {
+          "text": "Respiración anaerobia",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El metabolismo CAM es típico de los cactus y otras plantas suculentas.",
+      "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_150",
+      "question": "¿Qué estructura del oído interno es responsable del sentido del equilibrio?",
+      "answers": [
+        {
+          "text": "El tímpano",
+          "correct": false
+        },
+        {
+          "text": "El sistema vestibular",
+          "correct": true
+        },
+        {
+          "text": "La cóclea",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Los canales semicirculares del sistema vestibular detectan el movimiento de la cabeza.",
+      "category": "Naturaleza"
+    }
+  ]
+}

--- a/custom_components/quizify/questions/versions.json
+++ b/custom_components/quizify/questions/versions.json
@@ -21,5 +21,8 @@
   "world-cup": "1.0",
   "weltmeisterschaft": "1.0",
   "schaetzfragen-de": "1.0",
-  "estimation-en": "1.0"
+  "estimation-en": "1.0",
+  "naturaleza-es": "1.0",
+  "ciencia-es": "1.0",
+  "historia-es": "1.0"
 }

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -374,6 +374,21 @@
       "q5": "¿Qué idioma?",
       "q6": "¿Ronda Relámpago?",
       "lightningHint": "Ronda rápida sorpresa a mitad de la partida"
+    },
+    "tts": {
+      "title": "¿Voz del presentador?",
+      "enable": "Narrar el juego en voz alta",
+      "hint": "Tu altavoz de HA se convierte en el presentador.",
+      "question": "Leer cada pregunta",
+      "options": "Leer las opciones de respuesta",
+      "reveal": "Anunciar la respuesta",
+      "standings": "Anunciar el nuevo líder",
+      "join": "Dar la bienvenida a los jugadores",
+      "countdown": "Anunciar la cuenta atrás final",
+      "engine": "Motor de TTS",
+      "speaker": "Altavoz",
+      "usedefault": "Usar predeterminado",
+      "noentities": "Ninguno encontrado: configúralo en HA"
     }
   },
   "featured": {


### PR DESCRIPTION
Closes #373 (per-player picker split out to #492).

## What this does
Brings Spanish from an awkward half-state (1 pack, missing i18n keys) to genuinely usable.

### 1. i18n parity (`9b3e569`)
`es.json` was 507/520 — the v1.4.0 `setup.tts` block (13 keys) was never translated. Added native Spanish strings → **full 520/520 parity** with `en.json`.

### 2. Three native Spanish packs (`+9478 lines`)
Spanish had 1 pack (`geografia-es`) vs 7 DE / 7 EN. Adds 3 **native** (not translated) packs, 150 questions each:
| Pack | Theme | Questions |
|---|---|---|
| Naturaleza 🦋 | nature | 150 |
| Ciencia 🔬 | science | 150 |
| Historia 📜 | history | 150 |

Each: difficulty 48/66/36, 3 answers with exactly 1 correct (server shuffles per-player), Spanish `fun_fact`, no duplicates, registered in `versions.json` at 1.0. Pack discovery is data-driven → **zero HTML edits**. Spanish now has **4 packs / 600 questions**.

## Out of scope
- **Per-player UI language picker** → deferred to #492 (host already has a language selector in admin settings; the picker only translates minimal player chrome while questions stay in the host pack language — low ROI).

## Verification
- `es.json` 520/520 parity vs `en.json` (verified programmatically).
- All 3 packs structurally validated: 150 questions, exactly 1 correct answer, 3 options, non-empty fun_fact, correct category, no duplicate IDs/questions.
- `test_questions.py` green (38 passed).
- Factual spot-check on samples across all 3 packs passed.

## Caveat
Pack content is AI-generated (native Spanish). Structurally + spot-check verified, but a broader human factual review is recommended before the release that ships these.

Refs #373