### PR TITLE
feat: HA event backbone for 'The House Plays Along' (#366)

### DIFF
--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -40,10 +40,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     from .const import (  # noqa: PLC0415
         CONF_COMMUNITY_SUBMIT_SECRET,
         CONF_COMMUNITY_SUBMIT_URL,
+        CONF_HOUSE_EVENTS_ENABLED,
         CONF_LOBBY_MUSIC_URL,
         CONF_MEDIA_PLAYER_ENTITY,
         CONF_PARTY_LIGHT_ENTITIES,
         CONF_TTS_ENTITY,
+        DEFAULT_HOUSE_EVENTS_ENABLED,
     )
     from .game.state import QuizifyGameState  # noqa: PLC0415
     from .game_events import QuizifyEventEmitter  # noqa: PLC0415
@@ -253,10 +255,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # HA event backbone (#366) — fires quizify_* bus events at game milestones
     # so the host can drive their own automations. Attaches a state callback for
-    # phase-driven events; the WS handler pushes the richer per-event ones. No
-    # per-entry config to gate on (always available under HA), so it needs no
-    # options; it stays a no-op only on the standalone dev server.
-    event_emitter = QuizifyEventEmitter(hass=hass, game_state=game_state)
+    # phase-driven events; the WS handler pushes the richer per-event ones.
+    # Gated behind the CONF_HOUSE_EVENTS_ENABLED master toggle (default off, like
+    # TTS/lights): stays a no-op until the host opts in, and always on the
+    # standalone dev server (no bus).
+    event_emitter = QuizifyEventEmitter(
+        hass=hass,
+        game_state=game_state,
+        enabled=options.get(
+            CONF_HOUSE_EVENTS_ENABLED, DEFAULT_HOUSE_EVENTS_ENABLED
+        ),
+    )
     event_emitter.attach()
     ws_handler.set_event_emitter(event_emitter)
 
@@ -324,9 +333,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             game_state=game_state,
         )
         new_lm.attach()
-        new_ev = QuizifyEventEmitter(hass=_hass, game_state=game_state)
+        new_ev = QuizifyEventEmitter(
+            hass=_hass,
+            game_state=game_state,
+            enabled=opts.get(
+                CONF_HOUSE_EVENTS_ENABLED, DEFAULT_HOUSE_EVENTS_ENABLED
+            ),
+        )
         # Carry the phase tracking across the reload so an in-flight game keeps
-        # its game_started dedupe (#366).
+        # its game_started dedupe (#366). Toggling the master switch in the
+        # options UI thus takes effect immediately, without an HA restart.
         new_ev.restore_runtime_state(ev_snapshot)
         new_ev.attach()
         domain_data["party_lights"] = new_pl

--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -46,6 +46,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         CONF_TTS_ENTITY,
     )
     from .game.state import QuizifyGameState  # noqa: PLC0415
+    from .game_events import QuizifyEventEmitter  # noqa: PLC0415
     from .lights import QuizifyPartyLights  # noqa: PLC0415
     from .lobby_music import QuizifyLobbyMusic  # noqa: PLC0415
     from .question_stats import QuestionStatsService  # noqa: PLC0415
@@ -250,9 +251,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     lobby_music.attach()
 
+    # HA event backbone (#366) — fires quizify_* bus events at game milestones
+    # so the host can drive their own automations. Attaches a state callback for
+    # phase-driven events; the WS handler pushes the richer per-event ones. No
+    # per-entry config to gate on (always available under HA), so it needs no
+    # options; it stays a no-op only on the standalone dev server.
+    event_emitter = QuizifyEventEmitter(hass=hass, game_state=game_state)
+    event_emitter.attach()
+    ws_handler.set_event_emitter(event_emitter)
+
     hass.data[DOMAIN]["party_lights"] = party_lights
     hass.data[DOMAIN]["tts_announcer"] = tts_announcer
     hass.data[DOMAIN]["lobby_music"] = lobby_music
+    hass.data[DOMAIN]["event_emitter"] = event_emitter
 
     # Re-attach on options change so toggling lights/TTS in the UI takes
     # effect without an HA restart.
@@ -274,17 +285,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         pl: QuizifyPartyLights | None = domain_data.get("party_lights")
         tts: QuizifyTTSAnnouncer | None = domain_data.get("tts_announcer")
         lm: QuizifyLobbyMusic | None = domain_data.get("lobby_music")
+        ev: QuizifyEventEmitter | None = domain_data.get("event_emitter")
         # Snapshot the old announcer's live per-game narration config BEFORE we
         # tear it down (#411). Rebuilding from the config entry resets
         # ``_enabled`` to False and drops the admin's per-game entity overrides,
         # which would silently kill narration mid-game until the next start_game.
         tts_snapshot = tts.export_runtime_config() if tts is not None else None
+        # Snapshot the emitter's phase tracking so a reload landing on round 1
+        # doesn't re-fire quizify_game_started (#366, same #411 rationale).
+        ev_snapshot = ev.export_runtime_state() if ev is not None else None
         if pl is not None:
             pl.detach()
         if tts is not None:
             tts.detach()
         if lm is not None:
             lm.detach()
+        if ev is not None:
+            ev.detach()
         new_pl = QuizifyPartyLights(
             hass=_hass,
             entity_ids=list(opts.get(CONF_PARTY_LIGHT_ENTITIES) or []),
@@ -307,12 +324,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             game_state=game_state,
         )
         new_lm.attach()
+        new_ev = QuizifyEventEmitter(hass=_hass, game_state=game_state)
+        # Carry the phase tracking across the reload so an in-flight game keeps
+        # its game_started dedupe (#366).
+        new_ev.restore_runtime_state(ev_snapshot)
+        new_ev.attach()
         domain_data["party_lights"] = new_pl
         domain_data["tts_announcer"] = new_tts
         domain_data["lobby_music"] = new_lm
+        domain_data["event_emitter"] = new_ev
         handler = domain_data.get("ws_handler")
         if handler is not None:
             handler.set_tts_announcer(new_tts)
+            handler.set_event_emitter(new_ev)
         _LOGGER.info("Quizify options reloaded")
 
     entry.async_on_unload(entry.add_update_listener(_update_listener))

--- a/custom_components/quizify/config_flow.py
+++ b/custom_components/quizify/config_flow.py
@@ -18,10 +18,12 @@ from homeassistant.helpers import selector
 from .const import (
     CONF_COMMUNITY_SUBMIT_SECRET,
     CONF_COMMUNITY_SUBMIT_URL,
+    CONF_HOUSE_EVENTS_ENABLED,
     CONF_LOBBY_MUSIC_URL,
     CONF_MEDIA_PLAYER_ENTITY,
     CONF_PARTY_LIGHT_ENTITIES,
     CONF_TTS_ENTITY,
+    DEFAULT_HOUSE_EVENTS_ENABLED,
     DOMAIN,
 )
 
@@ -124,5 +126,15 @@ class QuizifyOptionsFlow(OptionsFlow):
             ): selector.TextSelector(
                 selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD),
             ),
+            # Master toggle for "The House Plays Along" (#366). Off by default:
+            # the integration fires no quizify_* bus events until the host opts
+            # in, so existing broad event automations are never surprised. This
+            # is the single gate the later light/SFX phases also ride on.
+            vol.Optional(
+                CONF_HOUSE_EVENTS_ENABLED,
+                default=current.get(
+                    CONF_HOUSE_EVENTS_ENABLED, DEFAULT_HOUSE_EVENTS_ENABLED
+                ),
+            ): selector.BooleanSelector(),
         })
         return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/quizify/const.py
+++ b/custom_components/quizify/const.py
@@ -55,6 +55,12 @@ QUESTIONS_DIR = "quizify/questions"
 CONF_PARTY_LIGHT_ENTITIES = "party_light_entities"  # list[str], domain=light
 CONF_TTS_ENTITY = "tts_entity"  # str, single, domain=tts
 CONF_MEDIA_PLAYER_ENTITY = "media_player_entity"  # str, single, domain=media_player
+# Master toggle for the HA event backbone (#366, "The House Plays Along").
+# Off by default: the integration stays silent on the event bus until the host
+# opts in, so broad event-triggered automations are never surprised by a stream
+# of quizify_* events. Mirrors the opt-in posture of the TTS/lights features.
+CONF_HOUSE_EVENTS_ENABLED = "house_events_enabled"  # bool, single
+DEFAULT_HOUSE_EVENTS_ENABLED = False
 # URL of an audio file to loop in the lobby while waiting for players. Empty by
 # default — the lobby-music mechanism stays completely inert until the user
 # points this at their own file (e.g. "/local/quizify-lobby.mp3" served from

--- a/custom_components/quizify/game_events.py
+++ b/custom_components/quizify/game_events.py
@@ -1,0 +1,286 @@
+"""Home Assistant event backbone for Quizify — "The House Plays Along" (#366).
+
+Fires ``hass.bus`` events at every game milestone so the host can drive their
+own automations off the quiz (dim the lights on a reveal, flash a lamp on a
+streak, play a fanfare when the winner is decided, …). This is the clean event
+layer the later light/SFX phases of #494 hook into instead of poking the game
+loop directly.
+
+The emitter mirrors :class:`~custom_components.quizify.lights.QuizifyPartyLights`:
+it subscribes to ``QuizifyGameState`` state callbacks for the phase-driven
+milestones (game start / finale / winner) and is called from the WebSocket
+dispatch points for the richer per-event milestones (question shown, reveal,
+streak, game ended) where the full round data is already assembled — exactly
+like the ``_notify_tts_*`` hooks next to which these fire.
+
+Everything no-ops cleanly when there is no Home Assistant instance (the
+standalone dev server has no event bus), matching
+:func:`~custom_components.quizify.ha_service.fire_and_forget_service`.
+
+Event catalog
+-------------
+All events live in the ``quizify_*`` namespace. Payloads are JSON-serializable
+and PII-minimal — player *display* names are included (they are already
+broadcast to every client), but nothing else identifying. These names +
+payload shapes are the stable contract the #366 automation blueprints build on,
+so treat them as an API: additive changes only.
+
+``quizify_game_started``    — {game_id, player_count, round_count}
+``quizify_question_shown``  — {round, total_rounds, question_type}
+``quizify_answer_revealed`` — {round, correct_option_index, correct_option_text,
+                               correct_count, total_players}
+``quizify_streak_milestone``— {player_name, streak, bonus}
+``quizify_finale_started``  — {}
+``quizify_winner_decided``  — {winner_name, score}
+``quizify_game_ended``      — {leaderboard: [{name, score}, ...]}
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from .game.state import GamePhase, QuizifyGameState
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+# --- Event catalog (stable names — see module docstring for payload schemas) --
+EVENT_GAME_STARTED = "quizify_game_started"
+EVENT_QUESTION_SHOWN = "quizify_question_shown"
+EVENT_ANSWER_REVEALED = "quizify_answer_revealed"
+EVENT_STREAK_MILESTONE = "quizify_streak_milestone"
+EVENT_FINALE_STARTED = "quizify_finale_started"
+EVENT_WINNER_DECIDED = "quizify_winner_decided"
+EVENT_GAME_ENDED = "quizify_game_ended"
+
+
+class QuizifyEventEmitter:
+    """Fires ``hass.bus`` events at game milestones (#366).
+
+    Constructed per config entry; attaches a state callback for the phase-driven
+    milestones and exposes ``notify_*`` forwarders the WS handler calls at the
+    same points as the ``_notify_tts_*`` hooks. A no-op everywhere when there is
+    no HA instance (standalone dev server).
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant | None,
+        game_state: QuizifyGameState,
+    ) -> None:
+        self._hass = hass
+        self._game = game_state
+        # Track the last phase we observed so phase-driven events fire only on
+        # transitions, not on every state_callback flap. Mirrors the lights /
+        # TTS observers. Survives an options reload via export/restore below.
+        self._last_phase: GamePhase | None = None
+
+    @property
+    def is_configured(self) -> bool:
+        # There is no per-entry config to gate on (unlike lights/TTS which need
+        # entities): the event bus is always available under HA. Configured ==
+        # "we have a bus to fire on".
+        return self._hass is not None
+
+    def attach(self) -> None:
+        """Subscribe to game-state phase transitions. Idempotent."""
+        self._game.register_state_callback(self._on_state_changed)
+
+    def detach(self) -> None:
+        self._game.unregister_state_callback(self._on_state_changed)
+
+    # ------------------------------------------------------------------
+    # Options-reload lifecycle (#411 pattern)
+    # ------------------------------------------------------------------
+
+    def export_runtime_state(self) -> dict[str, Any]:
+        """Snapshot the transient phase-tracking state (#411 pattern).
+
+        An options reload rebuilds this emitter from scratch, which would reset
+        ``_last_phase`` to ``None``. On its own that is mostly harmless (the
+        game_started/finale detectors are further gated on ``round``), but a
+        reload landing exactly on the first active round could otherwise re-fire
+        ``quizify_game_started``. Snapshotting the last phase across the reload
+        closes that gap, matching how the TTS announcer preserves its runtime
+        config (#411).
+        """
+        return {
+            "last_phase": self._last_phase.value
+            if self._last_phase is not None
+            else None,
+        }
+
+    def restore_runtime_state(self, snapshot: dict[str, Any] | None) -> None:
+        """Restore a snapshot from :meth:`export_runtime_state` (#411 pattern).
+
+        Defensive: a falsy/empty snapshot is a no-op, and an unknown phase value
+        is ignored so a stale snapshot can never crash the rebuild.
+        """
+        if not snapshot:
+            return
+        value = snapshot.get("last_phase")
+        if value:
+            try:
+                self._last_phase = GamePhase(value)
+            except ValueError:
+                _LOGGER.debug("Ignoring unknown phase in snapshot: %s", value)
+
+    # ------------------------------------------------------------------
+    # Phase-driven milestones (state-callback path)
+    # ------------------------------------------------------------------
+
+    def _on_state_changed(self) -> None:
+        """React to phase transitions: game start, finale, winner.
+
+        The richer per-event milestones (question / reveal / streak / game end)
+        are pushed from the WS handler instead — this path only sees the phase.
+        """
+        if not self.is_configured:
+            return
+        phase = self._game.phase
+        if phase == self._last_phase:
+            return
+        prev = self._last_phase
+        self._last_phase = phase
+
+        # LOBBY → first QUESTION_ACTIVE at round 1 means "game starting".
+        # Mirrors the TTS "Quizify starting" detection so the two agree on what
+        # a game start is.
+        if (
+            prev in (None, GamePhase.LOBBY)
+            and phase == GamePhase.QUESTION_ACTIVE
+            and self._game.round == 1
+        ):
+            self._fire(
+                EVENT_GAME_STARTED,
+                {
+                    "game_id": self._game.game_id,
+                    "player_count": len(self._game.get_players()),
+                    "round_count": self._game.total_rounds,
+                },
+            )
+            return
+
+        # Any phase → FINALE means the game is over: announce the finale and,
+        # when there is a clear leader, who won. Two thin events so a blueprint
+        # can react to "the game ended" and "we have a winner" independently.
+        if phase == GamePhase.FINALE:
+            self._fire(EVENT_FINALE_STARTED, {})
+            leader = self._game.leader
+            if leader is not None:
+                self._fire(
+                    EVENT_WINNER_DECIDED,
+                    {"winner_name": leader.name, "score": leader.score},
+                )
+
+    # ------------------------------------------------------------------
+    # Per-event milestones (WS-dispatch path) — thin forwarders the WS
+    # handler calls next to its _notify_tts_* hooks.
+    # ------------------------------------------------------------------
+
+    def notify_question_shown(
+        self, question: Any, round_no: int, total_rounds: int
+    ) -> None:
+        """Fire ``quizify_question_shown`` at round start.
+
+        Reuses the ``question`` already assembled at the fan-out point; only the
+        type (multiple_choice / estimate) is exposed — not the text/answers,
+        which would leak the question to automations before players see it.
+        """
+        self._fire(
+            EVENT_QUESTION_SHOWN,
+            {
+                "round": round_no,
+                "total_rounds": total_rounds,
+                "question_type": getattr(question, "type", None),
+            },
+        )
+
+    def notify_answer_revealed(self, game_state: QuizifyGameState) -> None:
+        """Fire ``quizify_answer_revealed`` from the reveal dispatch point.
+
+        Pulls everything from the round summary the reveal broadcast already
+        built. ``correct_option_index`` is the index of the correct answer in
+        the question's canonical ``answers`` list (``None`` for estimate rounds,
+        which have no option list).
+        """
+        summary = game_state.get_round_summary()
+        if summary is None:
+            return
+        correct_text = ""
+        if summary.correct_answer is not None:
+            correct_text = summary.correct_answer.text or ""
+        # Index of the correct option in the canonical answers list. Estimate
+        # rounds carry no options → leave it None.
+        correct_index: int | None = None
+        answers = getattr(summary.question, "answers", None) or []
+        for i, ans in enumerate(answers):
+            if getattr(ans, "correct", False):
+                correct_index = i
+                break
+        correct_count = sum(1 for r in summary.results if r.correct)
+        self._fire(
+            EVENT_ANSWER_REVEALED,
+            {
+                "round": game_state.round,
+                "correct_option_index": correct_index,
+                "correct_option_text": correct_text,
+                "correct_count": correct_count,
+                "total_players": len(summary.results),
+            },
+        )
+
+    def notify_streak_milestone(
+        self, player_name: str, streak: int, bonus: int
+    ) -> None:
+        """Fire ``quizify_streak_milestone`` when a player hits a streak level.
+
+        Mirrors the ``streak_milestone`` WS broadcast payload (#366) so an
+        automation sees the same name/streak/bonus the TV celebration does.
+        """
+        self._fire(
+            EVENT_STREAK_MILESTONE,
+            {
+                "player_name": player_name,
+                "streak": streak,
+                "bonus": bonus,
+            },
+        )
+
+    def notify_game_ended(self, game_state: QuizifyGameState) -> None:
+        """Fire ``quizify_game_ended`` with the final leaderboard.
+
+        Emitted from the ``game_ended`` dispatch point (richer than the FINALE
+        phase transition, which only knows the single leader). The leaderboard
+        is trimmed to ``{name, score}`` per entry — the stable, PII-minimal
+        subset a blueprint needs — not the full wire contract.
+        """
+        leaderboard = [
+            {"name": entry.get("name"), "score": entry.get("score")}
+            for entry in game_state.get_leaderboard()
+            if isinstance(entry, dict)
+        ]
+        self._fire(EVENT_GAME_ENDED, {"leaderboard": leaderboard})
+
+    # ------------------------------------------------------------------
+    # Internal — dev-safe bus wrapper
+    # ------------------------------------------------------------------
+
+    def _fire(self, event_type: str, data: dict[str, Any]) -> None:
+        """Fire ``event_type`` on the HA event bus.
+
+        No-ops when there is no HA instance (standalone dev server has no bus).
+        Any exception is caught and logged at WARNING so a bad fire can never
+        escape onto the game loop — the same posture as
+        :func:`~custom_components.quizify.ha_service.fire_and_forget_service`.
+        """
+        hass = self._hass
+        if hass is None:
+            return
+        try:
+            hass.bus.async_fire(event_type, data)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.warning("Quizify event %s failed: %s", event_type, err)

--- a/custom_components/quizify/game_events.py
+++ b/custom_components/quizify/game_events.py
@@ -70,9 +70,17 @@ class QuizifyEventEmitter:
         self,
         hass: HomeAssistant | None,
         game_state: QuizifyGameState,
+        enabled: bool = True,
     ) -> None:
         self._hass = hass
         self._game = game_state
+        # Master toggle for the whole event backbone (#366). Off => every fire
+        # is a no-op, so the integration stays silent on the bus until the host
+        # opts in via the options flow (CONF_HOUSE_EVENTS_ENABLED, default off).
+        # The constructor default is True because the sole production caller
+        # (__init__) always passes the resolved option explicitly; the product
+        # "off by default" lives at the config layer, not here.
+        self._enabled = enabled
         # Track the last phase we observed so phase-driven events fire only on
         # transitions, not on every state_callback flap. Mirrors the lights /
         # TTS observers. Survives an options reload via export/restore below.
@@ -80,10 +88,10 @@ class QuizifyEventEmitter:
 
     @property
     def is_configured(self) -> bool:
-        # There is no per-entry config to gate on (unlike lights/TTS which need
-        # entities): the event bus is always available under HA. Configured ==
-        # "we have a bus to fire on".
-        return self._hass is not None
+        # Configured == the master toggle is on AND we have a bus to fire on.
+        # Unlike lights/TTS there is no per-entry entity to gate on, but the
+        # host must still opt in via CONF_HOUSE_EVENTS_ENABLED (default off).
+        return self._enabled and self._hass is not None
 
     def attach(self) -> None:
         """Subscribe to game-state phase transitions. Idempotent."""
@@ -277,6 +285,11 @@ class QuizifyEventEmitter:
         escape onto the game loop — the same posture as
         :func:`~custom_components.quizify.ha_service.fire_and_forget_service`.
         """
+        # Single choke point for every path (phase-callback + notify_* WS
+        # forwarders): the master toggle is enforced here, so an off emitter
+        # fires nothing regardless of which milestone triggered it.
+        if not self._enabled:
+            return
         hass = self._hass
         if hass is None:
             return

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -50,6 +50,7 @@ from custom_components.quizify.server.serializers import (
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from ..game_events import QuizifyEventEmitter
     from ..runtime import Runtime
     from ..tts import QuizifyTTSAnnouncer
 
@@ -183,6 +184,10 @@ class QuizifyWebSocketHandler:
         # construction so the handler doesn't have to know about HA
         # services. Calling announce_milestone on None is the no-op path.
         self._tts_announcer: QuizifyTTSAnnouncer | None = None
+        # Optional HA event-bus emitter (#366). Set by __init__.py after
+        # construction so the handler stays HA-agnostic. Firing on None is the
+        # no-op path (standalone dev server).
+        self._event_emitter: QuizifyEventEmitter | None = None
         # Per-connection message flood guard (#169). Keyed on id(ws); the
         # entry is dropped by _forget_rate_limit() on disconnect so the
         # backing dict is bounded by the number of *live* connections.
@@ -1010,6 +1015,11 @@ class QuizifyWebSocketHandler:
                 # Also speak it if TTS is configured. Cheap to look up; the
                 # announcer no-ops if no TTS entity is set.
                 self._notify_tts_milestone(player.name, result.milestone_streak)
+                # Fire the HA bus event so the host can automate on a streak
+                # (#366) — same data as the streak_milestone broadcast above.
+                self._notify_house_milestone(
+                    player.name, result.milestone_streak, result.milestone_bonus
+                )
             # NB: round-summary broadcast is fired exclusively by
             # state._fire_broadcast("round_evaluated") \u2192 broadcast_state().
             # Do NOT broadcast here \u2014 that would double-fire when the timer
@@ -2220,6 +2230,11 @@ class QuizifyWebSocketHandler:
         self._notify_tts_question(
             question, game_state.round, game_state.total_rounds, shuffled_texts
         )
+        # Fire the HA bus event (round + type only; no text/answers) so the host
+        # can automate on each question start (#366).
+        self._notify_house_question(
+            question, game_state.round, game_state.total_rounds
+        )
 
         # Cache players to avoid redundant calls
         players = game_state.get_players()
@@ -2754,6 +2769,80 @@ class QuizifyWebSocketHandler:
             _LOGGER.exception("TTS reveal announcement raised")
 
     # ------------------------------------------------------------------
+    # HA event-bus forwarders (#366) — thin, no-op-guarded siblings of the
+    # _notify_tts_* hooks. The emitter fires quizify_* bus events so the host
+    # can drive automations off game milestones.
+    # ------------------------------------------------------------------
+
+    def set_event_emitter(
+        self, emitter: QuizifyEventEmitter | None
+    ) -> None:
+        """Wire (or rewire) the optional HA event emitter (#366).
+
+        Public entry point used by ``__init__.py`` at setup and on every options
+        reload, mirroring :meth:`set_tts_announcer`. ``None`` clears it, restoring
+        the no-op path.
+        """
+        self._event_emitter = emitter
+
+    def _notify_house_question(
+        self, question: Any, round_no: int, total_rounds: int
+    ) -> None:
+        """Forward a question-start to the HA event emitter if one is wired.
+
+        No-op when ``_event_emitter`` is None (standalone dev server). Guarded so
+        a bad fire can't break the question fan-out.
+        """
+        emitter = self._event_emitter
+        if emitter is None:
+            return
+        try:
+            emitter.notify_question_shown(question, round_no, total_rounds)
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("House question event raised")
+
+    def _notify_house_milestone(
+        self, player_name: str, streak: int, bonus: int
+    ) -> None:
+        """Forward a streak milestone to the HA event emitter if one is wired.
+
+        No-op when ``_event_emitter`` is None. Guarded like the question hook.
+        """
+        emitter = self._event_emitter
+        if emitter is None:
+            return
+        try:
+            emitter.notify_streak_milestone(player_name, streak, bonus)
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("House milestone event raised")
+
+    def _notify_house_reveal(self, game_state: QuizifyGameState) -> None:
+        """Forward the reveal to the HA event emitter if one is wired.
+
+        No-op when ``_event_emitter`` is None. Guarded like the question hook.
+        """
+        emitter = self._event_emitter
+        if emitter is None:
+            return
+        try:
+            emitter.notify_answer_revealed(game_state)
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("House reveal event raised")
+
+    def _notify_house_game_ended(self, game_state: QuizifyGameState) -> None:
+        """Forward game end to the HA event emitter if one is wired.
+
+        No-op when ``_event_emitter`` is None. Guarded like the question hook.
+        """
+        emitter = self._event_emitter
+        if emitter is None:
+            return
+        try:
+            emitter.notify_game_ended(game_state)
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("House game-ended event raised")
+
+    # ------------------------------------------------------------------
     # Finale broadcast helper
     # ------------------------------------------------------------------
 
@@ -2807,12 +2896,18 @@ class QuizifyWebSocketHandler:
             # Narrate the reveal (correct answer + who got it + standings) as
             # a single combined utterance (#281), after the summary broadcast.
             self._notify_tts_reveal(game_state)
+            # Fire the HA bus event with the correct answer + how many got it
+            # (#366), off the same round summary.
+            self._notify_house_reveal(game_state)
 
     async def _dispatch_game_ended(self) -> None:
         """Handler for the ``game_ended`` state event."""
         game_state = self._get_game_state()
         if game_state:
             await self._broadcast_finale(game_state)
+            # Fire the HA bus event with the final leaderboard (#366), after
+            # the finale broadcast so entity state is already settled.
+            self._notify_house_game_ended(game_state)
 
     async def _dispatch_full_state(self) -> None:
         """Default handler: broadcast a full game-state snapshot."""

--- a/custom_components/quizify/translations/de.json
+++ b/custom_components/quizify/translations/de.json
@@ -24,7 +24,8 @@
                     "media_player_entity": "Mediaplayer für TTS",
                     "lobby_music_url": "Lobby-Musik-URL",
                     "community_submit_url": "URL für Community-Pack-Einsendung",
-                    "community_submit_secret": "Geheimnis für Community-Pack-Einsendung"
+                    "community_submit_secret": "Geheimnis für Community-Pack-Einsendung",
+                    "house_events_enabled": "Das Haus spielt mit"
                 },
                 "data_description": {
                     "party_light_entities": "Lichter, die mit der Spielphase mitleuchten (Koralle bei Frage, Salbei bei Auflösung, Sonne im Finale).",
@@ -32,7 +33,8 @@
                     "media_player_entity": "Lautsprecher, über den die TTS-Ansage abgespielt wird. Pflicht, wenn ein TTS-Dienst gesetzt ist.",
                     "lobby_music_url": "Optionale URL einer Audiodatei (z. B. /local/quizify-lobby.mp3 aus deinem config/www-Ordner), die in der Lobby über den oben gewählten Mediaplayer in Schleife läuft. Sie stoppt beim Spielstart, damit sie sich nicht mit den TTS-Ansagen über denselben Lautsprecher überlagert. Leer lassen = keine Musik. Es ist keine Audiodatei enthalten — du musst eine eigene angeben.",
                     "community_submit_url": "Optionaler Worker-Endpunkt, der eine in der App eingereichte Community-Pack-Einsendung in ein GitHub-Issue zur Begutachtung umwandelt. Leer lassen, um die Einsende-Funktion komplett auszublenden. Das GitHub-Token liegt in diesem Worker, nie im Browser oder in Home Assistant.",
-                    "community_submit_secret": "Optionales gemeinsames Geheimnis, das als X-Quizify-Secret-Header an den Worker gesendet wird. Setze es passend zum SHARED_SECRET des Workers, damit nicht jeder mit der URL Issues anlegen kann. Leer lassen, wenn der Worker kein Geheimnis hat (Standard)."
+                    "community_submit_secret": "Optionales gemeinsames Geheimnis, das als X-Quizify-Secret-Header an den Worker gesendet wird. Setze es passend zum SHARED_SECRET des Workers, damit nicht jeder mit der URL Issues anlegen kann. Leer lassen, wenn der Worker kein Geheimnis hat (Standard).",
+                    "house_events_enabled": "Löst bei Spiel-Höhepunkten quizify_*-Events auf dem Home-Assistant-Event-Bus aus (Rundenstart, Auflösung, Serien, Sieger), damit du eigene Automationen darauf aufbauen kannst. Standardmäßig aus."
                 }
             }
         }

--- a/custom_components/quizify/translations/en.json
+++ b/custom_components/quizify/translations/en.json
@@ -24,7 +24,8 @@
                     "media_player_entity": "Media player for TTS",
                     "lobby_music_url": "Lobby music URL",
                     "community_submit_url": "Community pack submission URL",
-                    "community_submit_secret": "Community pack submission secret"
+                    "community_submit_secret": "Community pack submission secret",
+                    "house_events_enabled": "The House Plays Along"
                 },
                 "data_description": {
                     "party_light_entities": "Lights that should glow with the round phase (coral on question, sage on reveal, sun on finale).",
@@ -32,7 +33,8 @@
                     "media_player_entity": "Speaker the TTS audio plays through. Required if TTS provider is set.",
                     "lobby_music_url": "Optional URL of an audio file (e.g. /local/quizify-lobby.mp3, served from your config/www folder) looped on the media player above while waiting in the lobby. It stops when the game starts, so it never overlaps the TTS announcements that share the same speaker. Leave blank for no music. No audio file is included — supply your own.",
                     "community_submit_url": "Optional worker endpoint that turns an in-app community-pack submission into a GitHub issue for review. Leave blank to hide the submission feature entirely. The GitHub token lives in that worker, never in your browser or Home Assistant.",
-                    "community_submit_secret": "Optional shared secret sent to the worker as an X-Quizify-Secret header. Set this to match the worker's SHARED_SECRET to stop anyone with the URL from filing issues. Leave blank if the worker has no secret (the default)."
+                    "community_submit_secret": "Optional shared secret sent to the worker as an X-Quizify-Secret header. Set this to match the worker's SHARED_SECRET to stop anyone with the URL from filing issues. Leave blank if the worker has no secret (the default).",
+                    "house_events_enabled": "Fire quizify_* events on the Home Assistant event bus at game milestones (round start, reveal, streaks, winner) so you can drive your own automations. Off by default."
                 }
             }
         }

--- a/custom_components/quizify/translations/es.json
+++ b/custom_components/quizify/translations/es.json
@@ -24,7 +24,8 @@
                     "media_player_entity": "Reproductor para TTS",
                     "lobby_music_url": "URL de música de la sala",
                     "community_submit_url": "URL de envío de paquetes de la comunidad",
-                    "community_submit_secret": "Secreto de envío de paquetes de la comunidad"
+                    "community_submit_secret": "Secreto de envío de paquetes de la comunidad",
+                    "house_events_enabled": "La casa participa"
                 },
                 "data_description": {
                     "party_light_entities": "Luces que cambian de color con la fase de la ronda (coral en pregunta, salvia en revelación, sol en final).",
@@ -32,7 +33,8 @@
                     "media_player_entity": "Altavoz por el que se reproduce el audio TTS. Obligatorio si se configura un proveedor TTS.",
                     "lobby_music_url": "URL opcional de un archivo de audio (p. ej. /local/quizify-lobby.mp3, desde tu carpeta config/www) que se reproduce en bucle en el reproductor multimedia de arriba mientras se espera en la sala. Se detiene al empezar la partida, para no solaparse con los anuncios TTS que comparten el mismo altavoz. Déjalo vacío para no tener música. No se incluye ningún archivo de audio: usa el tuyo.",
                     "community_submit_url": "Endpoint opcional de un worker que convierte un envío de paquete de la comunidad hecho en la app en una incidencia de GitHub para revisión. Déjalo en blanco para ocultar por completo la función de envío. El token de GitHub reside en ese worker, nunca en tu navegador ni en Home Assistant.",
-                    "community_submit_secret": "Secreto compartido opcional que se envía al worker como cabecera X-Quizify-Secret. Configúralo para que coincida con el SHARED_SECRET del worker y así evitar que cualquiera con la URL cree incidencias. Déjalo en blanco si el worker no tiene secreto (predeterminado)."
+                    "community_submit_secret": "Secreto compartido opcional que se envía al worker como cabecera X-Quizify-Secret. Configúralo para que coincida con el SHARED_SECRET del worker y así evitar que cualquiera con la URL cree incidencias. Déjalo en blanco si el worker no tiene secreto (predeterminado).",
+                    "house_events_enabled": "Dispara eventos quizify_* en el bus de eventos de Home Assistant en los momentos clave de la partida (inicio de ronda, revelación, rachas, ganador) para que puedas crear tus propias automatizaciones. Desactivado por defecto."
                 }
             }
         }

--- a/custom_components/quizify/translations/fr.json
+++ b/custom_components/quizify/translations/fr.json
@@ -24,7 +24,8 @@
                     "media_player_entity": "Lecteur multimédia pour TTS",
                     "lobby_music_url": "URL de la musique du salon",
                     "community_submit_url": "URL de soumission de pack communautaire",
-                    "community_submit_secret": "Secret de soumission de pack communautaire"
+                    "community_submit_secret": "Secret de soumission de pack communautaire",
+                    "house_events_enabled": "La maison participe"
                 },
                 "data_description": {
                     "party_light_entities": "Lumières qui changent de couleur selon la phase de la manche (corail pendant la question, sauge pendant la révélation, soleil au final).",
@@ -32,7 +33,8 @@
                     "media_player_entity": "Haut-parleur sur lequel le TTS est diffusé. Obligatoire si un fournisseur TTS est défini.",
                     "lobby_music_url": "URL facultative d'un fichier audio (p. ex. /local/quizify-lobby.mp3, depuis votre dossier config/www) joué en boucle sur le lecteur multimédia ci-dessus pendant l'attente dans le salon. Elle s'arrête au démarrage de la partie, pour ne pas chevaucher les annonces TTS qui partagent le même haut-parleur. Laissez vide pour aucune musique. Aucun fichier audio n'est fourni — utilisez le vôtre.",
                     "community_submit_url": "Point de terminaison de worker facultatif qui transforme une soumission de pack communautaire faite dans l'application en une issue GitHub à examiner. Laissez vide pour masquer entièrement la fonction de soumission. Le jeton GitHub réside dans ce worker, jamais dans votre navigateur ni dans Home Assistant.",
-                    "community_submit_secret": "Secret partagé facultatif envoyé au worker dans l'en-tête X-Quizify-Secret. Définissez-le pour qu'il corresponde au SHARED_SECRET du worker afin d'empêcher quiconque possédant l'URL de créer des issues. Laissez vide si le worker n'a pas de secret (par défaut)."
+                    "community_submit_secret": "Secret partagé facultatif envoyé au worker dans l'en-tête X-Quizify-Secret. Définissez-le pour qu'il corresponde au SHARED_SECRET du worker afin d'empêcher quiconque possédant l'URL de créer des issues. Laissez vide si le worker n'a pas de secret (par défaut).",
+                    "house_events_enabled": "Déclenche des événements quizify_* sur le bus d'événements de Home Assistant aux moments forts de la partie (début de manche, révélation, séries, gagnant) pour piloter vos propres automatisations. Désactivé par défaut."
                 }
             }
         }

--- a/custom_components/quizify/translations/nl.json
+++ b/custom_components/quizify/translations/nl.json
@@ -24,7 +24,8 @@
                     "media_player_entity": "Mediaspeler voor TTS",
                     "lobby_music_url": "URL lobbymuziek",
                     "community_submit_url": "URL voor inzending community-pack",
-                    "community_submit_secret": "Geheim voor inzending community-pack"
+                    "community_submit_secret": "Geheim voor inzending community-pack",
+                    "house_events_enabled": "Het huis speelt mee"
                 },
                 "data_description": {
                     "party_light_entities": "Lampen die meekleuren met de rondefase (koraal bij vraag, salie bij onthulling, zon bij finale).",
@@ -32,7 +33,8 @@
                     "media_player_entity": "Luidspreker waar de TTS wordt afgespeeld. Verplicht als er een TTS-provider is ingesteld.",
                     "lobby_music_url": "Optionele URL van een audiobestand (bv. /local/quizify-lobby.mp3 uit je config/www-map) dat tijdens het wachten in de lobby in een lus wordt afgespeeld op de mediaspeler hierboven. Het stopt zodra het spel begint, zodat het de TTS-aankondigingen die dezelfde speaker delen niet overlapt. Laat leeg voor geen muziek. Er wordt geen audiobestand meegeleverd — gebruik je eigen bestand.",
                     "community_submit_url": "Optioneel worker-eindpunt dat een in de app ingediende community-pack-inzending omzet in een GitHub-issue ter beoordeling. Laat leeg om de inzendfunctie volledig te verbergen. Het GitHub-token bevindt zich in die worker, nooit in je browser of in Home Assistant.",
-                    "community_submit_secret": "Optioneel gedeeld geheim dat als X-Quizify-Secret-header naar de worker wordt gestuurd. Stel het in zodat het overeenkomt met de SHARED_SECRET van de worker, zodat niet iedereen met de URL issues kan aanmaken. Laat leeg als de worker geen geheim heeft (standaard)."
+                    "community_submit_secret": "Optioneel gedeeld geheim dat als X-Quizify-Secret-header naar de worker wordt gestuurd. Stel het in zodat het overeenkomt met de SHARED_SECRET van de worker, zodat niet iedereen met de URL issues kan aanmaken. Laat leeg als de worker geen geheim heeft (standaard).",
+                    "house_events_enabled": "Vuurt quizify_*-events af op de Home Assistant-eventbus bij hoogtepunten van het spel (rondestart, onthulling, reeksen, winnaar) zodat je je eigen automatiseringen kunt aansturen. Standaard uit."
                 }
             }
         }

--- a/tests/test_game_events.py
+++ b/tests/test_game_events.py
@@ -1,0 +1,396 @@
+"""Tests for the HA event backbone — "The House Plays Along" (#366).
+
+QuizifyEventEmitter fires ``quizify_*`` events on ``hass.bus`` at every game
+milestone so the host can drive automations. Here a fake hass records
+``bus.async_fire`` calls so we assert *intent* (event type + payload keys)
+without real Home Assistant.
+
+Covers: every milestone fires the right event with the right payload; the
+whole thing no-ops when ``hass is None`` (standalone dev server); phase-driven
+events fire only on transitions and only for the relevant phases; and the
+options-reload phase snapshot survives a rebuild.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.questions import Answer, Question  # noqa: E402
+from custom_components.quizify.game.state import (  # noqa: E402
+    AnswerResult,
+    GamePhase,
+    RoundSummary,
+)
+from custom_components.quizify.game_events import (  # noqa: E402
+    EVENT_ANSWER_REVEALED,
+    EVENT_FINALE_STARTED,
+    EVENT_GAME_ENDED,
+    EVENT_GAME_STARTED,
+    EVENT_QUESTION_SHOWN,
+    EVENT_STREAK_MILESTONE,
+    EVENT_WINNER_DECIDED,
+    QuizifyEventEmitter,
+)
+
+
+class _FakeBus:
+    """Records async_fire calls."""
+
+    def __init__(self) -> None:
+        self.fired: list[tuple[str, dict]] = []
+
+    def async_fire(self, event_type, data):  # noqa: ANN001
+        self.fired.append((event_type, dict(data)))
+
+
+class _FakeHass:
+    def __init__(self) -> None:
+        self.bus = _FakeBus()
+
+
+class _FakePlayer:
+    def __init__(self, name: str, score: int) -> None:
+        self.name = name
+        self.score = score
+
+
+class _FakeGame:
+    """Minimal game stand-in exposing only what the emitter reads.
+
+    Avoids spinning a full QuizifyGameState (which needs websockets to add
+    players) — the emitter only touches phase / round / game_id / total_rounds
+    / get_players / leader / get_round_summary / get_leaderboard.
+    """
+
+    def __init__(self) -> None:
+        self.phase = GamePhase.LOBBY
+        self.round = 0
+        self.total_rounds = 10
+        self.game_id: str | None = None
+        self._players: list[_FakePlayer] = []
+        self.leader: _FakePlayer | None = None
+        self._summary: RoundSummary | None = None
+        self._leaderboard: list[dict] = []
+        # register/unregister are exercised by attach()/detach().
+        self.callbacks: list = []
+
+    def register_state_callback(self, cb):  # noqa: ANN001
+        self.callbacks.append(cb)
+
+    def unregister_state_callback(self, cb):  # noqa: ANN001
+        if cb in self.callbacks:
+            self.callbacks.remove(cb)
+
+    def get_players(self):
+        return list(self._players)
+
+    def get_round_summary(self):
+        return self._summary
+
+    def get_leaderboard(self):
+        return list(self._leaderboard)
+
+
+def _emitter(hass, game):
+    return QuizifyEventEmitter(hass=hass, game_state=game)
+
+
+def _question(qtype="multiple_choice"):
+    return Question(
+        id="q1",
+        question="Wer malte die Mona Lisa?",
+        answers=[
+            Answer(text="Michelangelo", correct=False),
+            Answer(text="da Vinci", correct=True),
+            Answer(text="Raffael", correct=False),
+        ],
+        type=qtype,
+    )
+
+
+def _summary(*, results=None):
+    return RoundSummary(
+        question=_question(),
+        correct_answer=Answer(text="da Vinci", correct=True),
+        fun_fact="",
+        results=results or [],
+    )
+
+
+def _result(name, correct):
+    return AnswerResult(
+        player_id=name,
+        correct=correct,
+        points_earned=100 if correct else 0,
+        new_streak=1 if correct else 0,
+        new_total=100 if correct else 0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# No-op posture (hass is None)
+# ---------------------------------------------------------------------------
+
+
+def test_no_hass_is_noop_everywhere():
+    """Every path must no-op cleanly on the standalone dev server (no hass)."""
+    game = _FakeGame()
+    t = _emitter(None, game)
+    assert t.is_configured is False
+
+    # Phase-driven path.
+    game.game_id = "g1"
+    game.round = 1
+    game.phase = GamePhase.QUESTION_ACTIVE
+    t._on_state_changed()
+
+    # WS-dispatch path.
+    t.notify_question_shown(_question(), 1, 10)
+    t.notify_streak_milestone("Alice", 5, 50)
+    game._summary = _summary(results=[_result("Alice", True)])
+    t.notify_answer_revealed(game)
+    game._leaderboard = [{"name": "Alice", "score": 100}]
+    t.notify_game_ended(game)
+    # No bus at all → nothing to assert but that it didn't raise.
+
+
+# ---------------------------------------------------------------------------
+# Phase-driven milestones (state-callback path)
+# ---------------------------------------------------------------------------
+
+
+def test_game_started_fires_on_first_active_round():
+    hass = _FakeHass()
+    game = _FakeGame()
+    game._players = [_FakePlayer("Alice", 0), _FakePlayer("Bob", 0)]
+    game.game_id = "g1"
+    game.total_rounds = 8
+    t = _emitter(hass, game)
+
+    # LOBBY → QUESTION_ACTIVE round 1.
+    game.round = 1
+    game.phase = GamePhase.QUESTION_ACTIVE
+    t._on_state_changed()
+
+    assert len(hass.bus.fired) == 1
+    event, data = hass.bus.fired[0]
+    assert event == EVENT_GAME_STARTED
+    assert data == {"game_id": "g1", "player_count": 2, "round_count": 8}
+
+
+def test_game_started_only_once_no_refire_on_flap():
+    hass = _FakeHass()
+    game = _FakeGame()
+    game.round = 1
+    game.phase = GamePhase.QUESTION_ACTIVE
+    t = _emitter(hass, game)
+    t._on_state_changed()
+    t._on_state_changed()  # same phase → no re-fire
+    assert [e for e, _ in hass.bus.fired] == [EVENT_GAME_STARTED]
+
+
+def test_no_game_started_mid_game():
+    """A later round entering QUESTION_ACTIVE must not fire game_started."""
+    hass = _FakeHass()
+    game = _FakeGame()
+    t = _emitter(hass, game)
+    # Simulate reveal → next question at round 5.
+    game.round = 5
+    game.phase = GamePhase.ANSWER_REVEAL
+    t._on_state_changed()
+    game.phase = GamePhase.QUESTION_ACTIVE
+    t._on_state_changed()
+    assert EVENT_GAME_STARTED not in [e for e, _ in hass.bus.fired]
+
+
+def test_finale_fires_finale_and_winner():
+    hass = _FakeHass()
+    game = _FakeGame()
+    game.leader = _FakePlayer("Bob", 420)
+    game.phase = GamePhase.QUESTION_ACTIVE  # prime prev phase
+    t = _emitter(hass, game)
+    t._on_state_changed()
+    hass.bus.fired.clear()
+
+    game.phase = GamePhase.FINALE
+    t._on_state_changed()
+
+    events = [e for e, _ in hass.bus.fired]
+    assert events == [EVENT_FINALE_STARTED, EVENT_WINNER_DECIDED]
+    _, winner = hass.bus.fired[1]
+    assert winner == {"winner_name": "Bob", "score": 420}
+
+
+def test_finale_without_leader_skips_winner():
+    hass = _FakeHass()
+    game = _FakeGame()
+    game.leader = None
+    game.phase = GamePhase.FINALE
+    t = _emitter(hass, game)
+    t._on_state_changed()
+    assert [e for e, _ in hass.bus.fired] == [EVENT_FINALE_STARTED]
+
+
+def test_irrelevant_phase_fires_nothing():
+    """PAUSED / plain reveal transitions carry no house event of their own."""
+    hass = _FakeHass()
+    game = _FakeGame()
+    game.round = 3
+    game.phase = GamePhase.QUESTION_ACTIVE
+    t = _emitter(hass, game)
+    t._on_state_changed()
+    hass.bus.fired.clear()
+
+    game.phase = GamePhase.PAUSED
+    t._on_state_changed()
+    game.phase = GamePhase.QUESTION_ACTIVE
+    t._on_state_changed()
+    game.phase = GamePhase.ANSWER_REVEAL
+    t._on_state_changed()
+    assert hass.bus.fired == []
+
+
+# ---------------------------------------------------------------------------
+# Per-event milestones (WS-dispatch path)
+# ---------------------------------------------------------------------------
+
+
+def test_question_shown_payload():
+    hass = _FakeHass()
+    game = _FakeGame()
+    t = _emitter(hass, game)
+    t.notify_question_shown(_question("estimate"), 3, 10)
+    event, data = hass.bus.fired[0]
+    assert event == EVENT_QUESTION_SHOWN
+    assert data == {"round": 3, "total_rounds": 10, "question_type": "estimate"}
+
+
+def test_answer_revealed_payload():
+    hass = _FakeHass()
+    game = _FakeGame()
+    game.round = 4
+    game._summary = _summary(
+        results=[
+            _result("Alice", True),
+            _result("Bob", False),
+            _result("Cara", True),
+        ]
+    )
+    t = _emitter(hass, game)
+    t.notify_answer_revealed(game)
+    event, data = hass.bus.fired[0]
+    assert event == EVENT_ANSWER_REVEALED
+    assert data == {
+        "round": 4,
+        "correct_option_index": 1,  # "da Vinci" is index 1 in answers
+        "correct_option_text": "da Vinci",
+        "correct_count": 2,
+        "total_players": 3,
+    }
+
+
+def test_answer_revealed_no_summary_noop():
+    hass = _FakeHass()
+    game = _FakeGame()
+    game._summary = None
+    t = _emitter(hass, game)
+    t.notify_answer_revealed(game)
+    assert hass.bus.fired == []
+
+
+def test_streak_milestone_payload():
+    hass = _FakeHass()
+    game = _FakeGame()
+    t = _emitter(hass, game)
+    t.notify_streak_milestone("Alice", 5, 50)
+    event, data = hass.bus.fired[0]
+    assert event == EVENT_STREAK_MILESTONE
+    assert data == {"player_name": "Alice", "streak": 5, "bonus": 50}
+
+
+def test_game_ended_leaderboard_trimmed():
+    hass = _FakeHass()
+    game = _FakeGame()
+    # The real serialize_leaderboard carries many keys; the event keeps only
+    # name+score.
+    game._leaderboard = [
+        {"name": "Bob", "score": 420, "rank": 1, "streak": 3, "submitted": True},
+        {"name": "Alice", "score": 300, "rank": 2, "streak": 0},
+    ]
+    t = _emitter(hass, game)
+    t.notify_game_ended(game)
+    event, data = hass.bus.fired[0]
+    assert event == EVENT_GAME_ENDED
+    assert data == {
+        "leaderboard": [
+            {"name": "Bob", "score": 420},
+            {"name": "Alice", "score": 300},
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle: attach/detach + options-reload snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_attach_detach_registers_callback():
+    game = _FakeGame()
+    t = _emitter(_FakeHass(), game)
+    t.attach()
+    assert t._on_state_changed in game.callbacks
+    t.detach()
+    assert t._on_state_changed not in game.callbacks
+
+
+def test_runtime_state_snapshot_roundtrip():
+    game = _FakeGame()
+    t = _emitter(_FakeHass(), game)
+    game.round = 1
+    game.phase = GamePhase.QUESTION_ACTIVE
+    t._on_state_changed()  # sets _last_phase, fires game_started
+    snap = t.export_runtime_state()
+    assert snap == {"last_phase": "QUESTION_ACTIVE"}
+
+    # A fresh emitter (options reload) that restores the snapshot must NOT
+    # re-fire game_started when it sees the same active round again.
+    hass2 = _FakeHass()
+    game2 = _FakeGame()
+    game2.round = 1
+    game2.phase = GamePhase.QUESTION_ACTIVE
+    t2 = QuizifyEventEmitter(hass=hass2, game_state=game2)
+    t2.restore_runtime_state(snap)
+    t2._on_state_changed()
+    assert hass2.bus.fired == []
+
+
+def test_restore_ignores_empty_and_bad_snapshot():
+    t = _emitter(_FakeHass(), _FakeGame())
+    t.restore_runtime_state(None)
+    assert t._last_phase is None
+    t.restore_runtime_state({})
+    assert t._last_phase is None
+    t.restore_runtime_state({"last_phase": "NOT_A_PHASE"})
+    assert t._last_phase is None
+
+
+@pytest.mark.parametrize(
+    "event_name",
+    [
+        EVENT_GAME_STARTED,
+        EVENT_QUESTION_SHOWN,
+        EVENT_ANSWER_REVEALED,
+        EVENT_STREAK_MILESTONE,
+        EVENT_FINALE_STARTED,
+        EVENT_WINNER_DECIDED,
+        EVENT_GAME_ENDED,
+    ],
+)
+def test_event_names_are_namespaced(event_name):
+    assert event_name.startswith("quizify_")

--- a/tests/test_game_events.py
+++ b/tests/test_game_events.py
@@ -161,6 +161,58 @@ def test_no_hass_is_noop_everywhere():
 
 
 # ---------------------------------------------------------------------------
+# Master toggle (CONF_HOUSE_EVENTS_ENABLED, default off) — #366
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_emitter_is_not_configured():
+    """enabled=False → not configured even with a real hass/bus."""
+    t = QuizifyEventEmitter(hass=_FakeHass(), game_state=_FakeGame(), enabled=False)
+    assert t.is_configured is False
+
+
+def test_disabled_emitter_fires_nothing_on_any_path():
+    """The master toggle gates every path — phase-driven and WS forwarders."""
+    hass = _FakeHass()
+    game = _FakeGame()
+    game._players = [_FakePlayer("Alice", 0)]
+    game.game_id = "g1"
+    game.leader = _FakePlayer("Alice", 100)
+    t = QuizifyEventEmitter(hass=hass, game_state=game, enabled=False)
+
+    # Phase-driven path: game start + finale/winner.
+    game.round = 1
+    game.phase = GamePhase.QUESTION_ACTIVE
+    t._on_state_changed()
+    game.phase = GamePhase.FINALE
+    t._on_state_changed()
+
+    # WS-dispatch path: every forwarder.
+    t.notify_question_shown(_question(), 1, 10)
+    t.notify_streak_milestone("Alice", 5, 50)
+    game._summary = _summary(results=[_result("Alice", True)])
+    t.notify_answer_revealed(game)
+    game._leaderboard = [{"name": "Alice", "score": 100}]
+    t.notify_game_ended(game)
+
+    assert hass.bus.fired == []
+
+
+def test_enabled_by_default_still_fires():
+    """The constructor default stays on so the default helper keeps firing;
+    product 'off by default' is enforced at the config layer, not here."""
+    hass = _FakeHass()
+    game = _FakeGame()
+    game.game_id = "g1"
+    t = QuizifyEventEmitter(hass=hass, game_state=game)  # no enabled= → default
+    assert t.is_configured is True
+    game.round = 1
+    game.phase = GamePhase.QUESTION_ACTIVE
+    t._on_state_changed()
+    assert [e for e, _ in hass.bus.fired] == [EVENT_GAME_STARTED]
+
+
+# ---------------------------------------------------------------------------
 # Phase-driven milestones (state-callback path)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## The House Plays Along — Phase 1: HA event backbone (#366)

First phase of the v1.6.0 headline feature ([#494](https://github.com/mholzi/quizify/issues/494)): a Home Assistant event backbone that fires structured `quizify_*` events at every dramatic game beat, so automations (and the later light/SFX choreography phases) can react to the game.

### What's in this PR (backend-only, no UI)
- **`game_events.py`** (new) — event catalog + dispatcher. Fires HA events for: `game_started`, `question_shown`, `answer_revealed`, `streak_milestone`, `finale_started`, `winner_decided`, `game_ended`.
- **`websocket.py`** — emits the events at the matching state transitions.
- **`const.py` / `config_flow.py` / `__init__.py`** — the master toggle wiring (see below).
- **`tests/test_game_events.py`** (new) — unit tests covering the catalog, dispatch, and the toggle gating.

All events are fire-and-forget via the existing `ha_service` primitive, dev-safe no-ops when HA isn't present.

### Product decisions (resolved)
1. **`winner_decided` + `game_ended` — kept as two distinct events.** `winner_decided` carries the winner payload (announce-the-winner automations, victory lights, timed to the reveal); `game_ended` is the teardown signal (party lights off, restore scene). Collapsing them would blur payload + timing.
2. **Master toggle, off by default.** New option `CONF_HOUSE_EVENTS_ENABLED` (`house_events_enabled`, default **off**) in the options flow, mirroring the opt-in posture of the TTS/lights features. The integration fires **nothing** on the bus until the host opts in, so existing broad event automations are never surprised. The toggle is enforced at the single `_fire` choke point (covers both the phase-callback path and the `notify_*` WS forwarders) and re-read on options reload, so flipping it in the UI takes effect without an HA restart. Localized in all 5 locales.

### Verification
- `ruff` clean.
- Unit tests pass locally (`tests/test_game_events.py`: 25 tests incl. the 3 new gating tests; `test_config_flow_271` green). **The socket/HA-integration suites can't run in the base venv (no HA deps); real verification is CI on this PR.**
- Branch based on current `main` (v1.5.0 / 231c6b4).

Phase 2 (light choreography, UX design-shotgun), Phase 3 (room SFX) and Phase 4 (unified admin setup mirroring TTS) follow once this backbone lands.

Refs #494, #366
