### PR TITLE
feat(lights): Variant B 'Game Show' event accents — House Plays Along Phase 2 (#494)

### DIFF
--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -233,6 +233,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         game_state=game_state,
     )
     party_lights.attach()
+    # Accent choreography (#494 Phase 2): react to the quizify_* bus events on
+    # top of the phase-driven ambient glow. No-op unless lights are configured.
+    party_lights.attach_events()
 
     tts_announcer = QuizifyTTSAnnouncer(
         hass=hass,
@@ -317,6 +320,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             game_state=game_state,
         )
         new_pl.attach()
+        # Re-subscribe the accent choreography (#494) symmetrically — the old
+        # pl.detach() above already dropped its listeners + cancelled any pulse.
+        new_pl.attach_events()
         new_tts = QuizifyTTSAnnouncer(
             hass=_hass,
             tts_entity_id=opts.get(CONF_TTS_ENTITY) or None,

--- a/custom_components/quizify/lights.py
+++ b/custom_components/quizify/lights.py
@@ -5,10 +5,19 @@ preset to a configured set of HA light entities each time the game
 phase changes — the room glows coral while a question is live, sage
 on reveal, sun on the finale. Off when the game returns to lobby.
 
+On top of that phase-driven *ambient* glow, the lights also react to the
+``quizify_*`` HA bus events (the #366 event backbone) with momentary
+"accent" effects — Variant B "Game Show" choreography (#494 Phase 2). A
+question appearing bumps the coral; a reveal flashes green (crowd got it)
+or amber (they missed); a streak double-pulses; the winner triggers a
+victory sweep. Every accent is transient and RESTORES to the current phase
+baseline afterwards, so the ambient recipe stays the single source of the
+resting colour — accents only layer on top.
+
 Colours come straight from DESIGN.md (Soft Parlor palette) so the
 lights match the on-screen accent. Brightness/transition are
-intentionally subtle — no strobing. This is a cozy family-board-game
-party, not a club.
+intentionally subtle — single gentle pulses, no strobing, every accent
+well under ~1.5s. This is a cozy family-board-game party, not a club.
 
 The service no-ops cleanly when:
 - no light entities are configured
@@ -18,13 +27,23 @@ The service no-ops cleanly when:
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from typing import TYPE_CHECKING
 
 from .game.state import GamePhase, QuizifyGameState
+from .game_events import (
+    EVENT_ANSWER_REVEALED,
+    EVENT_QUESTION_SHOWN,
+    EVENT_STREAK_MILESTONE,
+    EVENT_WINNER_DECIDED,
+)
 from .ha_service import fire_and_forget_service
 
 if TYPE_CHECKING:
-    from homeassistant.core import HomeAssistant
+    from collections.abc import Callable
+
+    from homeassistant.core import Event, HomeAssistant
 
 
 # Per-phase light recipe. Colours are RGB triples matching DESIGN.md.
@@ -57,6 +76,81 @@ _PHASE_LIGHT_RECIPES: dict[GamePhase, dict[str, object] | None] = {
 }
 
 
+# --- Accent choreography (Variant B "Game Show", #494 Phase 2) ----------------
+# Momentary effects layered on top of the ambient phase glow. Each accent is a
+# short list of pulse steps: (command, hold_seconds). ``command`` is either a
+# ``light.turn_on`` payload (rgb/brightness/transition, entity_id is added at
+# call time) or the ``_BASELINE`` sentinel, which re-applies the current phase
+# recipe so the room settles back to its resting colour. ``hold_seconds`` is how
+# long to wait before the next step (asyncio.sleep). Total accent stays < ~1.5s;
+# single gentle pulses only — no strobing (physical bulbs, no reduced-motion).
+_BASELINE = "baseline"
+
+# question_shown: brief brightness bump on the *current* coral (no colour set →
+# keeps whatever the QUESTION_ACTIVE recipe is showing), then settle back.
+_ACCENT_QUESTION_SHOWN: list[tuple[object, float]] = [
+    ({"brightness_pct": 88, "transition": 0.2}, 0.5),
+    (_BASELINE, 0.0),
+]
+
+# answer_revealed reactions — one pulse, then restore. Green when the crowd
+# mostly got it, amber when they mostly missed.
+_ACCENT_REVEAL_GREEN: list[tuple[object, float]] = [
+    ({"rgb_color": [120, 200, 140], "brightness_pct": 85, "transition": 0.3}, 0.5),
+    (_BASELINE, 0.0),
+]
+_ACCENT_REVEAL_AMBER: list[tuple[object, float]] = [
+    ({"rgb_color": [235, 175, 95], "brightness_pct": 85, "transition": 0.3}, 0.5),
+    (_BASELINE, 0.0),
+]
+
+# streak_milestone: double-pulse bright coral — up, baseline, up, settle.
+_STREAK_UP: dict[str, object] = {
+    "rgb_color": [255, 150, 120],
+    "brightness_pct": 92,
+    "transition": 0.15,
+}
+_ACCENT_STREAK: list[tuple[object, float]] = [
+    (_STREAK_UP, 0.2),
+    (_BASELINE, 0.25),
+    (_STREAK_UP, 0.2),
+    (_BASELINE, 0.0),
+]
+
+# winner_decided: victory sweep in sun — 3-beat up/down/up/down/up, then settle
+# to a steady 90% sun. Settles to an explicit sun 90% rather than the phase
+# baseline because it fires alongside the FINALE transition, whose recipe is
+# also sun 90% — settling explicitly keeps the two in agreement.
+_WINNER_UP: dict[str, object] = {
+    "rgb_color": [232, 196, 127],
+    "brightness_pct": 100,
+    "transition": 0.15,
+}
+_WINNER_DOWN: dict[str, object] = {
+    "rgb_color": [232, 196, 127],
+    "brightness_pct": 55,
+    "transition": 0.15,
+}
+_WINNER_SETTLE: dict[str, object] = {
+    "rgb_color": [232, 196, 127],
+    "brightness_pct": 90,
+    "transition": 0.3,
+}
+_ACCENT_WINNER: list[tuple[object, float]] = [
+    (_WINNER_UP, 0.2),
+    (_WINNER_DOWN, 0.2),
+    (_WINNER_UP, 0.2),
+    (_WINNER_DOWN, 0.2),
+    (_WINNER_UP, 0.2),
+    (_WINNER_SETTLE, 0.0),
+]
+
+# NOTE: there is deliberately NO finale_started accent. The FINALE phase recipe
+# already drives the room to sun 90% at the same instant quizify_finale_started
+# fires; a competing accent build would race the ambient transition. The winner
+# sweep (above) is the finale's celebration instead.
+
+
 class QuizifyPartyLights:
     """Pushes phase-based light presets to HA light entities."""
 
@@ -78,6 +172,11 @@ class QuizifyPartyLights:
         self._entity_ids = cleaned
         self._game = game_state
         self._last_phase: GamePhase | None = None
+        # Accent choreography (#494). Unsub handles for the four bus listeners
+        # and the single in-flight multi-step pulse task (cancel-safe: only one
+        # accent runs at a time — a new accent cancels the old).
+        self._event_unsubs: list[Callable[[], None]] = []
+        self._pulse_task: asyncio.Task | None = None
 
     @property
     def is_configured(self) -> bool:
@@ -86,8 +185,37 @@ class QuizifyPartyLights:
     def attach(self) -> None:
         self._game.register_state_callback(self._on_state_changed)
 
+    def attach_events(self) -> None:
+        """Subscribe to the ``quizify_*`` bus events for accent choreography.
+
+        Registers the four accent listeners (#494 Phase 2). Idempotent, and a
+        no-op unless configured (needs a hass bus + at least one entity). The
+        emitter (#366) only fires these when the host has opted into house
+        events, so an off toggle means the listeners simply never trigger.
+        """
+        if not self.is_configured or self._event_unsubs:
+            return
+        hass = self._hass
+        if hass is None:  # narrow for type-checkers; is_configured already guards
+            return
+        self._event_unsubs = [
+            hass.bus.async_listen(EVENT_QUESTION_SHOWN, self._on_question_shown),
+            hass.bus.async_listen(EVENT_ANSWER_REVEALED, self._on_answer_revealed),
+            hass.bus.async_listen(EVENT_STREAK_MILESTONE, self._on_streak_milestone),
+            hass.bus.async_listen(EVENT_WINNER_DECIDED, self._on_winner_decided),
+        ]
+
     def detach(self) -> None:
         self._game.unregister_state_callback(self._on_state_changed)
+        # Tear down accent choreography: drop the bus listeners and cancel any
+        # in-flight pulse so the reload path (which already calls detach()) or an
+        # unload leaves nothing dangling.
+        for unsub in self._event_unsubs:
+            # Never let an unsub failure escape the reload/unload path.
+            with contextlib.suppress(Exception):
+                unsub()
+        self._event_unsubs = []
+        self._cancel_pulse()
 
     def _on_state_changed(self) -> None:
         if not self.is_configured:
@@ -131,3 +259,92 @@ class QuizifyPartyLights:
             data,
             f"Party lights {domain}.{service} (entities={self._entity_ids})",
         )
+
+    # ------------------------------------------------------------------
+    # Accent choreography (#494 Phase 2) — bus-event handlers
+    # ------------------------------------------------------------------
+
+    def _on_question_shown(self, event: Event) -> None:  # noqa: ARG002
+        """Brightness bump on the live coral when a question appears."""
+        self._start_pulse(_ACCENT_QUESTION_SHOWN)
+
+    def _on_answer_revealed(self, event: Event) -> None:
+        """Green when the crowd mostly nailed it, amber when they mostly missed.
+
+        Guards ``total_players == 0`` (no div-by-zero) → treated as the minority
+        case (amber). A strict majority (> half) flips it green.
+        """
+        data = event.data or {}
+        correct = data.get("correct_count") or 0
+        total = data.get("total_players") or 0
+        majority = total > 0 and correct > total / 2
+        self._start_pulse(_ACCENT_REVEAL_GREEN if majority else _ACCENT_REVEAL_AMBER)
+
+    def _on_streak_milestone(self, event: Event) -> None:  # noqa: ARG002
+        """Double-pulse bright coral to celebrate a hot streak."""
+        self._start_pulse(_ACCENT_STREAK)
+
+    def _on_winner_decided(self, event: Event) -> None:  # noqa: ARG002
+        """Victory sweep in sun, settling to a steady celebratory glow."""
+        self._start_pulse(_ACCENT_WINNER)
+
+    # ------------------------------------------------------------------
+    # Accent choreography — pulse scheduling
+    # ------------------------------------------------------------------
+
+    def _apply_phase_baseline(self) -> None:
+        """Re-apply the current phase's ambient recipe (no-op if None).
+
+        The restore target for every accent: after a momentary effect the room
+        settles back onto the phase-driven glow, so the ambient recipe stays the
+        single owner of the resting colour.
+        """
+        recipe = _PHASE_LIGHT_RECIPES.get(self._last_phase)
+        if recipe is None:
+            return
+        self._call("light", "turn_on", {"entity_id": self._entity_ids, **recipe})
+
+    def _start_pulse(self, steps: list[tuple[object, float]]) -> None:
+        """Kick off a multi-step accent as a cancel-safe background task.
+
+        Cancels any in-flight accent first (no stacking), then schedules the new
+        one. No-op unless configured. Gated so an off/unconfigured integration
+        never touches the lights.
+        """
+        if not self.is_configured:
+            return
+        hass = self._hass
+        if hass is None:  # narrow for type-checkers; is_configured already guards
+            return
+        self._cancel_pulse()
+        self._pulse_task = hass.async_create_task(self._run_pulse(steps))
+
+    def _cancel_pulse(self) -> None:
+        """Cancel any pending accent pulse (re-entrant, safe if none running)."""
+        if self._pulse_task is not None and not self._pulse_task.done():
+            self._pulse_task.cancel()
+        self._pulse_task = None
+
+    async def _run_pulse(self, steps: list[tuple[object, float]]) -> None:
+        """Walk the accent steps, sleeping between each.
+
+        Each step is ``(command, hold_seconds)``; ``command`` is either a
+        ``light.turn_on`` payload or ``_BASELINE`` (restore the phase recipe).
+        A cancel (a newer accent, or detach) unwinds cleanly — the
+        ``CancelledError`` is swallowed so it never leaks onto the loop.
+        """
+        try:
+            for command, hold in steps:
+                if command == _BASELINE:
+                    self._apply_phase_baseline()
+                elif isinstance(command, dict):
+                    self._call(
+                        "light",
+                        "turn_on",
+                        {"entity_id": self._entity_ids, **command},
+                    )
+                if hold:
+                    await asyncio.sleep(hold)
+        except asyncio.CancelledError:
+            # Normal path: a newer accent or detach cancelled us. Stay quiet.
+            pass

--- a/custom_components/quizify/lights.py
+++ b/custom_components/quizify/lights.py
@@ -299,7 +299,10 @@ class QuizifyPartyLights:
         settles back onto the phase-driven glow, so the ambient recipe stays the
         single owner of the resting colour.
         """
-        recipe = _PHASE_LIGHT_RECIPES.get(self._last_phase)
+        phase = self._last_phase
+        if phase is None:
+            return
+        recipe = _PHASE_LIGHT_RECIPES.get(phase)
         if recipe is None:
             return
         self._call("light", "turn_on", {"entity_id": self._entity_ids, **recipe})

--- a/tests/test_light_choreography.py
+++ b/tests/test_light_choreography.py
@@ -1,0 +1,384 @@
+"""Tests for the party-light accent choreography — Variant B "Game Show" (#494).
+
+QuizifyPartyLights layers momentary "accent" effects on top of its phase-driven
+ambient glow by subscribing to the ``quizify_*`` HA bus events (#366 backbone).
+Here a fake hass records bus listeners + service calls and runs the pulse task
+deterministically (asyncio.sleep monkeypatched to a no-op), so we assert the
+*intent* — which colour/brightness a given event drives, that it restores the
+phase baseline, that a new accent cancels an in-flight one, and that detach()
+tears everything down — without a real Home Assistant.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify import lights as lights_mod  # noqa: E402
+from custom_components.quizify.game.state import GamePhase  # noqa: E402
+from custom_components.quizify.game_events import (  # noqa: E402
+    EVENT_ANSWER_REVEALED,
+    EVENT_QUESTION_SHOWN,
+    EVENT_STREAK_MILESTONE,
+    EVENT_WINNER_DECIDED,
+)
+from custom_components.quizify.lights import QuizifyPartyLights  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeEvent:
+    def __init__(self, data: dict) -> None:
+        self.data = data
+
+
+class _FakeTask:
+    """Cancel-tracking stand-in for asyncio.Task.
+
+    When ``run`` is True the coroutine is driven straight to completion (sleeps
+    are no-ops), so service calls land synchronously. When False the coroutine
+    is left suspended so a test can observe cancel() semantics on an in-flight
+    accent.
+    """
+
+    def __init__(self, coro, run: bool) -> None:
+        self._coro = coro
+        self.cancelled = False
+        self._done = False
+        if run:
+            with contextlib.suppress(StopIteration):
+                coro.send(None)
+            self._done = True
+
+    def done(self) -> bool:
+        return self._done
+
+    def cancel(self) -> None:
+        self.cancelled = True
+        if not self._done:
+            # Unwind (or discard an unstarted) coroutine cleanly — no
+            # "never awaited" warning.
+            self._coro.close()
+        self._done = True
+
+
+class _FakeBus:
+    def __init__(self) -> None:
+        self.listeners: dict[str, list] = {}
+
+    def async_listen(self, event_type, cb):  # noqa: ANN001
+        self.listeners.setdefault(event_type, []).append(cb)
+
+        def _unsub() -> None:
+            lst = self.listeners.get(event_type, [])
+            if cb in lst:
+                lst.remove(cb)
+
+        return _unsub
+
+    def dispatch(self, event_type, data):  # noqa: ANN001
+        """Test helper: deliver a fake Event to every registered listener."""
+        for cb in list(self.listeners.get(event_type, [])):
+            cb(_FakeEvent(data))
+
+
+class _FakeHass:
+    def __init__(self, run_tasks: bool = True) -> None:
+        self.bus = _FakeBus()
+        self.run_tasks = run_tasks
+        self.tasks: list[_FakeTask] = []
+
+    def async_create_task(self, coro):  # noqa: ANN001
+        task = _FakeTask(coro, run=self.run_tasks)
+        self.tasks.append(task)
+        return task
+
+
+class _FakeGame:
+    """Minimal game stand-in — the lights only register/unregister a callback
+    and (for the ambient path, untouched here) read phase/round/game_id."""
+
+    def __init__(self) -> None:
+        self.phase = GamePhase.LOBBY
+        self.round = 0
+        self.game_id = None
+        self.callbacks: list = []
+
+    def register_state_callback(self, cb):  # noqa: ANN001
+        self.callbacks.append(cb)
+
+    def unregister_state_callback(self, cb):  # noqa: ANN001
+        if cb in self.callbacks:
+            self.callbacks.remove(cb)
+
+
+@pytest.fixture(autouse=True)
+def _fast_sleep(monkeypatch):
+    """Make asyncio.sleep a no-op so pulse tasks run to completion instantly."""
+
+    async def _noop(*_args, **_kwargs):
+        return
+
+    monkeypatch.setattr(asyncio, "sleep", _noop)
+
+
+@pytest.fixture
+def calls(monkeypatch):
+    """Capture (domain, service, data) tuples from every light service call."""
+    recorded: list[tuple[str, str, dict]] = []
+
+    def _record(_hass, domain, service, data, _ctx):  # noqa: ANN001
+        recorded.append((domain, service, dict(data)))
+
+    monkeypatch.setattr(lights_mod, "fire_and_forget_service", _record)
+    return recorded
+
+
+def _lights(hass, *, phase=GamePhase.QUESTION_ACTIVE, entities=("light.party",)):
+    game = _FakeGame()
+    pl = QuizifyPartyLights(hass=hass, entity_ids=list(entities), game_state=game)
+    # Prime the ambient phase so baseline restores have something to apply.
+    pl._last_phase = phase
+    return pl
+
+
+def _turn_ons(calls):
+    return [data for (_d, service, data) in calls if service == "turn_on"]
+
+
+# ---------------------------------------------------------------------------
+# attach_events / gating
+# ---------------------------------------------------------------------------
+
+
+def test_attach_events_registers_four_listeners():
+    hass = _FakeHass()
+    pl = _lights(hass)
+    pl.attach_events()
+    assert set(hass.bus.listeners) == {
+        EVENT_QUESTION_SHOWN,
+        EVENT_ANSWER_REVEALED,
+        EVENT_STREAK_MILESTONE,
+        EVENT_WINNER_DECIDED,
+    }
+
+
+def test_attach_events_idempotent():
+    hass = _FakeHass()
+    pl = _lights(hass)
+    pl.attach_events()
+    pl.attach_events()  # second call must not double-register
+    assert all(len(v) == 1 for v in hass.bus.listeners.values())
+    assert len(pl._event_unsubs) == 4
+
+
+def test_not_configured_no_hass_registers_nothing_and_noops(calls):
+    pl = _lights(None)  # hass is None → not configured
+    pl.attach_events()
+    assert pl._event_unsubs == []
+    pl._on_question_shown(_FakeEvent({}))  # accent must be a no-op
+    assert calls == []
+
+
+def test_not_configured_no_entities_registers_nothing(calls):
+    hass = _FakeHass()
+    pl = _lights(hass, entities=())  # no entities → not configured
+    pl.attach_events()
+    assert hass.bus.listeners == {}
+    pl._on_streak_milestone(_FakeEvent({}))
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Accents fire the expected colour / brightness
+# ---------------------------------------------------------------------------
+
+
+def test_question_shown_bumps_brightness_then_restores(calls):
+    hass = _FakeHass()
+    pl = _lights(hass, phase=GamePhase.QUESTION_ACTIVE)
+    pl.attach_events()
+    hass.bus.dispatch(EVENT_QUESTION_SHOWN, {"round": 1})
+
+    outs = _turn_ons(calls)
+    # First: brightness bump (no colour set → keeps live coral).
+    assert outs[0] == {
+        "entity_id": ["light.party"],
+        "brightness_pct": 88,
+        "transition": 0.2,
+    }
+    # Last: restore QUESTION_ACTIVE baseline (coral 70%).
+    assert outs[-1] == {
+        "entity_id": ["light.party"],
+        **lights_mod._PHASE_LIGHT_RECIPES[GamePhase.QUESTION_ACTIVE],
+    }
+
+
+def test_answer_revealed_majority_is_green(calls):
+    hass = _FakeHass()
+    pl = _lights(hass)
+    pl.attach_events()
+    hass.bus.dispatch(
+        EVENT_ANSWER_REVEALED, {"correct_count": 3, "total_players": 4}
+    )
+    outs = _turn_ons(calls)
+    assert outs[0]["rgb_color"] == [120, 200, 140]
+    assert outs[0]["brightness_pct"] == 85
+
+
+def test_answer_revealed_minority_is_amber(calls):
+    hass = _FakeHass()
+    pl = _lights(hass)
+    pl.attach_events()
+    hass.bus.dispatch(
+        EVENT_ANSWER_REVEALED, {"correct_count": 1, "total_players": 4}
+    )
+    outs = _turn_ons(calls)
+    assert outs[0]["rgb_color"] == [235, 175, 95]
+
+
+def test_answer_revealed_exact_half_is_amber(calls):
+    """Half-right is not a *strict* majority → amber."""
+    hass = _FakeHass()
+    pl = _lights(hass)
+    pl.attach_events()
+    hass.bus.dispatch(
+        EVENT_ANSWER_REVEALED, {"correct_count": 2, "total_players": 4}
+    )
+    assert _turn_ons(calls)[0]["rgb_color"] == [235, 175, 95]
+
+
+def test_answer_revealed_zero_players_no_crash_amber(calls):
+    hass = _FakeHass()
+    pl = _lights(hass)
+    pl.attach_events()
+    # total_players == 0 must not divide-by-zero; treated as minority (amber).
+    hass.bus.dispatch(
+        EVENT_ANSWER_REVEALED, {"correct_count": 0, "total_players": 0}
+    )
+    assert _turn_ons(calls)[0]["rgb_color"] == [235, 175, 95]
+
+
+def test_streak_milestone_double_pulses_coral(calls):
+    hass = _FakeHass()
+    pl = _lights(hass, phase=GamePhase.QUESTION_ACTIVE)
+    pl.attach_events()
+    hass.bus.dispatch(EVENT_STREAK_MILESTONE, {"player_name": "Alice", "streak": 5})
+
+    outs = _turn_ons(calls)
+    coral = [o for o in outs if o.get("rgb_color") == [255, 150, 120]]
+    assert len(coral) == 2  # two "up" beats
+    assert all(o["brightness_pct"] == 92 for o in coral)
+    # Settles back on the phase baseline.
+    assert outs[-1] == {
+        "entity_id": ["light.party"],
+        **lights_mod._PHASE_LIGHT_RECIPES[GamePhase.QUESTION_ACTIVE],
+    }
+
+
+def test_winner_decided_sweep_settles_to_sun_90(calls):
+    hass = _FakeHass()
+    pl = _lights(hass, phase=GamePhase.FINALE)
+    pl.attach_events()
+    hass.bus.dispatch(EVENT_WINNER_DECIDED, {"winner_name": "Bob", "score": 420})
+
+    outs = _turn_ons(calls)
+    ups = [o for o in outs if o.get("brightness_pct") == 100]
+    assert len(ups) == 3  # three up-beats
+    assert all(o["rgb_color"] == [232, 196, 127] for o in ups)
+    # Final settle: steady sun 90% (explicit, not a baseline restore).
+    assert outs[-1] == {
+        "entity_id": ["light.party"],
+        "rgb_color": [232, 196, 127],
+        "brightness_pct": 90,
+        "transition": 0.3,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Baseline restore respects the current phase
+# ---------------------------------------------------------------------------
+
+
+def test_baseline_restore_uses_current_phase(calls):
+    hass = _FakeHass()
+    pl = _lights(hass, phase=GamePhase.ANSWER_REVEAL)
+    pl.attach_events()
+    hass.bus.dispatch(EVENT_QUESTION_SHOWN, {})
+    assert _turn_ons(calls)[-1] == {
+        "entity_id": ["light.party"],
+        **lights_mod._PHASE_LIGHT_RECIPES[GamePhase.ANSWER_REVEAL],
+    }
+
+
+def test_baseline_restore_noop_when_phase_recipe_is_none(calls):
+    hass = _FakeHass()
+    pl = _lights(hass, phase=GamePhase.PAUSED)  # PAUSED recipe is None
+    pl.attach_events()
+    hass.bus.dispatch(EVENT_QUESTION_SHOWN, {})
+    outs = _turn_ons(calls)
+    # Only the brightness bump lands; the baseline step is a no-op (PAUSED=None).
+    assert outs == [
+        {"entity_id": ["light.party"], "brightness_pct": 88, "transition": 0.2}
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Pulse cancellation / no stacking
+# ---------------------------------------------------------------------------
+
+
+def test_new_accent_cancels_in_flight_pulse():
+    hass = _FakeHass(run_tasks=False)  # leave pulses suspended
+    pl = _lights(hass)
+    pl.attach_events()
+
+    hass.bus.dispatch(EVENT_QUESTION_SHOWN, {})
+    first = pl._pulse_task
+    assert first is not None and not first.cancelled
+
+    hass.bus.dispatch(EVENT_STREAK_MILESTONE, {})
+    # Starting the second accent must cancel the first (no stacking).
+    assert first.cancelled is True
+    assert pl._pulse_task is not first
+    assert pl._pulse_task.cancelled is False
+
+    # Tidy the still-suspended second pulse (run_tasks=False leaves it live).
+    pl.detach()
+
+
+def test_detach_unregisters_listeners_and_cancels_pulse():
+    hass = _FakeHass(run_tasks=False)
+    pl = _lights(hass)
+    pl.attach_events()
+    hass.bus.dispatch(EVENT_QUESTION_SHOWN, {})
+    task = pl._pulse_task
+    assert task is not None
+
+    pl.detach()
+
+    # All listeners gone.
+    assert all(len(v) == 0 for v in hass.bus.listeners.values())
+    assert pl._event_unsubs == []
+    # In-flight pulse cancelled and cleared.
+    assert task.cancelled is True
+    assert pl._pulse_task is None
+
+
+def test_detach_without_events_is_safe():
+    """detach() must be safe even if attach_events() was never called."""
+    hass = _FakeHass()
+    pl = _lights(hass)
+    pl.attach()
+    pl.detach()  # no listeners, no pulse → must not raise
+    assert pl._event_unsubs == []
+    assert pl._pulse_task is None


### PR DESCRIPTION
## The House Plays Along — Phase 2: light choreography (Variant B "Game Show")

Second phase of the v1.6.0 headline feature ([#494](https://github.com/mholzi/quizify/issues/494)), building on the event backbone from #495. The party lights now react to the `quizify_*` HA bus events with momentary **accent** effects — the lights become the first consumer of the #366 event API, which is exactly the pattern users' own automations will use.

### Design decision
Variant **B "Game Show"** (the locked personality). The existing phase-driven **ambient** glow (coral on question, sage on reveal, sun on finale) stays the single source of the resting colour and is **unchanged**; accents are transient effects layered on top that restore to the current phase baseline afterward.

### Event → accent
- `quizify_question_shown` → brief brightness bump on the live coral (88% / 0.2s), then settle.
- `quizify_answer_revealed` → verdict flash: **green** when the crowd mostly got it (`correct_count > total/2`), **amber** when they mostly missed. One pulse, then restore. Zero players → amber, no div-by-zero.
- `quizify_streak_milestone` → double-pulse bright coral.
- `quizify_winner_decided` → victory sweep in sun (3-beat), settling to a steady 90%.
- `quizify_finale_started` → **deliberately no accent**: the FINALE phase recipe already drives the room to sun 90% at the same instant, so a competing build would race the ambient transition. The winner sweep is the finale's celebration instead.

### Safety
Single gentle pulses, no strobing, every accent well under ~1.5s (streak ~0.65s, winner ~1.0s). Physical bulbs have no browser reduced-motion — the restraint is in the design. Only one accent runs at a time: a new accent cancels the in-flight pulse (no stacking), and `detach()` cancels it + drops the listeners on reload/unload.

### Gating
Accents only fire when the lights are configured **and** `house_events_enabled` is on (off → the emitter fires nothing, so the listeners never trigger). No new config field.

### Implementation
- `lights.py` — `QuizifyPartyLights` (single owner, no new class) gains `attach_events()`, four bus-event handlers, `_apply_phase_baseline()`, and a cancel-safe pulse task (`_start_pulse`/`_cancel_pulse`/`_run_pulse`).
- `__init__.py` — `attach_events()` wired at setup and in the options-reload path (old `pl.detach()` already cleans up symmetrically).
- `tests/test_light_choreography.py` (new) — 16 tests: listener registration/idempotency, not-configured no-ops, each accent's colour/brightness, majority/minority/exact-half/zero-players, baseline restore per phase (incl. PAUSED no-op), new-accent-cancels-in-flight, detach teardown.

### Verification
- `ruff` clean.
- `tests/test_light_choreography.py` + `test_game_events.py` + `test_config_flow_271`: 41 passed locally. The full suite can't run in the local env (system Python 3.9 vs `datetime.UTC` in unrelated modules — pre-existing, verified by stashing this diff); **CI runs modern Python and is the real green.**
- On-device colour/timing is best judged live per the mobile/hardware-verify workflow before ship.

Refs #494, #366
