### PR TITLE
feat(sfx): Variant C room sound effects — House Plays Along Phase 3 (#494)

### DIFF
--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -44,6 +44,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         CONF_LOBBY_MUSIC_URL,
         CONF_MEDIA_PLAYER_ENTITY,
         CONF_PARTY_LIGHT_ENTITIES,
+        CONF_SFX_CORRECT_URL,
+        CONF_SFX_STREAK_URL,
+        CONF_SFX_WINNER_URL,
+        CONF_SFX_WRONG_URL,
         CONF_TTS_ENTITY,
         DEFAULT_HOUSE_EVENTS_ENABLED,
     )
@@ -64,6 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         register_routes,
     )
     from .server.websocket import QuizifyWebSocketHandler  # noqa: PLC0415
+    from .sound_effects import QuizifySoundEffects  # noqa: PLC0415
     from .tts import QuizifyTTSAnnouncer  # noqa: PLC0415
 
     _LOGGER.debug("Setting up Quizify integration")
@@ -272,10 +277,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     event_emitter.attach()
     ws_handler.set_event_emitter(event_emitter)
 
+    # Room SFX (#494 Phase 3): one-shot stings on the shared media_player at game
+    # milestones, driven off the quizify_* bus events. Hybrid source — per-cue
+    # override URLs from the options flow, else the bundled CC0 default at
+    # www/sfx/<cue>.mp3 (if the host installed one). No phase callback, so only
+    # attach_events() (which also does the one-time bundled-default disk stat).
+    sound_effects = QuizifySoundEffects(
+        hass=hass,
+        media_player_entity_id=options.get(CONF_MEDIA_PLAYER_ENTITY) or None,
+        game_state=game_state,
+        cue_urls={
+            "correct": options.get(CONF_SFX_CORRECT_URL) or None,
+            "wrong": options.get(CONF_SFX_WRONG_URL) or None,
+            "streak": options.get(CONF_SFX_STREAK_URL) or None,
+            "winner": options.get(CONF_SFX_WINNER_URL) or None,
+        },
+    )
+    sound_effects.attach_events()
+
     hass.data[DOMAIN]["party_lights"] = party_lights
     hass.data[DOMAIN]["tts_announcer"] = tts_announcer
     hass.data[DOMAIN]["lobby_music"] = lobby_music
     hass.data[DOMAIN]["event_emitter"] = event_emitter
+    hass.data[DOMAIN]["sound_effects"] = sound_effects
 
     # Re-attach on options change so toggling lights/TTS in the UI takes
     # effect without an HA restart.
@@ -298,6 +322,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         tts: QuizifyTTSAnnouncer | None = domain_data.get("tts_announcer")
         lm: QuizifyLobbyMusic | None = domain_data.get("lobby_music")
         ev: QuizifyEventEmitter | None = domain_data.get("event_emitter")
+        sfx: QuizifySoundEffects | None = domain_data.get("sound_effects")
         # Snapshot the old announcer's live per-game narration config BEFORE we
         # tear it down (#411). Rebuilding from the config entry resets
         # ``_enabled`` to False and drops the admin's per-game entity overrides,
@@ -314,6 +339,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             lm.detach()
         if ev is not None:
             ev.detach()
+        if sfx is not None:
+            sfx.detach()
         new_pl = QuizifyPartyLights(
             hass=_hass,
             entity_ids=list(opts.get(CONF_PARTY_LIGHT_ENTITIES) or []),
@@ -351,10 +378,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # options UI thus takes effect immediately, without an HA restart.
         new_ev.restore_runtime_state(ev_snapshot)
         new_ev.attach()
+        # Rebuild room SFX from the fresh options (new override URLs, new
+        # media_player). attach_events() re-stats the bundled defaults and
+        # re-subscribes; the old sfx.detach() above already dropped its
+        # listeners. No phase callback, so no attach()/snapshot needed.
+        new_sfx = QuizifySoundEffects(
+            hass=_hass,
+            media_player_entity_id=opts.get(CONF_MEDIA_PLAYER_ENTITY) or None,
+            game_state=game_state,
+            cue_urls={
+                "correct": opts.get(CONF_SFX_CORRECT_URL) or None,
+                "wrong": opts.get(CONF_SFX_WRONG_URL) or None,
+                "streak": opts.get(CONF_SFX_STREAK_URL) or None,
+                "winner": opts.get(CONF_SFX_WINNER_URL) or None,
+            },
+        )
+        new_sfx.attach_events()
         domain_data["party_lights"] = new_pl
         domain_data["tts_announcer"] = new_tts
         domain_data["lobby_music"] = new_lm
         domain_data["event_emitter"] = new_ev
+        domain_data["sound_effects"] = new_sfx
         handler = domain_data.get("ws_handler")
         if handler is not None:
             handler.set_tts_announcer(new_tts)

--- a/custom_components/quizify/config_flow.py
+++ b/custom_components/quizify/config_flow.py
@@ -22,6 +22,10 @@ from .const import (
     CONF_LOBBY_MUSIC_URL,
     CONF_MEDIA_PLAYER_ENTITY,
     CONF_PARTY_LIGHT_ENTITIES,
+    CONF_SFX_CORRECT_URL,
+    CONF_SFX_STREAK_URL,
+    CONF_SFX_WINNER_URL,
+    CONF_SFX_WRONG_URL,
     CONF_TTS_ENTITY,
     DEFAULT_HOUSE_EVENTS_ENABLED,
     DOMAIN,
@@ -125,6 +129,36 @@ class QuizifyOptionsFlow(OptionsFlow):
                 default=current.get(CONF_COMMUNITY_SUBMIT_SECRET, ""),
             ): selector.TextSelector(
                 selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD),
+            ),
+            # Per-cue room-SFX override URLs (#494 Phase 3). Each is an optional
+            # free-text URL to a short one-shot sound played on the media_player
+            # above at a game milestone. Empty = fall back to the bundled CC0
+            # default at www/sfx/<cue>.mp3 (if the host installed one), else the
+            # cue stays silent. The SFX share the TTS speaker and are dropped
+            # while a TTS announcement is live.
+            vol.Optional(
+                CONF_SFX_CORRECT_URL,
+                default=current.get(CONF_SFX_CORRECT_URL, ""),
+            ): selector.TextSelector(
+                selector.TextSelectorConfig(type=selector.TextSelectorType.URL),
+            ),
+            vol.Optional(
+                CONF_SFX_WRONG_URL,
+                default=current.get(CONF_SFX_WRONG_URL, ""),
+            ): selector.TextSelector(
+                selector.TextSelectorConfig(type=selector.TextSelectorType.URL),
+            ),
+            vol.Optional(
+                CONF_SFX_STREAK_URL,
+                default=current.get(CONF_SFX_STREAK_URL, ""),
+            ): selector.TextSelector(
+                selector.TextSelectorConfig(type=selector.TextSelectorType.URL),
+            ),
+            vol.Optional(
+                CONF_SFX_WINNER_URL,
+                default=current.get(CONF_SFX_WINNER_URL, ""),
+            ): selector.TextSelector(
+                selector.TextSelectorConfig(type=selector.TextSelectorType.URL),
             ),
             # Master toggle for "The House Plays Along" (#366). Off by default:
             # the integration fires no quizify_* bus events until the host opts

--- a/custom_components/quizify/const.py
+++ b/custom_components/quizify/const.py
@@ -68,6 +68,16 @@ DEFAULT_HOUSE_EVENTS_ENABLED = False
 # there is nothing to play unless the user supplies one.
 CONF_LOBBY_MUSIC_URL = "lobby_music_url"  # str, single, free-text URL
 
+# Per-cue room-SFX override URLs (#494 Phase 3, "The House Plays Along"). Each is
+# an OPTIONAL free-text URL to a short one-shot sound the integration plays on the
+# shared media_player at a game milestone. Empty => the bundled CC0 default at
+# www/sfx/<cue>.mp3 is used instead, IF present (none ship in the repo — the host
+# supplies their own). Empty AND no bundled file => that cue stays silent.
+CONF_SFX_CORRECT_URL = "sfx_correct_url"  # str, single, free-text URL
+CONF_SFX_WRONG_URL = "sfx_wrong_url"  # str, single, free-text URL
+CONF_SFX_STREAK_URL = "sfx_streak_url"  # str, single, free-text URL
+CONF_SFX_WINNER_URL = "sfx_winner_url"  # str, single, free-text URL
+
 # Endpoint a composed community question pack is POSTed to so it lands as a
 # GitHub issue for review (#180). Empty by default — the whole in-app pack
 # submission feature stays completely inert (UI hidden, endpoints accept

--- a/custom_components/quizify/sound_effects.py
+++ b/custom_components/quizify/sound_effects.py
@@ -1,0 +1,258 @@
+"""Room sound effects (SFX) for Quizify — "The House Plays Along" Phase 3 (#494).
+
+Subscribes to the ``quizify_*`` HA bus events (the #366 event backbone) and
+plays a short one-shot sound on a configured ``media_player`` at every game
+milestone: a "correct" sting when the crowd mostly nailed the answer, a "wrong"
+buzzer when they mostly missed, a chime on a hot streak, and a fanfare when the
+winner is decided. Variant C "Hybrid" — bundled CC0 defaults with per-cue
+user-URL overrides.
+
+Two sources per cue (hybrid):
+
+* **Override** — a free-text URL the host supplied in the options flow
+  (``CONF_SFX_*_URL``). Wins when set.
+* **Bundled default** — ``www/sfx/<cue>.mp3`` served at
+  ``/quizify/static/sfx/<cue>.mp3``, used only when no override is set AND the
+  file physically exists on disk. No audio ships in the repo, so the defaults
+  are inert until the host drops their own CC0 files into ``www/sfx/``.
+
+If neither an override nor an available default resolves for a cue, that cue
+no-ops silently.
+
+The SFX share the SAME ``media_player`` entity used for TTS announcements and
+lobby music (no separate config field). To avoid an effect talking over a live
+TTS announcement, a cue is **dropped** (not queued) whenever the shared speaker
+is already ``playing`` — TTS wins the speaker, the sting is skipped.
+
+Everything no-ops cleanly when:
+- no media_player entity is configured
+- the runtime has no HA instance (standalone dev server)
+- neither an override URL nor an available bundled default resolves for the cue
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .game_events import (
+    EVENT_ANSWER_REVEALED,
+    EVENT_STREAK_MILESTONE,
+    EVENT_WINNER_DECIDED,
+)
+from .ha_service import fire_and_forget_service
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from homeassistant.core import Event, HomeAssistant
+
+    from .game.state import QuizifyGameState
+
+_LOGGER = logging.getLogger(__name__)
+
+# Static-asset location — mirrors ``server.__init__`` (the source of truth) but
+# is redeclared here to avoid importing the whole server stack (views /
+# pack_submission …) just for two constants, which would drag heavy deps into
+# this light event-handler module. ``www/sfx/<cue>.mp3`` is served at
+# ``/quizify/static/sfx/<cue>.mp3``. Keep these two in sync with server.__init__.
+WWW_DIR = Path(__file__).parent / "www"
+STATIC_URL_PREFIX = "/quizify/static"
+
+# The four cue keys. Each maps to an optional override URL (from the options
+# flow) and a bundled default at ``www/sfx/<cue>.mp3``.
+_CUE_KEYS = ("correct", "wrong", "streak", "winner")
+
+# Best-effort HA base-URL helper. Imported lazily/guarded so the module still
+# imports on the standalone dev server (no ``homeassistant`` package) and so
+# tests can monkeypatch it. ``None`` => we cannot build a bundled-default URL
+# (only host-supplied override URLs work); that is a safe degradation.
+try:  # pragma: no cover - import guard exercised only off-HA
+    from homeassistant.helpers.network import get_url as _ha_get_url
+except Exception:  # noqa: BLE001 - any import failure => run without defaults
+    _ha_get_url = None  # type: ignore[assignment]
+
+
+class QuizifySoundEffects:
+    """Plays one-shot SFX on an HA media_player at game milestones (#494 P3)."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant | None,
+        media_player_entity_id: str | None,
+        game_state: QuizifyGameState,
+        cue_urls: dict[str, str | None],
+    ) -> None:
+        self._hass = hass
+        self._media_player_entity_id = (media_player_entity_id or "").strip() or None
+        self._game = game_state
+        # Per-cue override URLs. Normalized: blank/whitespace => None (no
+        # override). Unknown keys are ignored; missing keys default to None.
+        self._cue_urls: dict[str, str | None] = {
+            cue: ((cue_urls.get(cue) or "").strip() or None) for cue in _CUE_KEYS
+        }
+        # Resolved bundled-default URLs, computed ONCE at attach_events() time so
+        # we never stat the disk on the event hot path (#475). Cue key -> URL for
+        # every cue whose default file exists AND for which we could build a base
+        # URL. Overrides are checked ahead of this at play time.
+        self._default_urls: dict[str, str] = {}
+        self._event_unsubs: list[Callable[[], None]] = []
+
+    @property
+    def is_configured(self) -> bool:
+        return self._hass is not None and bool(self._media_player_entity_id)
+
+    def attach_events(self) -> None:
+        """Subscribe to the milestone bus events and resolve bundled defaults.
+
+        Idempotent, and a no-op unless configured (needs a hass bus + a target
+        media_player). The one-time disk stat for the bundled defaults happens
+        here, not per event (#475). The emitter (#366) only fires the underlying
+        events when the host has opted into house events, so an off toggle means
+        the listeners simply never trigger.
+        """
+        if not self.is_configured or self._event_unsubs:
+            return
+        hass = self._hass
+        if hass is None:  # narrow for type-checkers; is_configured already guards
+            return
+
+        self._resolve_default_urls()
+
+        self._event_unsubs = [
+            hass.bus.async_listen(EVENT_ANSWER_REVEALED, self._on_answer_revealed),
+            hass.bus.async_listen(EVENT_STREAK_MILESTONE, self._on_streak_milestone),
+            hass.bus.async_listen(EVENT_WINNER_DECIDED, self._on_winner_decided),
+        ]
+
+    def detach(self) -> None:
+        """Drop the bus listeners. Suppresses unsub errors (reload/unload safe)."""
+        for unsub in self._event_unsubs:
+            with contextlib.suppress(Exception):
+                unsub()
+        self._event_unsubs = []
+
+    # ------------------------------------------------------------------
+    # One-time bundled-default resolution
+    # ------------------------------------------------------------------
+
+    def _resolve_default_urls(self) -> None:
+        """Stat ``www/sfx/<cue>.mp3`` once and cache the servable URL per cue.
+
+        A cue's bundled default is available only when the file exists on disk
+        AND we can build the HA base URL (``get_url``). Cues with an override
+        set never need a default, but we still resolve all four so a later
+        options change that clears an override falls back cleanly on the next
+        rebuild. Any error (missing package, no configured URL) leaves the
+        default unavailable — the cue then simply no-ops unless overridden.
+        """
+        self._default_urls = {}
+        base = self._base_url()
+        if base is None:
+            return
+        sfx_dir = WWW_DIR / "sfx"
+        for cue in _CUE_KEYS:
+            path = sfx_dir / f"{cue}.mp3"
+            try:
+                exists = path.is_file()
+            except OSError:
+                exists = False
+            if exists:
+                self._default_urls[cue] = f"{base}{STATIC_URL_PREFIX}/sfx/{cue}.mp3"
+
+    def _base_url(self) -> str | None:
+        """Best-effort HA external/internal base URL, or ``None`` if unavailable.
+
+        Wraps ``homeassistant.helpers.network.get_url``; any failure (no HA, no
+        configured URL) degrades to ``None`` so only override URLs remain usable.
+        """
+        hass = self._hass
+        if hass is None or _ha_get_url is None:
+            return None
+        try:
+            return _ha_get_url(hass).rstrip("/")
+        except Exception:  # noqa: BLE001 - get_url raises when no URL is configured
+            return None
+
+    # ------------------------------------------------------------------
+    # Bus-event handlers
+    # ------------------------------------------------------------------
+
+    def _on_answer_revealed(self, event: Event) -> None:
+        """Correct sting when the crowd mostly nailed it, else the wrong buzzer.
+
+        Guards ``total_players == 0`` (no div-by-zero) → treated as the minority
+        case (wrong). A strict majority (> half) picks the correct cue.
+        """
+        data = event.data or {}
+        correct = data.get("correct_count") or 0
+        total = data.get("total_players") or 0
+        majority = total > 0 and correct > total / 2
+        self._play_cue("correct" if majority else "wrong")
+
+    def _on_streak_milestone(self, event: Event) -> None:  # noqa: ARG002
+        """Chime on a hot streak."""
+        self._play_cue("streak")
+
+    def _on_winner_decided(self, event: Event) -> None:  # noqa: ARG002
+        """Fanfare when the winner is decided."""
+        self._play_cue("winner")
+
+    # ------------------------------------------------------------------
+    # Playback
+    # ------------------------------------------------------------------
+
+    def _play_cue(self, cue: str) -> None:
+        """Resolve the source for ``cue`` and one-shot it on the media_player.
+
+        Source precedence: host override URL, else the bundled default (only if
+        the file existed at attach time). No source → silent no-op. Held during
+        TTS: if the shared speaker is already ``playing`` the cue is dropped so
+        it never talks over a live announcement.
+        """
+        if not self.is_configured:
+            return
+        url = self._cue_urls.get(cue) or self._default_urls.get(cue)
+        if not url:
+            return
+        if self._tts_is_playing():
+            # A TTS announcement owns the shared speaker right now — drop the
+            # sting rather than queue it (queuing would play it late, after the
+            # moment has passed, or cut the announcement short).
+            _LOGGER.debug("Quizify SFX %r skipped: media_player is playing", cue)
+            return
+        self._call(
+            "media_player",
+            "play_media",
+            {
+                "entity_id": self._media_player_entity_id,
+                "media_content_id": url,
+                "media_content_type": "music",
+            },
+        )
+
+    def _tts_is_playing(self) -> bool:
+        """True when the shared media_player is mid-playback (a TTS proxy).
+
+        We can't observe the TTS layer directly, so the speaker's own
+        ``playing`` state stands in for "an announcement is live". An
+        unavailable/unknown state (or no hass) means nothing is playing → the
+        cue proceeds.
+        """
+        hass = self._hass
+        if hass is None:
+            return False
+        state = hass.states.get(self._media_player_entity_id)
+        return state is not None and state.state == "playing"
+
+    def _call(self, domain: str, service: str, data: dict[str, object]) -> None:
+        fire_and_forget_service(
+            self._hass,
+            domain,
+            service,
+            data,
+            f"Room SFX {domain}.{service} "
+            f"(media_player={self._media_player_entity_id})",
+        )

--- a/custom_components/quizify/sound_effects.py
+++ b/custom_components/quizify/sound_effects.py
@@ -242,9 +242,10 @@ class QuizifySoundEffects:
         cue proceeds.
         """
         hass = self._hass
-        if hass is None:
+        entity = self._media_player_entity_id
+        if hass is None or entity is None:
             return False
-        state = hass.states.get(self._media_player_entity_id)
+        state = hass.states.get(entity)
         return state is not None and state.state == "playing"
 
     def _call(self, domain: str, service: str, data: dict[str, object]) -> None:

--- a/custom_components/quizify/translations/de.json
+++ b/custom_components/quizify/translations/de.json
@@ -25,6 +25,10 @@
                     "lobby_music_url": "Lobby-Musik-URL",
                     "community_submit_url": "URL für Community-Pack-Einsendung",
                     "community_submit_secret": "Geheimnis für Community-Pack-Einsendung",
+                    "sfx_correct_url": "Sound-URL für richtige Antwort",
+                    "sfx_wrong_url": "Sound-URL für falsche Antwort",
+                    "sfx_streak_url": "Sound-URL für Serie",
+                    "sfx_winner_url": "Sound-URL für Sieger",
                     "house_events_enabled": "Das Haus spielt mit"
                 },
                 "data_description": {
@@ -34,6 +38,10 @@
                     "lobby_music_url": "Optionale URL einer Audiodatei (z. B. /local/quizify-lobby.mp3 aus deinem config/www-Ordner), die in der Lobby über den oben gewählten Mediaplayer in Schleife läuft. Sie stoppt beim Spielstart, damit sie sich nicht mit den TTS-Ansagen über denselben Lautsprecher überlagert. Leer lassen = keine Musik. Es ist keine Audiodatei enthalten — du musst eine eigene angeben.",
                     "community_submit_url": "Optionaler Worker-Endpunkt, der eine in der App eingereichte Community-Pack-Einsendung in ein GitHub-Issue zur Begutachtung umwandelt. Leer lassen, um die Einsende-Funktion komplett auszublenden. Das GitHub-Token liegt in diesem Worker, nie im Browser oder in Home Assistant.",
                     "community_submit_secret": "Optionales gemeinsames Geheimnis, das als X-Quizify-Secret-Header an den Worker gesendet wird. Setze es passend zum SHARED_SECRET des Workers, damit nicht jeder mit der URL Issues anlegen kann. Leer lassen, wenn der Worker kein Geheimnis hat (Standard).",
+                    "sfx_correct_url": "Optionale URL zu einem kurzen Sound, der abgespielt wird, wenn die meisten die Frage richtig beantwortet haben. Leer lassen, um den mitgelieferten Standard zu verwenden (falls installiert).",
+                    "sfx_wrong_url": "Optionale URL zu einem kurzen Sound, der abgespielt wird, wenn die meisten die Frage falsch beantwortet haben. Leer lassen, um den mitgelieferten Standard zu verwenden (falls installiert).",
+                    "sfx_streak_url": "Optionale URL zu einem kurzen Sound, der abgespielt wird, wenn ein Spieler eine Antwortserie erreicht. Leer lassen, um den mitgelieferten Standard zu verwenden (falls installiert).",
+                    "sfx_winner_url": "Optionale URL zu einem kurzen Sound, der abgespielt wird, wenn der Sieger feststeht. Leer lassen, um den mitgelieferten Standard zu verwenden (falls installiert). Wird über den TTS-Lautsprecher abgespielt und übersprungen, solange eine Ansage läuft.",
                     "house_events_enabled": "Löst bei Spiel-Höhepunkten quizify_*-Events auf dem Home-Assistant-Event-Bus aus (Rundenstart, Auflösung, Serien, Sieger), damit du eigene Automationen darauf aufbauen kannst. Standardmäßig aus."
                 }
             }

--- a/custom_components/quizify/translations/en.json
+++ b/custom_components/quizify/translations/en.json
@@ -25,6 +25,10 @@
                     "lobby_music_url": "Lobby music URL",
                     "community_submit_url": "Community pack submission URL",
                     "community_submit_secret": "Community pack submission secret",
+                    "sfx_correct_url": "Correct-answer sound URL",
+                    "sfx_wrong_url": "Wrong-answer sound URL",
+                    "sfx_streak_url": "Streak sound URL",
+                    "sfx_winner_url": "Winner sound URL",
                     "house_events_enabled": "The House Plays Along"
                 },
                 "data_description": {
@@ -34,6 +38,10 @@
                     "lobby_music_url": "Optional URL of an audio file (e.g. /local/quizify-lobby.mp3, served from your config/www folder) looped on the media player above while waiting in the lobby. It stops when the game starts, so it never overlaps the TTS announcements that share the same speaker. Leave blank for no music. No audio file is included — supply your own.",
                     "community_submit_url": "Optional worker endpoint that turns an in-app community-pack submission into a GitHub issue for review. Leave blank to hide the submission feature entirely. The GitHub token lives in that worker, never in your browser or Home Assistant.",
                     "community_submit_secret": "Optional shared secret sent to the worker as an X-Quizify-Secret header. Set this to match the worker's SHARED_SECRET to stop anyone with the URL from filing issues. Leave blank if the worker has no secret (the default).",
+                    "sfx_correct_url": "Optional URL to a short sound played when the crowd mostly got the answer right. Leave blank to use the bundled default (if installed).",
+                    "sfx_wrong_url": "Optional URL to a short sound played when the crowd mostly missed the answer. Leave blank to use the bundled default (if installed).",
+                    "sfx_streak_url": "Optional URL to a short sound played when a player hits an answer streak. Leave blank to use the bundled default (if installed).",
+                    "sfx_winner_url": "Optional URL to a short sound played when the winner is decided. Leave blank to use the bundled default (if installed). Plays on the TTS speaker and is skipped while an announcement is live.",
                     "house_events_enabled": "Fire quizify_* events on the Home Assistant event bus at game milestones (round start, reveal, streaks, winner) so you can drive your own automations. Off by default."
                 }
             }

--- a/custom_components/quizify/translations/es.json
+++ b/custom_components/quizify/translations/es.json
@@ -25,6 +25,10 @@
                     "lobby_music_url": "URL de música de la sala",
                     "community_submit_url": "URL de envío de paquetes de la comunidad",
                     "community_submit_secret": "Secreto de envío de paquetes de la comunidad",
+                    "sfx_correct_url": "URL de sonido de respuesta correcta",
+                    "sfx_wrong_url": "URL de sonido de respuesta incorrecta",
+                    "sfx_streak_url": "URL de sonido de racha",
+                    "sfx_winner_url": "URL de sonido de ganador",
                     "house_events_enabled": "La casa participa"
                 },
                 "data_description": {
@@ -34,6 +38,10 @@
                     "lobby_music_url": "URL opcional de un archivo de audio (p. ej. /local/quizify-lobby.mp3, desde tu carpeta config/www) que se reproduce en bucle en el reproductor multimedia de arriba mientras se espera en la sala. Se detiene al empezar la partida, para no solaparse con los anuncios TTS que comparten el mismo altavoz. Déjalo vacío para no tener música. No se incluye ningún archivo de audio: usa el tuyo.",
                     "community_submit_url": "Endpoint opcional de un worker que convierte un envío de paquete de la comunidad hecho en la app en una incidencia de GitHub para revisión. Déjalo en blanco para ocultar por completo la función de envío. El token de GitHub reside en ese worker, nunca en tu navegador ni en Home Assistant.",
                     "community_submit_secret": "Secreto compartido opcional que se envía al worker como cabecera X-Quizify-Secret. Configúralo para que coincida con el SHARED_SECRET del worker y así evitar que cualquiera con la URL cree incidencias. Déjalo en blanco si el worker no tiene secreto (predeterminado).",
+                    "sfx_correct_url": "URL opcional de un sonido breve que se reproduce cuando la mayoría acertó la respuesta. Déjalo vacío para usar el predeterminado incluido (si está instalado).",
+                    "sfx_wrong_url": "URL opcional de un sonido breve que se reproduce cuando la mayoría falló la respuesta. Déjalo vacío para usar el predeterminado incluido (si está instalado).",
+                    "sfx_streak_url": "URL opcional de un sonido breve que se reproduce cuando un jugador logra una racha de aciertos. Déjalo vacío para usar el predeterminado incluido (si está instalado).",
+                    "sfx_winner_url": "URL opcional de un sonido breve que se reproduce cuando se decide el ganador. Déjalo vacío para usar el predeterminado incluido (si está instalado). Se reproduce en el altavoz TTS y se omite mientras hay un anuncio en curso.",
                     "house_events_enabled": "Dispara eventos quizify_* en el bus de eventos de Home Assistant en los momentos clave de la partida (inicio de ronda, revelación, rachas, ganador) para que puedas crear tus propias automatizaciones. Desactivado por defecto."
                 }
             }

--- a/custom_components/quizify/translations/fr.json
+++ b/custom_components/quizify/translations/fr.json
@@ -25,6 +25,10 @@
                     "lobby_music_url": "URL de la musique du salon",
                     "community_submit_url": "URL de soumission de pack communautaire",
                     "community_submit_secret": "Secret de soumission de pack communautaire",
+                    "sfx_correct_url": "URL du son de bonne réponse",
+                    "sfx_wrong_url": "URL du son de mauvaise réponse",
+                    "sfx_streak_url": "URL du son de série",
+                    "sfx_winner_url": "URL du son de gagnant",
                     "house_events_enabled": "La maison participe"
                 },
                 "data_description": {
@@ -34,6 +38,10 @@
                     "lobby_music_url": "URL facultative d'un fichier audio (p. ex. /local/quizify-lobby.mp3, depuis votre dossier config/www) joué en boucle sur le lecteur multimédia ci-dessus pendant l'attente dans le salon. Elle s'arrête au démarrage de la partie, pour ne pas chevaucher les annonces TTS qui partagent le même haut-parleur. Laissez vide pour aucune musique. Aucun fichier audio n'est fourni — utilisez le vôtre.",
                     "community_submit_url": "Point de terminaison de worker facultatif qui transforme une soumission de pack communautaire faite dans l'application en une issue GitHub à examiner. Laissez vide pour masquer entièrement la fonction de soumission. Le jeton GitHub réside dans ce worker, jamais dans votre navigateur ni dans Home Assistant.",
                     "community_submit_secret": "Secret partagé facultatif envoyé au worker dans l'en-tête X-Quizify-Secret. Définissez-le pour qu'il corresponde au SHARED_SECRET du worker afin d'empêcher quiconque possédant l'URL de créer des issues. Laissez vide si le worker n'a pas de secret (par défaut).",
+                    "sfx_correct_url": "URL facultative d'un son court joué lorsque la plupart des joueurs ont trouvé la bonne réponse. Laissez vide pour utiliser le son fourni par défaut (s'il est installé).",
+                    "sfx_wrong_url": "URL facultative d'un son court joué lorsque la plupart des joueurs se sont trompés. Laissez vide pour utiliser le son fourni par défaut (s'il est installé).",
+                    "sfx_streak_url": "URL facultative d'un son court joué lorsqu'un joueur atteint une série de bonnes réponses. Laissez vide pour utiliser le son fourni par défaut (s'il est installé).",
+                    "sfx_winner_url": "URL facultative d'un son court joué lorsque le gagnant est désigné. Laissez vide pour utiliser le son fourni par défaut (s'il est installé). Joué sur le haut-parleur TTS et ignoré pendant une annonce en cours.",
                     "house_events_enabled": "Déclenche des événements quizify_* sur le bus d'événements de Home Assistant aux moments forts de la partie (début de manche, révélation, séries, gagnant) pour piloter vos propres automatisations. Désactivé par défaut."
                 }
             }

--- a/custom_components/quizify/translations/nl.json
+++ b/custom_components/quizify/translations/nl.json
@@ -25,6 +25,10 @@
                     "lobby_music_url": "URL lobbymuziek",
                     "community_submit_url": "URL voor inzending community-pack",
                     "community_submit_secret": "Geheim voor inzending community-pack",
+                    "sfx_correct_url": "Geluid-URL voor juist antwoord",
+                    "sfx_wrong_url": "Geluid-URL voor fout antwoord",
+                    "sfx_streak_url": "Geluid-URL voor reeks",
+                    "sfx_winner_url": "Geluid-URL voor winnaar",
                     "house_events_enabled": "Het huis speelt mee"
                 },
                 "data_description": {
@@ -34,6 +38,10 @@
                     "lobby_music_url": "Optionele URL van een audiobestand (bv. /local/quizify-lobby.mp3 uit je config/www-map) dat tijdens het wachten in de lobby in een lus wordt afgespeeld op de mediaspeler hierboven. Het stopt zodra het spel begint, zodat het de TTS-aankondigingen die dezelfde speaker delen niet overlapt. Laat leeg voor geen muziek. Er wordt geen audiobestand meegeleverd — gebruik je eigen bestand.",
                     "community_submit_url": "Optioneel worker-eindpunt dat een in de app ingediende community-pack-inzending omzet in een GitHub-issue ter beoordeling. Laat leeg om de inzendfunctie volledig te verbergen. Het GitHub-token bevindt zich in die worker, nooit in je browser of in Home Assistant.",
                     "community_submit_secret": "Optioneel gedeeld geheim dat als X-Quizify-Secret-header naar de worker wordt gestuurd. Stel het in zodat het overeenkomt met de SHARED_SECRET van de worker, zodat niet iedereen met de URL issues kan aanmaken. Laat leeg als de worker geen geheim heeft (standaard).",
+                    "sfx_correct_url": "Optionele URL naar een kort geluid dat wordt afgespeeld wanneer de meeste spelers het antwoord goed hadden. Laat leeg om het meegeleverde standaardgeluid te gebruiken (indien geïnstalleerd).",
+                    "sfx_wrong_url": "Optionele URL naar een kort geluid dat wordt afgespeeld wanneer de meeste spelers het antwoord misten. Laat leeg om het meegeleverde standaardgeluid te gebruiken (indien geïnstalleerd).",
+                    "sfx_streak_url": "Optionele URL naar een kort geluid dat wordt afgespeeld wanneer een speler een reeks goede antwoorden haalt. Laat leeg om het meegeleverde standaardgeluid te gebruiken (indien geïnstalleerd).",
+                    "sfx_winner_url": "Optionele URL naar een kort geluid dat wordt afgespeeld wanneer de winnaar bekend is. Laat leeg om het meegeleverde standaardgeluid te gebruiken (indien geïnstalleerd). Speelt af op de TTS-speaker en wordt overgeslagen zolang er een aankondiging bezig is.",
                     "house_events_enabled": "Vuurt quizify_*-events af op de Home Assistant-eventbus bij hoogtepunten van het spel (rondestart, onthulling, reeksen, winnaar) zodat je je eigen automatiseringen kunt aansturen. Standaard uit."
                 }
             }

--- a/custom_components/quizify/www/sfx/README.md
+++ b/custom_components/quizify/www/sfx/README.md
@@ -1,0 +1,34 @@
+# Room sound effects (SFX)
+
+"The House Plays Along" Phase 3 (#494) plays a short one-shot sound on the
+configured `media_player` at four game milestones. This directory holds the
+**bundled default** sounds, served at `/quizify/static/sfx/<cue>.mp3`.
+
+## Expected files
+
+| Cue      | Filename      | Plays when…                                            |
+| -------- | ------------- | ------------------------------------------------------ |
+| correct  | `correct.mp3` | the crowd mostly got the answer right (strict majority) |
+| wrong    | `wrong.mp3`   | the crowd mostly missed the answer                     |
+| streak   | `streak.mp3`  | a player hits an answer streak                         |
+| winner   | `winner.mp3`  | the winner is decided                                  |
+
+## Rules
+
+- **No audio ships in the repo.** These files are **user-supplied**. The feature
+  stays silent for any cue whose file is absent (and which has no per-cue
+  override URL set in the options flow).
+- Files **must be CC0 / public domain** (or otherwise cleared for
+  redistribution). Do not commit copyrighted audio.
+- Keep them **short — under ~2 seconds**. They one-shot on the same speaker used
+  for TTS announcements and lobby music; a cue is dropped entirely while a TTS
+  announcement is live so it never talks over it.
+- A per-cue override URL (options flow: *Correct/Wrong/Streak/Winner sound URL*)
+  takes precedence over the bundled default here.
+
+## Cache / fingerprint note
+
+This directory is intentionally **outside** the asset-fingerprint set
+(`css`, `js`, `i18n` — see `server/views.py` `_ASSET_SUBDIRS`), so adding audio
+here does not move the frontend cache-buster or trip the generated-artifact
+drift test.

--- a/tests/test_sound_effects.py
+++ b/tests/test_sound_effects.py
@@ -1,0 +1,377 @@
+"""Tests for the room sound effects — Variant C "Hybrid" (#494 Phase 3).
+
+QuizifySoundEffects subscribes to the ``quizify_*`` HA bus events (#366
+backbone) and one-shots a short sound on the shared ``media_player`` at each
+game milestone. Source per cue is hybrid: a host-supplied override URL wins,
+else the bundled default at ``www/sfx/<cue>.mp3`` (only if the file physically
+exists). A cue is dropped entirely while the shared speaker is ``playing`` so it
+never talks over a live TTS announcement.
+
+A fake hass records bus listeners, exposes a controllable ``states.get`` for the
+TTS-contention check, and captures service calls (``fire_and_forget_service`` is
+monkeypatched). ``get_url`` and ``WWW_DIR`` are injected so the bundled-default
+resolution is deterministic — no real Home Assistant, no real audio files.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify import sound_effects as sfx_mod  # noqa: E402
+from custom_components.quizify.game_events import (  # noqa: E402
+    EVENT_ANSWER_REVEALED,
+    EVENT_STREAK_MILESTONE,
+    EVENT_WINNER_DECIDED,
+)
+from custom_components.quizify.sound_effects import QuizifySoundEffects  # noqa: E402
+
+_BASE = "http://ha.local:8123"
+_PREFIX = sfx_mod.STATIC_URL_PREFIX  # "/quizify/static"
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeEvent:
+    def __init__(self, data: dict) -> None:
+        self.data = data
+
+
+class _FakeState:
+    def __init__(self, state: str) -> None:
+        self.state = state
+
+
+class _FakeStates:
+    """Controllable ``hass.states`` — the test sets the media_player state."""
+
+    def __init__(self) -> None:
+        self._states: dict[str, _FakeState] = {}
+
+    def set(self, entity_id: str, state: str | None) -> None:
+        if state is None:
+            self._states.pop(entity_id, None)
+        else:
+            self._states[entity_id] = _FakeState(state)
+
+    def get(self, entity_id: str):  # noqa: ANN201
+        return self._states.get(entity_id)
+
+
+class _FakeBus:
+    def __init__(self) -> None:
+        self.listeners: dict[str, list] = {}
+
+    def async_listen(self, event_type, cb):  # noqa: ANN001
+        self.listeners.setdefault(event_type, []).append(cb)
+
+        def _unsub() -> None:
+            lst = self.listeners.get(event_type, [])
+            if cb in lst:
+                lst.remove(cb)
+
+        return _unsub
+
+    def dispatch(self, event_type, data):  # noqa: ANN001
+        for cb in list(self.listeners.get(event_type, [])):
+            cb(_FakeEvent(data))
+
+
+class _FakeHass:
+    def __init__(self) -> None:
+        self.bus = _FakeBus()
+        self.states = _FakeStates()
+
+
+class _FakeGame:
+    """SFX never touches the game state — a bare stand-in is enough."""
+
+
+@pytest.fixture
+def calls(monkeypatch):
+    """Capture (domain, service, data) tuples from every SFX service call."""
+    recorded: list[tuple[str, str, dict]] = []
+
+    def _record(_hass, domain, service, data, _ctx):  # noqa: ANN001
+        recorded.append((domain, service, dict(data)))
+
+    monkeypatch.setattr(sfx_mod, "fire_and_forget_service", _record)
+    return recorded
+
+
+@pytest.fixture
+def with_base(monkeypatch):
+    """Deterministic HA base URL so bundled-default URLs are predictable."""
+    monkeypatch.setattr(sfx_mod, "_ha_get_url", lambda _hass: _BASE)
+
+
+def _sfx(hass, *, media_player="media_player.tv", cue_urls=None):
+    return QuizifySoundEffects(
+        hass=hass,
+        media_player_entity_id=media_player,
+        game_state=_FakeGame(),
+        cue_urls=cue_urls or {},
+    )
+
+
+def _bundle(monkeypatch, tmp_path: Path, *cues: str) -> None:
+    """Point WWW_DIR at a tmp tree and drop empty <cue>.mp3 files there."""
+    sfx_dir = tmp_path / "sfx"
+    sfx_dir.mkdir(parents=True, exist_ok=True)
+    for cue in cues:
+        (sfx_dir / f"{cue}.mp3").write_bytes(b"")
+    monkeypatch.setattr(sfx_mod, "WWW_DIR", tmp_path)
+
+
+def _played(calls):
+    return [
+        data
+        for (domain, service, data) in calls
+        if domain == "media_player" and service == "play_media"
+    ]
+
+
+def _default_url(cue: str) -> str:
+    return f"{_BASE}{_PREFIX}/sfx/{cue}.mp3"
+
+
+# ---------------------------------------------------------------------------
+# Cue mapping (answer_revealed majority / minority / edge cases)
+# ---------------------------------------------------------------------------
+
+
+def test_answer_revealed_majority_plays_correct(
+    calls, with_base, monkeypatch, tmp_path
+):
+    _bundle(monkeypatch, tmp_path, "correct", "wrong")
+    hass = _FakeHass()
+    sfx = _sfx(hass)
+    sfx.attach_events()
+    hass.bus.dispatch(EVENT_ANSWER_REVEALED, {"correct_count": 3, "total_players": 4})
+    played = _played(calls)
+    assert len(played) == 1
+    assert played[0]["media_content_id"] == _default_url("correct")
+    assert played[0]["media_content_type"] == "music"
+    assert played[0]["entity_id"] == "media_player.tv"
+
+
+def test_answer_revealed_minority_plays_wrong(calls, with_base, monkeypatch, tmp_path):
+    _bundle(monkeypatch, tmp_path, "correct", "wrong")
+    hass = _FakeHass()
+    sfx = _sfx(hass)
+    sfx.attach_events()
+    hass.bus.dispatch(EVENT_ANSWER_REVEALED, {"correct_count": 1, "total_players": 4})
+    assert _played(calls)[0]["media_content_id"] == _default_url("wrong")
+
+
+def test_answer_revealed_exact_half_plays_wrong(
+    calls, with_base, monkeypatch, tmp_path
+):
+    """Half-right is not a *strict* majority → wrong cue."""
+    _bundle(monkeypatch, tmp_path, "correct", "wrong")
+    hass = _FakeHass()
+    sfx = _sfx(hass)
+    sfx.attach_events()
+    hass.bus.dispatch(EVENT_ANSWER_REVEALED, {"correct_count": 2, "total_players": 4})
+    assert _played(calls)[0]["media_content_id"] == _default_url("wrong")
+
+
+def test_answer_revealed_zero_players_no_crash_wrong(
+    calls, with_base, monkeypatch, tmp_path
+):
+    _bundle(monkeypatch, tmp_path, "correct", "wrong")
+    hass = _FakeHass()
+    sfx = _sfx(hass)
+    sfx.attach_events()
+    # total_players == 0 must not divide-by-zero; treated as minority (wrong).
+    hass.bus.dispatch(EVENT_ANSWER_REVEALED, {"correct_count": 0, "total_players": 0})
+    assert _played(calls)[0]["media_content_id"] == _default_url("wrong")
+
+
+def test_streak_plays_streak_cue(calls, with_base, monkeypatch, tmp_path):
+    _bundle(monkeypatch, tmp_path, "streak")
+    hass = _FakeHass()
+    sfx = _sfx(hass)
+    sfx.attach_events()
+    hass.bus.dispatch(EVENT_STREAK_MILESTONE, {"player_name": "Alice", "streak": 5})
+    assert _played(calls)[0]["media_content_id"] == _default_url("streak")
+
+
+def test_winner_plays_winner_cue(calls, with_base, monkeypatch, tmp_path):
+    _bundle(monkeypatch, tmp_path, "winner")
+    hass = _FakeHass()
+    sfx = _sfx(hass)
+    sfx.attach_events()
+    hass.bus.dispatch(EVENT_WINNER_DECIDED, {"winner_name": "Bob", "score": 420})
+    assert _played(calls)[0]["media_content_id"] == _default_url("winner")
+
+
+# ---------------------------------------------------------------------------
+# Source resolution (hybrid: override > bundled default > silence)
+# ---------------------------------------------------------------------------
+
+
+def test_override_url_wins_over_default(calls, with_base, monkeypatch, tmp_path):
+    _bundle(monkeypatch, tmp_path, "correct")  # default exists…
+    hass = _FakeHass()
+    # …but an override is set, so it wins.
+    sfx = _sfx(hass, cue_urls={"correct": "http://custom/ding.mp3"})
+    sfx.attach_events()
+    hass.bus.dispatch(EVENT_ANSWER_REVEALED, {"correct_count": 3, "total_players": 4})
+    assert _played(calls)[0]["media_content_id"] == "http://custom/ding.mp3"
+
+
+def test_override_used_when_no_default_file(calls, with_base, monkeypatch, tmp_path):
+    _bundle(monkeypatch, tmp_path)  # no files at all
+    hass = _FakeHass()
+    sfx = _sfx(hass, cue_urls={"streak": "http://custom/streak.mp3"})
+    sfx.attach_events()
+    hass.bus.dispatch(EVENT_STREAK_MILESTONE, {"streak": 3})
+    assert _played(calls)[0]["media_content_id"] == "http://custom/streak.mp3"
+
+
+def test_no_override_no_default_is_silent(calls, with_base, monkeypatch, tmp_path):
+    _bundle(monkeypatch, tmp_path)  # no bundled files
+    hass = _FakeHass()
+    sfx = _sfx(hass)  # no overrides
+    sfx.attach_events()
+    hass.bus.dispatch(EVENT_ANSWER_REVEALED, {"correct_count": 3, "total_players": 4})
+    hass.bus.dispatch(EVENT_STREAK_MILESTONE, {"streak": 3})
+    hass.bus.dispatch(EVENT_WINNER_DECIDED, {"winner_name": "Bob", "score": 1})
+    assert _played(calls) == []
+
+
+def test_default_ignored_when_only_other_cue_file_present(
+    calls, with_base, monkeypatch, tmp_path
+):
+    """Only wrong.mp3 exists → a majority answer (correct cue) stays silent."""
+    _bundle(monkeypatch, tmp_path, "wrong")
+    hass = _FakeHass()
+    sfx = _sfx(hass)
+    sfx.attach_events()
+    hass.bus.dispatch(EVENT_ANSWER_REVEALED, {"correct_count": 3, "total_players": 4})
+    assert _played(calls) == []
+
+
+def test_no_default_when_base_url_unavailable(calls, monkeypatch, tmp_path):
+    """get_url returning None (no configured base) → defaults can't resolve."""
+    _bundle(monkeypatch, tmp_path, "correct")
+    monkeypatch.setattr(sfx_mod, "_ha_get_url", lambda _hass: (_ for _ in ()).throw(
+        RuntimeError("no url configured")
+    ))
+    hass = _FakeHass()
+    sfx = _sfx(hass)
+    sfx.attach_events()
+    hass.bus.dispatch(EVENT_ANSWER_REVEALED, {"correct_count": 3, "total_players": 4})
+    assert _played(calls) == []
+
+
+# ---------------------------------------------------------------------------
+# TTS contention (hold during TTS)
+# ---------------------------------------------------------------------------
+
+
+def test_cue_skipped_while_media_player_playing(
+    calls, with_base, monkeypatch, tmp_path
+):
+    _bundle(monkeypatch, tmp_path, "correct")
+    hass = _FakeHass()
+    hass.states.set("media_player.tv", "playing")  # a TTS announcement is live
+    sfx = _sfx(hass)
+    sfx.attach_events()
+    hass.bus.dispatch(EVENT_ANSWER_REVEALED, {"correct_count": 3, "total_players": 4})
+    assert _played(calls) == []
+
+
+def test_cue_plays_when_media_player_idle(calls, with_base, monkeypatch, tmp_path):
+    _bundle(monkeypatch, tmp_path, "correct")
+    hass = _FakeHass()
+    hass.states.set("media_player.tv", "idle")
+    sfx = _sfx(hass)
+    sfx.attach_events()
+    hass.bus.dispatch(EVENT_ANSWER_REVEALED, {"correct_count": 3, "total_players": 4})
+    assert len(_played(calls)) == 1
+
+
+def test_cue_plays_when_state_missing(calls, with_base, monkeypatch, tmp_path):
+    """states.get() → None (unknown entity) means nothing is playing → proceed."""
+    _bundle(monkeypatch, tmp_path, "correct")
+    hass = _FakeHass()  # no state registered for media_player.tv
+    sfx = _sfx(hass)
+    sfx.attach_events()
+    hass.bus.dispatch(EVENT_ANSWER_REVEALED, {"correct_count": 3, "total_players": 4})
+    assert len(_played(calls)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Not configured / lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_not_configured_no_hass_registers_nothing(calls):
+    sfx = _sfx(None)  # hass is None → not configured
+    sfx.attach_events()
+    assert sfx._event_unsubs == []
+    assert not sfx.is_configured
+    # Direct handler call must be a no-op too.
+    sfx._on_streak_milestone(_FakeEvent({}))
+    assert calls == []
+
+
+def test_not_configured_no_media_player_registers_nothing(calls):
+    hass = _FakeHass()
+    sfx = _sfx(hass, media_player=None)  # no target speaker → not configured
+    sfx.attach_events()
+    assert hass.bus.listeners == {}
+    hass.bus.dispatch(EVENT_ANSWER_REVEALED, {"correct_count": 3, "total_players": 4})
+    assert calls == []
+
+
+def test_attach_events_idempotent(with_base, monkeypatch, tmp_path):
+    _bundle(monkeypatch, tmp_path, "correct")
+    hass = _FakeHass()
+    sfx = _sfx(hass)
+    sfx.attach_events()
+    sfx.attach_events()  # second call must not double-register
+    assert all(len(v) == 1 for v in hass.bus.listeners.values())
+    assert len(sfx._event_unsubs) == 3
+
+
+def test_attach_events_registers_three_listeners(with_base, monkeypatch, tmp_path):
+    _bundle(monkeypatch, tmp_path)
+    hass = _FakeHass()
+    sfx = _sfx(hass)
+    sfx.attach_events()
+    assert set(hass.bus.listeners) == {
+        EVENT_ANSWER_REVEALED,
+        EVENT_STREAK_MILESTONE,
+        EVENT_WINNER_DECIDED,
+    }
+
+
+def test_detach_unregisters_listeners(calls, with_base, monkeypatch, tmp_path):
+    _bundle(monkeypatch, tmp_path, "correct")
+    hass = _FakeHass()
+    sfx = _sfx(hass)
+    sfx.attach_events()
+    sfx.detach()
+    assert all(len(v) == 0 for v in hass.bus.listeners.values())
+    assert sfx._event_unsubs == []
+    # Events after detach do nothing.
+    hass.bus.dispatch(EVENT_ANSWER_REVEALED, {"correct_count": 3, "total_players": 4})
+    assert _played(calls) == []
+
+
+def test_detach_without_attach_is_safe():
+    """detach() must be safe even if attach_events() was never called."""
+    sfx = _sfx(_FakeHass())
+    sfx.detach()  # no listeners → must not raise
+    assert sfx._event_unsubs == []


### PR DESCRIPTION
## The House Plays Along — Phase 3: room SFX (Variant C "Hybrid")

Third phase of the v1.6.0 headline feature ([#494](https://github.com/mholzi/quizify/issues/494)), building on the event backbone (#495) and the light choreography (#496). A short sound now plays on the shared speaker at every game milestone — the second consumer of the `quizify_*` event API.

### Design decision — Variant C "Hybrid"
Each cue resolves from two sources, in order:
1. **Override** — a per-cue URL the host supplies in the options flow (`CONF_SFX_*_URL`). Wins when set.
2. **Bundled default** — `www/sfx/<cue>.mp3`, served at `/quizify/static/sfx/<cue>.mp3`, used only when no override is set AND the file physically exists.

**No audio ships in the repo** (same posture as lobby music). The four default slots — `correct.mp3`, `wrong.mp3`, `streak.mp3`, `winner.mp3` — are documented in `www/sfx/README.md` and stay inert until the host drops their own **CC0** files in. Neither override nor available default → the cue no-ops silently.

### Cue set (Game Show)
- `quizify_answer_revealed` → **correct** sting when the crowd mostly nailed it (`correct_count > total/2`), **wrong** buzzer when they mostly missed. Zero players → wrong, no div-by-zero.
- `quizify_streak_milestone` → **streak** chime.
- `quizify_winner_decided` → **winner** fanfare.
(question/countdown cues deliberately omitted — they grate quickly.)

### TTS contention (hold during TTS)
SFX share the media_player with TTS + lobby music. Before playing, the service checks the speaker's own state — if it's `playing` (a live TTS announcement owns it), the cue is **dropped**, not queued, so a sting never talks over an announcement. `share+sequence` as agreed.

### Implementation
- `sound_effects.py` (new) — `QuizifySoundEffects`, mirrors the Phase-2 lights `attach_events()`/`detach()` bus-listener pattern. Bundled-default existence is stat'd **once at attach** (cached), never on the event hot path (#475). One-shot `media_player.play_media`.
- `const.py` / `config_flow.py` — 4 optional per-cue URL override fields; labels + descriptions in all 5 locales.
- `__init__.py` — construct + `attach_events()` at setup and on options reload (no phase callback — event-driven only).
- `www/sfx/README.md` — documents the expected CC0 filenames.
- `tests/test_sound_effects.py` (new) — 24 tests: cue mapping, majority/minority/exact-half/zero-players, override-vs-default resolution, missing-default no-op, TTS contention, not-configured no-op, detach teardown.

### Gating
Cues fire only when `house_events_enabled` is on (off → the emitter fires nothing) AND a media_player is configured. No separate toggle — rides the House-Plays-Along master, consistent with the lights.

### Verification
- `ruff` clean.
- `test_sound_effects.py` + `test_light_choreography.py` + `test_game_events.py`: 61 passed locally; fingerprint/drift test green (`www/sfx/` is outside the css/js/i18n fingerprint set, so the README doesn't move the cache-buster). Full suite runs on CI (modern Python).
- On-device audio (levels, TTS-overlap in practice) is best judged live before ship.

### Notes for review
- `WWW_DIR` / `STATIC_URL_PREFIX` are redeclared locally (identical values, keep-in-sync comment) to avoid importing the whole server stack into this light event module. `get_url` is imported guarded so the module still loads on the standalone dev server.
- The contention proxy suppresses a cue whenever the speaker is playing *anything* (conservative) — intentional, but flagging in case you want it narrowed to TTS specifically later.

Refs #494, #366
