### PR TITLE
feat(lights): countdown pulse + finale scene selector (#280)

### DIFF
--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -40,6 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     from .const import (  # noqa: PLC0415
         CONF_COMMUNITY_SUBMIT_SECRET,
         CONF_COMMUNITY_SUBMIT_URL,
+        CONF_FINALE_SCENE,
         CONF_HOUSE_EVENTS_ENABLED,
         CONF_LOBBY_MUSIC_URL,
         CONF_MEDIA_PLAYER_ENTITY,
@@ -236,6 +237,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass=hass,
         entity_ids=list(options.get(CONF_PARTY_LIGHT_ENTITIES) or []),
         game_state=game_state,
+        finale_scene=options.get(CONF_FINALE_SCENE),
     )
     party_lights.attach()
     # Accent choreography (#494 Phase 2): react to the quizify_* bus events on
@@ -345,6 +347,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass=_hass,
             entity_ids=list(opts.get(CONF_PARTY_LIGHT_ENTITIES) or []),
             game_state=game_state,
+            finale_scene=opts.get(CONF_FINALE_SCENE),
         )
         new_pl.attach()
         # Re-subscribe the accent choreography (#494) symmetrically — the old

--- a/custom_components/quizify/config_flow.py
+++ b/custom_components/quizify/config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.helpers import selector
 from .const import (
     CONF_COMMUNITY_SUBMIT_SECRET,
     CONF_COMMUNITY_SUBMIT_URL,
+    CONF_FINALE_SCENE,
     CONF_HOUSE_EVENTS_ENABLED,
     CONF_LOBBY_MUSIC_URL,
     CONF_MEDIA_PLAYER_ENTITY,
@@ -170,5 +171,14 @@ class QuizifyOptionsFlow(OptionsFlow):
                     CONF_HOUSE_EVENTS_ENABLED, DEFAULT_HOUSE_EVENTS_ENABLED
                 ),
             ): selector.BooleanSelector(),
+            # Optional scene fired on the finale/winner alongside the party-light
+            # victory sweep (#280). Empty = no scene is touched. Lets the host
+            # drive a whole-room "victory" look from one of their own HA scenes.
+            vol.Optional(
+                CONF_FINALE_SCENE,
+                default=current.get(CONF_FINALE_SCENE, ""),
+            ): selector.EntitySelector(
+                selector.EntitySelectorConfig(domain="scene"),
+            ),
         })
         return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/quizify/const.py
+++ b/custom_components/quizify/const.py
@@ -61,6 +61,10 @@ CONF_MEDIA_PLAYER_ENTITY = "media_player_entity"  # str, single, domain=media_pl
 # of quizify_* events. Mirrors the opt-in posture of the TTS/lights features.
 CONF_HOUSE_EVENTS_ENABLED = "house_events_enabled"  # bool, single
 DEFAULT_HOUSE_EVENTS_ENABLED = False
+# Optional scene activated on the finale/winner alongside the party-light victory
+# sweep (#280, "The House Plays Along"). Empty by default — no scene is touched
+# until the host points this at one of their own HA scenes.
+CONF_FINALE_SCENE = "finale_scene"  # str, single, domain=scene
 # URL of an audio file to loop in the lobby while waiting for players. Empty by
 # default — the lobby-music mechanism stays completely inert until the user
 # points this at their own file (e.g. "/local/quizify-lobby.mp3" served from

--- a/custom_components/quizify/game_events.py
+++ b/custom_components/quizify/game_events.py
@@ -25,14 +25,15 @@ broadcast to every client), but nothing else identifying. These names +
 payload shapes are the stable contract the #366 automation blueprints build on,
 so treat them as an API: additive changes only.
 
-``quizify_game_started``    — {game_id, player_count, round_count}
-``quizify_question_shown``  — {round, total_rounds, question_type}
-``quizify_answer_revealed`` — {round, correct_option_index, correct_option_text,
-                               correct_count, total_players}
-``quizify_streak_milestone``— {player_name, streak, bonus}
-``quizify_finale_started``  — {}
-``quizify_winner_decided``  — {winner_name, score}
-``quizify_game_ended``      — {leaderboard: [{name, score}, ...]}
+``quizify_game_started``      — {game_id, player_count, round_count}
+``quizify_question_shown``    — {round, total_rounds, question_type}
+``quizify_time_running_out``  — {seconds_remaining}
+``quizify_answer_revealed``   — {round, correct_option_index, correct_option_text,
+                                 correct_count, total_players}
+``quizify_streak_milestone``  — {player_name, streak, bonus}
+``quizify_finale_started``    — {}
+``quizify_winner_decided``    — {winner_name, score}
+``quizify_game_ended``        — {leaderboard: [{name, score}, ...]}
 """
 
 from __future__ import annotations
@@ -50,11 +51,19 @@ _LOGGER = logging.getLogger(__name__)
 # --- Event catalog (stable names — see module docstring for payload schemas) --
 EVENT_GAME_STARTED = "quizify_game_started"
 EVENT_QUESTION_SHOWN = "quizify_question_shown"
+EVENT_TIME_RUNNING_OUT = "quizify_time_running_out"
 EVENT_ANSWER_REVEALED = "quizify_answer_revealed"
 EVENT_STREAK_MILESTONE = "quizify_streak_milestone"
 EVENT_FINALE_STARTED = "quizify_finale_started"
 EVENT_WINNER_DECIDED = "quizify_winner_decided"
 EVENT_GAME_ENDED = "quizify_game_ended"
+
+# Seconds-remaining threshold for the ``quizify_time_running_out`` event. Fires
+# once per round when the round timer first drops to/below this — the final
+# stretch that drives the faster "breathing" light pulse. Deliberately tighter
+# than the TTS spoken warning (10s, see tts.COUNTDOWN_THRESHOLD_SECONDS) so the
+# accent reads as the truly-final urgency, not the same moment as the narration.
+TIME_RUNNING_OUT_THRESHOLD_SECONDS = 5.0
 
 
 class QuizifyEventEmitter:
@@ -85,6 +94,10 @@ class QuizifyEventEmitter:
         # transitions, not on every state_callback flap. Mirrors the lights /
         # TTS observers. Survives an options reload via export/restore below.
         self._last_phase: GamePhase | None = None
+        # One-shot guard so the "time running out" event fires at most once per
+        # round. Reset at every question start (see ``notify_question_shown``),
+        # mirroring the TTS announcer's ``_countdown_announced`` pattern.
+        self._time_running_out_fired: bool = False
 
     @property
     def is_configured(self) -> bool:
@@ -197,7 +210,13 @@ class QuizifyEventEmitter:
         Reuses the ``question`` already assembled at the fan-out point; only the
         type (multiple_choice / estimate) is exposed — not the text/answers,
         which would leak the question to automations before players see it.
+
+        Resets the per-round "time running out" one-shot guard unconditionally
+        (round start is the lifecycle point the TTS announcer resets its own
+        ``_countdown_announced`` guard) so the countdown event can fire once
+        more this round.
         """
+        self._time_running_out_fired = False
         self._fire(
             EVENT_QUESTION_SHOWN,
             {
@@ -205,6 +224,28 @@ class QuizifyEventEmitter:
                 "total_rounds": total_rounds,
                 "question_type": getattr(question, "type", None),
             },
+        )
+
+    def notify_time_running_out(self, seconds_remaining: float) -> None:
+        """Fire ``quizify_time_running_out`` in the final seconds of a round.
+
+        Driven from the timer-tick loop, which calls this every tick with the
+        room's minimum remaining time — mirroring the spoken countdown warning
+        (:meth:`~custom_components.quizify.tts.QuizifyTTSAnnouncer.announce_countdown`).
+        Fires the first time that crosses to/below
+        ``TIME_RUNNING_OUT_THRESHOLD_SECONDS`` and then no-ops for the rest of
+        the round via the ``_time_running_out_fired`` one-shot guard (reset at
+        every question start), so a blueprint sees a single "hurry up" pulse in
+        the final stretch rather than a stream of ticks.
+        """
+        if self._time_running_out_fired:
+            return
+        if not 0 < seconds_remaining <= TIME_RUNNING_OUT_THRESHOLD_SECONDS:
+            return
+        self._time_running_out_fired = True
+        self._fire(
+            EVENT_TIME_RUNNING_OUT,
+            {"seconds_remaining": seconds_remaining},
         )
 
     def notify_answer_revealed(self, game_state: QuizifyGameState) -> None:

--- a/custom_components/quizify/lights.py
+++ b/custom_components/quizify/lights.py
@@ -36,6 +36,7 @@ from .game_events import (
     EVENT_ANSWER_REVEALED,
     EVENT_QUESTION_SHOWN,
     EVENT_STREAK_MILESTONE,
+    EVENT_TIME_RUNNING_OUT,
     EVENT_WINNER_DECIDED,
 )
 from .ha_service import fire_and_forget_service
@@ -90,6 +91,21 @@ _BASELINE = "baseline"
 # keeps whatever the QUESTION_ACTIVE recipe is showing), then settle back.
 _ACCENT_QUESTION_SHOWN: list[tuple[object, float]] = [
     ({"brightness_pct": 88, "transition": 0.2}, 0.5),
+    (_BASELINE, 0.0),
+]
+
+# time_running_out (#280): a faster "breathing" brightness pulse for the final
+# seconds of a round. Brightness ONLY (no rgb) so it breathes on whatever colour
+# the live phase recipe is showing, then settles to _BASELINE. Two quick
+# down/up beats — shorter holds than the other accents to read as urgency —
+# kept subtle (no strobing) and well under ~2s total.
+_COUNTDOWN_DOWN: dict[str, object] = {"brightness_pct": 45, "transition": 0.15}
+_COUNTDOWN_UP: dict[str, object] = {"brightness_pct": 85, "transition": 0.15}
+_ACCENT_COUNTDOWN: list[tuple[object, float]] = [
+    (_COUNTDOWN_DOWN, 0.25),
+    (_COUNTDOWN_UP, 0.25),
+    (_COUNTDOWN_DOWN, 0.25),
+    (_COUNTDOWN_UP, 0.25),
     (_BASELINE, 0.0),
 ]
 
@@ -159,6 +175,7 @@ class QuizifyPartyLights:
         hass: HomeAssistant | None,
         entity_ids: list[str],
         game_state: QuizifyGameState,
+        finale_scene: str | None = None,
     ) -> None:
         self._hass = hass
         # Normalize: strip whitespace, drop empties, dedupe while keeping order.
@@ -170,6 +187,10 @@ class QuizifyPartyLights:
                 seen.add(e)
                 cleaned.append(e)
         self._entity_ids = cleaned
+        # Optional finale scene (#280). Activated alongside the winner sweep so
+        # the host can drive a whole-room "victory" look (their own scene) on top
+        # of the party lights. Cleaned: empty/whitespace → None (no-op).
+        self._finale_scene = (finale_scene or "").strip() or None
         self._game = game_state
         self._last_phase: GamePhase | None = None
         # Accent choreography (#494). Unsub handles for the four bus listeners
@@ -188,10 +209,11 @@ class QuizifyPartyLights:
     def attach_events(self) -> None:
         """Subscribe to the ``quizify_*`` bus events for accent choreography.
 
-        Registers the four accent listeners (#494 Phase 2). Idempotent, and a
-        no-op unless configured (needs a hass bus + at least one entity). The
-        emitter (#366) only fires these when the host has opted into house
-        events, so an off toggle means the listeners simply never trigger.
+        Registers the accent listeners (#494 Phase 2 + the #280 countdown pulse).
+        Idempotent, and a no-op unless configured (needs a hass bus + at least
+        one entity). The emitter (#366) only fires these when the host has opted
+        into house events, so an off toggle means the listeners simply never
+        trigger.
         """
         if not self.is_configured or self._event_unsubs:
             return
@@ -200,6 +222,9 @@ class QuizifyPartyLights:
             return
         self._event_unsubs = [
             hass.bus.async_listen(EVENT_QUESTION_SHOWN, self._on_question_shown),
+            hass.bus.async_listen(
+                EVENT_TIME_RUNNING_OUT, self._on_time_running_out
+            ),
             hass.bus.async_listen(EVENT_ANSWER_REVEALED, self._on_answer_revealed),
             hass.bus.async_listen(EVENT_STREAK_MILESTONE, self._on_streak_milestone),
             hass.bus.async_listen(EVENT_WINNER_DECIDED, self._on_winner_decided),
@@ -268,6 +293,14 @@ class QuizifyPartyLights:
         """Brightness bump on the live coral when a question appears."""
         self._start_pulse(_ACCENT_QUESTION_SHOWN)
 
+    def _on_time_running_out(self, event: Event) -> None:  # noqa: ARG002
+        """Faster breathing brightness pulse in the final seconds of a round.
+
+        Brightness-only, so it breathes on whatever colour the live phase is
+        showing, then settles back to the baseline (#280).
+        """
+        self._start_pulse(_ACCENT_COUNTDOWN)
+
     def _on_answer_revealed(self, event: Event) -> None:
         """Green when the crowd mostly nailed it, amber when they mostly missed.
 
@@ -285,8 +318,26 @@ class QuizifyPartyLights:
         self._start_pulse(_ACCENT_STREAK)
 
     def _on_winner_decided(self, event: Event) -> None:  # noqa: ARG002
-        """Victory sweep in sun, settling to a steady celebratory glow."""
+        """Victory sweep in sun, settling to a steady celebratory glow.
+
+        When the host has configured a finale scene (#280), also fire it
+        alongside the sweep so a whole-room "victory" look layers on top of the
+        party lights. No-op when no scene is set.
+        """
         self._start_pulse(_ACCENT_WINNER)
+        self._activate_finale_scene()
+
+    def _activate_finale_scene(self) -> None:
+        """Turn on the configured finale scene, if any (#280).
+
+        Fire-and-forget via ``scene.turn_on`` through the same ``_call`` path the
+        light services use. No-op when no scene is configured or the integration
+        isn't configured (no hass / no lights), so a bare install never touches
+        an unset scene.
+        """
+        if self._finale_scene is None or not self.is_configured:
+            return
+        self._call("scene", "turn_on", {"entity_id": self._finale_scene})
 
     # ------------------------------------------------------------------
     # Accent choreography — pulse scheduling

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -2325,6 +2325,9 @@ class QuizifyWebSocketHandler:
                     min_remaining = tick.dashboard_remaining
                     # Spoken "time running out" warning (#281), once per round.
                     self._notify_tts_countdown(min_remaining)
+                    # House "time running out" bus event (#280), once per round —
+                    # drives the faster countdown light pulse.
+                    self._notify_house_time_running_out(min_remaining)
                     dash_shown = math.ceil(max(0.0, min_remaining))
                     if dash_shown != last_dashboard_shown:
                         last_dashboard_shown = dash_shown
@@ -2800,6 +2803,22 @@ class QuizifyWebSocketHandler:
             emitter.notify_question_shown(question, round_no, total_rounds)
         except Exception:  # noqa: BLE001
             _LOGGER.exception("House question event raised")
+
+    def _notify_house_time_running_out(self, seconds_remaining: float) -> None:
+        """Forward the per-tick remaining time to the HA event emitter (#280).
+
+        Called every timer tick alongside :meth:`_notify_tts_countdown`; the
+        emitter fires its one-shot ``quizify_time_running_out`` event at most
+        once per round in the final seconds. No-op when ``_event_emitter`` is
+        None (standalone dev server). Guarded like the question hook.
+        """
+        emitter = self._event_emitter
+        if emitter is None:
+            return
+        try:
+            emitter.notify_time_running_out(seconds_remaining)
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("House time-running-out event raised")
 
     def _notify_house_milestone(
         self, player_name: str, streak: int, bonus: int

--- a/custom_components/quizify/translations/de.json
+++ b/custom_components/quizify/translations/de.json
@@ -29,7 +29,8 @@
                     "sfx_wrong_url": "Sound-URL für falsche Antwort",
                     "sfx_streak_url": "Sound-URL für Serie",
                     "sfx_winner_url": "Sound-URL für Sieger",
-                    "house_events_enabled": "Das Haus spielt mit"
+                    "house_events_enabled": "Das Haus spielt mit",
+                    "finale_scene": "Finale-Szene"
                 },
                 "data_description": {
                     "party_light_entities": "Lichter, die mit der Spielphase mitleuchten (Koralle bei Frage, Salbei bei Auflösung, Sonne im Finale).",
@@ -42,7 +43,8 @@
                     "sfx_wrong_url": "Optionale URL zu einem kurzen Sound, der abgespielt wird, wenn die meisten die Frage falsch beantwortet haben. Leer lassen, um den mitgelieferten Standard zu verwenden (falls installiert).",
                     "sfx_streak_url": "Optionale URL zu einem kurzen Sound, der abgespielt wird, wenn ein Spieler eine Antwortserie erreicht. Leer lassen, um den mitgelieferten Standard zu verwenden (falls installiert).",
                     "sfx_winner_url": "Optionale URL zu einem kurzen Sound, der abgespielt wird, wenn der Sieger feststeht. Leer lassen, um den mitgelieferten Standard zu verwenden (falls installiert). Wird über den TTS-Lautsprecher abgespielt und übersprungen, solange eine Ansage läuft.",
-                    "house_events_enabled": "Löst bei Spiel-Höhepunkten quizify_*-Events auf dem Home-Assistant-Event-Bus aus (Rundenstart, Auflösung, Serien, Sieger), damit du eigene Automationen darauf aufbauen kannst. Standardmäßig aus."
+                    "house_events_enabled": "Löst bei Spiel-Höhepunkten quizify_*-Events auf dem Home-Assistant-Event-Bus aus (Rundenstart, Auflösung, Serien, Sieger), damit du eigene Automationen darauf aufbauen kannst. Standardmäßig aus.",
+                    "finale_scene": "Optionale Szene, die aktiviert wird, sobald der Sieger feststeht — zusätzlich zum Sieges-Lichtschwenk der Party-Lichter, damit du einen raumweiten Feier-Look auslösen kannst. Leer lassen = keine Szene."
                 }
             }
         }

--- a/custom_components/quizify/translations/en.json
+++ b/custom_components/quizify/translations/en.json
@@ -29,7 +29,8 @@
                     "sfx_wrong_url": "Wrong-answer sound URL",
                     "sfx_streak_url": "Streak sound URL",
                     "sfx_winner_url": "Winner sound URL",
-                    "house_events_enabled": "The House Plays Along"
+                    "house_events_enabled": "The House Plays Along",
+                    "finale_scene": "Finale scene"
                 },
                 "data_description": {
                     "party_light_entities": "Lights that should glow with the round phase (coral on question, sage on reveal, sun on finale).",
@@ -42,7 +43,8 @@
                     "sfx_wrong_url": "Optional URL to a short sound played when the crowd mostly missed the answer. Leave blank to use the bundled default (if installed).",
                     "sfx_streak_url": "Optional URL to a short sound played when a player hits an answer streak. Leave blank to use the bundled default (if installed).",
                     "sfx_winner_url": "Optional URL to a short sound played when the winner is decided. Leave blank to use the bundled default (if installed). Plays on the TTS speaker and is skipped while an announcement is live.",
-                    "house_events_enabled": "Fire quizify_* events on the Home Assistant event bus at game milestones (round start, reveal, streaks, winner) so you can drive your own automations. Off by default."
+                    "house_events_enabled": "Fire quizify_* events on the Home Assistant event bus at game milestones (round start, reveal, streaks, winner) so you can drive your own automations. Off by default.",
+                    "finale_scene": "Optional scene activated when the winner is decided, alongside the party-light victory sweep, so you can drive a whole-room celebration look. Leave blank for no scene."
                 }
             }
         }

--- a/custom_components/quizify/translations/es.json
+++ b/custom_components/quizify/translations/es.json
@@ -29,7 +29,8 @@
                     "sfx_wrong_url": "URL de sonido de respuesta incorrecta",
                     "sfx_streak_url": "URL de sonido de racha",
                     "sfx_winner_url": "URL de sonido de ganador",
-                    "house_events_enabled": "La casa participa"
+                    "house_events_enabled": "La casa participa",
+                    "finale_scene": "Escena del final"
                 },
                 "data_description": {
                     "party_light_entities": "Luces que cambian de color con la fase de la ronda (coral en pregunta, salvia en revelación, sol en final).",
@@ -42,7 +43,8 @@
                     "sfx_wrong_url": "URL opcional de un sonido breve que se reproduce cuando la mayoría falló la respuesta. Déjalo vacío para usar el predeterminado incluido (si está instalado).",
                     "sfx_streak_url": "URL opcional de un sonido breve que se reproduce cuando un jugador logra una racha de aciertos. Déjalo vacío para usar el predeterminado incluido (si está instalado).",
                     "sfx_winner_url": "URL opcional de un sonido breve que se reproduce cuando se decide el ganador. Déjalo vacío para usar el predeterminado incluido (si está instalado). Se reproduce en el altavoz TTS y se omite mientras hay un anuncio en curso.",
-                    "house_events_enabled": "Dispara eventos quizify_* en el bus de eventos de Home Assistant en los momentos clave de la partida (inicio de ronda, revelación, rachas, ganador) para que puedas crear tus propias automatizaciones. Desactivado por defecto."
+                    "house_events_enabled": "Dispara eventos quizify_* en el bus de eventos de Home Assistant en los momentos clave de la partida (inicio de ronda, revelación, rachas, ganador) para que puedas crear tus propias automatizaciones. Desactivado por defecto.",
+                    "finale_scene": "Escena opcional que se activa cuando se decide el ganador, junto con el barrido de luces de victoria, para lanzar una ambientación de celebración en toda la sala. Déjalo en blanco para no usar ninguna escena."
                 }
             }
         }

--- a/custom_components/quizify/translations/fr.json
+++ b/custom_components/quizify/translations/fr.json
@@ -29,7 +29,8 @@
                     "sfx_wrong_url": "URL du son de mauvaise réponse",
                     "sfx_streak_url": "URL du son de série",
                     "sfx_winner_url": "URL du son de gagnant",
-                    "house_events_enabled": "La maison participe"
+                    "house_events_enabled": "La maison participe",
+                    "finale_scene": "Scène de finale"
                 },
                 "data_description": {
                     "party_light_entities": "Lumières qui changent de couleur selon la phase de la manche (corail pendant la question, sauge pendant la révélation, soleil au final).",
@@ -42,7 +43,8 @@
                     "sfx_wrong_url": "URL facultative d'un son court joué lorsque la plupart des joueurs se sont trompés. Laissez vide pour utiliser le son fourni par défaut (s'il est installé).",
                     "sfx_streak_url": "URL facultative d'un son court joué lorsqu'un joueur atteint une série de bonnes réponses. Laissez vide pour utiliser le son fourni par défaut (s'il est installé).",
                     "sfx_winner_url": "URL facultative d'un son court joué lorsque le gagnant est désigné. Laissez vide pour utiliser le son fourni par défaut (s'il est installé). Joué sur le haut-parleur TTS et ignoré pendant une annonce en cours.",
-                    "house_events_enabled": "Déclenche des événements quizify_* sur le bus d'événements de Home Assistant aux moments forts de la partie (début de manche, révélation, séries, gagnant) pour piloter vos propres automatisations. Désactivé par défaut."
+                    "house_events_enabled": "Déclenche des événements quizify_* sur le bus d'événements de Home Assistant aux moments forts de la partie (début de manche, révélation, séries, gagnant) pour piloter vos propres automatisations. Désactivé par défaut.",
+                    "finale_scene": "Scène facultative activée lorsque le gagnant est désigné, en même temps que le balayage lumineux de victoire, pour déclencher une ambiance de célébration dans toute la pièce. Laissez vide pour aucune scène."
                 }
             }
         }

--- a/custom_components/quizify/translations/nl.json
+++ b/custom_components/quizify/translations/nl.json
@@ -29,7 +29,8 @@
                     "sfx_wrong_url": "Geluid-URL voor fout antwoord",
                     "sfx_streak_url": "Geluid-URL voor reeks",
                     "sfx_winner_url": "Geluid-URL voor winnaar",
-                    "house_events_enabled": "Het huis speelt mee"
+                    "house_events_enabled": "Het huis speelt mee",
+                    "finale_scene": "Finalescène"
                 },
                 "data_description": {
                     "party_light_entities": "Lampen die meekleuren met de rondefase (koraal bij vraag, salie bij onthulling, zon bij finale).",
@@ -42,7 +43,8 @@
                     "sfx_wrong_url": "Optionele URL naar een kort geluid dat wordt afgespeeld wanneer de meeste spelers het antwoord misten. Laat leeg om het meegeleverde standaardgeluid te gebruiken (indien geïnstalleerd).",
                     "sfx_streak_url": "Optionele URL naar een kort geluid dat wordt afgespeeld wanneer een speler een reeks goede antwoorden haalt. Laat leeg om het meegeleverde standaardgeluid te gebruiken (indien geïnstalleerd).",
                     "sfx_winner_url": "Optionele URL naar een kort geluid dat wordt afgespeeld wanneer de winnaar bekend is. Laat leeg om het meegeleverde standaardgeluid te gebruiken (indien geïnstalleerd). Speelt af op de TTS-speaker en wordt overgeslagen zolang er een aankondiging bezig is.",
-                    "house_events_enabled": "Vuurt quizify_*-events af op de Home Assistant-eventbus bij hoogtepunten van het spel (rondestart, onthulling, reeksen, winnaar) zodat je je eigen automatiseringen kunt aansturen. Standaard uit."
+                    "house_events_enabled": "Vuurt quizify_*-events af op de Home Assistant-eventbus bij hoogtepunten van het spel (rondestart, onthulling, reeksen, winnaar) zodat je je eigen automatiseringen kunt aansturen. Standaard uit.",
+                    "finale_scene": "Optionele scène die wordt geactiveerd zodra de winnaar bekend is, samen met de overwinnings-lichtsweep, zodat je een feestelijke sfeer in de hele kamer kunt aansturen. Laat leeg voor geen scène."
                 }
             }
         }

--- a/tests/test_config_flow_271.py
+++ b/tests/test_config_flow_271.py
@@ -39,6 +39,7 @@ if str(_REPO_ROOT) not in sys.path:
 from custom_components.quizify.const import (  # noqa: E402
     CONF_COMMUNITY_SUBMIT_SECRET,
     CONF_COMMUNITY_SUBMIT_URL,
+    CONF_FINALE_SCENE,
     CONF_LOBBY_MUSIC_URL,
     CONF_MEDIA_PLAYER_ENTITY,
     CONF_PARTY_LIGHT_ENTITIES,
@@ -120,6 +121,9 @@ async def test_options_flow_saves_community_submit_options(
         CONF_PARTY_LIGHT_ENTITIES: [],
         CONF_TTS_ENTITY: "tts.test",
         CONF_MEDIA_PLAYER_ENTITY: "media_player.test",
+        # finale_scene (#280) is a single EntitySelector like tts/media_player —
+        # it too rejects "", so give a valid-format id.
+        CONF_FINALE_SCENE: "scene.test",
         CONF_LOBBY_MUSIC_URL: "",
         CONF_COMMUNITY_SUBMIT_URL: "https://worker.example.com/submit",
         CONF_COMMUNITY_SUBMIT_SECRET: "s3cret-token",

--- a/tests/test_finale_scene_countdown_280.py
+++ b/tests/test_finale_scene_countdown_280.py
@@ -1,0 +1,376 @@
+"""Tests for the #280 remaining delta — countdown pulse + finale scene.
+
+Two additive features on top of "The House Plays Along" (#494):
+
+* Item A — a ``quizify_time_running_out`` bus event fired once per round in the
+  final seconds (``QuizifyEventEmitter.notify_time_running_out``), which the
+  party lights turn into a faster "breathing" brightness pulse.
+* Item B — an optional finale scene the party lights activate alongside the
+  winner victory sweep (``QuizifyPartyLights`` ``finale_scene`` arg).
+
+Fakes mirror the existing suite (``test_game_events`` / ``test_light_choreography``):
+a fake hass records ``bus.async_fire`` / service calls so we assert *intent*
+without a real Home Assistant. The options-flow round-trip needs the real HA
+harness and is skipped where it (Python 3.13+) is unavailable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify import lights as lights_mod  # noqa: E402
+from custom_components.quizify.game.state import GamePhase  # noqa: E402
+from custom_components.quizify.game_events import (  # noqa: E402
+    EVENT_TIME_RUNNING_OUT,
+    QuizifyEventEmitter,
+)
+from custom_components.quizify.lights import QuizifyPartyLights  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fakes (shared style with test_game_events / test_light_choreography)
+# ---------------------------------------------------------------------------
+
+
+class _FakeBus:
+    def __init__(self) -> None:
+        self.fired: list[tuple[str, dict]] = []
+        self.listeners: dict[str, list] = {}
+
+    def async_fire(self, event_type, data):  # noqa: ANN001
+        self.fired.append((event_type, dict(data)))
+
+    def async_listen(self, event_type, cb):  # noqa: ANN001
+        self.listeners.setdefault(event_type, []).append(cb)
+
+        def _unsub() -> None:
+            lst = self.listeners.get(event_type, [])
+            if cb in lst:
+                lst.remove(cb)
+
+        return _unsub
+
+    def dispatch(self, event_type, data):  # noqa: ANN001
+        for cb in list(self.listeners.get(event_type, [])):
+            cb(_FakeEvent(data))
+
+
+class _FakeEvent:
+    def __init__(self, data: dict) -> None:
+        self.data = data
+
+
+class _FakeTask:
+    """Runs the pulse coroutine straight to completion (sleeps no-op'd)."""
+
+    def __init__(self, coro) -> None:
+        self._coro = coro
+        self._done = False
+        with contextlib.suppress(StopIteration):
+            coro.send(None)
+        self._done = True
+
+    def done(self) -> bool:
+        return self._done
+
+    def cancel(self) -> None:
+        if not self._done:
+            self._coro.close()
+        self._done = True
+
+
+class _FakeHass:
+    def __init__(self) -> None:
+        self.bus = _FakeBus()
+        self.tasks: list[_FakeTask] = []
+
+    def async_create_task(self, coro):  # noqa: ANN001
+        task = _FakeTask(coro)
+        self.tasks.append(task)
+        return task
+
+
+class _FakeGame:
+    def __init__(self) -> None:
+        self.phase = GamePhase.LOBBY
+        self.round = 0
+        self.total_rounds = 10
+        self.game_id = None
+        self.callbacks: list = []
+
+    def register_state_callback(self, cb):  # noqa: ANN001
+        self.callbacks.append(cb)
+
+    def unregister_state_callback(self, cb):  # noqa: ANN001
+        if cb in self.callbacks:
+            self.callbacks.remove(cb)
+
+
+class _Question:
+    type = "multiple_choice"
+
+
+# ---------------------------------------------------------------------------
+# Item A — emitter: notify_time_running_out one-shot guard (#280)
+# ---------------------------------------------------------------------------
+
+
+def _emitter(hass, game, *, enabled=True):
+    return QuizifyEventEmitter(hass=hass, game_state=game, enabled=enabled)
+
+
+def test_time_running_out_fires_once_and_is_suppressed_same_round():
+    """First in-window tick fires; later ticks in the same round no-op."""
+    hass = _FakeHass()
+    t = _emitter(hass, _FakeGame())
+
+    t.notify_time_running_out(4.0)
+    t.notify_time_running_out(3.0)
+    t.notify_time_running_out(1.0)
+
+    fired = [(e, d) for e, d in hass.bus.fired if e == EVENT_TIME_RUNNING_OUT]
+    assert len(fired) == 1
+    assert fired[0][1] == {"seconds_remaining": 4.0}
+
+
+def test_time_running_out_ignores_ticks_outside_final_window():
+    """Ticks above the threshold (early in the round) never fire."""
+    hass = _FakeHass()
+    t = _emitter(hass, _FakeGame())
+
+    # 30s / 6s remaining are outside the <=5s "final seconds" window.
+    t.notify_time_running_out(30.0)
+    t.notify_time_running_out(6.0)
+    assert hass.bus.fired == []
+
+    # Crossing into the window fires exactly once.
+    t.notify_time_running_out(5.0)
+    assert [e for e, _ in hass.bus.fired] == [EVENT_TIME_RUNNING_OUT]
+
+
+def test_time_running_out_rearms_after_round_reset_hook():
+    """notify_question_shown (round start) re-arms the one-shot guard."""
+    hass = _FakeHass()
+    t = _emitter(hass, _FakeGame())
+
+    t.notify_time_running_out(3.0)
+    # Round rolls over: the question-shown forwarder resets the guard.
+    t.notify_question_shown(_Question(), 2, 10)
+    t.notify_time_running_out(2.0)
+
+    fired = [e for e, _ in hass.bus.fired if e == EVENT_TIME_RUNNING_OUT]
+    assert len(fired) == 2
+
+
+def test_time_running_out_noop_when_house_events_disabled():
+    """Master toggle off (CONF_HOUSE_EVENTS_ENABLED) => nothing fires."""
+    hass = _FakeHass()
+    t = _emitter(hass, _FakeGame(), enabled=False)
+    assert t.is_configured is False
+
+    t.notify_time_running_out(3.0)
+    assert hass.bus.fired == []
+
+
+def test_time_running_out_noop_without_hass():
+    """Standalone dev server (no hass) never raises and fires nothing."""
+    t = _emitter(None, _FakeGame())
+    # No bus to assert on — just prove it doesn't raise.
+    t.notify_time_running_out(3.0)
+
+
+# ---------------------------------------------------------------------------
+# Item A — lights: the countdown pulse accent (#280)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fast_sleep(monkeypatch):
+    """asyncio.sleep -> no-op so pulse tasks run to completion synchronously."""
+
+    async def _noop(*_args, **_kwargs):
+        return
+
+    monkeypatch.setattr(asyncio, "sleep", _noop)
+
+
+@pytest.fixture
+def calls(monkeypatch):
+    """Capture (domain, service, data) tuples from every fired service call."""
+    recorded: list[tuple[str, str, dict]] = []
+
+    def _record(_hass, domain, service, data, _ctx):  # noqa: ANN001
+        recorded.append((domain, service, dict(data)))
+
+    monkeypatch.setattr(lights_mod, "fire_and_forget_service", _record)
+    return recorded
+
+
+def _lights(hass, *, phase=GamePhase.QUESTION_ACTIVE, entities=("light.party",),
+            finale_scene=None):
+    game = _FakeGame()
+    pl = QuizifyPartyLights(
+        hass=hass,
+        entity_ids=list(entities),
+        game_state=game,
+        finale_scene=finale_scene,
+    )
+    pl._last_phase = phase  # prime ambient so baseline restores apply
+    return pl
+
+
+def test_time_running_out_event_drives_brightness_only_pulse(calls):
+    """The countdown accent breathes brightness with no rgb, then settles."""
+    hass = _FakeHass()
+    pl = _lights(hass, phase=GamePhase.QUESTION_ACTIVE)
+    pl.attach_events()
+    assert EVENT_TIME_RUNNING_OUT in hass.bus.listeners
+
+    hass.bus.dispatch(EVENT_TIME_RUNNING_OUT, {"seconds_remaining": 3.0})
+
+    turn_ons = [d for (_d, s, d) in calls if s == "turn_on"]
+    # At least the two down/up beats plus the baseline restore ran.
+    assert len(turn_ons) >= 3
+    # The pulse steps set brightness but never a colour (works on live colour).
+    pulse_steps = [
+        d for d in turn_ons if "brightness_pct" in d and "rgb_color" not in d
+    ]
+    assert pulse_steps, "countdown pulse must set brightness only"
+    assert all("rgb_color" not in d for d in pulse_steps)
+
+
+# ---------------------------------------------------------------------------
+# Item B — lights: finale scene on winner (#280)
+# ---------------------------------------------------------------------------
+
+
+def _scene_calls(calls):
+    return [d for (domain, s, d) in calls if domain == "scene" and s == "turn_on"]
+
+
+def test_winner_activates_configured_finale_scene(calls):
+    """A configured finale scene is turned on alongside the winner sweep."""
+    hass = _FakeHass()
+    pl = _lights(hass, phase=GamePhase.FINALE, finale_scene="scene.victory")
+    pl.attach_events()
+
+    hass.bus.dispatch("quizify_winner_decided", {"winner_name": "Alice", "score": 5})
+
+    scenes = _scene_calls(calls)
+    assert scenes == [{"entity_id": "scene.victory"}]
+
+
+def test_winner_without_finale_scene_does_not_touch_scenes(calls):
+    """No finale scene configured => no scene.turn_on is ever fired."""
+    hass = _FakeHass()
+    pl = _lights(hass, phase=GamePhase.FINALE, finale_scene=None)
+    pl.attach_events()
+
+    hass.bus.dispatch("quizify_winner_decided", {"winner_name": "Alice", "score": 5})
+
+    assert _scene_calls(calls) == []
+
+
+def test_finale_scene_blank_string_is_normalized_to_none(calls):
+    """Whitespace-only finale scene is treated as unset (no scene call)."""
+    hass = _FakeHass()
+    pl = _lights(hass, phase=GamePhase.FINALE, finale_scene="   ")
+    assert pl._finale_scene is None
+    pl.attach_events()
+
+    hass.bus.dispatch("quizify_winner_decided", {"winner_name": "Bob", "score": 3})
+    assert _scene_calls(calls) == []
+
+
+def test_finale_scene_noop_when_unconfigured(calls):
+    """No hass or no lights => finale scene activation is a clean no-op."""
+    # No hass at all.
+    pl_no_hass = _lights(None, finale_scene="scene.victory")
+    pl_no_hass._activate_finale_scene()
+    # No light entities.
+    hass = _FakeHass()
+    pl_no_lights = _lights(hass, entities=(), finale_scene="scene.victory")
+    pl_no_lights._activate_finale_scene()
+
+    assert _scene_calls(calls) == []
+
+
+# ---------------------------------------------------------------------------
+# Item B — options flow round-trip (#280). Needs the real HA harness.
+# ---------------------------------------------------------------------------
+
+pytest.importorskip("homeassistant")
+pytest.importorskip("pytest_homeassistant_custom_component")
+
+from homeassistant import data_entry_flow  # noqa: E402
+from homeassistant.core import HomeAssistant  # noqa: E402
+from pytest_homeassistant_custom_component.common import (  # noqa: E402
+    MockConfigEntry,
+)
+
+from custom_components.quizify.const import (  # noqa: E402
+    CONF_FINALE_SCENE,
+    CONF_MEDIA_PLAYER_ENTITY,
+    CONF_TTS_ENTITY,
+    DOMAIN,
+)
+
+pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+
+async def test_options_flow_lists_finale_scene(hass: HomeAssistant) -> None:
+    """The options form exposes the new finale_scene field (#280)."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    schema_keys = {str(marker) for marker in result["data_schema"].schema}
+    assert CONF_FINALE_SCENE in schema_keys
+
+
+async def test_options_flow_round_trips_finale_scene(hass: HomeAssistant) -> None:
+    """Submitting a finale_scene value persists it onto the entry options."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    # EntitySelectors validate entity-id FORMAT and reject "" — so give the
+    # other single-entity fields valid-format ids; finale_scene is under test.
+    user_input = {
+        CONF_TTS_ENTITY: "tts.test",
+        CONF_MEDIA_PLAYER_ENTITY: "media_player.test",
+        CONF_FINALE_SCENE: "scene.movie_night",
+    }
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input=user_input
+    )
+    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result2["data"][CONF_FINALE_SCENE] == "scene.movie_night"
+    assert entry.options[CONF_FINALE_SCENE] == "scene.movie_night"
+
+
+async def test_options_flow_defaults_finale_scene_from_existing(
+    hass: HomeAssistant,
+) -> None:
+    """Re-opening the options form pre-fills the finale_scene default."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=DOMAIN,
+        options={CONF_FINALE_SCENE: "scene.preset"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    for marker in result["data_schema"].schema:
+        if str(marker) == CONF_FINALE_SCENE:
+            assert marker.default() == "scene.preset"
+            break
+    else:  # pragma: no cover
+        pytest.fail("finale_scene marker not found in options schema")

--- a/tests/test_light_choreography.py
+++ b/tests/test_light_choreography.py
@@ -27,6 +27,7 @@ from custom_components.quizify.game_events import (  # noqa: E402
     EVENT_ANSWER_REVEALED,
     EVENT_QUESTION_SHOWN,
     EVENT_STREAK_MILESTONE,
+    EVENT_TIME_RUNNING_OUT,
     EVENT_WINNER_DECIDED,
 )
 from custom_components.quizify.lights import QuizifyPartyLights  # noqa: E402
@@ -160,12 +161,13 @@ def _turn_ons(calls):
 # ---------------------------------------------------------------------------
 
 
-def test_attach_events_registers_four_listeners():
+def test_attach_events_registers_all_listeners():
     hass = _FakeHass()
     pl = _lights(hass)
     pl.attach_events()
     assert set(hass.bus.listeners) == {
         EVENT_QUESTION_SHOWN,
+        EVENT_TIME_RUNNING_OUT,
         EVENT_ANSWER_REVEALED,
         EVENT_STREAK_MILESTONE,
         EVENT_WINNER_DECIDED,
@@ -178,7 +180,7 @@ def test_attach_events_idempotent():
     pl.attach_events()
     pl.attach_events()  # second call must not double-register
     assert all(len(v) == 1 for v in hass.bus.listeners.values())
-    assert len(pl._event_unsubs) == 4
+    assert len(pl._event_unsubs) == 5
 
 
 def test_not_configured_no_hass_registers_nothing_and_noops(calls):


### PR DESCRIPTION
Implements the two remaining #280 items on top of "The House Plays Along". The majority-aware green/amber reveal flash, per-event light accents, and the winner sweep already landed earlier in #494 / #496, so they are **not** rebuilt here.

## What shipped

### Item A — Countdown pulse
- **`game_events.py`**: new additive event `quizify_time_running_out` (payload `{seconds_remaining}`, added to the event-catalog docstring). New `notify_time_running_out()` forwarder with a per-round one-shot guard (mirrors the TTS announcer's `_countdown_announced`, reset at question start in `notify_question_shown`) plus a 5s "final seconds" threshold.
- **`server/websocket.py`**: calls the emitter at the same tick-loop spot as `_notify_tts_countdown`, via a new sibling `_notify_house_time_running_out` helper.
- **`lights.py`**: new `_ACCENT_COUNTDOWN` — a faster brightness-only "breathing" pulse on the live phase colour (no rgb set, so it works whatever the current colour is), settling back to baseline. New `_on_time_running_out` listener registered in `attach_events()`.

### Item B — Finale scene selector
- **`const.py`**: new `CONF_FINALE_SCENE` (str, single, domain=scene).
- **`config_flow.py`**: optional `EntitySelector(domain="scene")` field in the options schema.
- **`lights.py`**: `QuizifyPartyLights` takes a `finale_scene` arg (cleaned, empty→None). On the winner, it also fires `scene.turn_on` alongside the victory sweep. No-op when unset or unconfigured.
- **`__init__.py`**: `finale_scene` passed to both light construction sites (initial setup + options-reload rebuild).
- **Translations**: `finale_scene` name + description added to all five locales (en/de/es/fr/nl).

## Tests
- New `tests/test_finale_scene_countdown_280.py` (13 cases): one-shot guard fires once + re-arms after the round-reset hook, master-toggle/no-hass no-ops, options-flow round-trip, and the finale-scene winner path (configured → `scene.turn_on`; unset/blank/unconfigured → no-op).
- Updated the two existing tests that assert the exact listener set / options fields for the additive 5th listener + new field. No existing coverage weakened.
- Full suite: **1094 passed**. The only failures (19, all in the `test_ws_*` aiohttp-server files) are pre-existing `pytest-socket` blocks in the local HA harness and fail identically on clean `main` — unrelated to this change.
- `ruff check custom_components/quizify` clean; `mypy custom_components/quizify` clean (42 files).

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)