### PR TITLE
feat(services): game-control HA services for automations & voice (#367)

### DIFF
--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -221,6 +221,88 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.services.async_register(DOMAIN, "reset_admin_session", reset_admin_session)
     _LOGGER.debug("Quizify reset_admin_session service registered")
 
+    # Game-control services (#367). Expose a safe subset of the admin game
+    # controls as HA services so hosts can drive the game via Assist voice
+    # ("Hey Nabu, next question"), a Zigbee remote, a dashboard button or an
+    # automation — instead of only the admin WebSocket UI. Each delegates to
+    # the SAME socket-independent core the admin WS handler now uses (the
+    # ``admin_action_*`` methods), so there is one implementation and the
+    # broadcast that refreshes entities + connected clients always fires.
+    from homeassistant.exceptions import (  # noqa: PLC0415
+        ServiceValidationError,
+    )
+
+    from .game.state import GamePhase  # noqa: PLC0415
+
+    def _require_runtime() -> tuple[QuizifyWebSocketHandler, QuizifyGameState]:
+        """Return (ws_handler, game_state) or raise if setup isn't complete.
+
+        Guards against a raw ``KeyError`` when a service fires before/without a
+        loaded config entry (e.g. during teardown): the host sees a clear
+        message in the HA UI / voice response instead of an opaque crash.
+        """
+        domain_data = hass.data.get(DOMAIN)
+        if not domain_data:
+            raise ServiceValidationError(
+                "Quizify is not set up. Add the Quizify integration first."
+            )
+        handler = domain_data.get("ws_handler")
+        game = domain_data.get("game")
+        if handler is None or game is None:
+            raise ServiceValidationError(
+                "Quizify is not ready yet. Try again in a moment."
+            )
+        return handler, game
+
+    async def start_game_service(call: ServiceCall) -> None:  # noqa: ARG001
+        handler, game = _require_runtime()
+        try:
+            await handler.admin_action_start_game(game)
+        except ValueError as err:
+            raise ServiceValidationError(
+                "Cannot start a new quiz right now — a game is already in "
+                "progress. End it first, then start a new one."
+            ) from err
+
+    async def next_round_service(call: ServiceCall) -> None:  # noqa: ARG001
+        handler, game = _require_runtime()
+        try:
+            await handler.admin_action_next_round(game)
+        except ValueError as err:
+            raise ServiceValidationError(
+                "Cannot advance to the next question right now. Start a game "
+                "first, or wait until the current question has been revealed."
+            ) from err
+
+    async def pause_service(call: ServiceCall) -> None:  # noqa: ARG001
+        handler, game = _require_runtime()
+        if not await handler.admin_action_pause(game):
+            raise ServiceValidationError(
+                "There is no active question to pause right now."
+            )
+
+    async def resume_service(call: ServiceCall) -> None:  # noqa: ARG001
+        handler, game = _require_runtime()
+        if not await handler.admin_action_resume(game):
+            raise ServiceValidationError(
+                "The game is not paused, so there is nothing to resume."
+            )
+
+    async def end_game_service(call: ServiceCall) -> None:  # noqa: ARG001
+        handler, game = _require_runtime()
+        if game.phase == GamePhase.LOBBY:
+            raise ServiceValidationError(
+                "No game is currently running, so there is nothing to end."
+            )
+        await handler.admin_action_end_game(game)
+
+    hass.services.async_register(DOMAIN, "start_game", start_game_service)
+    hass.services.async_register(DOMAIN, "next_round", next_round_service)
+    hass.services.async_register(DOMAIN, "pause", pause_service)
+    hass.services.async_register(DOMAIN, "resume", resume_service)
+    hass.services.async_register(DOMAIN, "end_game", end_game_service)
+    _LOGGER.debug("Quizify game-control services registered (#367)")
+
     # Forward to sensor/binary_sensor platforms so HA exposes Quizify game
     # state as entities (sensor.quizify_current_round, etc.).
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -1524,11 +1524,28 @@ class QuizifyWebSocketHandler:
             await self._conn.send_error(ws, code, str(err))
             return
 
+        # Socket-independent continuation (TTS config, grace, first question).
+        # Shared with the HA ``quizify.start_game`` service so the WS path and
+        # the service path drive one implementation (#367).
+        await self._after_start_game(game_state, data.get("tts") or {})
+
+    async def _after_start_game(
+        self, game_state: QuizifyGameState, tts_config: dict
+    ) -> None:
+        """Continue a just-started game: TTS config, grace, first question.
+
+        Socket-independent core split out of ``_handle_start_game`` (#367) so
+        the ``quizify.start_game`` service reuses the identical sequence without
+        synthesizing a fake admin connection. Nothing here touches a specific
+        ``ws`` — it only reads/mutates ``game_state`` and fans out over the
+        shared connection layer, exactly as the admin path did inline.
+        """
         # Apply per-game TTS narration settings (#281). The toggles ride the
         # start_game payload (like lightning_enabled), persisted in admin
         # localStorage — not config-entry options. No-op when no announcer is
-        # wired (standalone dev server, HA without a TTS entity).
-        self._apply_tts_config(data.get("tts") or {})
+        # wired (standalone dev server, HA without a TTS entity). The service
+        # path passes an empty dict (no per-game overrides).
+        self._apply_tts_config(tts_config)
 
         # Snapshot the game_id start_game just minted (#352). We're about to
         # yield the loop for the grace sleep below; another admin socket can
@@ -1567,6 +1584,27 @@ class QuizifyWebSocketHandler:
         # Start the first question
         await self._start_next_question(game_state)
 
+    async def admin_action_start_game(self, game_state: QuizifyGameState) -> None:
+        """Start a game with default settings — HA-service entry point (#367).
+
+        Callable without an admin WebSocket connection so hosts can start the
+        quiz via Assist voice, a Zigbee remote or a dashboard button. Only valid
+        from the LOBBY phase: unlike ``_handle_start_game`` (which force-resets a
+        lingering game because the admin explicitly re-picked settings in the
+        UI), the service refuses to nuke a game already in progress — a voice
+        "start the quiz" mid-round should be a clear error, not a silent wipe.
+        Raises ``ValueError`` (game already started / no questions) for the
+        caller to translate; on success runs the same continuation as the admin
+        path.
+        """
+        if game_state.phase != GamePhase.LOBBY:
+            raise ValueError(ERR_GAME_ALREADY_STARTED)
+        # Default settings: mixed packs, default difficulty, 10 rounds, HA
+        # language default. start_game() re-raises ERR_GAME_ALREADY_STARTED /
+        # ERR_NO_QUESTIONS_REMAINING which the service surfaces to the host.
+        game_state.start_game()
+        await self._after_start_game(game_state, {})
+
     # ------------------------------------------------------------------
     # Admin: next question
     # ------------------------------------------------------------------
@@ -1575,6 +1613,19 @@ class QuizifyWebSocketHandler:
         self, ws: web.WebSocketResponse, game_state: QuizifyGameState
     ) -> None:
         """Handle admin next_question command."""
+        err = await self._advance_round(game_state)
+        if err is not None:
+            await self._conn.send_error(ws, err, "Cannot advance now")
+
+    async def _advance_round(self, game_state: QuizifyGameState) -> str | None:
+        """Advance to the next question — socket-independent core (#367).
+
+        Shared by the admin ``next_question`` / ``next_round`` WS handler and
+        the ``quizify.next_round`` HA service so both drive one implementation.
+        Returns ``None`` after a successful advance, or an error-code string
+        when the current phase forbids advancing (the caller decides how to
+        surface it — a WS error frame vs a ``ServiceValidationError``).
+        """
         # Auto Lightning Round recap (#285): the host's normal advance after a
         # mid-game lightning recap resumes the paused main game. resume_after_
         # lightning() flips LIGHTNING_RECAP→ANSWER_REVEAL and restores the
@@ -1584,11 +1635,10 @@ class QuizifyWebSocketHandler:
             self._cancel_lightning_loop()
             if game_state.resume_after_lightning():
                 await self._start_next_question(game_state)
-            return
+            return None
 
         if game_state.phase not in (GamePhase.LOBBY, GamePhase.ANSWER_REVEAL):
-            await self._conn.send_error(ws, ERR_INVALID_ACTION, "Cannot advance now")
-            return
+            return ERR_INVALID_ACTION
 
         # #298: a stray next_round/next_question in a *real* lobby (stale admin
         # tab, double-fire) must NOT advance — start_game doesn't change phase,
@@ -1599,10 +1649,22 @@ class QuizifyWebSocketHandler:
         # _start_next_question directly (see _handle_start_game), so gating the
         # public handler here doesn't break it.
         if game_state.phase == GamePhase.LOBBY and game_state.game_id is None:
-            await self._conn.send_error(ws, ERR_INVALID_ACTION, "Cannot advance now")
-            return
+            return ERR_INVALID_ACTION
 
         await self._start_next_question(game_state)
+        return None
+
+    async def admin_action_next_round(self, game_state: QuizifyGameState) -> None:
+        """Advance to the next question — HA-service entry point (#367).
+
+        Mirrors the admin "Next" button (``next_round`` → ``_handle_next_
+        question``). Raises ``ValueError`` when the phase forbids advancing so
+        the service can surface a clear ``ServiceValidationError`` instead of
+        silently no-opping.
+        """
+        err = await self._advance_round(game_state)
+        if err is not None:
+            raise ValueError(err)
 
     async def _handle_admin_skip(
         self, ws: web.WebSocketResponse, game_state: QuizifyGameState
@@ -1634,6 +1696,14 @@ class QuizifyWebSocketHandler:
         self, ws: web.WebSocketResponse, game_state: QuizifyGameState
     ) -> None:
         """Handle admin end_game command."""
+        await self.admin_action_end_game(game_state)
+
+    async def admin_action_end_game(self, game_state: QuizifyGameState) -> None:
+        """End the game now — socket-independent core (#367).
+
+        Shared by the admin ``end_game`` WS handler and the ``quizify.end_game``
+        HA service.
+        """
         self._cancel_timer_tick()
         # end_game() fires the ``game_ended`` state event, which the
         # BroadcastDispatcher routes to _broadcast_finale — that's the single
@@ -1650,21 +1720,43 @@ class QuizifyWebSocketHandler:
         self, ws: web.WebSocketResponse, game_state: QuizifyGameState
     ) -> None:
         """Pause the current question. No-op if not in QUESTION_ACTIVE."""
+        # Silent no-op on a non-pausable phase — the admin UI can call this
+        # anytime. The service path (admin_action_pause) instead surfaces the
+        # False as a ServiceValidationError.
+        await self.admin_action_pause(game_state)
+
+    async def admin_action_pause(self, game_state: QuizifyGameState) -> bool:
+        """Pause the current question — socket-independent core (#367).
+
+        Returns ``True`` if the game was paused, ``False`` if the phase wasn't
+        pausable (only QUESTION_ACTIVE is). Shared by the admin ``pause_game``
+        WS handler and the ``quizify.pause`` HA service.
+        """
         if not game_state.pause(reason="admin_paused"):
-            return  # Silent no-op — UI can call this anytime
+            return False
         # Stop sending tick updates while paused.
         self._cancel_timer_tick()
         state = game_state.get_state_snapshot()
         state["type"] = "game_state"
         state["pause_reason"] = "admin_paused"
         await self._conn.broadcast(state)
+        return True
 
     async def _handle_resume_game(
         self, ws: web.WebSocketResponse, game_state: QuizifyGameState
     ) -> None:
         """Resume from PAUSED → restart timer ticks and broadcast state."""
+        await self.admin_action_resume(game_state)
+
+    async def admin_action_resume(self, game_state: QuizifyGameState) -> bool:
+        """Resume a paused game — socket-independent core (#367).
+
+        Returns ``True`` if the game was resumed, ``False`` if it wasn't paused.
+        Shared by the admin ``resume_game`` WS handler and the ``quizify.resume``
+        HA service.
+        """
         if not game_state.resume():
-            return
+            return False
         # Fan out per-player PROJECTED snapshots (#286): the raw snapshot
         # carries canonical answer order, so a plain broadcast here mis-scored
         # ~2/3 of taps after resume because the players re-render their answer
@@ -1672,6 +1764,7 @@ class QuizifyWebSocketHandler:
         await self._broadcast_state_projected(game_state)
         # Restart the per-player tick loop.
         self._start_timer_tick(game_state)
+        return True
 
     async def _handle_play_again(
         self, ws: web.WebSocketResponse, game_state: QuizifyGameState

--- a/custom_components/quizify/services.yaml
+++ b/custom_components/quizify/services.yaml
@@ -6,3 +6,46 @@ reset_admin_session:
     cleared, persistent storage edited externally). The next admin
     connection will bootstrap a fresh token. Only callable by HA admins.
   fields: {}
+
+start_game:
+  name: Start game
+  description: >-
+    Start a new Quizify game with the default settings (mixed packs, default
+    difficulty, 10 rounds). Wire it to an Assist sentence ("Hey Nabu, start the
+    quiz"), a Zigbee remote button or a dashboard button so the host can kick
+    off the game without reaching for the admin panel. Only works from the
+    lobby — it will not interrupt a game already in progress.
+  fields: {}
+
+next_round:
+  name: Next question
+  description: >-
+    Advance to the next question — the same action as the admin "Next" button.
+    Handy on a Zigbee remote or via Assist ("Hey Nabu, next question") so the
+    host can move the game along from across the room. Only valid once the
+    current question has been revealed (or to start the first round).
+  fields: {}
+
+pause:
+  name: Pause game
+  description: >-
+    Pause the active question, freezing every player's timer. Useful for a
+    quick break, mapped to a remote button, dashboard button or Assist
+    sentence. Only works while a question is running.
+  fields: {}
+
+resume:
+  name: Resume game
+  description: >-
+    Resume a paused game and restart the countdown. Pair it with the pause
+    service on a remote/automation. Only works when the game is currently
+    paused.
+  fields: {}
+
+end_game:
+  name: End game
+  description: >-
+    End the current game immediately and jump to the final leaderboard. Wire
+    it to a remote button, dashboard button or Assist sentence ("Hey Nabu, end
+    the quiz"). Only works while a game is running.
+  fields: {}

--- a/custom_components/quizify/translations/de.json
+++ b/custom_components/quizify/translations/de.json
@@ -55,6 +55,26 @@
         "reset_admin_session": {
             "name": "Admin-Sitzung zurücksetzen",
             "description": "Löscht das gespeicherte Admin-Session-Token. Nutze dies, wenn du nicht auf das Admin-Panel zugreifen kannst, weil das gespeicherte Token nicht mehr synchron ist. Die nächste Admin-Verbindung erzeugt ein neues Token."
+        },
+        "start_game": {
+            "name": "Spiel starten",
+            "description": "Startet ein neues Quizify-Spiel mit den Standardeinstellungen. Verknüpfe es mit einem Assist-Satz, einer Zigbee-Fernbedienung oder einem Dashboard-Button, damit der Host das Quiz ohne das Admin-Panel starten kann. Funktioniert nur in der Lobby."
+        },
+        "next_round": {
+            "name": "Nächste Frage",
+            "description": "Springt zur nächsten Frage, wie der Admin-Button \"Weiter\". Praktisch auf einer Fernbedienung oder per Assist, damit der Host das Spiel aus der Ferne weiterführen kann. Nur gültig, sobald die aktuelle Frage aufgelöst wurde."
+        },
+        "pause": {
+            "name": "Spiel pausieren",
+            "description": "Pausiert die aktive Frage und friert den Timer aller Spieler ein. Verknüpfe es mit einem Fernbedienungs-Button, Dashboard-Button oder Assist-Satz. Funktioniert nur, während eine Frage läuft."
+        },
+        "resume": {
+            "name": "Spiel fortsetzen",
+            "description": "Setzt ein pausiertes Spiel fort und startet den Countdown neu. Funktioniert nur, wenn das Spiel gerade pausiert ist."
+        },
+        "end_game": {
+            "name": "Spiel beenden",
+            "description": "Beendet das aktuelle Spiel sofort und springt zur End-Rangliste. Verknüpfe es mit einem Fernbedienungs-Button, Dashboard-Button oder Assist-Satz. Funktioniert nur, während ein Spiel läuft."
         }
     }
 }

--- a/custom_components/quizify/translations/en.json
+++ b/custom_components/quizify/translations/en.json
@@ -55,6 +55,26 @@
         "reset_admin_session": {
             "name": "Reset admin session",
             "description": "Wipe the persisted admin session token. Use this if you can't access the admin panel because the saved token is out of sync. The next admin connection will bootstrap a fresh token."
+        },
+        "start_game": {
+            "name": "Start game",
+            "description": "Start a new Quizify game with the default settings. Wire it to an Assist sentence, a Zigbee remote or a dashboard button so the host can start the quiz without the admin panel. Only works from the lobby."
+        },
+        "next_round": {
+            "name": "Next question",
+            "description": "Advance to the next question, like the admin Next button. Great on a remote or via Assist so the host can move the game along from across the room. Only valid once the current question has been revealed."
+        },
+        "pause": {
+            "name": "Pause game",
+            "description": "Pause the active question and freeze every player's timer. Map it to a remote button, dashboard button or Assist sentence. Only works while a question is running."
+        },
+        "resume": {
+            "name": "Resume game",
+            "description": "Resume a paused game and restart the countdown. Only works when the game is currently paused."
+        },
+        "end_game": {
+            "name": "End game",
+            "description": "End the current game immediately and jump to the final leaderboard. Wire it to a remote button, dashboard button or Assist sentence. Only works while a game is running."
         }
     }
 }

--- a/custom_components/quizify/translations/es.json
+++ b/custom_components/quizify/translations/es.json
@@ -55,6 +55,26 @@
         "reset_admin_session": {
             "name": "Restablecer sesión de administrador",
             "description": "Borra el token de sesión de administrador guardado. Úsalo si no puedes acceder al panel de administración porque el token está desincronizado. La próxima conexión de administrador generará un token nuevo."
+        },
+        "start_game": {
+            "name": "Iniciar juego",
+            "description": "Inicia una nueva partida de Quizify con la configuración predeterminada. Vincúlalo a una frase de Assist, un mando Zigbee o un botón del panel para que el anfitrión pueda empezar el quiz sin el panel de administración. Solo funciona desde la sala de espera."
+        },
+        "next_round": {
+            "name": "Siguiente pregunta",
+            "description": "Avanza a la siguiente pregunta, como el botón Siguiente del administrador. Ideal en un mando o mediante Assist para que el anfitrión avance la partida desde lejos. Solo válido una vez revelada la pregunta actual."
+        },
+        "pause": {
+            "name": "Pausar juego",
+            "description": "Pausa la pregunta activa y congela el temporizador de todos los jugadores. Asígnalo a un botón de mando, un botón del panel o una frase de Assist. Solo funciona mientras hay una pregunta en curso."
+        },
+        "resume": {
+            "name": "Reanudar juego",
+            "description": "Reanuda una partida en pausa y reinicia la cuenta atrás. Solo funciona cuando la partida está en pausa."
+        },
+        "end_game": {
+            "name": "Terminar juego",
+            "description": "Termina la partida actual de inmediato y salta a la clasificación final. Vincúlalo a un botón de mando, un botón del panel o una frase de Assist. Solo funciona mientras hay una partida en curso."
         }
     }
 }

--- a/custom_components/quizify/translations/fr.json
+++ b/custom_components/quizify/translations/fr.json
@@ -55,6 +55,26 @@
         "reset_admin_session": {
             "name": "Réinitialiser la session admin",
             "description": "Efface le jeton de session admin persistant. À utiliser si vous ne pouvez plus accéder au panneau admin parce que le jeton est désynchronisé. La prochaine connexion admin générera un nouveau jeton."
+        },
+        "start_game": {
+            "name": "Démarrer la partie",
+            "description": "Démarre une nouvelle partie Quizify avec les réglages par défaut. Associez-le à une phrase Assist, une télécommande Zigbee ou un bouton de tableau de bord pour que l'hôte lance le quiz sans le panneau admin. Ne fonctionne que depuis le salon."
+        },
+        "next_round": {
+            "name": "Question suivante",
+            "description": "Passe à la question suivante, comme le bouton Suivant de l'admin. Pratique sur une télécommande ou via Assist pour que l'hôte fasse avancer la partie à distance. Valable uniquement une fois la question actuelle révélée."
+        },
+        "pause": {
+            "name": "Mettre en pause",
+            "description": "Met en pause la question active et gèle le minuteur de tous les joueurs. Associez-le à un bouton de télécommande, un bouton de tableau de bord ou une phrase Assist. Ne fonctionne que pendant une question en cours."
+        },
+        "resume": {
+            "name": "Reprendre la partie",
+            "description": "Reprend une partie en pause et relance le compte à rebours. Ne fonctionne que lorsque la partie est en pause."
+        },
+        "end_game": {
+            "name": "Terminer la partie",
+            "description": "Termine immédiatement la partie en cours et affiche le classement final. Associez-le à un bouton de télécommande, un bouton de tableau de bord ou une phrase Assist. Ne fonctionne que pendant une partie en cours."
         }
     }
 }

--- a/custom_components/quizify/translations/nl.json
+++ b/custom_components/quizify/translations/nl.json
@@ -55,6 +55,26 @@
         "reset_admin_session": {
             "name": "Admin-sessie resetten",
             "description": "Wist het opgeslagen admin-sessietoken. Gebruik dit als je geen toegang meer hebt tot het admin-paneel omdat het token niet meer synchroon loopt. De volgende admin-verbinding maakt een nieuw token aan."
+        },
+        "start_game": {
+            "name": "Spel starten",
+            "description": "Start een nieuw Quizify-spel met de standaardinstellingen. Koppel het aan een Assist-zin, een Zigbee-afstandsbediening of een dashboardknop zodat de host de quiz kan starten zonder het admin-paneel. Werkt alleen vanuit de lobby."
+        },
+        "next_round": {
+            "name": "Volgende vraag",
+            "description": "Ga naar de volgende vraag, net als de admin-knop Volgende. Handig op een afstandsbediening of via Assist zodat de host het spel van een afstand kan voortzetten. Alleen geldig zodra de huidige vraag is onthuld."
+        },
+        "pause": {
+            "name": "Spel pauzeren",
+            "description": "Pauzeert de actieve vraag en bevriest de timer van elke speler. Koppel het aan een afstandsbedieningsknop, dashboardknop of Assist-zin. Werkt alleen terwijl er een vraag loopt."
+        },
+        "resume": {
+            "name": "Spel hervatten",
+            "description": "Hervat een gepauzeerd spel en start het aftellen opnieuw. Werkt alleen wanneer het spel is gepauzeerd."
+        },
+        "end_game": {
+            "name": "Spel beëindigen",
+            "description": "Beëindigt het huidige spel direct en gaat naar het eindklassement. Koppel het aan een afstandsbedieningsknop, dashboardknop of Assist-zin. Werkt alleen terwijl er een spel loopt."
         }
     }
 }

--- a/tests/test_game_control_services_367.py
+++ b/tests/test_game_control_services_367.py
@@ -1,0 +1,390 @@
+"""Tests for the game-control HA services (issue #367).
+
+Exposes a safe subset of the admin game controls (``start_game``,
+``next_round``, ``pause``, ``resume``, ``end_game``) as Home Assistant services
+so hosts can drive the game via Assist voice, a Zigbee remote, a dashboard
+button or an automation instead of the admin WebSocket UI.
+
+Two surfaces are covered:
+
+* Integration level (real ``hass`` fixture, like ``test_init_313``): the
+  services are registered, they transition the game with the same phase
+  preconditions as the admin handlers, they raise ``ServiceValidationError``
+  (never a raw ``KeyError``) on a bad phase / when the integration isn't set
+  up, and a successful call fans out a broadcast so entities + clients refresh.
+* Unit level (WS handler + game state with a fake connection): the refactored
+  admin ``_handle_*`` and the ``admin_action_*`` service core drive ONE shared
+  implementation — the WS path and the service path reach the same result.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.const import DOMAIN  # noqa: E402
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+
+# ---------------------------------------------------------------------------
+# Unit-level: shared-core equivalence (WS path == service path)
+# ---------------------------------------------------------------------------
+#
+# These don't need Home Assistant — they drive the WS handler + game state with
+# a fake connection, mirroring test_admin_pause_cleanup_362.
+
+from custom_components.quizify.server.connection import (  # noqa: E402
+    ConnectionManager,
+)
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _Runtime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+    def create_task(self, coro):  # noqa: ANN001
+        import asyncio
+
+        return asyncio.ensure_future(coro)
+
+
+def _fake_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    ws.close = AsyncMock()
+    return ws
+
+
+def _make_handler(
+    game: QuizifyGameState, tmp_path: Path
+) -> QuizifyWebSocketHandler:
+    runtime = _Runtime(tmp_path)
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    h._conn = ConnectionManager(runtime, lambda: game)
+    h._conn.broadcast = AsyncMock()
+    # Keep grace/timer machinery out of the way for the deterministic asserts.
+    h.START_REDIRECT_GRACE = 0.0
+    return h
+
+
+def _new_active_game(tmp_path: Path) -> QuizifyGameState:
+    """A game driven to QUESTION_ACTIVE on round 1 (lightning disabled)."""
+    gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="test")
+    gs.add_player("A", _fake_ws())
+    gs.start_game(num_rounds=10, lightning_enabled=False)
+    gs.start_next_question()
+    assert gs.phase == GamePhase.QUESTION_ACTIVE
+    return gs
+
+
+@pytest.mark.asyncio
+async def test_pause_ws_and_service_paths_match(tmp_path: Path) -> None:
+    """``_handle_pause_game`` (WS) and ``admin_action_pause`` (service core)
+    reach the identical result: both pause the round and both broadcast."""
+    gs_ws = _new_active_game(tmp_path)
+    gs_svc = _new_active_game(tmp_path)
+    handler = _make_handler(gs_ws, tmp_path)
+
+    # WS admin path.
+    await handler._handle_pause_game(_fake_ws(), gs_ws)
+    # Service-core path.
+    paused = await handler.admin_action_pause(gs_svc)
+
+    assert paused is True
+    assert gs_ws.phase == GamePhase.PAUSED
+    assert gs_svc.phase == GamePhase.PAUSED
+    # Both drove a broadcast through the same shared core.
+    assert handler._conn.broadcast.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_pause_service_core_reports_noop_off_active_phase(
+    tmp_path: Path,
+) -> None:
+    """The service core returns False when nothing is pausable (LOBBY), so the
+    service layer can turn that into a ServiceValidationError."""
+    gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="test")
+    handler = _make_handler(gs, tmp_path)
+    assert gs.phase == GamePhase.LOBBY
+    assert await handler.admin_action_pause(gs) is False
+
+
+@pytest.mark.asyncio
+async def test_resume_service_core_roundtrips_paused(tmp_path: Path) -> None:
+    """pause then resume via the service cores round-trips through PAUSED."""
+    gs = _new_active_game(tmp_path)
+    handler = _make_handler(gs, tmp_path)
+
+    assert await handler.admin_action_pause(gs) is True
+    assert gs.phase == GamePhase.PAUSED
+    assert await handler.admin_action_resume(gs) is True
+    assert gs.phase == GamePhase.QUESTION_ACTIVE
+    handler._cancel_timer_tick()
+
+    # Resuming a non-paused game is a no-op → False (service raises on it).
+    assert await handler.admin_action_resume(gs) is False
+
+
+@pytest.mark.asyncio
+async def test_next_round_core_matches_ws_advance(tmp_path: Path) -> None:
+    """``admin_action_next_round`` and ``_handle_next_question`` advance the
+    same way from ANSWER_REVEAL (both call the shared ``_advance_round``)."""
+    gs_ws = _new_active_game(tmp_path)
+    gs_svc = _new_active_game(tmp_path)
+    handler = _make_handler(gs_ws, tmp_path)
+    # Both need to be at an advanceable phase.
+    gs_ws.evaluate_round()
+    gs_svc.evaluate_round()
+    assert gs_ws.phase == GamePhase.ANSWER_REVEAL
+    assert gs_svc.phase == GamePhase.ANSWER_REVEAL
+
+    await handler._handle_next_question(_fake_ws(), gs_ws)
+    await handler.admin_action_next_round(gs_svc)
+
+    assert gs_ws.round == 2
+    assert gs_svc.round == 2
+    assert gs_ws.phase == GamePhase.QUESTION_ACTIVE
+    assert gs_svc.phase == GamePhase.QUESTION_ACTIVE
+    handler._cancel_timer_tick()
+
+
+@pytest.mark.asyncio
+async def test_next_round_core_raises_off_phase(tmp_path: Path) -> None:
+    """From QUESTION_ACTIVE the advance is invalid → the core raises so the
+    service surfaces a ServiceValidationError (WS path would send an error)."""
+    gs = _new_active_game(tmp_path)
+    handler = _make_handler(gs, tmp_path)
+    with pytest.raises(ValueError):
+        await handler.admin_action_next_round(gs)
+
+
+@pytest.mark.asyncio
+async def test_end_game_core_ends(tmp_path: Path) -> None:
+    """``admin_action_end_game`` transitions to FINALE (shared by WS + svc)."""
+    gs = _new_active_game(tmp_path)
+    handler = _make_handler(gs, tmp_path)
+    await handler.admin_action_end_game(gs)
+    assert gs.phase == GamePhase.FINALE
+
+
+@pytest.mark.asyncio
+async def test_start_game_core_requires_lobby(tmp_path: Path) -> None:
+    """The start service core only starts from LOBBY — it must NOT nuke a game
+    already in progress (unlike the admin re-pick handler)."""
+    gs = _new_active_game(tmp_path)
+    handler = _make_handler(gs, tmp_path)
+    with pytest.raises(ValueError):
+        await handler.admin_action_start_game(gs)
+
+
+# ---------------------------------------------------------------------------
+# Integration-level: real hass fixture, real service registry
+# ---------------------------------------------------------------------------
+
+pytest.importorskip("homeassistant")
+pytest.importorskip("pytest_homeassistant_custom_component")
+
+from homeassistant.core import HomeAssistant  # noqa: E402
+from homeassistant.exceptions import ServiceValidationError  # noqa: E402
+from homeassistant.setup import async_setup_component  # noqa: E402
+from pytest_homeassistant_custom_component.common import (  # noqa: E402
+    MockConfigEntry,
+)
+
+pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+_NEW_SERVICES = ("start_game", "next_round", "pause", "resume", "end_game")
+
+
+@pytest.fixture(autouse=True)
+def _stub_frontend_panel():
+    """Stub the frontend panel helpers (the hass_frontend wheel is absent under
+    the test harness). Mirrors test_init_313."""
+    panels: dict = {}
+
+    def _register_panel(_hass, *, frontend_url_path, **_kw):
+        panels[frontend_url_path] = True
+
+    def _remove_panel(_hass, path):
+        if path not in panels:
+            raise KeyError(path)
+        del panels[path]
+
+    with (
+        patch(
+            "homeassistant.components.frontend.async_register_built_in_panel",
+            side_effect=_register_panel,
+        ),
+        patch(
+            "homeassistant.components.frontend.async_remove_panel",
+            side_effect=_remove_panel,
+        ),
+    ):
+        yield panels
+
+
+@pytest.fixture
+async def http_hass(hass: HomeAssistant) -> HomeAssistant:
+    """A hass with the HTTP component set up (setup mounts routes on it)."""
+    assert await async_setup_component(hass, "http", {"http": {}})
+    await hass.async_block_till_done()
+    return hass
+
+
+async def _setup(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id) is True
+    await hass.async_block_till_done()
+    # Drop the start-redirect grace so the start_game service test doesn't
+    # sleep 2.5s before emitting round 1.
+    hass.data[DOMAIN]["ws_handler"].START_REDIRECT_GRACE = 0.0
+    return entry
+
+
+async def test_all_game_control_services_registered(
+    http_hass: HomeAssistant,
+) -> None:
+    """Setup registers every #367 game-control service on the domain."""
+    hass = http_hass
+    await _setup(hass)
+    for name in _NEW_SERVICES:
+        assert hass.services.has_service(DOMAIN, name), f"missing service {name}"
+
+
+async def test_start_game_service_transitions_and_broadcasts(
+    http_hass: HomeAssistant,
+) -> None:
+    """From LOBBY, quizify.start_game starts the game and fans out a broadcast;
+    calling it again (now not in LOBBY) raises ServiceValidationError."""
+    hass = http_hass
+    await _setup(hass)
+    ws_handler = hass.data[DOMAIN]["ws_handler"]
+    game = hass.data[DOMAIN]["game"]
+    assert game.phase == GamePhase.LOBBY
+
+    spy = AsyncMock()
+    ws_handler._conn.broadcast = spy
+
+    await hass.services.async_call(DOMAIN, "start_game", {}, blocking=True)
+    await hass.async_block_till_done()
+
+    assert game.phase == GamePhase.QUESTION_ACTIVE
+    assert game.round == 1
+    assert spy.await_count >= 1  # entities + clients refreshed
+    ws_handler._cancel_timer_tick()
+
+    # A second start while a game is running is refused, not a silent wipe.
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(DOMAIN, "start_game", {}, blocking=True)
+
+
+async def test_pause_then_resume_roundtrip(http_hass: HomeAssistant) -> None:
+    """quizify.pause then quizify.resume round-trips through PAUSED; resuming a
+    non-paused game raises ServiceValidationError."""
+    hass = http_hass
+    await _setup(hass)
+    game = hass.data[DOMAIN]["game"]
+    # Drive to QUESTION_ACTIVE directly (bypass the WS grace/timer path).
+    game.start_game(num_rounds=10, lightning_enabled=False)
+    game.start_next_question()
+    assert game.phase == GamePhase.QUESTION_ACTIVE
+
+    await hass.services.async_call(DOMAIN, "pause", {}, blocking=True)
+    assert game.phase == GamePhase.PAUSED
+
+    await hass.services.async_call(DOMAIN, "resume", {}, blocking=True)
+    await hass.async_block_till_done()
+    assert game.phase == GamePhase.QUESTION_ACTIVE
+    hass.data[DOMAIN]["ws_handler"]._cancel_timer_tick()
+
+    # Resuming when not paused → validation error.
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(DOMAIN, "resume", {}, blocking=True)
+
+
+async def test_pause_off_active_phase_raises(http_hass: HomeAssistant) -> None:
+    """Pausing with no active question (LOBBY) raises ServiceValidationError
+    rather than silently no-opping."""
+    hass = http_hass
+    await _setup(hass)
+    game = hass.data[DOMAIN]["game"]
+    assert game.phase == GamePhase.LOBBY
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(DOMAIN, "pause", {}, blocking=True)
+
+
+async def test_next_round_advances_and_end_game_ends(
+    http_hass: HomeAssistant,
+) -> None:
+    """quizify.next_round advances mid-game; quizify.end_game ends the game."""
+    hass = http_hass
+    await _setup(hass)
+    game = hass.data[DOMAIN]["game"]
+    ws_handler = hass.data[DOMAIN]["ws_handler"]
+    game.start_game(num_rounds=10, lightning_enabled=False)
+    game.start_next_question()
+    game.evaluate_round()
+    assert game.phase == GamePhase.ANSWER_REVEAL
+    assert game.round == 1
+
+    await hass.services.async_call(DOMAIN, "next_round", {}, blocking=True)
+    await hass.async_block_till_done()
+    assert game.round == 2
+    assert game.phase == GamePhase.QUESTION_ACTIVE
+    ws_handler._cancel_timer_tick()
+
+    await hass.services.async_call(DOMAIN, "end_game", {}, blocking=True)
+    assert game.phase == GamePhase.FINALE
+    # end_game() schedules fire-and-forget analytics/question-stats save tasks;
+    # drain them so they don't linger into the hass-fixture teardown (which the
+    # harness flags as an unclosed-task error).
+    await hass.async_block_till_done()
+
+
+async def test_next_round_off_phase_raises(http_hass: HomeAssistant) -> None:
+    """next_round from a fresh lobby (no game) raises ServiceValidationError."""
+    hass = http_hass
+    await _setup(hass)
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(DOMAIN, "next_round", {}, blocking=True)
+
+
+async def test_end_game_off_phase_raises(http_hass: HomeAssistant) -> None:
+    """end_game with no running game (LOBBY) raises ServiceValidationError."""
+    hass = http_hass
+    await _setup(hass)
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(DOMAIN, "end_game", {}, blocking=True)
+
+
+async def test_service_without_setup_raises_validation_error(
+    http_hass: HomeAssistant,
+) -> None:
+    """After the entry is unloaded (hass.data[DOMAIN] gone) a game-control
+    service raises ServiceValidationError, not a raw KeyError."""
+    hass = http_hass
+    entry = await _setup(hass)
+    assert await hass.config_entries.async_unload(entry.entry_id) is True
+    await hass.async_block_till_done()
+    assert DOMAIN not in hass.data
+
+    for name in _NEW_SERVICES:
+        with pytest.raises(ServiceValidationError):
+            await hass.services.async_call(DOMAIN, name, {}, blocking=True)


### PR DESCRIPTION
## What

Exposes a safe subset of the admin game controls as Home Assistant services so hosts can drive the game via Assist voice, a Zigbee remote, a dashboard button or an automation — instead of only the admin WebSocket UI. Backend only, no frontend.

## Services shipped (no fields)

- `quizify.start_game` — start a new game with default settings (only from the lobby)
- `quizify.next_round` — advance to the next question (the admin "Next" action)
- `quizify.pause` — pause the active question
- `quizify.resume` — resume a paused game
- `quizify.end_game` — end the game and jump to the finale

Each raises `ServiceValidationError` (never a raw `KeyError`) when the integration isn't set up or the current phase forbids the action, so the host sees a clear reason in the HA UI / voice response — no silent no-ops, no crashes.

## Example Assist sentences

- "Hey Nabu, start the quiz" → `quizify.start_game`
- "Hey Nabu, next question" → `quizify.next_round`
- "Hey Nabu, pause the quiz" / "resume the quiz" → `quizify.pause` / `quizify.resume`
- "Hey Nabu, end the quiz" → `quizify.end_game`

## Shared-core refactor (no fake WS connection)

Rather than synthesize a fake admin WebSocket connection to reuse the admin handlers, the socket-independent core of each handler is factored into reusable `admin_action_*` methods on `QuizifyWebSocketHandler`. The existing `_handle_*` WS handlers now delegate to that same core, so the WS path and the service path run **one** implementation and the state broadcast that refreshes `sensor.quizify_*` entities + connected clients always fires — exactly like the admin path.

Existing WS behavior is byte-for-byte equivalent (contiguous blocks extracted): `_handle_next_question` keeps its exact `Cannot advance now` error frames via a shared `_advance_round`; `_handle_pause_game` keeps its silent no-op (only the service turns a non-pausable phase into a validation error); `_handle_start_game` keeps its reset-to-lobby + grace + first-question sequence (extracted into `_after_start_game`, reused by the service).

Phase preconditions are preserved: `start_game` only from LOBBY (it refuses to wipe a game already in progress, unlike the admin re-pick handler which force-resets on an explicit re-pick), `next_round` only mid-game/at reveal, `resume` only from PAUSED, `pause` only during an active question, `end_game` only while a game is running.

## Exclusions

- **`kick_player` excluded** — it needs a player target and is riskier to trigger blindly from voice/a remote; deliberately left out of this safe subset (per the issue's Sketch).
- **`start_lightning` descoped** — the Lightning Round is fully auto-triggered mid-game (#285); the host-manual `start_lightning` entry was retired and there is no clean host-trigger path (the auto path detours out of the current round with bookkeeping + drives a dedicated loop). Manually invoking it would be risky and duplicate loop machinery, so it is not exposed. Documented here rather than forced.

## Translations

`services.<name>.name` / `.description` added to `en`, `de`, `es`, `fr`, `nl` matching the `reset_admin_session` structure.

## Tests

`tests/test_game_control_services_367.py` — 15 tests: every service registered on the domain after setup; `start_game` from LOBBY transitions + broadcasts and is refused off-lobby; `pause`→`resume` round-trips through PAUSED (resume off-paused raises); `next_round` advances mid-game and `end_game` ends; the WS admin handler and the service core hit the same shared core (equivalence); and a service call with the integration not set up raises `ServiceValidationError`, not `KeyError`.

Full suite: **1119 passed, 19 failed** — the 19 are the pre-existing `pytest-socket` `SocketBlockedError` failures in the aiohttp `test_ws_*` files (they fail at test-server socket creation, unrelated to this change; identical on clean `main`). `ruff check custom_components/quizify` clean; `mypy custom_components/quizify` clean.

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)