### PR TITLE
fix(admin): deliver TTS entity lists over the admin WS frame (#502)

### DIFF
--- a/custom_components/quizify/server/serializers.py
+++ b/custom_components/quizify/server/serializers.py
@@ -10,6 +10,42 @@ if TYPE_CHECKING:
     from custom_components.quizify.game.state import QuizifyGameState
 
 
+def snapshot_tts_entities(hass: Any) -> dict[str, list[dict[str, str]]]:
+    """List the TTS engines + media players for the admin narration dropdowns.
+
+    Backs BOTH the admin-token-gated ``/api/quizify/tts-entities`` HTTP endpoint
+    and the admin-connect WebSocket payload. Delivering the same lists over the
+    already-authenticated admin socket lets the dropdowns populate without a
+    separate token-gated fetch racing the admin token's arrival (#356 gated the
+    endpoint; the HTTP fetch first fires at page-init, before the token lands,
+    so it 401s and the dropdowns fall back to "None found"). The WS carries the
+    lists directly, so there is no race.
+
+    ``hass`` is None on the standalone dev server — both lists come back empty
+    and the dropdowns show their "configure in HA" fallback.
+
+    Returns ``{"tts": [...], "media_players": [...]}`` where each item is
+    ``{entity_id, friendly_name}``, sorted by friendly_name.
+    """
+    if hass is None:
+        return {"tts": [], "media_players": []}
+
+    def _entities(domain: str) -> list[dict[str, str]]:
+        items = [
+            {
+                "entity_id": state.entity_id,
+                "friendly_name": state.attributes.get(
+                    "friendly_name", state.entity_id
+                ),
+            }
+            for state in hass.states.async_all(domain)
+        ]
+        items.sort(key=lambda e: e["friendly_name"].lower())
+        return items
+
+    return {"tts": _entities("tts"), "media_players": _entities("media_player")}
+
+
 def build_game_status_response(
     game_state: QuizifyGameState | None,
     game_id: str | None,

--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -29,7 +29,7 @@ from .pack_submission import (
     submit_pack_view,
 )
 from .rate_limit import SlidingWindowLimiter
-from .serializers import build_game_status_response
+from .serializers import build_game_status_response, snapshot_tts_entities
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -796,25 +796,7 @@ async def tts_entities_view(request: web.Request) -> web.Response:
     ctx = _get_ctx(request)
     # Only the HA runtime exposes ``hass``; the standalone dev server does not.
     hass = getattr(ctx.runtime, "hass", None)
-    if hass is None:
-        return web.json_response({"tts": [], "media_players": []})
-
-    def _entities(domain: str) -> list[dict]:
-        items = [
-            {
-                "entity_id": state.entity_id,
-                "friendly_name": state.attributes.get(
-                    "friendly_name", state.entity_id
-                ),
-            }
-            for state in hass.states.async_all(domain)
-        ]
-        items.sort(key=lambda e: e["friendly_name"].lower())
-        return items
-
-    return web.json_response(
-        {"tts": _entities("tts"), "media_players": _entities("media_player")}
-    )
+    return web.json_response(snapshot_tts_entities(hass))
 
 
 async def analytics_data_view(request: web.Request) -> web.Response:

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -45,6 +45,7 @@ from custom_components.quizify.server.serializers import (
     serialize_finale,
     serialize_leaderboard,
     serialize_player_list,
+    snapshot_tts_entities,
 )
 
 if TYPE_CHECKING:
@@ -585,6 +586,16 @@ class QuizifyWebSocketHandler:
         state["type"] = "game_state"
         state["join_url"] = "/quizify/player"
         state["admin_session_token"] = admin_token
+        # Ride the TTS-engine + media-player lists for the narration dropdowns
+        # (#281) on this already-authenticated admin frame, so the panel never
+        # depends on the separate admin-token-gated /api/quizify/tts-entities
+        # fetch racing the token's arrival (#356/#501). ``hass`` is None on the
+        # standalone dev server → empty lists → the dropdowns' "configure in HA"
+        # fallback, exactly like the HTTP endpoint.
+        hass = getattr(self._runtime, "hass", None)
+        entities = snapshot_tts_entities(hass)
+        state["tts_entities"] = entities["tts"]
+        state["media_players"] = entities["media_players"]
         await self._conn.send(ws, state)
 
     # ------------------------------------------------------------------

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -1102,13 +1102,24 @@
         currentPhase = msg.phase;
         if (msg.admin_session_token) {
             sessionStorage.setItem('quizify_admin_session_token', msg.admin_session_token);
-            // The TTS entity dropdowns (#281) load at page-init, before this
-            // token exists — that first fetch of the admin-token-gated
-            // tts-entities endpoint (#356) 401s and shows "None found". Now that
-            // the token is stored, refetch once so the dropdowns populate.
-            if (!_ttsEntitiesLoaded && _ttsEls && _ttsEls.engine) {
-                _loadTtsEntities(_readTtsConfig());
-            }
+        }
+        // The admin-connect frame now carries the TTS-engine + media-player
+        // lists directly (server-side, over this already-authenticated socket),
+        // so the narration dropdowns (#281) populate WITHOUT the separate
+        // admin-token-gated /api/quizify/tts-entities fetch racing the token's
+        // arrival (#356/#501 were a fragile refetch band-aid for exactly that
+        // race). Populate straight from the payload and mark loaded. An empty
+        // array is still "present" (JS: [] is truthy), so a host with no
+        // TTS/media_player entities correctly shows "None found".
+        if ((msg.tts_entities || msg.media_players) && _ttsEls && _ttsEls.engine) {
+            var _ttsCfg = _readTtsConfig();
+            _populateEntitySelect(_ttsEls.engine, msg.tts_entities || [], _ttsCfg.tts_entity);
+            _populateEntitySelect(_ttsEls.speaker, msg.media_players || [], _ttsCfg.media_player);
+            _ttsEntitiesLoaded = true;
+        } else if (msg.admin_session_token && !_ttsEntitiesLoaded && _ttsEls && _ttsEls.engine) {
+            // Fallback for an older server that doesn't send the lists on the
+            // admin frame: now that the token is stored, refetch over HTTP once.
+            _loadTtsEntities(_readTtsConfig());
         }
         if (msg.players) renderLobbyPlayers(msg.players);
 

--- a/tests/test_tts_entities_ws_piggyback_502.py
+++ b/tests/test_tts_entities_ws_piggyback_502.py
@@ -120,9 +120,16 @@ async def _make_client(handler: QuizifyWebSocketHandler) -> TestClient:
 
 
 async def _first_game_state(ws) -> dict:  # noqa: ANN001
-    """Return the first game_state frame the server pushes."""
+    """Return the first ``game_state`` frame after an ``admin_connect`` message.
+
+    ``_handle_admin_connect`` (which carries the entity lists) fires only in
+    response to an ``admin_connect`` frame from a ?role=admin socket — the admin
+    page sends it right after connect. Each receive is bounded by a timeout so a
+    regression can never hang the whole suite.
+    """
+    await ws.send_json({"type": "admin_connect"})
     for _ in range(100):
-        msg = await ws.receive_json()
+        msg = await asyncio.wait_for(ws.receive_json(), timeout=5)
         if msg.get("type") == "game_state":
             return msg
     raise AssertionError("no game_state frame received")

--- a/tests/test_tts_entities_ws_piggyback_502.py
+++ b/tests/test_tts_entities_ws_piggyback_502.py
@@ -1,0 +1,177 @@
+"""Tests for the TTS-entities WebSocket piggyback (#502).
+
+The admin narration dropdowns (#281) used to populate only from the separate
+``/api/quizify/tts-entities`` HTTP endpoint, which #356 put behind the admin
+session token. That fetch fires at page-init, *before* the token arrives over
+the WebSocket, so it 401s and the dropdowns fall back to "None found"; #501's
+one-shot refetch was a fragile band-aid for the race.
+
+Fix (#502): the admin-connect frame carries the TTS-engine + media-player lists
+directly, over the already-authenticated admin socket, so the dropdowns never
+depend on the token-gated HTTP fetch. ``snapshot_tts_entities`` is the shared
+builder used by both the WS handler and the HTTP endpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server import WS_PATH  # noqa: E402
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    snapshot_tts_entities,
+)
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+# --------------------------------------------------------------------------
+# snapshot_tts_entities (pure helper)
+# --------------------------------------------------------------------------
+
+
+class _FakeState:
+    def __init__(self, entity_id: str, friendly_name: str | None = None) -> None:
+        self.entity_id = entity_id
+        self.attributes = {}
+        if friendly_name is not None:
+            self.attributes["friendly_name"] = friendly_name
+
+
+class _FakeStates:
+    def __init__(self, by_domain: dict[str, list[_FakeState]]) -> None:
+        self._by_domain = by_domain
+
+    def async_all(self, domain: str) -> list[_FakeState]:
+        return list(self._by_domain.get(domain, []))
+
+
+class _FakeHass:
+    def __init__(self, by_domain: dict[str, list[_FakeState]]) -> None:
+        self.states = _FakeStates(by_domain)
+
+
+def test_snapshot_none_hass_returns_empty_lists() -> None:
+    """Standalone dev server (no hass) → empty lists, no crash."""
+    assert snapshot_tts_entities(None) == {"tts": [], "media_players": []}
+
+
+def test_snapshot_sorts_and_falls_back_to_entity_id() -> None:
+    hass = _FakeHass(
+        {
+            "tts": [_FakeState("tts.b", "Bravo"), _FakeState("tts.a", "alpha")],
+            "media_player": [_FakeState("media_player.bare")],
+        }
+    )
+    out = snapshot_tts_entities(hass)
+    # Case-insensitive sort by friendly_name.
+    assert [e["friendly_name"] for e in out["tts"]] == ["alpha", "Bravo"]
+    # Missing friendly_name falls back to entity_id.
+    assert out["media_players"] == [
+        {"entity_id": "media_player.bare", "friendly_name": "media_player.bare"}
+    ]
+
+
+# --------------------------------------------------------------------------
+# admin-connect frame carries the lists (integration over a live WS)
+# --------------------------------------------------------------------------
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path, hass=None) -> None:  # noqa: ANN001
+        self.data_dir = tmp_path
+        # Mirrors HARuntime.hass — the WS handler reads it via getattr, so a
+        # missing attribute (standalone) degrades to empty lists.
+        if hass is not None:
+            self.hass = hass
+
+    def create_task(self, coro):  # noqa: ANN001, ANN202
+        return asyncio.ensure_future(coro)
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func, *args)
+
+
+def _make_handler(tmp_path: Path, hass=None) -> QuizifyWebSocketHandler:  # noqa: ANN001
+    runtime = _FakeRuntime(tmp_path, hass=hass)
+    game = QuizifyGameState(runtime=runtime, entry_id="test")
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    h._conn = ConnectionManager(runtime, lambda: game)
+    return h
+
+
+async def _make_client(handler: QuizifyWebSocketHandler) -> TestClient:
+    app = web.Application()
+    app.router.add_get(WS_PATH, handler.handle)
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    return client
+
+
+async def _first_game_state(ws) -> dict:  # noqa: ANN001
+    """Return the first game_state frame the server pushes."""
+    for _ in range(100):
+        msg = await ws.receive_json()
+        if msg.get("type") == "game_state":
+            return msg
+    raise AssertionError("no game_state frame received")
+
+
+@pytest.mark.asyncio
+async def test_admin_connect_frame_includes_entity_lists(tmp_path: Path) -> None:
+    """A freshly-bootstrapped admin receives tts_entities + media_players on the
+    admin-connect frame — no separate token-gated HTTP fetch needed."""
+    hass = _FakeHass(
+        {
+            "tts": [
+                _FakeState("tts.cloud", "Home Assistant Cloud"),
+                _FakeState("tts.google", "Google Translate"),
+            ],
+            "media_player": [_FakeState("media_player.wohnzimmer", "Wohnzimmer")],
+        }
+    )
+    handler = _make_handler(tmp_path, hass=hass)
+    client = await _make_client(handler)
+    try:
+        # No token yet → the first ?role=admin connection wins bootstrap and is
+        # granted admin, so _handle_admin_connect fires.
+        ws = await client.ws_connect(WS_PATH + "?role=admin")
+        msg = await _first_game_state(ws)
+
+        assert "admin_session_token" in msg  # still authenticated as before
+        assert [e["friendly_name"] for e in msg["tts_entities"]] == [
+            "Google Translate",
+            "Home Assistant Cloud",
+        ]
+        assert msg["media_players"] == [
+            {"entity_id": "media_player.wohnzimmer", "friendly_name": "Wohnzimmer"}
+        ]
+        await ws.close()
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_admin_connect_frame_empty_lists_without_hass(tmp_path: Path) -> None:
+    """Standalone runtime (no hass) → the frame still carries the keys, empty."""
+    handler = _make_handler(tmp_path, hass=None)
+    client = await _make_client(handler)
+    try:
+        ws = await client.ws_connect(WS_PATH + "?role=admin")
+        msg = await _first_game_state(ws)
+        assert msg["tts_entities"] == []
+        assert msg["media_players"] == []
+        await ws.close()
+    finally:
+        await client.close()


### PR DESCRIPTION
## Problem
On v1.6.0-RC2 the admin narration dropdowns (engine + speaker, #281) are still empty. Since #356 gated `/api/quizify/tts-entities` behind the admin session token, and that token only reaches the browser later over the admin WebSocket, the dropdown's page-init HTTP fetch 401s → "None found". #501's one-shot refetch was a fragile band-aid and didn't close the race.

Server-side is fine: with a valid token the endpoint returns the full entity lists — the failure was purely the client-side token race.

## Fix
Deliver the TTS-engine + media-player lists **on the admin-connect WebSocket frame**, which is already admin-authenticated at that point. The dropdowns populate from a trusted channel with no separate token-gated fetch and no race.

- New shared `snapshot_tts_entities(hass)` builder in `serializers.py`, used by both the WS handler and the HTTP endpoint (kept as a fallback, now deduped onto the helper).
- `_handle_admin_connect` adds `tts_entities` + `media_players` to the frame.
- `admin.js` populates the selects straight from the frame and marks them loaded; only falls back to the HTTP fetch for an older server that doesn't send the lists.

No visual change — same dropdowns, reliable data source.

## Tests
- New `test_tts_entities_ws_piggyback_502.py`: unit-tests the shared builder (sort, friendly_name fallback, `hass=None` empty) and an integration test that the admin-connect frame carries the populated lists (mirrors the existing #359 WS harness).
- Existing `test_tts_entities_view_281.py` unchanged and still green (endpoint output shape preserved via the helper).

Closes #502