### PR TITLE
feat(admin): offer a 180 s per-question timer (#506)

### DIFF
--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -620,7 +620,9 @@ class QuizifyGameState:
 
         # Determine time limit. Admin-chosen timer override (set in
         # start_game) wins over the difficulty-derived default — the
-        # picker in the admin UI lets the host pick 20/30/45s up front.
+        # picker in the admin UI lets the host pick 20/30/45/60/90/120s
+        # up front (the longer options came from #506: reading a question
+        # plus four answers takes small kids well over 45 s).
         if self._timer_override is not None:
             round_duration = float(self._timer_override)
         else:

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -620,9 +620,9 @@ class QuizifyGameState:
 
         # Determine time limit. Admin-chosen timer override (set in
         # start_game) wins over the difficulty-derived default — the
-        # picker in the admin UI lets the host pick 20/30/45/60/90/120s
-        # up front (the longer options came from #506: reading a question
-        # plus four answers takes small kids well over 45 s).
+        # picker in the admin UI lets the host pick 20/30/45/180s up front
+        # (the 180 s option came from #506: reading a question plus four
+        # answers takes small kids well over 45 s).
         if self._timer_override is not None:
             round_duration = float(self._timer_override)
         else:

--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -244,18 +244,19 @@
                     <div class="vF-step">
                         <div class="vF-q"><span class="num">4</span><span data-i18n="setup.eigene.q4">How long per question?</span></div>
                         <div class="vF-answers chip-group" id="timer-chips" role="group" data-i18n-aria-label="admin.timer" aria-label="Timer">
-                            <!-- Longer options (60/90/120 s) added for #506: a host
-                                 playing with small kids reported they cannot read the
-                                 question and four answers in time even at 45 s. The
-                                 backend already accepts 5..300 s, so these need no
-                                 server change. The group flex-wraps, so the extra
-                                 chips fall to a second row on a 390 px phone. -->
+                            <!-- The 180 s option was added for #506: a host playing
+                                 with small kids reported they cannot read the question
+                                 and four answers in time even at 45 s. It is a
+                                 deliberate jump rather than a 60/90/120 ladder — the
+                                 three short values stay the normal party range and
+                                 180 s is the "read it to the kids" setting. The
+                                 backend already accepts 5..300 s, so no server change
+                                 is needed, and four chips still fit one row on a
+                                 390 px phone. -->
                             <button type="button" class="chip" data-value="20">20 s</button>
                             <button type="button" class="chip active" data-value="30">30 s</button>
                             <button type="button" class="chip" data-value="45">45 s</button>
-                            <button type="button" class="chip" data-value="60">60 s</button>
-                            <button type="button" class="chip" data-value="90">90 s</button>
-                            <button type="button" class="chip" data-value="120">120 s</button>
+                            <button type="button" class="chip" data-value="180">180 s</button>
                         </div>
                     </div>
 

--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -244,9 +244,18 @@
                     <div class="vF-step">
                         <div class="vF-q"><span class="num">4</span><span data-i18n="setup.eigene.q4">How long per question?</span></div>
                         <div class="vF-answers chip-group" id="timer-chips" role="group" data-i18n-aria-label="admin.timer" aria-label="Timer">
+                            <!-- Longer options (60/90/120 s) added for #506: a host
+                                 playing with small kids reported they cannot read the
+                                 question and four answers in time even at 45 s. The
+                                 backend already accepts 5..300 s, so these need no
+                                 server change. The group flex-wraps, so the extra
+                                 chips fall to a second row on a 390 px phone. -->
                             <button type="button" class="chip" data-value="20">20 s</button>
                             <button type="button" class="chip active" data-value="30">30 s</button>
                             <button type="button" class="chip" data-value="45">45 s</button>
+                            <button type="button" class="chip" data-value="60">60 s</button>
+                            <button type="button" class="chip" data-value="90">90 s</button>
+                            <button type="button" class="chip" data-value="120">120 s</button>
                         </div>
                     </div>
 

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -53,7 +53,7 @@
         }
         return 'en';
     })();
-    let selectedTimer = 30;  // seconds per question (20 / 30 / 45)
+    let selectedTimer = 30;  // seconds per question (20 / 30 / 45 / 180, #506)
     // Auto Lightning Round toggle (#285), default ON. The surprise fast round
     // fires once at a random mid-game round; the host opts out via the setup
     // toggle. Read live from the checkbox at start_game time.

--- a/tests/test_timer_chips_506.py
+++ b/tests/test_timer_chips_506.py
@@ -1,14 +1,14 @@
-"""Regression: the longer per-question timer options from #506.
+"""Regression: the long per-question timer option from #506.
 
 An external host (#506) plays with small kids and reported they cannot read the
 question plus four answers in time *even at 45 s* — which was the highest value
-the admin timer picker offered. The picker now also offers 60/90/120 s.
+the admin timer picker offered. The picker now also offers 180 s.
 
 The ceiling was purely a frontend one: ``_handle_start_game`` has always
 accepted 5..300 s and silently dropped anything outside that range back to the
 difficulty-derived default. So these tests guard both ends of that contract:
 
-1. the new values actually survive validation and become the round duration
+1. the new value actually survives validation and becomes the round duration
    (a value that got clamped would silently fall back to 20/15/10 s, which is
    exactly the *opposite* of what the host asked for), and
 2. every chip rendered in ``admin.html`` stays inside the backend's accepted
@@ -87,11 +87,11 @@ def _timer_chip_values() -> list[int]:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("seconds", [60, 90, 120])
+@pytest.mark.parametrize("seconds", [180])
 async def test_long_timer_reaches_the_round(
     handler: QuizifyWebSocketHandler, game: QuizifyGameState, seconds: int
 ) -> None:
-    """60/90/120 s must survive validation, not fall back to the default."""
+    """180 s must survive validation, not fall back to the default."""
     admin = _ws()
     game.add_player("Markus", admin)
     game.get_player("Markus").is_admin = True
@@ -141,10 +141,10 @@ async def test_out_of_range_timer_still_falls_back(
     assert game._timer_override is None
 
 
-def test_admin_picker_offers_the_longer_options() -> None:
-    """#506: the picker must actually expose the longer values."""
+def test_admin_picker_offers_the_longer_option() -> None:
+    """#506: the picker must actually expose the long value."""
     values = _timer_chip_values()
-    assert values == [20, 30, 45, 60, 90, 120]
+    assert values == [20, 30, 45, 180]
 
 
 def test_every_timer_chip_is_accepted_by_the_backend() -> None:

--- a/tests/test_timer_chips_506.py
+++ b/tests/test_timer_chips_506.py
@@ -1,0 +1,161 @@
+"""Regression: the longer per-question timer options from #506.
+
+An external host (#506) plays with small kids and reported they cannot read the
+question plus four answers in time *even at 45 s* — which was the highest value
+the admin timer picker offered. The picker now also offers 60/90/120 s.
+
+The ceiling was purely a frontend one: ``_handle_start_game`` has always
+accepted 5..300 s and silently dropped anything outside that range back to the
+difficulty-derived default. So these tests guard both ends of that contract:
+
+1. the new values actually survive validation and become the round duration
+   (a value that got clamped would silently fall back to 20/15/10 s, which is
+   exactly the *opposite* of what the host asked for), and
+2. every chip rendered in ``admin.html`` stays inside the backend's accepted
+   range — so a future chip added to the markup can't silently no-op.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+_ADMIN_HTML = (
+    _REPO_ROOT / "custom_components" / "quizify" / "www" / "admin.html"
+)
+
+# Mirrors the backend clamp in websocket.py::_handle_start_game.
+_MIN_TIMER = 5
+_MAX_TIMER = 300
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+@pytest.fixture
+def handler(game: QuizifyGameState, monkeypatch) -> QuizifyWebSocketHandler:
+    runtime = _FakeRuntime(game._runtime.data_dir)  # type: ignore[attr-defined]
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    h._conn = ConnectionManager(runtime, lambda: game)
+    h._conn.broadcast = AsyncMock()
+    h._conn.send_error = AsyncMock()
+    # _handle_start_game sleeps 2.5s for the admin-redirect grace — skip it.
+    monkeypatch.setattr(
+        "custom_components.quizify.server.websocket.asyncio.sleep", AsyncMock()
+    )
+    # The tick loop counts real wall-clock time; neutralise it. These tests
+    # assert the configured duration, not the countdown itself.
+    monkeypatch.setattr(h, "_start_timer_tick", lambda *a, **k: None)
+    return h
+
+
+def _timer_chip_values() -> list[int]:
+    """The data-value of every chip inside #timer-chips in admin.html."""
+    html = _ADMIN_HTML.read_text(encoding="utf-8")
+    group = re.search(
+        r'id="timer-chips".*?</div>', html, re.DOTALL
+    )
+    assert group is not None, "#timer-chips group not found in admin.html"
+    return [int(v) for v in re.findall(r'data-value="(\d+)"', group.group(0))]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("seconds", [60, 90, 120])
+async def test_long_timer_reaches_the_round(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState, seconds: int
+) -> None:
+    """60/90/120 s must survive validation, not fall back to the default."""
+    admin = _ws()
+    game.add_player("Markus", admin)
+    game.get_player("Markus").is_admin = True
+
+    await handler._handle_start_game(
+        admin,
+        {
+            "category": None,
+            "difficulty": None,
+            "num_rounds": 5,
+            "language": "de",
+            "timer_duration": seconds,
+        },
+        game,
+    )
+
+    assert game._timer_override == seconds
+    assert game._current_question is not None
+    assert game._round_duration == float(seconds)
+
+
+@pytest.mark.asyncio
+async def test_out_of_range_timer_still_falls_back(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState
+) -> None:
+    """Sanity: the clamp is untouched — 301 s is still rejected.
+
+    Guards the other direction of #506: widening the picker must not have
+    widened the backend's accepted range.
+    """
+    admin = _ws()
+    game.add_player("Markus", admin)
+    game.get_player("Markus").is_admin = True
+
+    await handler._handle_start_game(
+        admin,
+        {
+            "category": None,
+            "difficulty": None,
+            "num_rounds": 5,
+            "language": "de",
+            "timer_duration": 301,
+        },
+        game,
+    )
+
+    assert game._timer_override is None
+
+
+def test_admin_picker_offers_the_longer_options() -> None:
+    """#506: the picker must actually expose the longer values."""
+    values = _timer_chip_values()
+    assert values == [20, 30, 45, 60, 90, 120]
+
+
+def test_every_timer_chip_is_accepted_by_the_backend() -> None:
+    """No chip may sit outside the 5..300 s window the backend accepts.
+
+    A chip outside that range would be silently swallowed by the clamp in
+    ``_handle_start_game`` and the host would get the difficulty default
+    instead of the value they picked — with no error anywhere.
+    """
+    for value in _timer_chip_values():
+        assert _MIN_TIMER <= value <= _MAX_TIMER, (
+            f"timer chip {value}s is outside the backend's accepted "
+            f"{_MIN_TIMER}..{_MAX_TIMER}s range and would silently no-op"
+        )


### PR DESCRIPTION
## Why

The admin timer picker topped out at **45 s**. In #506 an external host reports they play Quizify with small kids, combined with *chores4kids* as a reward for finished morning chores — and the kids "can't read the question and the answers quick enough to understand/decide what they want to do, **even at 45 seconds**". At their pace the game simply isn't playable.

## What this does

Adds one chip to the "How long per question?" picker: **180 s**.

The picker is now **20 / 30 / 45 / 180 s**. The three short values stay the normal party range; 180 s is the distinct "read it out to the kids" setting, rather than a 60/90/120 ladder of near-identical steps nobody picks between. Four chips also fit one row on a 390 px phone, where six wrapped to two.

That is the entire change. The 45 s ceiling was purely a frontend one — `_handle_start_game` has always accepted `5..300 s` and silently dropped anything outside that range back to the difficulty-derived default, so no server change is needed.

## Why it is safe

- The speed bonus is **relative** (`scoring.py`: `1 - elapsed / time_limit`), so a longer round does not inflate scores.
- The player's warning/critical thresholds (10 s / 5 s), the tick SFX and the spoken TTS countdown are **absolute**, so they stay meaningful at 180 s.
- The Lightning Round keeps its own fixed 15 s window.
- The timer readout is `tabular-nums` text in no fixed box, so a three-digit value does not clip.

## Tests

`tests/test_timer_chips_506.py`: 180 s survives validation and becomes the round duration, 301 s still falls back, and a markup guard asserts every chip rendered in `admin.html` sits inside the backend's accepted 5..300 s range — so a future chip cannot silently no-op.