### PR TITLE
feat(admin): add a kids preset carrying the 180 s timer (#506)

### DIFF
--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -156,7 +156,11 @@
                          (~3 / ~8 / ~15 / ~20 min). -->
                     <button type="button" class="preset-card" data-preset="kinder"
                             data-rounds="5" data-difficulty="easy" data-timer="180">
-                        <span class="preset-icon qz-icon qz-icon--sage" data-ui-icon="sparkle" aria-hidden="true">🧸</span>
+                        <!-- Deliberately no data-ui-icon: _paintUiIcons() only
+                             swaps the emoji for an SVG on slots that carry one,
+                             so leaving it off keeps the teddy while the sage
+                             disc still matches the other preset icons. -->
+                        <span class="preset-icon qz-icon qz-icon--sage" aria-hidden="true">🧸</span>
                         <span class="preset-body">
                             <span class="preset-name" data-i18n="setup.preset.kidsName">With kids</span>
                             <span class="preset-meta" data-i18n="setup.preset.kidsMeta">5 rounds · Easy · 180 s</span>

--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -146,6 +146,23 @@
                         </span>
                         <span class="preset-duration">~8 min</span>
                     </button>
+                    <!-- Kids preset (#506). An external host plays with small
+                         children and reported they cannot read a question plus
+                         four answers in time even at 45 s. The 180 s timer chip
+                         exists now, but it lives in the "Eigene" flow — a host
+                         who taps a preset card never sees it. This card puts the
+                         long timer where that host actually looks. Sits before
+                         Marathon so the cards stay ordered by session length
+                         (~3 / ~8 / ~15 / ~20 min). -->
+                    <button type="button" class="preset-card" data-preset="kinder"
+                            data-rounds="5" data-difficulty="easy" data-timer="180">
+                        <span class="preset-icon qz-icon qz-icon--sage" data-ui-icon="sparkle" aria-hidden="true">🧸</span>
+                        <span class="preset-body">
+                            <span class="preset-name" data-i18n="setup.preset.kidsName">With kids</span>
+                            <span class="preset-meta" data-i18n="setup.preset.kidsMeta">5 rounds · Easy · 180 s</span>
+                        </span>
+                        <span class="preset-duration">~15 min</span>
+                    </button>
                     <button type="button" class="preset-card" data-preset="marathon"
                             data-rounds="20" data-difficulty="hard" data-timer="45">
                         <span class="preset-icon qz-icon qz-icon--sun" data-ui-icon="trophy" aria-hidden="true">🏆</span>

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -360,10 +360,12 @@
       "fastName": "Schnellrunde",
       "classicName": "Klassiker",
       "marathonName": "Marathon",
+      "kidsName": "Mit Kindern",
       "customName": "Eigene Einstellungen",
       "fastMeta": "5 Runden · Einfach · 20 s",
       "classicMeta": "10 Runden · Mittel · 30 s",
       "marathonMeta": "20 Runden · Schwer · 45 s",
+      "kidsMeta": "5 Runden · Einfach · 180 s",
       "customMeta": "Kategorie, Schwere, Runden frei wählen"
     },
     "eigene": {

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -360,10 +360,12 @@
       "fastName": "Quick round",
       "classicName": "Classic",
       "marathonName": "Marathon",
+      "kidsName": "With kids",
       "customName": "Custom settings",
       "fastMeta": "5 rounds · Easy · 20 s",
       "classicMeta": "10 rounds · Medium · 30 s",
       "marathonMeta": "20 rounds · Hard · 45 s",
+      "kidsMeta": "5 rounds · Easy · 180 s",
       "customMeta": "Pick category, difficulty, rounds yourself"
     },
     "eigene": {

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -360,10 +360,12 @@
       "fastName": "Ronda rápida",
       "classicName": "Clásica",
       "marathonName": "Maratón",
+      "kidsName": "Con niños",
       "customName": "Configuración personalizada",
       "fastMeta": "5 rondas · Fácil · 20 s",
       "classicMeta": "10 rondas · Media · 30 s",
       "marathonMeta": "20 rondas · Difícil · 45 s",
+      "kidsMeta": "5 rondas · Fácil · 180 s",
       "customMeta": "Elige tú la categoría, la dificultad y las rondas"
     },
     "eigene": {

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -739,6 +739,10 @@
     var _PRESETS = [
         { id: 'schnellrunde', rounds: 5,  difficulty: 'easy',   timer: 20, labelKey: 'setup.preset.fastName'     },
         { id: 'klassiker',    rounds: 10, difficulty: 'medium', timer: 30, labelKey: 'setup.preset.classicName'  },
+        // #506: the long-timer bundle for hosts playing with small kids. Its
+        // timer must stay one of the #timer-chips values — _applyPreset calls
+        // _activateChip, which silently highlights nothing otherwise.
+        { id: 'kinder',       rounds: 5,  difficulty: 'easy',   timer: 180, labelKey: 'setup.preset.kidsName'   },
         { id: 'marathon',     rounds: 20, difficulty: 'hard',   timer: 45, labelKey: 'setup.preset.marathonName' },
     ];
 

--- a/tests/test_kids_preset_506.py
+++ b/tests/test_kids_preset_506.py
@@ -1,0 +1,134 @@
+"""The kids preset card from #506, and the invariants it depends on.
+
+#507 widened the timer picker to 180 s, but the picker lives in the "Eigene"
+flow — a host who taps a preset card never sees it. So #506 also needs a preset
+that carries the long timer. This adds one ("Mit Kindern": 5 rounds, easy,
+180 s), placed before Marathon so the cards stay ordered by session length.
+
+The values behind a preset live in *two* places: as ``data-rounds`` /
+``data-difficulty`` / ``data-timer`` on the button in ``admin.html`` (read by
+``_applyPreset``) and in the ``_PRESETS`` array in ``admin.js`` (read by
+``_matchingPreset`` to decide which card to mark active). If the two ever drift
+apart, tapping a card would apply one bundle while the highlight tracks
+another — a bug with no error anywhere. These tests pin them together.
+
+They also pin the quieter dependency: a preset's timer must be one of the
+``#timer-chips`` values, because ``_applyPreset`` hands it to ``_activateChip``,
+which just walks the chips and highlights the one whose ``data-value`` matches.
+A preset timer with no matching chip highlights nothing and leaves the host
+looking at an unselected picker.
+
+Pure text parsing — no Home Assistant imports, so this runs everywhere.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_WWW = Path(__file__).resolve().parent.parent / "custom_components" / "quizify" / "www"
+_ADMIN_HTML = _WWW / "admin.html"
+_ADMIN_JS = _WWW / "js" / "admin.js"
+_I18N = _WWW / "i18n"
+
+# Mirrors the backend clamp in websocket.py::_handle_start_game.
+_MIN_TIMER = 5
+_MAX_TIMER = 300
+
+
+def _cards_from_html() -> dict[str, dict[str, str]]:
+    """Every preset card in admin.html, keyed by its data-preset id."""
+    html = _ADMIN_HTML.read_text(encoding="utf-8")
+    cards: dict[str, dict[str, str]] = {}
+    for match in re.finditer(
+        r'<button[^>]*class="preset-card[^"]*"[^>]*data-preset="(?P<id>[^"]+)"'
+        r"(?P<attrs>[^>]*)>",
+        html,
+    ):
+        attrs = dict(re.findall(r'data-(\w+)="([^"]+)"', match.group("attrs")))
+        cards[match.group("id")] = attrs
+    return cards
+
+
+def _presets_from_js() -> dict[str, dict[str, str]]:
+    """The _PRESETS array in admin.js, keyed by id."""
+    js = _ADMIN_JS.read_text(encoding="utf-8")
+    block = re.search(r"var _PRESETS = \[(.*?)\];", js, re.DOTALL)
+    assert block is not None, "_PRESETS array not found in admin.js"
+    presets: dict[str, dict[str, str]] = {}
+    for line in re.findall(r"\{[^}]*\}", block.group(1)):
+        fields = dict(re.findall(r"(\w+):\s*'?([\w.]+)'?", line))
+        presets[fields["id"]] = fields
+    return presets
+
+
+def _timer_chip_values() -> list[int]:
+    html = _ADMIN_HTML.read_text(encoding="utf-8")
+    group = re.search(r'id="timer-chips".*?</div>', html, re.DOTALL)
+    assert group is not None, "#timer-chips group not found in admin.html"
+    return [int(v) for v in re.findall(r'data-value="(\d+)"', group.group(0))]
+
+
+def test_kids_preset_card_exists_with_the_long_timer() -> None:
+    """#506: the long timer must be reachable from a preset card."""
+    card = _cards_from_html()["kinder"]
+    assert card["rounds"] == "5"
+    assert card["difficulty"] == "easy"
+    assert card["timer"] == "180"
+
+
+def test_kids_preset_sits_before_marathon() -> None:
+    """Cards stay ordered by session length (~3 / ~8 / ~15 / ~20 min)."""
+    ids = list(_cards_from_html())
+    assert ids.index("kinder") < ids.index("marathon")
+
+
+def test_html_cards_and_js_presets_agree() -> None:
+    """The two places a preset's values live must not drift apart.
+
+    admin.html drives what tapping a card applies; _PRESETS drives which card
+    is shown as active. A mismatch applies one bundle and highlights another,
+    silently.
+    """
+    cards = _cards_from_html()
+    presets = _presets_from_js()
+
+    # "eigene" is a mode switch, not a value bundle — it has no data-* values
+    # and no _PRESETS entry.
+    assert set(presets) == set(cards) - {"eigene"}
+
+    for preset_id, preset in presets.items():
+        card = cards[preset_id]
+        assert card["rounds"] == preset["rounds"], preset_id
+        assert card["difficulty"] == preset["difficulty"], preset_id
+        assert card["timer"] == preset["timer"], preset_id
+
+
+def test_every_preset_timer_has_a_matching_chip() -> None:
+    """_applyPreset highlights the chip whose data-value equals the timer.
+
+    A preset timer with no matching chip leaves the picker with nothing
+    selected — no error, just a setup screen that looks broken.
+    """
+    chips = _timer_chip_values()
+    for preset_id, preset in _presets_from_js().items():
+        assert int(preset["timer"]) in chips, (
+            f"preset {preset_id} uses timer {preset['timer']}s, which is not "
+            f"one of the timer chips {chips}"
+        )
+
+
+def test_every_preset_timer_is_accepted_by_the_backend() -> None:
+    for preset_id, preset in _presets_from_js().items():
+        assert _MIN_TIMER <= int(preset["timer"]) <= _MAX_TIMER, preset_id
+
+
+def test_kids_preset_is_translated_everywhere() -> None:
+    """Every shipped locale carries the new card's name and meta line."""
+    import json
+
+    for path in sorted(_I18N.glob("*.json")):
+        preset = json.loads(path.read_text(encoding="utf-8"))["setup"]["preset"]
+        assert preset.get("kidsName"), path.name
+        assert preset.get("kidsMeta"), path.name
+        assert "180" in preset["kidsMeta"], path.name


### PR DESCRIPTION
## Why

#507 widened the timer picker to **180 s**, but that picker lives in the "Eigene" (custom) flow. A host who taps a preset card never sees it — and the host from #506, who plays Quizify with small children, is exactly the kind of host who taps a card. Without a bundle carrying the long timer, our answer to them is effectively "go into the custom flow".

## What this does

Adds a fourth game preset — **Mit Kindern / With kids / Con niños**, 5 rounds · Easy · **180 s**, ~15 min — placed **before Marathon** so the cards stay ordered by session length (~3 / ~8 / ~15 / ~20 min).

This is design variant **A** of four that were mocked at 390 px: a plain fifth card (A), a highlighted "family" card in position 2 (B), a standalone toggle row that combines with any preset (C), and a 2×2 grid re-layout (D). A was picked because it introduces no new interaction pattern — B adds a second card colour next to the active state, C needs extra logic so the preset highlight does not silently jump to "Eigene", and D changes the layout for every preset.

## Tests

`tests/test_kids_preset_506.py` pins two invariants that were previously unguarded:

- A preset's values live in **two** places — `data-rounds`/`data-difficulty`/`data-timer` on the button in `admin.html` (read by `_applyPreset`) and the `_PRESETS` array in `admin.js` (read by `_matchingPreset`). Drift between them applies one bundle while the highlight tracks another, with no error anywhere.
- A preset's timer must be one of the `#timer-chips` values, because `_applyPreset` hands it to `_activateChip`, which only highlights a chip whose `data-value` matches. A preset timer with no matching chip leaves the picker with nothing selected.

Plus a translation guard: every shipped locale (de/en/es) carries the new name and meta line.

## Verified

390×844 screenshot: the card renders in third position with the sage icon badge, the active state applies on tap, the durations read ascending, and nothing clips (`document.scrollWidth` stays at 390).