### PR TITLE
feat(player): per-player UI language picker on the join screen (#492)

### DIFF
--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import time
+from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -350,6 +351,14 @@ async def _serve_html(request: web.Request, filename: str) -> web.Response:
     # just to skip the (cheap) bank read for non-admin pages.
     if _LANGUAGE_CHIPS_TOKEN in html_content or _CATEGORY_CHIPS_TOKEN in html_content:
         html_content = _apply_admin_chip_tokens(ctx, html_content)
+    # The player's UI-language picker (#492). Separate guard from the admin
+    # chips above: player.html carries only this token, and resolving it needs
+    # no question-bank read at all.
+    if _UI_LANGUAGE_CHIPS_TOKEN in html_content:
+        html_content = html_content.replace(
+            _UI_LANGUAGE_CHIPS_TOKEN,
+            _render_ui_language_chips(_resolve_default_lang(ctx.ha_language)),
+        )
     return web.Response(
         text=html_content, content_type="text/html", headers=_NO_CACHE_HEADERS
     )
@@ -475,6 +484,14 @@ _THEME_ICONS = {
 # ---------------------------------------------------------------------------
 _LANGUAGE_CHIPS_TOKEN = "{{LANGUAGE_CHIPS}}"
 _CATEGORY_CHIPS_TOKEN = "{{CATEGORY_CHIPS}}"
+# The player's own UI-language picker (#492) uses its own token, because it
+# answers a different question than {{LANGUAGE_CHIPS}} above. That one lists
+# the languages the host has *packs* for; this one lists the languages the
+# *interface* is translated into. On a German-only install those sets differ,
+# and the difference is precisely the user this feature exists for: the
+# Spanish-speaking guest at a German host's party. Deriving the player picker
+# from pack languages would offer them nothing.
+_UI_LANGUAGE_CHIPS_TOKEN = "{{UI_LANGUAGE_CHIPS}}"
 
 # Language code → (flag emoji, native display name). Drives the flag-only
 # language chips: the flag is the visible glyph, the name is exposed via
@@ -534,6 +551,58 @@ def _render_language_chips(pack_versions: dict[str, dict], default_lang: str) ->
         name_esc = _html.escape(name, quote=True)
         buttons.append(
             f'<button type="button" class="{cls}" data-value="{_html.escape(code)}" '
+            f'aria-label="{name_esc}" title="{name_esc}">{flag}</button>'
+        )
+    return "".join(buttons)
+
+
+@lru_cache(maxsize=1)
+def _available_ui_languages() -> tuple[str, ...]:
+    """UI-chrome languages, from the i18n bundles actually shipped.
+
+    Read from disk rather than hard-coded so dropping in a new
+    ``www/i18n/<code>.json`` surfaces a chip with no Python edit — the same
+    data-driven move #335 made for the admin chips. Cached because this sits
+    on the HTML hot path and the bundle set cannot change without a restart.
+
+    Ordered by ``_LANGUAGE_ORDER`` first, unknown codes alphabetically after,
+    so the chip row is stable across requests.
+
+    ``tests/test_player_language_picker_492.py`` pins this set against
+    ``SUPPORTED_LANGUAGES`` in ``i18n.js``: a bundle the client would refuse to
+    load must not get a chip, and a language the client supports must not be
+    missing one.
+    """
+    i18n_dir = Path(__file__).resolve().parent.parent / "www" / "i18n"
+    try:
+        present = {p.stem for p in i18n_dir.glob("*.json")}
+    except OSError:  # pragma: no cover - unreadable www/ is a broken install
+        present = set()
+    if not present:
+        return ("en",)
+    known = [code for code in _LANGUAGE_ORDER if code in present]
+    extra = sorted(present - set(_LANGUAGE_ORDER))
+    return tuple(known + extra)
+
+
+def _render_ui_language_chips(default_lang: str) -> str:
+    """Render the player's UI-language chips (#492).
+
+    Same flag-only Selector-B markup as the admin picker so the two read as one
+    family, but sourced from the shipped i18n bundles (see
+    ``_available_ui_languages``). No chip is marked ``active`` server-side:
+    the player's stored choice lives in ``localStorage`` and only the client
+    knows it, so marking one here would paint the wrong flag active for one
+    frame on every load. ``player-core.js`` sets the active chip once i18n has
+    resolved.
+    """
+    langs = _available_ui_languages()
+    buttons = []
+    for code in langs:
+        flag, name = _language_chip_meta(code)
+        name_esc = _html.escape(name, quote=True)
+        buttons.append(
+            f'<button type="button" class="chip" data-value="{_html.escape(code)}" '
             f'aria-label="{name_esc}" title="{name_esc}">{flag}</button>'
         )
     return "".join(buttons)

--- a/custom_components/quizify/www/css/src/04-lobby.css
+++ b/custom_components/quizify/www/css/src/04-lobby.css
@@ -23,6 +23,18 @@
     text-align: center;
 }
 
+/* Per-player UI-language chips on the join screen (#492). The chip visuals
+   come from .chip-group--flags in 02-shared.css; this only places the row.
+   Centred to match the form's text-align, and wrapping is inherited so a
+   fourth language drops to a second line instead of clipping on a 390 px
+   phone. Deliberately quiet: this changes the labels around the game, not
+   the language of the questions, so it should not out-shout the name field
+   it sits above. */
+.player-lang-chips {
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
 .waiting-message {
     color: var(--color-text-neon-muted);
     font-size: 1rem;

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -2047,6 +2047,18 @@ button, .btn {
     text-align: center;
 }
 
+/* Per-player UI-language chips on the join screen (#492). The chip visuals
+   come from .chip-group--flags in 02-shared.css; this only places the row.
+   Centred to match the form's text-align, and wrapping is inherited so a
+   fourth language drops to a second line instead of clipping on a 390 px
+   phone. Deliberately quiet: this changes the labels around the game, not
+   the language of the questions, so it should not out-shout the name field
+   it sits above. */
+.player-lang-chips {
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
 .waiting-message {
     color: var(--color-text-neon-muted);
     font-size: 1rem;

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -13,7 +13,8 @@
     "enterName": "Gib deinen Namen ein, um zu spielen",
     "namePlaceholder": "Dein Name",
     "joinButton": "Beitreten",
-    "joining": "Beitreten…"
+    "joining": "Beitreten…",
+    "languageAria": "Sprache der Oberfläche"
   },
   "lobby": {
     "title": "Lobby",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -13,7 +13,8 @@
     "enterName": "Enter your name to play",
     "namePlaceholder": "Your name",
     "joinButton": "Join Game",
-    "joining": "Joining…"
+    "joining": "Joining…",
+    "languageAria": "Interface language"
   },
   "lobby": {
     "title": "Lobby",

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -13,7 +13,8 @@
     "enterName": "Escribe tu nombre para jugar",
     "namePlaceholder": "Tu nombre",
     "joinButton": "Unirse al juego",
-    "joining": "Uniéndose…"
+    "joining": "Uniéndose…",
+    "languageAria": "Idioma de la interfaz"
   },
   "lobby": {
     "title": "Sala de espera",

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -432,17 +432,12 @@
             _clearFinaleCountdown();
         }
 
-        // Sync UI language with the server-side game language so a
-        // German game shows German labels even if the player's
-        // browser is English. Only triggers a reload of translations
-        // when the language actually changes.
-        if (msg.language && window.QuizifyI18n &&
-            window.QuizifyI18n.getLanguage() !== msg.language) {
-            window.QuizifyI18n.setLanguage(msg.language).then(function () {
-                window.QuizifyI18n.initPageTranslations();
-                updatePageTitle(msg.phase, msg);
-            });
-        } else {
+        // Sync UI language with the server-side game language so a German game
+        // shows German labels even if the player's browser is English — unless
+        // this player picked a language themselves (#492). See
+        // _syncServerLanguage; it returns false when it did not take over, in
+        // which case the title still needs updating here.
+        if (!_syncServerLanguage(msg)) {
             updatePageTitle(msg.phase, msg);
         }
 
@@ -1170,6 +1165,83 @@
     var _renderSoundToggle = null;
     var _renderA11yToggle = null;
 
+    // ============================================
+    // Per-player UI language (#492)
+    // ============================================
+
+    // Set only when the player taps a flag chip. Its presence — not its value
+    // — is what marks the language as *chosen* rather than *detected*, and
+    // that distinction is the whole feature: see _syncServerLanguage below.
+    var PLAYER_LANG_KEY = 'quizify-player-lang';
+
+    function _storedPlayerLang() {
+        try {
+            return window.localStorage.getItem(PLAYER_LANG_KEY) || null;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function _markActiveLangChip() {
+        var group = document.getElementById('player-lang-chips');
+        if (!group || !window.QuizifyI18n) return;
+        var active = QuizifyI18n.getLanguage();
+        group.querySelectorAll('.chip').forEach(function (chip) {
+            chip.classList.toggle('active', chip.dataset.value === active);
+            chip.setAttribute('aria-pressed', chip.dataset.value === active ? 'true' : 'false');
+        });
+    }
+
+    // Apply the server's game language to this phone — unless the player has
+    // picked one. Before #492 this was unconditional, with the reasoning that
+    // "a German game shows German labels even if the player's browser is
+    // English". That is still the right default, but it also meant every
+    // incoming game_state would stamp over a deliberate choice within
+    // milliseconds, so a picker without this guard would look broken rather
+    // than absent.
+    function _syncServerLanguage(msg) {
+        if (!msg.language || !window.QuizifyI18n) return false;
+        if (_storedPlayerLang()) return false;
+        if (QuizifyI18n.getLanguage() === msg.language) return false;
+        QuizifyI18n.setLanguage(msg.language).then(function () {
+            QuizifyI18n.initPageTranslations();
+            _markActiveLangChip();
+            updatePageTitle(msg.phase, msg);
+        });
+        return true;
+    }
+
+    function setupLanguagePicker() {
+        var group = document.getElementById('player-lang-chips');
+        if (!group) return;
+        // An unsubstituted token means the page was served by something that
+        // doesn't know about {{UI_LANGUAGE_CHIPS}}; hide the row rather than
+        // showing the raw braces.
+        if (group.textContent.indexOf('{{') !== -1) {
+            group.classList.add('hidden');
+            return;
+        }
+        if (!group.querySelector('.chip') || !window.QuizifyI18n) {
+            group.classList.add('hidden');
+            return;
+        }
+
+        group.addEventListener('click', function (e) {
+            var chip = e.target.closest('.chip');
+            if (!chip || !chip.dataset.value) return;
+            var code = chip.dataset.value;
+            if (code === QuizifyI18n.getLanguage()) return;
+            try {
+                window.localStorage.setItem(PLAYER_LANG_KEY, code);
+            } catch (_e) { /* private mode: choice holds for this page view */ }
+            QuizifyI18n.setLanguage(code).then(function () {
+                QuizifyI18n.initPageTranslations();
+                _markActiveLangChip();
+                _flushToggleLabels();
+            });
+        });
+    }
+
     function _flushToggleLabels() {
         if (_renderSoundToggle) _renderSoundToggle();
         if (_renderA11yToggle) _renderA11yToggle();
@@ -1235,6 +1307,7 @@
         setupReactionBar();
         setupSoundToggle();
         setupA11yToggle();
+        setupLanguagePicker();
         setupResetAffordance();
         pu.setupCollapsibles();
         if (lightning) { lightning.setSend(send); lightning.init(); }
@@ -1285,10 +1358,13 @@
             state.isAdmin = true;
         }
 
-        // i18n init
+        // i18n init. A stored per-player choice (#492) wins over browser
+        // detection — init() falls back to detectBrowserLanguage() when given
+        // nothing, which is what every player without a choice still gets.
         if (window.QuizifyI18n) {
-            QuizifyI18n.init().then(function () {
+            QuizifyI18n.init(_storedPlayerLang() || undefined).then(function () {
                 QuizifyI18n.initPageTranslations();
+                _markActiveLangChip();
                 // game_state may have already arrived before i18n loaded;
                 // re-fire the title update so we don't sit on the stale
                 // "— Beitreten" forever (see updatePageTitle for the why).

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -4665,17 +4665,12 @@
             _clearFinaleCountdown();
         }
 
-        // Sync UI language with the server-side game language so a
-        // German game shows German labels even if the player's
-        // browser is English. Only triggers a reload of translations
-        // when the language actually changes.
-        if (msg.language && window.QuizifyI18n &&
-            window.QuizifyI18n.getLanguage() !== msg.language) {
-            window.QuizifyI18n.setLanguage(msg.language).then(function () {
-                window.QuizifyI18n.initPageTranslations();
-                updatePageTitle(msg.phase, msg);
-            });
-        } else {
+        // Sync UI language with the server-side game language so a German game
+        // shows German labels even if the player's browser is English — unless
+        // this player picked a language themselves (#492). See
+        // _syncServerLanguage; it returns false when it did not take over, in
+        // which case the title still needs updating here.
+        if (!_syncServerLanguage(msg)) {
             updatePageTitle(msg.phase, msg);
         }
 
@@ -5403,6 +5398,83 @@
     var _renderSoundToggle = null;
     var _renderA11yToggle = null;
 
+    // ============================================
+    // Per-player UI language (#492)
+    // ============================================
+
+    // Set only when the player taps a flag chip. Its presence — not its value
+    // — is what marks the language as *chosen* rather than *detected*, and
+    // that distinction is the whole feature: see _syncServerLanguage below.
+    var PLAYER_LANG_KEY = 'quizify-player-lang';
+
+    function _storedPlayerLang() {
+        try {
+            return window.localStorage.getItem(PLAYER_LANG_KEY) || null;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function _markActiveLangChip() {
+        var group = document.getElementById('player-lang-chips');
+        if (!group || !window.QuizifyI18n) return;
+        var active = QuizifyI18n.getLanguage();
+        group.querySelectorAll('.chip').forEach(function (chip) {
+            chip.classList.toggle('active', chip.dataset.value === active);
+            chip.setAttribute('aria-pressed', chip.dataset.value === active ? 'true' : 'false');
+        });
+    }
+
+    // Apply the server's game language to this phone — unless the player has
+    // picked one. Before #492 this was unconditional, with the reasoning that
+    // "a German game shows German labels even if the player's browser is
+    // English". That is still the right default, but it also meant every
+    // incoming game_state would stamp over a deliberate choice within
+    // milliseconds, so a picker without this guard would look broken rather
+    // than absent.
+    function _syncServerLanguage(msg) {
+        if (!msg.language || !window.QuizifyI18n) return false;
+        if (_storedPlayerLang()) return false;
+        if (QuizifyI18n.getLanguage() === msg.language) return false;
+        QuizifyI18n.setLanguage(msg.language).then(function () {
+            QuizifyI18n.initPageTranslations();
+            _markActiveLangChip();
+            updatePageTitle(msg.phase, msg);
+        });
+        return true;
+    }
+
+    function setupLanguagePicker() {
+        var group = document.getElementById('player-lang-chips');
+        if (!group) return;
+        // An unsubstituted token means the page was served by something that
+        // doesn't know about {{UI_LANGUAGE_CHIPS}}; hide the row rather than
+        // showing the raw braces.
+        if (group.textContent.indexOf('{{') !== -1) {
+            group.classList.add('hidden');
+            return;
+        }
+        if (!group.querySelector('.chip') || !window.QuizifyI18n) {
+            group.classList.add('hidden');
+            return;
+        }
+
+        group.addEventListener('click', function (e) {
+            var chip = e.target.closest('.chip');
+            if (!chip || !chip.dataset.value) return;
+            var code = chip.dataset.value;
+            if (code === QuizifyI18n.getLanguage()) return;
+            try {
+                window.localStorage.setItem(PLAYER_LANG_KEY, code);
+            } catch (_e) { /* private mode: choice holds for this page view */ }
+            QuizifyI18n.setLanguage(code).then(function () {
+                QuizifyI18n.initPageTranslations();
+                _markActiveLangChip();
+                _flushToggleLabels();
+            });
+        });
+    }
+
     function _flushToggleLabels() {
         if (_renderSoundToggle) _renderSoundToggle();
         if (_renderA11yToggle) _renderA11yToggle();
@@ -5468,6 +5540,7 @@
         setupReactionBar();
         setupSoundToggle();
         setupA11yToggle();
+        setupLanguagePicker();
         setupResetAffordance();
         pu.setupCollapsibles();
         if (lightning) { lightning.setSend(send); lightning.init(); }
@@ -5518,10 +5591,13 @@
             state.isAdmin = true;
         }
 
-        // i18n init
+        // i18n init. A stored per-player choice (#492) wins over browser
+        // detection — init() falls back to detectBrowserLanguage() when given
+        // nothing, which is what every player without a choice still gets.
         if (window.QuizifyI18n) {
-            QuizifyI18n.init().then(function () {
+            QuizifyI18n.init(_storedPlayerLang() || undefined).then(function () {
                 QuizifyI18n.initPageTranslations();
+                _markActiveLangChip();
                 // game_state may have already arrived before i18n loaded;
                 // re-fire the title update so we don't sit on the stale
                 // "— Beitreten" forever (see updatePageTitle for the why).

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -109,6 +109,19 @@
         <!-- Join form -->
         <div id="join-view" class="view hidden">
             <div class="join-form">
+                <!-- Per-player UI-language picker (#492). Flag-only Selector-B
+                     chips, same markup family as the admin language chips, but
+                     filled from {{UI_LANGUAGE_CHIPS}} (the shipped i18n
+                     bundles) rather than the host's pack languages — see
+                     views.py for why those two differ. Only the chrome
+                     switches; questions stay in the host's pack language, so
+                     the row sits above the name field as a quiet setting
+                     rather than a headline choice. No chip is active in the
+                     served HTML; player-core.js marks the right one once i18n
+                     has resolved. -->
+                <div id="player-lang-chips" class="chip-group chip-group--flags player-lang-chips"
+                     role="group" data-i18n-aria-label="join.languageAria"
+                     aria-label="Interface language">{{UI_LANGUAGE_CHIPS}}</div>
                 <p data-i18n="join.enterName">Enter your name to play</p>
                 <div class="form-group">
                     <input type="text" id="name-input" class="name-input"

--- a/tests/test_player_language_picker_492.py
+++ b/tests/test_player_language_picker_492.py
@@ -1,0 +1,196 @@
+"""The per-player UI-language picker (#492) and the traps around it.
+
+The feature itself is small — flag chips on the join screen that call
+``QuizifyI18n.setLanguage`` and remember the choice. What makes it worth
+testing is everything that quietly undoes it:
+
+1. **The server used to stamp over the choice.** ``game_state`` carries the
+   host's game language, and ``player-core.js`` applied it unconditionally so
+   "a German game shows German labels even if the player's browser is
+   English". That default is right for a player who never chose, and fatal for
+   one who did — every incoming ``game_state`` would revert the picker within
+   milliseconds and the feature would look broken rather than absent. The
+   override now yields to a stored choice, and that is pinned here.
+
+2. **Two different questions about "languages".** ``{{LANGUAGE_CHIPS}}`` lists
+   the languages the host has *packs* for; ``{{UI_LANGUAGE_CHIPS}}`` lists the
+   languages the *interface* is translated into. On a German-only install
+   those differ, and the difference is exactly the user this feature serves —
+   the Spanish-speaking guest at a German host's party. Sourcing the player
+   picker from pack languages would silently offer them nothing.
+
+3. **Two lists of supported languages.** Python renders the chips from the
+   shipped ``www/i18n/*.json`` bundles; ``i18n.js`` gates ``setLanguage``
+   against its own ``SUPPORTED_LANGUAGES`` array. If those drift, either a
+   chip appears that the client refuses to load (tap does nothing) or a
+   supported language has no chip. They are compared to each other below.
+
+Pure text/JSON parsing — no Home Assistant imports, so this runs everywhere.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent.parent
+_WWW = _REPO / "custom_components" / "quizify" / "www"
+_PLAYER_HTML = _WWW / "player.html"
+_CORE_JS = _WWW / "js" / "player-core.js"
+_I18N_JS = _WWW / "js" / "i18n.js"
+_BUNDLE = _WWW / "js" / "player.bundle.js"
+_I18N_DIR = _WWW / "i18n"
+_LOBBY_CSS = _WWW / "css" / "src" / "04-lobby.css"
+_STYLES = _WWW / "css" / "styles.css"
+_VIEWS = _REPO / "custom_components" / "quizify" / "server" / "views.py"
+
+
+# --------------------------------------------------------------------------
+# 1. The override that would have made the picker look broken
+# --------------------------------------------------------------------------
+
+
+def test_server_language_yields_to_a_stored_choice() -> None:
+    """A chosen language must survive the next game_state broadcast."""
+    core = _CORE_JS.read_text("utf-8")
+
+    match = re.search(
+        r"function _syncServerLanguage\(msg\) \{(.*?)\n    \}", core, re.S
+    )
+    assert match, "_syncServerLanguage is gone — the override is unguarded again"
+    body = match.group(1)
+
+    assert "_storedPlayerLang()" in body, (
+        "the server-language sync no longer checks for a stored player choice; "
+        "every game_state will stamp over the picker"
+    )
+    # The guard has to come before the setLanguage call, not after it.
+    guard = body.index("_storedPlayerLang()")
+    apply_at = body.index("setLanguage(msg.language)")
+    assert guard < apply_at, "stored-choice guard runs after the language is applied"
+
+
+def test_game_state_handler_routes_through_the_guard() -> None:
+    """No second, unguarded setLanguage path on the game_state handler."""
+    core = _CORE_JS.read_text("utf-8")
+    assert "_syncServerLanguage(msg)" in core
+
+    # setLanguage may appear in: the guarded sync, and the chip click handler.
+    calls = re.findall(r"(?:QuizifyI18n|window\.QuizifyI18n)\.setLanguage\(", core)
+    assert len(calls) == 2, (
+        f"expected exactly 2 setLanguage call sites (guarded sync + chip tap), "
+        f"found {len(calls)} — a new unguarded one would revert the picker"
+    )
+
+
+# --------------------------------------------------------------------------
+# 2. Player picker is sourced from UI bundles, not pack languages
+# --------------------------------------------------------------------------
+
+
+def test_player_uses_its_own_token_not_the_admin_one() -> None:
+    html = _PLAYER_HTML.read_text("utf-8")
+    assert "{{UI_LANGUAGE_CHIPS}}" in html
+    assert "{{LANGUAGE_CHIPS}}" not in html, (
+        "player.html pulls the admin's pack-language chips — a German-only "
+        "install would then offer a Spanish guest no Spanish"
+    )
+
+
+def test_ui_chips_are_rendered_from_the_shipped_bundles() -> None:
+    views = _VIEWS.read_text("utf-8")
+    assert "_UI_LANGUAGE_CHIPS_TOKEN" in views
+    assert "_available_ui_languages" in views
+
+    match = re.search(
+        r"def _available_ui_languages\(\).*?\n\ndef ", views, re.S
+    )
+    assert match, "_available_ui_languages not found"
+    assert 'glob("*.json")' in match.group(0), (
+        "the UI language list is no longer read from www/i18n/ — a new bundle "
+        "would need a Python edit to surface"
+    )
+
+
+def test_ui_chip_renderer_marks_nothing_active() -> None:
+    """The stored choice is client-side; a server-picked active chip flickers."""
+    views = _VIEWS.read_text("utf-8")
+    match = re.search(
+        r"def _render_ui_language_chips\(.*?\n    return \"\"\.join\(buttons\)", views, re.S
+    )
+    assert match, "_render_ui_language_chips not found"
+    assert 'class="{cls}"' not in match.group(0), (
+        "player chips render an active class server-side; it would paint the "
+        "wrong flag for one frame on every load"
+    )
+
+
+# --------------------------------------------------------------------------
+# 3. Python's language list vs the client's gate
+# --------------------------------------------------------------------------
+
+
+def test_bundles_on_disk_match_the_clients_supported_languages() -> None:
+    """A chip the client refuses to load is a dead tap; a missing chip hides a language."""
+    on_disk = {p.stem for p in _I18N_DIR.glob("*.json")}
+
+    match = re.search(r"var SUPPORTED_LANGUAGES = \[([^\]]+)\]", _I18N_JS.read_text("utf-8"))
+    assert match, "SUPPORTED_LANGUAGES vanished from i18n.js"
+    supported = set(re.findall(r"'([a-z]{2})'", match.group(1)))
+
+    assert on_disk == supported, (
+        f"i18n bundles on disk {sorted(on_disk)} disagree with i18n.js "
+        f"SUPPORTED_LANGUAGES {sorted(supported)} — a chip would either do "
+        "nothing when tapped, or be missing for a language the client supports"
+    )
+
+
+def test_every_bundle_has_the_picker_label() -> None:
+    for path in sorted(_I18N_DIR.glob("*.json")):
+        data = json.loads(path.read_text("utf-8"))
+        label = data.get("join", {}).get("languageAria")
+        assert label, f"{path.name} is missing join.languageAria"
+        assert label.strip()
+
+
+# --------------------------------------------------------------------------
+# 4. Wiring
+# --------------------------------------------------------------------------
+
+
+def test_picker_is_wired_and_stores_the_choice() -> None:
+    core = _CORE_JS.read_text("utf-8")
+    assert "setupLanguagePicker" in core
+    assert re.search(r"function init\(\)[\s\S]{0,800}setupLanguagePicker\(\);", core), (
+        "setupLanguagePicker is defined but never called from init()"
+    )
+    assert "PLAYER_LANG_KEY = 'quizify-player-lang'" in core
+    assert "localStorage.setItem(PLAYER_LANG_KEY" in core
+
+
+def test_stored_choice_wins_at_startup() -> None:
+    """Without this the picker only holds until the next reload."""
+    core = _CORE_JS.read_text("utf-8")
+    assert re.search(r"QuizifyI18n\.init\(_storedPlayerLang\(\)", core), (
+        "i18n init ignores the stored choice; the picker would not survive a reload"
+    )
+
+
+def test_unsubstituted_token_hides_the_row() -> None:
+    """Served by something that doesn't know the token → no raw braces on screen."""
+    core = _CORE_JS.read_text("utf-8")
+    match = re.search(r"function setupLanguagePicker\(\) \{(.*?)\n    \}", core, re.S)
+    assert match
+    assert "'{{'" in match.group(1) or '"{{"' in match.group(1), (
+        "no guard against an unsubstituted {{UI_LANGUAGE_CHIPS}} token"
+    )
+
+
+def test_built_assets_carry_the_feature() -> None:
+    """styles.css and the bundle are committed; a missed rebuild ships a dead row."""
+    assert ".player-lang-chips" in _LOBBY_CSS.read_text("utf-8")
+    assert ".player-lang-chips" in _STYLES.read_text("utf-8"), "run scripts/build_css.py"
+    assert "quizify-player-lang" in _BUNDLE.read_text("utf-8"), (
+        "run scripts/build_bundle.py"
+    )


### PR DESCRIPTION
Closes #492.

Flag chips above the name field on the join screen let each phone pick its own chrome language.

Questions stay in the host's pack language — the issue is explicit that this only translates the small player chrome, and the row is deliberately styled as a quiet setting rather than a headline choice because of it.

## The part that mattered more than the picker

`game_state` carries the host's game language, and `player-core.js` applied it **unconditionally**:

```js
// Sync UI language with the server-side game language so a
// German game shows German labels even if the player's
// browser is English.
```

That default is right for a player who never chose, and fatal for one who did. Every incoming `game_state` would have stamped over the pick within milliseconds — the picker would have looked *broken* rather than merely absent, which is worse than not shipping it.

`_syncServerLanguage` now yields when a choice is stored. The test pins both the guard's **position** (ahead of the `setLanguage` call, not after it) and the **total number of `setLanguage` call sites**, so a new unguarded path fails CI rather than quietly reverting the feature.

Anyone picking up this area should know the override exists; it is not obvious from the picker's own code.

## Two different questions about "languages"

The chips get their own `{{UI_LANGUAGE_CHIPS}}` token rather than reusing the admin's `{{LANGUAGE_CHIPS}}`:

| Token | Lists |
|---|---|
| `{{LANGUAGE_CHIPS}}` (admin) | languages the host has **packs** for |
| `{{UI_LANGUAGE_CHIPS}}` (player) | languages the **interface** is translated into |

On a German-only install those sets differ — and the difference is exactly the person this feature exists for: the Spanish-speaking guest at a German host's party. Sourcing the player picker from pack languages would silently offer them nothing at all.

## Data-driven, and the drift that creates

The language list is read from the shipped `www/i18n/*.json` bundles rather than hard-coded, so dropping in a new bundle surfaces a chip with no Python edit — the same move #335 made for the admin chips.

That creates a second list to keep in step with `SUPPORTED_LANGUAGES` in `i18n.js`, which gates `setLanguage`. A test compares the two directly: a chip the client would refuse to load is a dead tap, and a supported language with no chip is a hidden feature. Neither fails loudly on its own.

No chip is marked `active` server-side — the choice lives in `localStorage` and only the client knows it, so a server-picked active flag would paint the wrong one for a frame on every load.

## Verification

390×844 over CDP:

- three chips render, German active from browser detection
- tapping **Español** switches the chrome and `<html lang>` immediately (`join.enterName` → "Escribe tu nombre para jugar")
- the choice survives a reload — chip, `QuizifyI18n.getLanguage()` and storage all still `es`
- **0** elements overflow across join / lobby / game / reveal / end
- the row coexists with the accessibility mode's larger type on a single line (right edge 350 px of 390)

**Honest gap:** the `game_state` guard is covered by the unit test, not by the browser check. Driving that path needs a live server, and `player-core` exposes only `init`/`send` — there is no handle to fire a synthetic message at.

11 new tests in `tests/test_player_language_picker_492.py`, pure text parsing so they run on any Python.

Not released — no tag, per the release gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
