### PR TITLE
fix(admin): kids preset turns the Lightning Round off (#513)

### DIFF
--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -129,7 +129,8 @@
                 <div class="setup-presets" id="setup-presets" role="radiogroup"
                      data-i18n-aria-label="setup.pickMode" aria-label="Pick a mode">
                     <button type="button" class="preset-card" data-preset="schnellrunde"
-                            data-rounds="5" data-difficulty="easy" data-timer="20">
+                            data-rounds="5" data-difficulty="easy" data-timer="20"
+                            data-lightning="1">
                         <span class="preset-icon qz-icon qz-icon--sun" data-ui-icon="bolt" aria-hidden="true">⚡</span>
                         <span class="preset-body">
                             <span class="preset-name" data-i18n="setup.preset.fastName">Quick round</span>
@@ -138,7 +139,8 @@
                         <span class="preset-duration">~3 min</span>
                     </button>
                     <button type="button" class="preset-card is-active" data-preset="klassiker"
-                            data-rounds="10" data-difficulty="medium" data-timer="30">
+                            data-rounds="10" data-difficulty="medium" data-timer="30"
+                            data-lightning="1">
                         <span class="preset-icon qz-icon qz-icon--sky" data-ui-icon="brain" aria-hidden="true">🧠</span>
                         <span class="preset-body">
                             <span class="preset-name" data-i18n="setup.preset.classicName">Classic</span>
@@ -154,8 +156,13 @@
                          long timer where that host actually looks. Sits before
                          Marathon so the cards stay ordered by session length
                          (~3 / ~8 / ~15 / ~20 min). -->
+                    <!-- data-lightning="0" (#513): the auto Lightning Round is
+                         5 questions at 15 s each. Leaving it armed would
+                         override the one setting this preset exists for — the
+                         long timer — for five questions mid-game. -->
                     <button type="button" class="preset-card" data-preset="kinder"
-                            data-rounds="5" data-difficulty="easy" data-timer="180">
+                            data-rounds="5" data-difficulty="easy" data-timer="180"
+                            data-lightning="0">
                         <!-- Deliberately no data-ui-icon: _paintUiIcons() only
                              swaps the emoji for an SVG on slots that carry one,
                              so leaving it off keeps the teddy while the sage
@@ -168,7 +175,8 @@
                         <span class="preset-duration">~15 min</span>
                     </button>
                     <button type="button" class="preset-card" data-preset="marathon"
-                            data-rounds="20" data-difficulty="hard" data-timer="45">
+                            data-rounds="20" data-difficulty="hard" data-timer="45"
+                            data-lightning="1">
                         <span class="preset-icon qz-icon qz-icon--sun" data-ui-icon="trophy" aria-hidden="true">🏆</span>
                         <span class="preset-body">
                             <span class="preset-name" data-i18n="setup.preset.marathonName">Marathon</span>

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -736,14 +736,18 @@
         return names;
     }
 
+    // `lightning` mirrors data-lightning on the cards in admin.html (1/0) and
+    // arms or disarms the auto Lightning Round (#285) for the bundle.
     var _PRESETS = [
-        { id: 'schnellrunde', rounds: 5,  difficulty: 'easy',   timer: 20, labelKey: 'setup.preset.fastName'     },
-        { id: 'klassiker',    rounds: 10, difficulty: 'medium', timer: 30, labelKey: 'setup.preset.classicName'  },
+        { id: 'schnellrunde', rounds: 5,  difficulty: 'easy',   timer: 20, lightning: true,  labelKey: 'setup.preset.fastName'     },
+        { id: 'klassiker',    rounds: 10, difficulty: 'medium', timer: 30, lightning: true,  labelKey: 'setup.preset.classicName'  },
         // #506: the long-timer bundle for hosts playing with small kids. Its
         // timer must stay one of the #timer-chips values — _applyPreset calls
         // _activateChip, which silently highlights nothing otherwise.
-        { id: 'kinder',       rounds: 5,  difficulty: 'easy',   timer: 180, labelKey: 'setup.preset.kidsName'   },
-        { id: 'marathon',     rounds: 20, difficulty: 'hard',   timer: 45, labelKey: 'setup.preset.marathonName' },
+        // #513: Lightning off — 5 questions at 15 s each would undo the long
+        // timer this preset exists for, right in the middle of the game.
+        { id: 'kinder',       rounds: 5,  difficulty: 'easy',   timer: 180, lightning: false, labelKey: 'setup.preset.kidsName'   },
+        { id: 'marathon',     rounds: 20, difficulty: 'hard',   timer: 45, lightning: true,  labelKey: 'setup.preset.marathonName' },
     ];
 
     function _matchingPreset() {
@@ -755,7 +759,10 @@
         if (selectedCategory !== 'mixed') return null;
         for (var i = 0; i < _PRESETS.length; i++) {
             var p = _PRESETS[i];
-            if (p.rounds === selectedRounds && p.difficulty === selectedDifficulty && p.timer === selectedTimer) {
+            // Lightning is part of the bundle (#513) — flipping the toggle by
+            // hand makes the run "Eigene" again, same as picking own topics.
+            if (p.rounds === selectedRounds && p.difficulty === selectedDifficulty
+                && p.timer === selectedTimer && p.lightning === selectedLightning) {
                 return { id: p.id, label: _t(p.labelKey) };
             }
         }
@@ -774,7 +781,7 @@
 
     // Apply preset: write to the active-chip state AND to the typed vars
     // so the existing chip group serialization works unchanged.
-    function _applyPreset(rounds, difficulty, timer) {
+    function _applyPreset(rounds, difficulty, timer, lightning) {
         if (rounds != null) {
             selectedRounds = rounds;
             _activateChip(els.roundsChips, String(rounds));
@@ -786,6 +793,14 @@
         if (timer != null) {
             selectedTimer = timer;
             _activateChip(els.timerChips, String(timer));
+        }
+        // #513: the Lightning Round rides the bundle. Write the checkbox too,
+        // not just the variable — _buildStartGamePayload reads the DOM first,
+        // and the host opening "Eigene" must see the state that will ship.
+        if (lightning != null) {
+            selectedLightning = lightning;
+            var lightningEl = document.getElementById('lightning-enabled-toggle');
+            if (lightningEl) lightningEl.checked = lightning;
         }
         updateSettingsSummary();
     }
@@ -828,7 +843,9 @@
                 var rounds = parseInt(card.getAttribute('data-rounds'), 10);
                 var difficulty = card.getAttribute('data-difficulty');
                 var timer = parseInt(card.getAttribute('data-timer'), 10);
-                _applyPreset(rounds, difficulty, timer);
+                var lightningAttr = card.getAttribute('data-lightning');
+                var lightning = lightningAttr == null ? null : lightningAttr === '1';
+                _applyPreset(rounds, difficulty, timer, lightning);
             });
         });
     }
@@ -865,6 +882,10 @@
         selectedLightning = !!lightningToggle.checked;
         on(lightningToggle, 'change', function () {
             selectedLightning = !!lightningToggle.checked;
+            // #513: Lightning is part of a preset bundle now, so flipping it
+            // by hand has to re-run the match — otherwise a kids run with
+            // Lightning switched back on still reads "Mit Kindern".
+            updateSettingsSummary();
         });
     }
     // TTS narration toggles (#281). Master switch defaults OFF; the per-event

--- a/tests/test_kids_preset_506.py
+++ b/tests/test_kids_preset_506.py
@@ -102,6 +102,8 @@ def test_html_cards_and_js_presets_agree() -> None:
         assert card["rounds"] == preset["rounds"], preset_id
         assert card["difficulty"] == preset["difficulty"], preset_id
         assert card["timer"] == preset["timer"], preset_id
+        # #513 added the Lightning Round to the bundle — same drift risk.
+        assert card["lightning"] == ("1" if preset["lightning"] == "true" else "0"), preset_id
 
 
 def test_every_preset_timer_has_a_matching_chip() -> None:

--- a/tests/test_kids_preset_lightning_513.py
+++ b/tests/test_kids_preset_lightning_513.py
@@ -1,0 +1,127 @@
+"""The kids preset must disarm the auto Lightning Round (#513).
+
+The "With kids" preset (#506) exists for one reason: an external host reported
+that small children cannot read a question plus four answers in time, so the
+bundle carries a 180 s timer. The auto Lightning Round (#285) is 5 questions at
+15 s each and fires mid-game — with the toggle left armed it silently overrode
+the exact setting the preset was created for.
+
+The fix makes ``lightning`` part of the preset bundle, which means it now lives
+in the same two places as rounds/difficulty/timer: ``data-lightning`` on the
+card in ``admin.html`` and the ``_PRESETS`` array in ``admin.js``. The drift
+guard for that pair is in ``test_kids_preset_506.py``; what follows pins the
+behaviour that guard cannot see — that applying a preset actually writes the
+checkbox, and that the active-card match takes Lightning into account.
+
+Pure text parsing — no Home Assistant imports, so this runs everywhere.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_WWW = Path(__file__).resolve().parent.parent / "custom_components" / "quizify" / "www"
+_ADMIN_HTML = _WWW / "admin.html"
+_ADMIN_JS = _WWW / "js" / "admin.js"
+
+
+def _presets_from_js() -> dict[str, dict[str, str]]:
+    js = _ADMIN_JS.read_text(encoding="utf-8")
+    block = re.search(r"var _PRESETS = \[(.*?)\];", js, re.DOTALL)
+    assert block is not None, "_PRESETS array not found in admin.js"
+    presets: dict[str, dict[str, str]] = {}
+    for line in re.findall(r"\{[^}]*\}", block.group(1)):
+        fields = dict(re.findall(r"(\w+):\s*'?([\w.]+)'?", line))
+        presets[fields["id"]] = fields
+    return presets
+
+
+def _cards_from_html() -> dict[str, dict[str, str]]:
+    html = _ADMIN_HTML.read_text(encoding="utf-8")
+    cards: dict[str, dict[str, str]] = {}
+    for match in re.finditer(
+        r'<button[^>]*class="preset-card[^"]*"[^>]*data-preset="(?P<id>[^"]+)"'
+        r"(?P<attrs>[^>]*)>",
+        html,
+    ):
+        attrs = dict(re.findall(r'data-(\w+)="([^"]+)"', match.group("attrs")))
+        cards[match.group("id")] = attrs
+    return cards
+
+
+def _fn_body(name: str) -> str:
+    """Source of a top-level ``function name(...) { … }`` in admin.js."""
+    js = _ADMIN_JS.read_text(encoding="utf-8")
+    start = js.index(f"function {name}(")
+    depth = 0
+    for i in range(js.index("{", start), len(js)):
+        if js[i] == "{":
+            depth += 1
+        elif js[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return js[start : i + 1]
+    raise AssertionError(f"unbalanced braces reading {name}()")
+
+
+def test_kids_preset_has_lightning_off() -> None:
+    """The whole point of #513."""
+    assert _presets_from_js()["kinder"]["lightning"] == "false"
+    assert _cards_from_html()["kinder"]["lightning"] == "0"
+
+
+def test_every_other_preset_keeps_lightning_on() -> None:
+    """#513 is scoped to the kids bundle — nothing else changes behaviour."""
+    for preset_id, preset in _presets_from_js().items():
+        if preset_id == "kinder":
+            continue
+        assert preset["lightning"] == "true", preset_id
+
+
+def test_every_preset_declares_lightning() -> None:
+    """A missing value would leave the toggle at whatever the last run set.
+
+    ``_applyPreset`` skips the field when it is null, so an undeclared preset
+    would silently inherit the previous bundle's Lightning state instead of
+    applying its own.
+    """
+    cards = _cards_from_html()
+    for preset_id, preset in _presets_from_js().items():
+        assert "lightning" in preset, preset_id
+        assert cards[preset_id].get("lightning") in {"0", "1"}, preset_id
+
+
+def test_apply_preset_writes_the_checkbox_not_just_the_variable() -> None:
+    """``_buildStartGamePayload`` reads the DOM first, ``selectedLightning`` second.
+
+    Setting only the variable would ship the host's choice correctly right up
+    until anything re-read the checkbox — and would show the wrong switch
+    position the moment the host opened "Eigene".
+    """
+    body = _fn_body("_applyPreset")
+    assert "lightning-enabled-toggle" in body
+    assert re.search(r"\.checked\s*=\s*lightning", body)
+    assert "selectedLightning = lightning" in body
+
+
+def test_matching_preset_compares_lightning() -> None:
+    """Otherwise a kids run with Lightning switched back on still reads "Mit Kindern"."""
+    body = _fn_body("_matchingPreset")
+    assert "p.lightning === selectedLightning" in body
+
+
+def test_toggling_lightning_by_hand_refreshes_the_active_card() -> None:
+    """The change handler has to re-run the match, or the highlight goes stale.
+
+    ``updateSettingsSummary`` is what repaints both the hero line and the
+    active preset card (it calls ``updateHeroSummary`` + ``markActivePreset``).
+    """
+    js = _ADMIN_JS.read_text(encoding="utf-8")
+    handler = re.search(
+        r"on\(lightningToggle, 'change', function \(\) \{(.*?)\}\);",
+        js,
+        re.DOTALL,
+    )
+    assert handler is not None, "lightning toggle change handler not found"
+    assert "updateSettingsSummary()" in handler.group(1)


### PR DESCRIPTION
Fixes #513.

## Why

The "With kids" preset (#506) exists for one reason: an external host playing with small children reported they cannot read a question plus four answers in time, even at 45 s. So the bundle carries a 180 s timer.

It left the auto Lightning Round (#285) armed. The toggle ships `checked` and `_applyPreset` only wrote rounds, difficulty and timer — so tapping "With kids" still bought a surprise mid-game round of **five questions at 15 s each**. The one setting the preset exists for was silently overridden, for exactly the audience that cannot keep up.

## What changed

Lightning becomes part of the preset bundle:

- `data-lightning` on every preset card in `admin.html` (`0` for kids, `1` for the rest).
- A `lightning` field in the `_PRESETS` array in `admin.js`.
- `_applyPreset` writes the **checkbox**, not just `selectedLightning` — `_buildStartGamePayload` reads the DOM live, and a host who opens "Custom settings" has to see the state that will actually ship.
- `_matchingPreset` compares it, so flipping the toggle back on by hand makes the run "Custom" instead of still reading "With kids" — the same rule that already de-selects a preset once the host picks their own topics.
- The toggle's `change` handler now calls `updateSettingsSummary()`, which is what repaints the hero line and the active card. Without it that new match would go stale the moment the host touched the switch.

No backend change: `_handle_start_game` already coerces `lightning_enabled` and leaves the round disarmed when it arrives `false`.

## Tests

`tests/test_kids_preset_lightning_513.py` (new, 6 tests) pins the behaviour: kids off, every other preset on, every preset declares a value (an undeclared one would silently inherit the previous bundle's state), `_applyPreset` writes the checkbox, `_matchingPreset` compares lightning, and the change handler re-runs the match.

`tests/test_kids_preset_506.py` gains the lightning field in its drift guard — the HTML `data-*` and the JS `_PRESETS` array are the two places a preset's values live, and a mismatch applies one bundle while highlighting another with no error anywhere.

12 tests pass locally. Both files are pure text parsing, no Home Assistant imports.

**Not verified on real hardware** — this is a setup-screen wiring change with no new layout, so no mobile screenshot pass was run. That belongs to the pre-release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)