### PR TITLE
fix(content): correct three fun facts in cultura-pop-es (#519)

### DIFF
--- a/custom_components/quizify/questions/cultura-pop-es.json
+++ b/custom_components/quizify/questions/cultura-pop-es.json
@@ -295,7 +295,7 @@
         }
       ],
       "difficulty": "medium",
-      "fun_fact": "La película usó menos de siete minutos de dinosaurios en pantalla en total.",
+      "fun_fact": "Los dinosaurios generados por ordenador aparecen apenas seis minutos en toda la película: el resto son animatrónicos a tamaño real.",
       "category": "Cultura Pop"
     },
     {
@@ -1597,7 +1597,7 @@
         }
       ],
       "difficulty": "easy",
-      "fun_fact": "Iba a llamarse Lunar Larry, pero el nombre final homenajea a un actor de wésterns.",
+      "fun_fact": "Su nombre homenajea al actor de wésterns Woody Strode. El que empezó llamándose 'Lunar Larry' fue Buzz.",
       "category": "Cultura Pop"
     },
     {
@@ -2752,7 +2752,7 @@
         }
       ],
       "difficulty": "easy",
-      "fun_fact": "Fue la primera película en juntar a protagonistas de cinco sagas distintas.",
+      "fun_fact": "Fue la primera película en juntar a los protagonistas de cuatro sagas distintas del mismo estudio.",
       "category": "Cultura Pop"
     },
     {


### PR DESCRIPTION
Closes #519.

Three `fun_fact` corrections in `cultura-pop-es`, found while quality-reviewing the Spanish packs. Questions and answers were correct in all three cases — only the trivia line was wrong.

**`pop_es_076` — Woody**

> ~~Iba a llamarse Lunar Larry, pero el nombre final homenajea a un actor de wésterns.~~
> Su nombre homenajea al actor de wésterns Woody Strode. El que empezó llamándose 'Lunar Larry' fue Buzz.

The two halves of the old sentence belonged to different characters. Keeping both, correctly attributed, is more interesting than dropping one.

**`pop_es_131` — The Avengers**

> ~~Fue la primera película en juntar a protagonistas de cinco sagas distintas.~~
> Fue la primera película en juntar a los protagonistas de cuatro sagas distintas del mismo estudio.

Four: Iron Man, The Incredible Hulk, Thor, Captain America.

**`pop_es_014` — Jurassic Park**

> ~~La película usó menos de siete minutos de dinosaurios en pantalla en total.~~
> Los dinosaurios generados por ordenador aparecen apenas seis minutos en toda la película: el resto son animatrónicos a tamaño real.

The ~6-minute figure is CGI-only. The new wording keeps the surprising number and says what it actually measures.

## Why this is worth a PR of its own

The fun fact is the line the host reads aloud after the reveal. A wrong one gets stated to the room as fact, which is worse than having none.

## Verification

`pytest tests/test_questions.py` — 38 passed. Diff is 3 lines; no question, answer, id or difficulty changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)