### PR TITLE
fix(dashboard): render the TV answer grid in round-shuffle order (#521)

### DIFF
--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -1992,10 +1992,20 @@ class QuizifyGameState:
             q = self._current_question
             # Calculate time remaining for mid-round joiners
             remaining = self._phase_controller.time_remaining_for_snapshot()
+            # Canonical-shuffle order (#521), matching the live
+            # ``question_started`` payload. Emitting question-JSON order here
+            # meant a dashboard reconnecting mid-question rebuilt its grid
+            # unshuffled — and most packs keep the correct answer first in the
+            # file. ``shuffled_answers`` is empty only before the first
+            # question of a game, where the fallback is the same list anyway.
             snapshot["question"] = {
                 "id": q.id,
                 "text": q.question,
-                "answers": [a.text for a in q.answers],
+                "answers": (
+                    list(self.shuffled_answers)
+                    if len(self.shuffled_answers) == len(q.answers)
+                    else [a.text for a in q.answers]
+                ),
                 "difficulty": q.difficulty,
                 "category": q.category,
                 "image_url": q.image_url,
@@ -2017,20 +2027,38 @@ class QuizifyGameState:
         if self.phase == GamePhase.ANSWER_REVEAL and self._round_summary:
             s = self._round_summary
             q = s.question
-            # Canonical (question-JSON) answer order, mirroring the
-            # QUESTION_ACTIVE snapshot's ``question.answers``. A TV/dashboard
-            # that (re)connects during the reveal has no live ``question``
-            # block to render, so without these fields its question view was
-            # blank (#296). The dashboard renders the unshuffled grid and
-            # highlights ``correct_answer_index_original``.
+            # Round-shuffle answer order, mirroring the QUESTION_ACTIVE
+            # snapshot's ``question.answers``. A TV/dashboard that (re)connects
+            # during the reveal has no live ``question`` block to render, so
+            # without these fields its question view was blank (#296).
+            # Both the order and the highlight index moved from question-JSON
+            # order to the round shuffle in #521 — in JSON order most packs
+            # keep the correct answer first, which put it on tile A every
+            # round. ``correct_answer_index_original`` stays in the payload for
+            # clients cached from before that change.
             correct_idx_original = next(
                 (i for i, a in enumerate(q.answers) if a.correct), -1
             )
+            order = self.shuffle_map
+            if len(order) == len(q.answers) and sorted(order) == list(
+                range(len(q.answers))
+            ):
+                reveal_answers = [q.answers[i].text for i in order]
+                if correct_idx_original >= 0:
+                    correct_idx_display = order.index(correct_idx_original)
+                else:
+                    correct_idx_display = -1
+            else:
+                # No usable shuffle (pre-first-question, or a malformed map):
+                # a mis-ordered grid is worse than an unshuffled one.
+                reveal_answers = [a.text for a in q.answers]
+                correct_idx_display = correct_idx_original
             snapshot["round_summary"] = {
                 "question_text": q.question,
                 "category": q.category,
                 "image_url": q.image_url,
-                "answers": [a.text for a in q.answers],
+                "answers": reveal_answers,
+                "correct_answer_index": correct_idx_display,
                 "correct_answer_index_original": correct_idx_original,
                 "correct_answer": s.correct_answer.text,
                 "fun_fact": s.fun_fact,

--- a/custom_components/quizify/server/round_message_builder.py
+++ b/custom_components/quizify/server/round_message_builder.py
@@ -76,12 +76,18 @@ class RoundMessageBuilder:
         *,
         question: Question,
     ) -> dict[str, Any]:
-        """Build the admin/dashboard question payload (with correct answer)."""
+        """Build the admin/dashboard question payload (with correct answer).
+
+        The answer grid rides the round's canonical shuffle (#521) so the TV
+        does not sit in question-JSON order, where most packs keep the correct
+        answer first.
+        """
         return serialize_question_for_admin(
             question=question,
             round_num=game_state.round,
             total_rounds=game_state.total_rounds,
             timer_duration=game_state.round_duration,
+            display_order=game_state.shuffle_map,
         )
 
     def build_game_state_with_leaderboard(
@@ -408,6 +414,7 @@ class RoundMessageBuilder:
             players=players_list,
             last_round=last_round,
             question_id=summary.question.id,
+            display_order=game_state.shuffle_map,
         )
         if store_cached is not None:
             store_cached(cache_key, msg)

--- a/custom_components/quizify/server/serializers.py
+++ b/custom_components/quizify/server/serializers.py
@@ -160,26 +160,50 @@ def serialize_question_for_player(
     return payload
 
 
+def _apply_display_order(items: list[Any], order: list[int] | None) -> list[Any]:
+    """Reorder ``items`` by ``order``, or return them untouched.
+
+    Guards a malformed/stale map (wrong length, out-of-range index) by falling
+    back to the original order — a mis-ordered answer grid is a worse failure
+    than an unshuffled one.
+    """
+    if not order or len(order) != len(items):
+        return list(items)
+    if sorted(order) != list(range(len(items))):
+        return list(items)
+    return [items[i] for i in order]
+
+
 def serialize_question_for_admin(
     question: Question,
     round_num: int,
     total_rounds: int,
     timer_duration: float,
+    display_order: list[int] | None = None,
 ) -> dict[str, Any]:
-    """Serialize a question for admin (includes correct answer)."""
+    """Serialize a question for admin (includes correct answer).
+
+    ``display_order`` is the round's canonical shuffle (``shuffle_map``). The
+    admin and the TV/cast dashboard share this payload and render the answer
+    tiles in the order they arrive, so without it the grid would sit in
+    question-JSON order — and most shipped packs put the correct answer first
+    in the file, which put it on tile A of the big screen every round (#521).
+    Passing the shuffle also lines the tiles up with ``correct_answer_index``
+    and with the option order the TTS narrator speaks.
+    """
     correct_answer = ""
     for a in question.answers:
         if a.correct:
             correct_answer = a.text
             break
 
+    ordered = _apply_display_order(question.answers, display_order)
+
     payload: dict[str, Any] = {
         "type": "question_started",
         "question_text": question.question,
         "correct_answer": correct_answer,
-        "answers": [
-            {"text": a.text, "correct": a.correct} for a in question.answers
-        ],
+        "answers": [{"text": a.text, "correct": a.correct} for a in ordered],
         "timer_duration": timer_duration,
         "round_num": round_num,
         "total_rounds": total_rounds,
@@ -317,19 +341,31 @@ def serialize_round_summary(
     correct_answer_index_original: int = -1,
     question_type: str = "multiple_choice",
     estimate: dict[str, Any] | None = None,
+    display_order: list[int] | None = None,
 ) -> dict[str, Any]:
     """Build round summary broadcast payload.
 
-    ``correct_answer_index`` is in CANONICAL-shuffle space — the per-player
-    reveal client uses it to highlight the right tile in its own shuffle.
-    ``correct_answer_index_original`` is in question-JSON-order — the TV
-    dashboard renders unshuffled answers (no per-spectator shuffle), so it
-    needs the original index to colour the correct tile. Both are sent in
-    the same payload to avoid a dashboard-only round_summary fork.
+    Three index spaces meet here, so they are named rather than implied:
+
+    * ``correct_answer_index`` — CANONICAL-shuffle space. The per-player
+      reveal client uses it to highlight the right tile in its own shuffle,
+      and since #521 the TV grid is rendered in this same order, so the
+      dashboard uses it too.
+    * ``correct_answer_index_original`` — question-JSON order. Retained for
+      clients cached from before #521, which still render an unshuffled grid.
+      New clients prefer ``correct_answer_index``.
+    * ``all_answers[].answer_index`` — question-JSON order, unchanged. The
+      player reveal maps it through its own shuffle, so moving it would break
+      that path for no gain.
+
+    ``answer_distribution`` is emitted in CANONICAL space so the #151 bars
+    attach to the tiles the dashboard actually drew.
     """
-    # Compute answer distribution from all_answers
+    # Compute answer distribution from all_answers. `answer_index` on those
+    # entries is question-JSON order; the bars hang off the canonical grid,
+    # so the mapping happens here rather than in the client.
     answer_distribution = _compute_answer_distribution(
-        all_answers or [], num_answer_options
+        all_answers or [], num_answer_options, display_order
     )
 
     summary: dict[str, Any] = {
@@ -366,23 +402,39 @@ def serialize_round_summary(
 
 
 def _compute_answer_distribution(
-    all_answers: list[dict[str, Any]], num_options: int
+    all_answers: list[dict[str, Any]],
+    num_options: int,
+    display_order: list[int] | None = None,
 ) -> list[dict[str, Any]]:
     """Compute per-option vote counts and percentages.
 
     Returns a list of dicts: [{"index": 0, "count": 3, "percent": 60}, ...]
     Includes a separate entry for no_answer (timeout) players.
+
+    ``answer_index`` on the incoming entries is question-JSON order.
+    ``display_order`` (the round's canonical shuffle) maps each vote onto the
+    tile the dashboard actually rendered (#521); without it the bars would
+    count the right votes against the wrong answers.
     """
     counts = [0] * num_options
     no_answer_count = 0
     total = len(all_answers)
+
+    # original index -> position in the rendered grid
+    to_display: dict[int, int] = {}
+    if (
+        display_order
+        and len(display_order) == num_options
+        and sorted(display_order) == list(range(num_options))
+    ):
+        to_display = {orig: pos for pos, orig in enumerate(display_order)}
 
     for entry in all_answers:
         idx = entry.get("answer_index")
         if entry.get("no_answer") or idx is None:
             no_answer_count += 1
         elif isinstance(idx, int) and 0 <= idx < num_options:
-            counts[idx] += 1
+            counts[to_display.get(idx, idx)] += 1
 
     distribution: list[dict[str, Any]] = []
     for i, count in enumerate(counts):

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -1728,8 +1728,14 @@
 
             var labels = ['A', 'B', 'C', 'D'];
             var answers = rs.answers || [];
-            var correctIdx = (typeof rs.correct_answer_index_original === 'number')
-                ? rs.correct_answer_index_original : -1;
+            // #521: the snapshot's answers ride the round shuffle, so the
+            // highlight must use the matching index. Older servers send only
+            // the question-JSON index, and their grid is unshuffled too — the
+            // fallback keeps those in step.
+            var correctIdx = (typeof rs.correct_answer_index === 'number')
+                ? rs.correct_answer_index
+                : (typeof rs.correct_answer_index_original === 'number')
+                    ? rs.correct_answer_index_original : -1;
             els.answersGrid.innerHTML = answers.map(function(answer, i) {
                 var text = (answer && typeof answer === 'object') ? answer.text : answer;
                 var cls = 'dashboard-answer revealed ' + (i === correctIdx ? 'correct' : 'wrong');
@@ -1921,16 +1927,15 @@
             }
 
             // Highlight correct answer.
-            // We prefer the ORIGINAL-order index when the server sends it
-            // (added 2026-05-29 in v1.1.47): the dashboard renders an
-            // unshuffled answer-grid, so the per-player canonical shuffle
-            // map would point at the wrong tile. Old payloads without the
-            // field fall back to the existing canonical index — that's the
-            // pre-fix behavior, only slightly wrong, so the UI doesn't
-            // break on stale clients.
-            var correctIdx = summary.correct_answer_index_original;
+            // Until #521 this preferred the ORIGINAL-order index, because the
+            // grid was drawn in question-JSON order. It now rides the round
+            // shuffle (the same order TTS speaks), so the canonical index is
+            // the one that points at the right tile. `answer_distribution`
+            // below is emitted in that same space.
+            var correctIdx = summary.correct_answer_index;
             if (correctIdx == null || correctIdx < 0) {
-                correctIdx = summary.correct_answer_index != null ? summary.correct_answer_index : -1;
+                correctIdx = summary.correct_answer_index_original != null
+                    ? summary.correct_answer_index_original : -1;
             }
             var answerEls = els.answersGrid.querySelectorAll('.dashboard-answer');
 

--- a/tests/test_reconnect_snapshot_projection_253.py
+++ b/tests/test_reconnect_snapshot_projection_253.py
@@ -265,8 +265,14 @@ def test_reveal_raw_snapshot_carries_question_for_dashboard(
     which keeps the nested ``round_summary``. Previously that blob lacked the
     question text + answers, so a TV that (re)connected during the reveal had
     nothing to render and showed a blank question view. The raw reveal snapshot
-    must now carry ``question_text``, the canonical ``answers`` list, and
-    ``correct_answer_index_original`` so the dashboard can rebuild the view."""
+    must carry ``question_text``, the ``answers`` list and a correct index the
+    dashboard can highlight with.
+
+    #521: those answers are emitted in the ROUND-SHUFFLE order, not
+    question-JSON order — most packs keep the correct answer first in the file,
+    so a JSON-ordered grid put it on tile A every round. ``answers`` must match
+    the live ``question_started`` payload, and ``correct_answer_index`` must
+    address that same order."""
     _start_round_with_shuffles(state)
     question = state.get_current_question()
     correct_idx = next(i for i, a in enumerate(question.answers) if a.correct)
@@ -276,9 +282,16 @@ def test_reveal_raw_snapshot_carries_question_for_dashboard(
 
     rs = state.get_state_snapshot()["round_summary"]
     assert rs["question_text"] == question.question
-    assert rs["answers"] == [a.text for a in question.answers]
+    # Round-shuffle order, i.e. what the TV drew while the question was live.
+    assert rs["answers"] == [question.answers[i].text for i in state.shuffle_map]
+    # Same texts, just reordered — nothing gained or dropped in the mapping.
+    assert sorted(rs["answers"]) == sorted(a.text for a in question.answers)
+    # The highlight index addresses the shuffled grid the dashboard renders.
+    assert rs["answers"][rs["correct_answer_index"]] == (
+        question.answers[correct_idx].text
+    )
+    # The question-JSON index stays in the payload for pre-#521 clients.
     assert rs["correct_answer_index_original"] == correct_idx
-    # The correct index points at the genuinely-correct answer.
     assert question.answers[rs["correct_answer_index_original"]].correct is True
 
 

--- a/tests/test_tv_grid_shuffle_521.py
+++ b/tests/test_tv_grid_shuffle_521.py
@@ -1,0 +1,261 @@
+"""Regression tests for issue #521 — the TV/cast grid leaked the answer.
+
+``_emit_question`` computes a per-round shuffle and stores it via
+``set_round_shuffle``. That shuffle reached the TTS narration and the reveal
+index, but the payload the admin and the TV dashboard render their grid from
+was built straight off ``question.answers`` — question-JSON order. In 16 of the
+26 shipped packs the correct answer sits at index 0 of *every* question, so on
+those packs the correct answer was tile A on the big screen for every question
+of every game. The phones were never affected: they get a genuine per-player
+shuffle, so nobody was mis-scored — it leaked to whoever watched the TV.
+
+The fix threads the shuffle that already exists (``shuffle_map``) into the
+admin/dashboard payload, the reveal's answer-distribution bars (#151) and the
+reconnect snapshots, instead of introducing a second one. These tests pin all
+four surfaces plus the guard that a malformed map falls back rather than
+mis-ordering the grid.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+from custom_components.quizify.server.round_message_builder import (  # noqa: E402
+    RoundMessageBuilder,
+)
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    _compute_answer_distribution,
+    serialize_question_for_admin,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _fake_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+@pytest.fixture
+def state(tmp_path: Path) -> QuizifyGameState:
+    runtime = _FakeRuntime(tmp_path)
+    return QuizifyGameState(runtime=runtime, entry_id="test")
+
+
+@pytest.fixture
+def builder() -> RoundMessageBuilder:
+    return RoundMessageBuilder()
+
+
+def _start_round(state: QuizifyGameState):
+    """Drive into QUESTION_ACTIVE with a FIXED non-identity canonical shuffle.
+
+    Pinning the permutation (rotate-by-1) instead of ``random.shuffle`` matters
+    here: a random shuffle is identity often enough that a leak test would pass
+    by luck. ``geographie`` is a multiple-choice pack — the mixed pool now
+    includes #275 estimate questions, which carry no answers to shuffle.
+    """
+    state.add_player("Alice", _fake_ws())
+    state.start_game(
+        category="geographie", language="de", num_rounds=3, difficulty="easy"
+    )
+    question = state.start_next_question()
+    assert question is not None
+    n = len(question.answers)
+    assert n >= 3
+    order = [(i + 1) % n for i in range(n)]
+    state.set_round_shuffle(order, [question.answers[i].text for i in order])
+    return question
+
+
+# ---------------------------------------------------------------------------
+# The live admin/TV payload
+# ---------------------------------------------------------------------------
+
+
+def test_admin_payload_rides_the_round_shuffle(
+    state: QuizifyGameState, builder: RoundMessageBuilder
+) -> None:
+    """The grid the TV draws must follow ``shuffle_map``, not JSON order."""
+    question = _start_round(state)
+    msg = builder.build_admin_question(state, question=question)
+
+    texts = [a["text"] for a in msg["answers"]]
+    assert texts == [question.answers[i].text for i in state.shuffle_map]
+    # Same answers, reordered — the mapping must not drop or duplicate one.
+    assert sorted(texts) == sorted(a.text for a in question.answers)
+    # And the correct flag travels with its own text, not with a position.
+    for entry, orig in zip(msg["answers"], state.shuffle_map, strict=True):
+        assert entry["correct"] is question.answers[orig].correct
+
+
+def test_correct_answer_is_not_always_the_first_tile(
+    state: QuizifyGameState, builder: RoundMessageBuilder
+) -> None:
+    """The leak itself: with the correct answer first in the JSON, an
+    unshuffled payload puts it on tile A. Under a rotate-by-1 shuffle it must
+    move off tile A."""
+    question = _start_round(state)
+    # Force the pathological pack layout: correct answer at index 0. The
+    # question objects come from the shared QuestionBank, so the swap is undone
+    # even if an assertion fails — otherwise this would bleed into other tests.
+    correct_pos = next(i for i, a in enumerate(question.answers) if a.correct)
+    question.answers[0], question.answers[correct_pos] = (
+        question.answers[correct_pos],
+        question.answers[0],
+    )
+    try:
+        assert question.answers[0].correct is True
+        msg = builder.build_admin_question(state, question=question)
+        assert msg["answers"][0]["correct"] is False
+        assert any(a["correct"] for a in msg["answers"])
+    finally:
+        question.answers[0], question.answers[correct_pos] = (
+            question.answers[correct_pos],
+            question.answers[0],
+        )
+
+
+def test_tts_options_match_the_rendered_grid(
+    state: QuizifyGameState, builder: RoundMessageBuilder
+) -> None:
+    """The narrator speaks ``shuffled_answers``; the TV renders the payload.
+    A spoken "B" has to name the tile the room is looking at."""
+    question = _start_round(state)
+    msg = builder.build_admin_question(state, question=question)
+    assert [a["text"] for a in msg["answers"]] == list(state.shuffled_answers)
+
+
+# ---------------------------------------------------------------------------
+# Reconnect snapshots — the two paths that rebuild a grid without a live event
+# ---------------------------------------------------------------------------
+
+
+def test_active_question_snapshot_matches_the_live_grid(
+    state: QuizifyGameState, builder: RoundMessageBuilder
+) -> None:
+    """A dashboard reconnecting mid-question rebuilds from the snapshot; it
+    must land on the same order the live payload used."""
+    question = _start_round(state)
+    live = builder.build_admin_question(state, question=question)
+    snap = state.get_state_snapshot()["question"]
+    assert snap["answers"] == [a["text"] for a in live["answers"]]
+
+
+def test_reveal_snapshot_index_addresses_its_own_answers(
+    state: QuizifyGameState,
+) -> None:
+    """At the reveal the snapshot ships both the answers and the index used to
+    colour them — they have to be in the same space."""
+    question = _start_round(state)
+    correct_idx = next(i for i, a in enumerate(question.answers) if a.correct)
+    state.submit_answer("Alice", correct_idx)
+    state.evaluate_round()
+    assert state.phase == GamePhase.ANSWER_REVEAL
+
+    rs = state.get_state_snapshot()["round_summary"]
+    assert rs["answers"][rs["correct_answer_index"]] == (
+        question.answers[correct_idx].text
+    )
+    assert rs["correct_answer_index_original"] == correct_idx
+
+
+# ---------------------------------------------------------------------------
+# #151 distribution bars — votes must land on the tile they were cast for
+# ---------------------------------------------------------------------------
+
+
+def test_distribution_bars_follow_the_displayed_order() -> None:
+    """``all_answers[].answer_index`` is question-JSON order. Mapping it into
+    display space is what keeps a vote attached to the answer it was cast for."""
+    # Grid shows [orig 2, orig 0, orig 1]; both players voted for original 2.
+    order = [2, 0, 1]
+    all_answers = [
+        {"player_name": "Alice", "answer_index": 2},
+        {"player_name": "Bob", "answer_index": 2},
+    ]
+    dist = _compute_answer_distribution(all_answers, 3, order)
+    by_index = {d["index"]: d["count"] for d in dist if "index" in d}
+    # Original 2 is drawn as tile 0.
+    assert by_index[0] == 2
+    assert by_index[1] == 0
+    assert by_index[2] == 0
+
+
+def test_distribution_without_a_map_is_unchanged() -> None:
+    """No shuffle passed (estimate rounds, legacy callers) → identity."""
+    all_answers = [{"player_name": "Alice", "answer_index": 2}]
+    dist = _compute_answer_distribution(all_answers, 3, None)
+    by_index = {d["index"]: d["count"] for d in dist if "index" in d}
+    assert by_index[2] == 1
+
+
+def test_no_answer_players_still_counted_with_a_map() -> None:
+    """Timeouts have no ``answer_index``; the mapping must not swallow them."""
+    all_answers = [
+        {"player_name": "Alice", "answer_index": 0},
+        {"player_name": "Bob", "answer_index": None, "no_answer": True},
+    ]
+    dist = _compute_answer_distribution(all_answers, 3, [1, 2, 0])
+    no_answer = [d for d in dist if d.get("no_answer")]
+    assert len(no_answer) == 1
+    assert no_answer[0]["count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Guards — a broken map must degrade to JSON order, never to a wrong order
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_order",
+    [
+        None,
+        [],
+        [0, 1],  # too short
+        [0, 1, 2, 3],  # too long
+        [0, 1, 1],  # duplicate index
+        [0, 1, 5],  # out of range
+    ],
+)
+def test_malformed_shuffle_falls_back_to_json_order(bad_order) -> None:
+    """A mis-ordered grid mislabels every tile; an unshuffled one only leaks.
+    When the map cannot be trusted, fall back rather than reorder."""
+
+    class _A:
+        def __init__(self, text: str, correct: bool) -> None:
+            self.text = text
+            self.correct = correct
+
+    class _Q:
+        question = "Q?"
+        category = "geo"
+        difficulty = "easy"
+        image_url = None
+        type = "multiple_choice"
+        is_estimate = False
+        answers = [_A("a", True), _A("b", False), _A("c", False)]
+
+    payload = serialize_question_for_admin(
+        question=_Q(),
+        round_num=1,
+        total_rounds=3,
+        timer_duration=30.0,
+        display_order=bad_order,
+    )
+    assert [a["text"] for a in payload["answers"]] == ["a", "b", "c"]


### PR DESCRIPTION
Fixes #521.

## The defect

`_emit_question` computes a per-round shuffle and stores it via `set_round_shuffle`. That shuffle reached the TTS narration and the reveal index — but not the grid the room looks at. `serialize_question_for_admin` built its answers straight off `question.answers` (question-JSON order) and `dashboard.html` labelled them A/B/C in the order received.

In **16 of the 26 shipped packs** the correct answer sits at index 0 of every question, so on those packs the correct answer was **tile A on the big screen, every question of every game**.

Phones were never affected — they get a genuine per-player shuffle via `build_player_question` / `ensure_player_shuffle` — so nobody was mis-scored. It leaked to whoever watched the TV, which at a party is the whole room.

## The fix

Thread the shuffle that already exists instead of adding a second one.

| Surface | Change |
|---|---|
| `serialize_question_for_admin` | takes `display_order` (`shuffle_map`) and emits answers through it |
| `_compute_answer_distribution` | maps `all_answers[].answer_index` (JSON order) into display space so the #151 bars stay on the right tile |
| `get_state_snapshot`, QUESTION_ACTIVE | emits `shuffled_answers` — a mid-question reconnect rebuilds the same grid |
| `get_state_snapshot`, ANSWER_REVEAL | answers shuffled + a matching `correct_answer_index` alongside the original |
| `dashboard.html` | highlights `correct_answer_index` on both the live and the snapshot reveal path |

**Malformed maps fall back rather than reorder.** Wrong length, duplicate or out-of-range index → JSON order. A mis-ordered grid mislabels every tile, which is worse than an unshuffled one.

**Backward compatibility.** `correct_answer_index_original` stays in the payload and both client call sites fall back to it, so a client cached from before this change still highlights correctly against an older server. A stale client against a *new* server would mis-highlight until it reloads — the version fingerprint cache-buster makes that a single reload.

Reordering the pack JSONs would have been the wrong layer: it hides the leak while leaving the TTS mismatch and both reconnect paths intact.

The comment above `_notify_tts_question` asserted that the spoken order already matched the TV grid. It did not — that becomes true with this PR.

## Verification

- Full suite: **1191 passed, 9 skipped**.
- New `tests/test_tv_grid_shuffle_521.py` (11 tests) pins the admin payload order, the TTS/grid agreement, both snapshot paths, the distribution mapping (including no-answer players), and the malformed-map fallback.
- `tests/test_reconnect_snapshot_projection_253.py` asserted the old JSON-order contract for the #296 reveal snapshot; updated to assert the shuffled one.
- `ruff check custom_components/` clean; mypy clean on the three changed modules.
- **Not verified on real hardware** — no live game was run against a TV/cast dashboard for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)