### PR TITLE
feat(player): shareable end-of-game result cards (#369)

### DIFF
--- a/custom_components/quizify/server/serializers.py
+++ b/custom_components/quizify/server/serializers.py
@@ -295,10 +295,57 @@ def serialize_player_list(players: list[PlayerSession]) -> list[dict[str, Any]]:
     ]
 
 
+def build_share_payload(
+    all_players: list[PlayerSession],
+    packs: list[str] | None = None,
+) -> dict[str, Any]:
+    """Per-player run summary for the shareable result card (#369).
+
+    Rides the finale message only — it is sent once per game, so the per-round
+    detail costs nothing on the hot round-summary path.
+
+    ``results`` is ``PlayerSession.round_history`` verbatim: one of
+    ``correct`` / ``wrong`` / ``timeout`` per round the player took part in.
+    Late joiners have a shorter list than the game had rounds; the client
+    renders what it gets rather than padding, so a card never claims the
+    player sat through a round they missed.
+
+    Power-ups are a per-game COUNT, not a per-round marker — the game never
+    records which round a power-up was spent in. The card therefore shows
+    "N power-ups" as a line, and the round strip stays a truthful
+    correct/wrong/timeout sequence.
+    """
+    ranked = sorted(all_players, key=lambda p: p.score, reverse=True)
+    total = len(ranked)
+    entries: list[dict[str, Any]] = []
+    rank = 0
+    prev: int | None = None
+    for i, p in enumerate(ranked):
+        # Competition ranking, identical to serialize_leaderboard: equal
+        # scores share a rank so two tied players don't get 1st/2nd by
+        # sort order. A shared card must not invent a placing.
+        if prev is None or p.score != prev:
+            rank = i + 1
+            prev = p.score
+        history = list(p.round_history)
+        entries.append({
+            "name": p.name,
+            "rank": rank,
+            "total_players": total,
+            "score": p.score,
+            "rounds": len(history),
+            "correct": history.count("correct"),
+            "results": history,
+            "powerups": p.powerups_used,
+        })
+    return {"packs": list(packs or []), "players": entries}
+
+
 def serialize_finale(
     podium: list[PlayerSession],
     all_players: list[PlayerSession],
     superlatives: list[dict[str, str]] | None = None,
+    packs: list[str] | None = None,
 ) -> dict[str, Any]:
     """Build finale payload with podium and full leaderboard."""
     # Shared-rank podium (#308): equal scores share a rank, same as the
@@ -314,7 +361,7 @@ def serialize_finale(
     # ``leaderboard`` and ``all_players`` carry the identical sorted list —
     # serialize it once instead of twice (#415).
     lb = serialize_leaderboard(all_players)
-    result = {
+    result: dict[str, Any] = {
         "type": "finale",
         "podium": podium_entries,
         "leaderboard": lb,
@@ -322,6 +369,9 @@ def serialize_finale(
     }
     if superlatives:
         result["superlatives"] = superlatives
+    # Shareable result cards (#369). Always present so the client can render
+    # the share block without probing for the key.
+    result["share"] = build_share_payload(all_players, packs)
     return result
 
 

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -3169,7 +3169,16 @@ class QuizifyWebSocketHandler:
             else compute_superlatives(all_players)
         )
         awards = [s.to_dict() for s in superlatives]
-        finale_msg = serialize_finale(podium, all_players, superlatives=awards)
+        # Pack labels for the shareable card (#369). ``categories`` is the
+        # multi-select the host picked; ``category`` is the single-pick
+        # fallback. Empty when the host played "mixed", and the card simply
+        # omits the line rather than inventing a pack name.
+        packs = list(getattr(game_state, "categories", None) or [])
+        if not packs and getattr(game_state, "category", None):
+            packs = [game_state.category]
+        finale_msg = serialize_finale(
+            podium, all_players, superlatives=awards, packs=packs
+        )
         await self._conn.broadcast(finale_msg)
 
     # ------------------------------------------------------------------

--- a/custom_components/quizify/www/css/src/05-finale.css
+++ b/custom_components/quizify/www/css/src/05-finale.css
@@ -411,3 +411,70 @@
     text-align: center;
 }
 
+
+/* ============================================================
+   Shareable result card (#369) — Variant C "Spielkarte"
+   A score slip the player can send into a chat. Soft Parlor:
+   lifted paper, warm ink, coral CTA, no confetti.
+   ============================================================ */
+
+.end-share-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm, 8px);
+    margin-top: var(--space-lg, 20px);
+}
+
+.end-share-slip {
+    background: var(--color-bg-card);
+    border: 1px solid var(--color-border, #E7DFCE);
+    border-radius: 12px;
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    /* Double edge reads as a slip torn off a pad rather than another card. */
+    box-shadow: 0 2px 0 var(--color-bg-card-alt), 0 3px 10px rgba(0, 0, 0, .05);
+}
+
+.end-share-title {
+    font-family: var(--font-display, inherit);
+    font-weight: 700;
+    font-size: var(--fs-md, 17px);
+}
+
+.end-share-facts {
+    margin: 0;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 4px 12px;
+    font-size: var(--fs-sm, 14px);
+}
+
+.end-share-facts dt { color: var(--color-text-muted, #6E675E); }
+
+.end-share-facts dd {
+    margin: 0;
+    text-align: right;
+    font-family: var(--font-mono, monospace);
+    font-variant-numeric: tabular-nums;
+}
+
+.end-share-strip {
+    border-top: 1px dashed var(--color-border, #E7DFCE);
+    padding-top: 8px;
+    text-align: center;
+    font-size: 17px;
+    letter-spacing: 2px;
+    /* A long game overflows on a 390px phone — scroll the strip, never the
+       page. Same rule the answer grid follows. */
+    overflow-x: auto;
+    white-space: nowrap;
+}
+
+.end-share-status {
+    text-align: center;
+    font-size: var(--fs-sm, 14px);
+    color: var(--color-text-muted, #6E675E);
+    min-height: 1.3em;
+}

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -2778,6 +2778,73 @@ button, .btn {
     text-align: center;
 }
 
+
+/* ============================================================
+   Shareable result card (#369) — Variant C "Spielkarte"
+   A score slip the player can send into a chat. Soft Parlor:
+   lifted paper, warm ink, coral CTA, no confetti.
+   ============================================================ */
+
+.end-share-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm, 8px);
+    margin-top: var(--space-lg, 20px);
+}
+
+.end-share-slip {
+    background: var(--color-bg-card);
+    border: 1px solid var(--color-border, #E7DFCE);
+    border-radius: 12px;
+    padding: 14px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    /* Double edge reads as a slip torn off a pad rather than another card. */
+    box-shadow: 0 2px 0 var(--color-bg-card-alt), 0 3px 10px rgba(0, 0, 0, .05);
+}
+
+.end-share-title {
+    font-family: var(--font-display, inherit);
+    font-weight: 700;
+    font-size: var(--fs-md, 17px);
+}
+
+.end-share-facts {
+    margin: 0;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 4px 12px;
+    font-size: var(--fs-sm, 14px);
+}
+
+.end-share-facts dt { color: var(--color-text-muted, #6E675E); }
+
+.end-share-facts dd {
+    margin: 0;
+    text-align: right;
+    font-family: var(--font-mono, monospace);
+    font-variant-numeric: tabular-nums;
+}
+
+.end-share-strip {
+    border-top: 1px dashed var(--color-border, #E7DFCE);
+    padding-top: 8px;
+    text-align: center;
+    font-size: 17px;
+    letter-spacing: 2px;
+    /* A long game overflows on a 390px phone — scroll the strip, never the
+       page. Same rule the answer grid follows. */
+    overflow-x: auto;
+    white-space: nowrap;
+}
+
+.end-share-status {
+    text-align: center;
+    font-size: var(--fs-sm, 14px);
+    color: var(--color-text-muted, #6E675E);
+    min-height: 1.3em;
+}
 /* ==========================================
    Launcher
    ========================================== */

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -668,5 +668,22 @@
     "correctCount": "{n}/{total} richtig",
     "pointsThisRound": "Punkte diese Runde",
     "backToResults": "Zurück zu den Ergebnissen"
+  },
+  "share": {
+    "button": "Karte teilen",
+    "slipTitle": "{name} — Platz {rank} von {total}",
+    "factPacks": "Packs",
+    "factCorrect": "Richtig",
+    "factScore": "Punkte",
+    "factPowerups": "Power-Ups",
+    "line": {
+      "rank": "Quizify — {name}, Platz {rank} von {total}",
+      "packs": "Packs: {packs}",
+      "score": "Richtig: {correct}/{rounds} · {score} Punkte",
+      "powerups": "⚡ {count} Power-Ups"
+    },
+    "shared": "Geteilt",
+    "copied": "In die Zwischenablage kopiert",
+    "copyFailed": "Kopieren ging nicht — markier die Karte und kopier sie von Hand"
   }
 }

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -668,5 +668,22 @@
     "correctCount": "{n}/{total} correct",
     "pointsThisRound": "points this round",
     "backToResults": "Back to results"
+  },
+  "share": {
+    "button": "Share card",
+    "slipTitle": "{name} — {rank} of {total}",
+    "factPacks": "Packs",
+    "factCorrect": "Correct",
+    "factScore": "Points",
+    "factPowerups": "Power-ups",
+    "line": {
+      "rank": "Quizify — {name}, {rank} of {total}",
+      "packs": "Packs: {packs}",
+      "score": "Correct: {correct}/{rounds} · {score} points",
+      "powerups": "⚡ {count} power-ups"
+    },
+    "shared": "Shared",
+    "copied": "Copied to clipboard",
+    "copyFailed": "Could not copy — select the card and copy it by hand"
   }
 }

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -668,5 +668,22 @@
     "correctCount": "{n}/{total} correctas",
     "pointsThisRound": "puntos esta ronda",
     "backToResults": "Volver a los resultados"
+  },
+  "share": {
+    "button": "Compartir tarjeta",
+    "slipTitle": "{name} — puesto {rank} de {total}",
+    "factPacks": "Packs",
+    "factCorrect": "Aciertos",
+    "factScore": "Puntos",
+    "factPowerups": "Power-ups",
+    "line": {
+      "rank": "Quizify — {name}, puesto {rank} de {total}",
+      "packs": "Packs: {packs}",
+      "score": "Aciertos: {correct}/{rounds} · {score} puntos",
+      "powerups": "⚡ {count} power-ups"
+    },
+    "shared": "Compartido",
+    "copied": "Copiado al portapapeles",
+    "copyFailed": "No se pudo copiar — selecciona la tarjeta y cópiala a mano"
   }
 }

--- a/custom_components/quizify/www/js/player-end.js
+++ b/custom_components/quizify/www/js/player-end.js
@@ -65,6 +65,10 @@
         // 4. Gesamtwertung scoreboard with bars + inline badges
         renderScoreboard(leaderboard, highlights);
 
+        // 5. Shareable result card (#369) — the player's own run, ready to
+        // send into a chat. Renders only for the viewer's own entry.
+        renderShareCard(data.share, state.playerName);
+
         // Admin / player controls.
         //
         // Source-of-truth: trust ``state.isAdmin`` for gating the
@@ -399,11 +403,173 @@
     }
 
     // ============================================
+    // Shareable result card (#369)
+    // ============================================
+
+    // One glyph per round. ``timeout`` gets its own mark instead of being
+    // folded into ❌ — "I ran out of time" and "I answered wrong" are
+    // different stories, and the server already tells them apart.
+    var RESULT_GLYPH = { correct: '✅', wrong: '❌', timeout: '⬜' };
+
+    /**
+     * Build the text that actually leaves the phone.
+     * Kept separate from rendering so it can be unit-tested and so the
+     * clipboard fallback and navigator.share send byte-identical text.
+     */
+    function buildShareText(entry, packs) {
+        if (!entry) { return ''; }
+        var lines = [];
+        lines.push(_tf('share.line.rank', 'Quizify — {name}, {rank} of {total}', {
+            name: entry.name, rank: entry.rank, total: entry.total_players
+        }));
+        if (packs && packs.length) {
+            lines.push(_tf('share.line.packs', 'Packs: {packs}', {
+                packs: packs.join(' · ')
+            }));
+        }
+        lines.push(_tf('share.line.score', 'Correct: {correct}/{rounds} · {score} points', {
+            correct: entry.correct, rounds: entry.rounds, score: entry.score
+        }));
+        if (entry.powerups) {
+            lines.push(_tf('share.line.powerups', '⚡ {count} power-ups', {
+                count: entry.powerups
+            }));
+        }
+        var strip = (entry.results || []).map(function (r) {
+            return RESULT_GLYPH[r] || RESULT_GLYPH.wrong;
+        }).join('');
+        if (strip) { lines.push(strip); }
+        lines.push('github.com/mholzi/quizify');
+        return lines.join('\n');
+    }
+
+    function findShareEntry(share, playerName) {
+        var players = (share && share.players) || [];
+        for (var i = 0; i < players.length; i++) {
+            if (players[i].name === playerName) { return players[i]; }
+        }
+        return null;
+    }
+
+    function renderShareCard(share, playerName) {
+        var section = document.getElementById('end-share-section');
+        if (!section) { return; }
+        var entry = findShareEntry(share, playerName);
+        // No entry means this viewer is a pure dashboard/spectator socket, or
+        // the player never played a round. Nothing honest to share.
+        if (!entry || !entry.rounds) {
+            section.classList.add('hidden');
+            return;
+        }
+        section.classList.remove('hidden');
+
+        var packs = (share && share.packs) || [];
+        var titleEl = document.getElementById('end-share-title');
+        if (titleEl) {
+            titleEl.textContent = _tf('share.slipTitle', '{name} — {rank} of {total}', {
+                name: entry.name, rank: entry.rank, total: entry.total_players
+            });
+        }
+
+        var facts = document.getElementById('end-share-facts');
+        if (facts) {
+            facts.innerHTML = '';
+            var rows = [];
+            if (packs.length) {
+                rows.push([_tf('share.factPacks', 'Packs'), packs.join(' · ')]);
+            }
+            rows.push([_tf('share.factCorrect', 'Correct'), entry.correct + ' / ' + entry.rounds]);
+            rows.push([_tf('share.factScore', 'Points'), String(entry.score)]);
+            if (entry.powerups) {
+                rows.push([_tf('share.factPowerups', 'Power-ups'), String(entry.powerups)]);
+            }
+            rows.forEach(function (row) {
+                var dt = document.createElement('dt');
+                dt.textContent = row[0];
+                var dd = document.createElement('dd');
+                dd.textContent = row[1];
+                facts.appendChild(dt);
+                facts.appendChild(dd);
+            });
+        }
+
+        var stripEl = document.getElementById('end-share-strip');
+        if (stripEl) {
+            stripEl.textContent = (entry.results || []).map(function (r) {
+                return RESULT_GLYPH[r] || RESULT_GLYPH.wrong;
+            }).join('');
+        }
+
+        setupShareButton(buildShareText(entry, packs));
+    }
+
+    function setupShareButton(text) {
+        var btn = document.getElementById('end-share-btn');
+        var status = document.getElementById('end-share-status');
+        if (!btn) { return; }
+        btn.onclick = function () {
+            function done(msgKey, fallback) {
+                if (status) { status.textContent = _tf(msgKey, fallback); }
+            }
+            // navigator.share is the good path: it opens the OS sheet, which
+            // is where "send to the family chat" actually lives. It needs a
+            // user gesture and HTTPS, so the clipboard is the fallback, not
+            // an afterthought — plenty of HA installs run over plain HTTP.
+            if (navigator.share) {
+                navigator.share({ text: text }).then(function () {
+                    done('share.shared', 'Shared');
+                }).catch(function (err) {
+                    // AbortError = the user closed the sheet. Saying
+                    // "copied" there would be a lie.
+                    if (err && err.name === 'AbortError') { return; }
+                    copyToClipboard(text, done);
+                });
+                return;
+            }
+            copyToClipboard(text, done);
+        };
+    }
+
+    function copyToClipboard(text, done) {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(function () {
+                done('share.copied', 'Copied to clipboard');
+            }).catch(function () {
+                legacyCopy(text, done);
+            });
+            return;
+        }
+        legacyCopy(text, done);
+    }
+
+    function legacyCopy(text, done) {
+        // execCommand is deprecated but still the only path on older
+        // in-app browsers, which is exactly where party guests land.
+        try {
+            var ta = document.createElement('textarea');
+            ta.value = text;
+            ta.setAttribute('readonly', '');
+            ta.style.position = 'fixed';
+            ta.style.opacity = '0';
+            document.body.appendChild(ta);
+            ta.select();
+            var ok = document.execCommand('copy');
+            document.body.removeChild(ta);
+            done(ok ? 'share.copied' : 'share.copyFailed',
+                 ok ? 'Copied to clipboard' : 'Could not copy — select the card and copy it by hand');
+        } catch (e) {
+            done('share.copyFailed', 'Could not copy — select the card and copy it by hand');
+        }
+    }
+
+    // ============================================
     // Export
     // ============================================
 
     window.QuizifyPlayerEnd = {
         updateEndView: updateEndView,
+        buildShareText: buildShareText,
+        renderShareCard: renderShareCard,
         renderWinnerHero: renderWinnerHero,
         renderScoreboard: renderScoreboard,
         renderHighlightChips: renderHighlightChips,

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -2428,6 +2428,10 @@
         // 4. Gesamtwertung scoreboard with bars + inline badges
         renderScoreboard(leaderboard, highlights);
 
+        // 5. Shareable result card (#369) — the player's own run, ready to
+        // send into a chat. Renders only for the viewer's own entry.
+        renderShareCard(data.share, state.playerName);
+
         // Admin / player controls.
         //
         // Source-of-truth: trust ``state.isAdmin`` for gating the
@@ -2762,11 +2766,173 @@
     }
 
     // ============================================
+    // Shareable result card (#369)
+    // ============================================
+
+    // One glyph per round. ``timeout`` gets its own mark instead of being
+    // folded into ❌ — "I ran out of time" and "I answered wrong" are
+    // different stories, and the server already tells them apart.
+    var RESULT_GLYPH = { correct: '✅', wrong: '❌', timeout: '⬜' };
+
+    /**
+     * Build the text that actually leaves the phone.
+     * Kept separate from rendering so it can be unit-tested and so the
+     * clipboard fallback and navigator.share send byte-identical text.
+     */
+    function buildShareText(entry, packs) {
+        if (!entry) { return ''; }
+        var lines = [];
+        lines.push(_tf('share.line.rank', 'Quizify — {name}, {rank} of {total}', {
+            name: entry.name, rank: entry.rank, total: entry.total_players
+        }));
+        if (packs && packs.length) {
+            lines.push(_tf('share.line.packs', 'Packs: {packs}', {
+                packs: packs.join(' · ')
+            }));
+        }
+        lines.push(_tf('share.line.score', 'Correct: {correct}/{rounds} · {score} points', {
+            correct: entry.correct, rounds: entry.rounds, score: entry.score
+        }));
+        if (entry.powerups) {
+            lines.push(_tf('share.line.powerups', '⚡ {count} power-ups', {
+                count: entry.powerups
+            }));
+        }
+        var strip = (entry.results || []).map(function (r) {
+            return RESULT_GLYPH[r] || RESULT_GLYPH.wrong;
+        }).join('');
+        if (strip) { lines.push(strip); }
+        lines.push('github.com/mholzi/quizify');
+        return lines.join('\n');
+    }
+
+    function findShareEntry(share, playerName) {
+        var players = (share && share.players) || [];
+        for (var i = 0; i < players.length; i++) {
+            if (players[i].name === playerName) { return players[i]; }
+        }
+        return null;
+    }
+
+    function renderShareCard(share, playerName) {
+        var section = document.getElementById('end-share-section');
+        if (!section) { return; }
+        var entry = findShareEntry(share, playerName);
+        // No entry means this viewer is a pure dashboard/spectator socket, or
+        // the player never played a round. Nothing honest to share.
+        if (!entry || !entry.rounds) {
+            section.classList.add('hidden');
+            return;
+        }
+        section.classList.remove('hidden');
+
+        var packs = (share && share.packs) || [];
+        var titleEl = document.getElementById('end-share-title');
+        if (titleEl) {
+            titleEl.textContent = _tf('share.slipTitle', '{name} — {rank} of {total}', {
+                name: entry.name, rank: entry.rank, total: entry.total_players
+            });
+        }
+
+        var facts = document.getElementById('end-share-facts');
+        if (facts) {
+            facts.innerHTML = '';
+            var rows = [];
+            if (packs.length) {
+                rows.push([_tf('share.factPacks', 'Packs'), packs.join(' · ')]);
+            }
+            rows.push([_tf('share.factCorrect', 'Correct'), entry.correct + ' / ' + entry.rounds]);
+            rows.push([_tf('share.factScore', 'Points'), String(entry.score)]);
+            if (entry.powerups) {
+                rows.push([_tf('share.factPowerups', 'Power-ups'), String(entry.powerups)]);
+            }
+            rows.forEach(function (row) {
+                var dt = document.createElement('dt');
+                dt.textContent = row[0];
+                var dd = document.createElement('dd');
+                dd.textContent = row[1];
+                facts.appendChild(dt);
+                facts.appendChild(dd);
+            });
+        }
+
+        var stripEl = document.getElementById('end-share-strip');
+        if (stripEl) {
+            stripEl.textContent = (entry.results || []).map(function (r) {
+                return RESULT_GLYPH[r] || RESULT_GLYPH.wrong;
+            }).join('');
+        }
+
+        setupShareButton(buildShareText(entry, packs));
+    }
+
+    function setupShareButton(text) {
+        var btn = document.getElementById('end-share-btn');
+        var status = document.getElementById('end-share-status');
+        if (!btn) { return; }
+        btn.onclick = function () {
+            function done(msgKey, fallback) {
+                if (status) { status.textContent = _tf(msgKey, fallback); }
+            }
+            // navigator.share is the good path: it opens the OS sheet, which
+            // is where "send to the family chat" actually lives. It needs a
+            // user gesture and HTTPS, so the clipboard is the fallback, not
+            // an afterthought — plenty of HA installs run over plain HTTP.
+            if (navigator.share) {
+                navigator.share({ text: text }).then(function () {
+                    done('share.shared', 'Shared');
+                }).catch(function (err) {
+                    // AbortError = the user closed the sheet. Saying
+                    // "copied" there would be a lie.
+                    if (err && err.name === 'AbortError') { return; }
+                    copyToClipboard(text, done);
+                });
+                return;
+            }
+            copyToClipboard(text, done);
+        };
+    }
+
+    function copyToClipboard(text, done) {
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(function () {
+                done('share.copied', 'Copied to clipboard');
+            }).catch(function () {
+                legacyCopy(text, done);
+            });
+            return;
+        }
+        legacyCopy(text, done);
+    }
+
+    function legacyCopy(text, done) {
+        // execCommand is deprecated but still the only path on older
+        // in-app browsers, which is exactly where party guests land.
+        try {
+            var ta = document.createElement('textarea');
+            ta.value = text;
+            ta.setAttribute('readonly', '');
+            ta.style.position = 'fixed';
+            ta.style.opacity = '0';
+            document.body.appendChild(ta);
+            ta.select();
+            var ok = document.execCommand('copy');
+            document.body.removeChild(ta);
+            done(ok ? 'share.copied' : 'share.copyFailed',
+                 ok ? 'Copied to clipboard' : 'Could not copy — select the card and copy it by hand');
+        } catch (e) {
+            done('share.copyFailed', 'Could not copy — select the card and copy it by hand');
+        }
+    }
+
+    // ============================================
     // Export
     // ============================================
 
     window.QuizifyPlayerEnd = {
         updateEndView: updateEndView,
+        buildShareText: buildShareText,
+        renderShareCard: renderShareCard,
         renderWinnerHero: renderWinnerHero,
         renderScoreboard: renderScoreboard,
         renderHighlightChips: renderHighlightChips,

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -567,6 +567,21 @@
                     </div>
                 </div>
 
+                <!-- Shareable result card (#369) — a score slip the player can
+                     send into a chat. Hidden until the finale payload carries a
+                     ``share`` block for this player. -->
+                <div id="end-share-section" class="end-share-section hidden">
+                    <div class="end-share-slip" id="end-share-slip">
+                        <div class="end-share-title" id="end-share-title">&nbsp;</div>
+                        <dl class="end-share-facts" id="end-share-facts"></dl>
+                        <div class="end-share-strip" id="end-share-strip" aria-hidden="true"></div>
+                    </div>
+                    <button id="end-share-btn" class="resbtn resbtn--primary end-share-btn" type="button" data-i18n="share.button">
+                        Share card
+                    </button>
+                    <div class="end-share-status" id="end-share-status" role="status" aria-live="polite"></div>
+                </div>
+
                 <!-- CTA stack — Nochmal spielen (play again) + Beenden (new game).
                      Admin-only; players see the waiting message instead. -->
                 <div id="end-admin-controls" class="end-admin-controls hidden">

--- a/tests/test_share_cards_369.py
+++ b/tests/test_share_cards_369.py
@@ -1,0 +1,165 @@
+"""Tests for issue #369 — shareable end-of-game result cards.
+
+The finale payload carries a ``share`` block: one entry per player with the
+per-round outcome sequence, so the phone can render a score slip and hand the
+text to ``navigator.share``.
+
+What these pin down is mostly honesty of the card. A shared result gets posted
+into a group chat, so every number on it is a public claim:
+
+* a late joiner must not be shown as having played rounds they missed
+* tied players must not be handed 1st/2nd by sort order
+* a timeout must not be laundered into a wrong answer
+* power-ups must not be placed on specific rounds — the game never records
+  which round they were spent in
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.player import PlayerSession  # noqa: E402
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    build_share_payload,
+    serialize_finale,
+)
+
+
+def _player(name: str, score: int, history: list[str], powerups: int = 0):
+    p = PlayerSession(name=name, ws=MagicMock())
+    p.score = score
+    p.round_history = list(history)
+    p.powerups_used = powerups
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Shape
+# ---------------------------------------------------------------------------
+
+
+def test_finale_always_carries_a_share_block() -> None:
+    """The client renders unconditionally; it must never probe for the key."""
+    players = [_player("Alice", 10, ["correct"])]
+    msg = serialize_finale(players, players)
+    assert "share" in msg
+    assert msg["share"]["players"][0]["name"] == "Alice"
+
+
+def test_packs_flow_through_and_default_to_empty() -> None:
+    msg = serialize_finale([], [], packs=["geographie", "musik"])
+    assert msg["share"]["packs"] == ["geographie", "musik"]
+    # No packs (mixed category) → empty list, and the card omits the line
+    # rather than inventing a pack name.
+    assert serialize_finale([], [])["share"]["packs"] == []
+
+
+# ---------------------------------------------------------------------------
+# Honesty of the numbers
+# ---------------------------------------------------------------------------
+
+
+def test_round_history_is_passed_through_verbatim() -> None:
+    """Three outcomes survive to the client, timeout included."""
+    hist = ["correct", "wrong", "timeout", "correct"]
+    share = build_share_payload([_player("Alice", 30, hist)])
+    entry = share["players"][0]
+    assert entry["results"] == hist
+    assert entry["rounds"] == 4
+    assert entry["correct"] == 2  # timeout is NOT counted as correct
+
+
+def test_timeout_is_not_folded_into_wrong() -> None:
+    """'I ran out of time' and 'I answered wrong' are different stories."""
+    share = build_share_payload([_player("Alice", 0, ["timeout", "wrong"])])
+    results = share["players"][0]["results"]
+    assert results[0] == "timeout"
+    assert results[1] == "wrong"
+    assert results[0] != results[1]
+
+
+def test_late_joiner_reports_only_the_rounds_they_played() -> None:
+    """A 2-round history in an 8-round game must stay 2, not be padded."""
+    early = _player("Alice", 80, ["correct"] * 8)
+    late = _player("Bob", 10, ["correct", "wrong"])
+    share = build_share_payload([early, late])
+    by_name = {e["name"]: e for e in share["players"]}
+    assert by_name["Bob"]["rounds"] == 2
+    assert len(by_name["Bob"]["results"]) == 2
+    assert by_name["Alice"]["rounds"] == 8
+
+
+def test_tied_players_share_a_rank() -> None:
+    """Equal scores must not be handed 1st/2nd by sort order — the card is
+    posted publicly and would misstate the outcome."""
+    a = _player("Alice", 50, ["correct"])
+    b = _player("Bob", 50, ["correct"])
+    c = _player("Cara", 10, ["wrong"])
+    share = build_share_payload([a, b, c])
+    ranks = {e["name"]: e["rank"] for e in share["players"]}
+    assert ranks["Alice"] == 1
+    assert ranks["Bob"] == 1
+    assert ranks["Cara"] == 3  # competition ranking: no rank 2 handed out
+    assert all(e["total_players"] == 3 for e in share["players"])
+
+
+def test_powerups_are_a_count_not_a_round_marker() -> None:
+    """The game never records WHICH round a power-up was spent in, so the
+    payload must not imply a position. It carries a count and nothing else."""
+    share = build_share_payload([_player("Alice", 40, ["correct"] * 4, powerups=2)])
+    entry = share["players"][0]
+    assert entry["powerups"] == 2
+    # No per-round power-up marker anywhere in the round sequence.
+    assert set(entry["results"]) <= {"correct", "wrong", "timeout"}
+
+
+def test_rank_order_is_by_score_regardless_of_input_order() -> None:
+    share = build_share_payload([
+        _player("Low", 5, ["wrong"]),
+        _player("High", 90, ["correct"]),
+        _player("Mid", 40, ["correct"]),
+    ])
+    assert [e["name"] for e in share["players"]] == ["High", "Mid", "Low"]
+    assert [e["rank"] for e in share["players"]] == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_player_who_never_played_a_round_gets_an_empty_strip() -> None:
+    """Joined the lobby, game ended. The client hides the card on rounds == 0
+    rather than sharing an empty brag."""
+    share = build_share_payload([_player("Ghost", 0, [])])
+    entry = share["players"][0]
+    assert entry["rounds"] == 0
+    assert entry["results"] == []
+
+
+def test_empty_game_produces_an_empty_player_list() -> None:
+    share = build_share_payload([])
+    assert share["players"] == []
+    assert share["packs"] == []
+
+
+@pytest.mark.parametrize("n", [1, 5, 20])
+def test_total_players_matches_the_actual_field(n: int) -> None:
+    players = [_player(f"P{i}", 100 - i, ["correct"]) for i in range(n)]
+    share = build_share_payload(players)
+    assert all(e["total_players"] == n for e in share["players"])
+
+
+def test_results_list_is_a_copy_not_the_live_history() -> None:
+    """Mutating the payload must not reach back into game state."""
+    p = _player("Alice", 10, ["correct"])
+    share = build_share_payload([p])
+    share["players"][0]["results"].append("wrong")
+    assert p.round_history == ["correct"]


### PR DESCRIPTION
Closes #369. Design direction picked from three hand-built wireframes — **variant C, "score slip"**.

## What lands on the phone

A slip under the scoreboard with the player's rank, the packs, hit rate, points and a round strip, plus a **Share card** button. What gets shared:

```
Quizify — Markus, Platz 2 von 8
Packs: Geografie · Musik
Richtig: 6/8 · 79 Punkte
⚡ 2 Power-Ups
✅✅❌⬜✅✅✅❌
github.com/mholzi/quizify
```

## Server

The finale payload gains a `share` block. It rides the finale message only — sent once per game — so the per-round detail costs nothing on the round-summary path. `PlayerSession.round_history` already records `correct` / `wrong` / `timeout` per round; the payload passes it through verbatim. Pack labels come from `game_state.categories`, falling back to `category`.

## Client

`player-end.js` renders the slip and hands the text to `navigator.share`, falling back to the clipboard (async API, then `execCommand` for older in-app browsers — which is exactly where party guests land). The OS share sheet needs a user gesture and HTTPS and plenty of HA installs run over plain HTTP, so the clipboard is a real path, not a courtesy. A closed share sheet (`AbortError`) reports nothing; saying "copied" there would be a lie.

Full i18n in de / en / es.

## Honesty of the card

A shared result is a public claim, so the payload refuses to flatter:

| Rule | Why |
|---|---|
| Timeouts keep their own glyph (⬜), not ❌ | The server already tells them apart; "I ran out of time" ≠ "I answered wrong" |
| A late joiner reports only the rounds they played | Padding to game length would claim rounds they never saw |
| Tied players share a rank | Matches `serialize_leaderboard`; sort order must not hand out 1st/2nd |
| A player who never answered gets no card | Nothing honest to share |

**One deviation from the approved wireframe:** it showed ⚡ inline in the round strip. The game never records *which* round a power-up was spent in, so placing it would be invented data. Power-ups appear as a count line instead. Adding per-round tracking is a separate change if it's wanted.

## Verification

- Full suite: **1205 passed, 9 skipped**. New `test_share_cards_369.py` (14 tests) pins the honesty rules above plus rank ordering, pack pass-through, and that `results` is a copy rather than live game state.
- `ruff check custom_components/` clean; mypy clean on the changed modules.
- `node --check` on `player-end.js` and the rebuilt bundle; all three i18n files parse.
- Generated artifacts rebuilt (`build_css.py`, `build_bundle.py`) so the drift gate stays green.
- **Not verified on real hardware.** This is a UI change and the 390×844 mobile check from CLAUDE.md needs a live HA — the same gap that blocks #494 and the #521 TV-grid fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)