### PR TITLE
fix(admin): stop a failed entity fetch from wiping the loaded pickers

### DIFF
--- a/custom_components/quizify/www/css/src/02-shared.css
+++ b/custom_components/quizify/www/css/src/02-shared.css
@@ -781,6 +781,13 @@ button, .btn {
     display: flex;
     align-items: center;
     cursor: pointer;
+    /* #526: the gap between the switch and its label belongs here, not on each
+       panel. It used to be declared per panel (.setup-lightning-toggle,
+       .setup-house-toggle) and the TTS panel simply never got one, so step 7's
+       labels butted against their switches while steps 6 and 8 looked right.
+       The hidden <input> is absolutely positioned and out of flow, so this
+       only ever spaces the switch from the label. */
+    gap: 10px;
 }
 
 .toggle-compact input {

--- a/custom_components/quizify/www/css/src/07-player.css
+++ b/custom_components/quizify/www/css/src/07-player.css
@@ -1530,8 +1530,7 @@
 /* Lightning Round toggle row (#285) — a .toggle-compact switch sitting in a
    vF-step, aligned with the answer chips above it (skip the number badge). */
 .setup-lightning-toggle {
-    padding-left: 30px;
-    gap: 10px;
+    padding-left: 30px;   /* gap now inherited from .toggle-compact (#526) */
 }
 .setup-lightning-toggle .toggle-label {
     font-size: 0.9rem;
@@ -1616,9 +1615,7 @@
    segmented control, an "Advanced" disclosure holding the ten per-effect
    toggles, and a scrollable checkbox list for the multi-choice light
    picker. Soft Parlor tokens only — no new colours. */
-.setup-house-toggle {
-    gap: 10px;
-}
+/* gap now inherited from .toggle-compact (#526) */
 .setup-house-toggle .toggle-label {
     font-size: 0.9rem;
     color: var(--color-text-secondary);

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -1487,6 +1487,13 @@ button, .btn {
     display: flex;
     align-items: center;
     cursor: pointer;
+    /* #526: the gap between the switch and its label belongs here, not on each
+       panel. It used to be declared per panel (.setup-lightning-toggle,
+       .setup-house-toggle) and the TTS panel simply never got one, so step 7's
+       labels butted against their switches while steps 6 and 8 looked right.
+       The hidden <input> is absolutely positioned and out of flow, so this
+       only ever spaces the switch from the label. */
+    gap: 10px;
 }
 
 .toggle-compact input {
@@ -4623,8 +4630,7 @@ footer {
 /* Lightning Round toggle row (#285) — a .toggle-compact switch sitting in a
    vF-step, aligned with the answer chips above it (skip the number badge). */
 .setup-lightning-toggle {
-    padding-left: 30px;
-    gap: 10px;
+    padding-left: 30px;   /* gap now inherited from .toggle-compact (#526) */
 }
 .setup-lightning-toggle .toggle-label {
     font-size: 0.9rem;
@@ -4709,9 +4715,7 @@ footer {
    segmented control, an "Advanced" disclosure holding the ten per-effect
    toggles, and a scrollable checkbox list for the multi-choice light
    picker. Soft Parlor tokens only — no new colours. */
-.setup-house-toggle {
-    gap: 10px;
-}
+/* gap now inherited from .toggle-compact (#526) */
 .setup-house-toggle .toggle-label {
     font-size: 0.9rem;
     color: var(--color-text-secondary);

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -1815,10 +1815,13 @@
             .then(function (resp) { return resp.ok ? resp.json() : null; })
             .then(function (data) {
                 if (!data) {
-                    // No token yet (401) or an error — leave the dropdowns on
-                    // their "None found" fallback WITHOUT marking loaded, so the
-                    // refetch in handleGameState retries once the admin token
-                    // arrives over the WebSocket.
+                    // No token yet (401) or an error. Show the "None found"
+                    // fallback WITHOUT marking loaded, so the refetch in
+                    // handleGameState retries once the admin token arrives —
+                    // but never over a list that already loaded (#524). A
+                    // request that failed learned nothing about the host's
+                    // entities and must not overwrite an answer that did.
+                    if (_ttsEntitiesLoaded) return;
                     _populateEntitySelect(_ttsEls.engine, null, cfg.tts_entity);
                     _populateEntitySelect(_ttsEls.speaker, null, cfg.media_player);
                     return;
@@ -1829,6 +1832,7 @@
             })
             .catch(function (e) {
                 console.warn('[quizify] tts-entities fetch failed:', e);
+                if (_ttsEntitiesLoaded) return;   // #524, see above
                 _populateEntitySelect(_ttsEls.engine, null, cfg.tts_entity);
                 _populateEntitySelect(_ttsEls.speaker, null, cfg.media_player);
             });
@@ -1859,8 +1863,15 @@
         });
         // Reflect the master→child enabled/dimmed state (Variant B, #281).
         _syncTtsChildState();
-        // Fetch + populate the entity dropdowns, restoring the saved selection.
-        _loadTtsEntities(cfg);
+        // NO entity fetch here (#524). The endpoint is admin-token gated and
+        // the token only arrives over the WebSocket, so a fetch at page-init
+        // can never carry one — sessionStorage is per-tab and empty on every
+        // fresh tab, making the 401 a certainty rather than a risk. Its late
+        // failure handler then repainted the "None found" fallback OVER the
+        // lists the admin-connect frame had already delivered. The lists ride
+        // that frame (#502); handleGameState populates them, and only an
+        // older server without them falls back to the HTTP fetch — by which
+        // point the token exists.
     }
 
     // ---- House Plays Along (#494), Variant D "Presets" ----
@@ -2113,6 +2124,11 @@
                     // No token yet (401) or an error — show the "none found"
                     // fallbacks WITHOUT marking loaded, so the refetch in
                     // handleGameState retries once the admin token arrives.
+                    // Never over an already-loaded list (#524/#527): a failed
+                    // fetch wiping the rendered light list is exactly how the
+                    // party-light picker came up empty on a host with 72
+                    // lights.
+                    if (_houseEntitiesLoaded) return;
                     _renderHouseLightList(null, cfg.light_entities);
                     _populateEntitySelect(_houseEls.speaker, null, cfg.media_player, 'setup.house.noentities');
                     _populateEntitySelect(_houseEls.scene, null, cfg.winner_scene_entity, 'setup.house.noentities');
@@ -2122,6 +2138,7 @@
             })
             .catch(function (e) {
                 console.warn('[quizify] house-entities fetch failed:', e);
+                if (_houseEntitiesLoaded) return;   // #524/#527, see above
                 _renderHouseLightList(null, cfg.light_entities);
                 _populateEntitySelect(_houseEls.speaker, null, cfg.media_player, 'setup.house.noentities');
                 _populateEntitySelect(_houseEls.scene, null, cfg.winner_scene_entity, 'setup.house.noentities');
@@ -2178,8 +2195,10 @@
         });
         // Reflect the master→children enabled/dimmed state.
         _syncHouseChildState();
-        // Fetch + populate the entity pickers, restoring the saved selection.
-        _loadHouseEntities(cfg);
+        // NO entity fetch here — same reasoning as the TTS panel (#524/#527):
+        // the token-gated fetch cannot succeed at page-init, and its failure
+        // handler wiped the light list the admin-connect frame had already
+        // rendered. The lists ride that frame (#502/#494 Phase 4).
     }
 
     function _buildStartGamePayload() {

--- a/tests/test_entity_picker_race_524.py
+++ b/tests/test_entity_picker_race_524.py
@@ -1,0 +1,186 @@
+"""Guard the entity-picker race fix (#524 / #527) and the toggle gap (#526).
+
+#524: on every fresh admin tab ``sessionStorage`` is empty, so the page-init
+fetch to the admin-token-gated ``/api/quizify/tts-entities`` went out without a
+token and 401'd *by construction*. Its failure handler then repainted the
+"None found — configure in HA" fallback over the lists the admin-connect frame
+(#502) had already delivered — the dropdown was briefly correct and then wiped.
+Remote hosts hit it reliably: the WebSocket is already open and pushes at once,
+while the HTTP leg makes a fresh round-trip, so the doomed 401 lands last.
+
+#527 is the same defect in the House-Plays-Along copy: the late 401 wiped the
+rendered party-light checkbox list, which is why a host with 72 lights could
+not select one.
+
+Two guarantees, asserted over the shipped ``admin.js`` text because the
+behaviour lives in the browser and there is no JS test runner in this repo:
+1. Neither panel fetches entities at page-init any more.
+2. Every failure branch bails out when the list already loaded, so a request
+   that learned nothing can never overwrite an answer that did.
+
+#526: the switch/label gap now lives on the shared ``.toggle-compact`` base
+instead of being re-declared per panel — the TTS panel was the call site that
+never got one, so step 7's labels butted against their switches.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+WWW = REPO / "custom_components" / "quizify" / "www"
+ADMIN_JS = WWW / "js" / "admin.js"
+STYLES = WWW / "css" / "styles.css"
+SHARED_SRC = WWW / "css" / "src" / "02-shared.css"
+
+
+def _function_body(js: str, name: str) -> str:
+    """Return the source of ``function <name>(...) { ... }`` by brace matching."""
+    m = re.search(r"function\s+" + re.escape(name) + r"\s*\([^)]*\)\s*\{", js)
+    assert m, f"{name}() not found in admin.js"
+    depth = 0
+    start = m.end() - 1
+    for i in range(start, len(js)):
+        if js[i] == "{":
+            depth += 1
+        elif js[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return js[start : i + 1]
+    raise AssertionError(f"unbalanced braces while scanning {name}()")
+
+
+def _rule(css: str, selector: str) -> str:
+    """Return the declaration block for the first rule matching ``selector``."""
+    idx = css.index(selector)
+    start = css.index("{", idx)
+    end = css.index("}", start)
+    return css[start + 1 : end]
+
+
+# --------------------------------------------------------------------------
+# #524 / #527 — no doomed fetch at page-init
+# --------------------------------------------------------------------------
+
+
+def test_tts_panel_does_not_fetch_entities_at_init() -> None:
+    """_initTtsToggles must not call the token-gated loader (#524).
+
+    At page-init no admin token exists yet, so the call could only ever 401.
+    """
+    body = _function_body(ADMIN_JS.read_text("utf-8"), "_initTtsToggles")
+    assert "_loadTtsEntities(" not in body, (
+        "_initTtsToggles() must not fetch entities at page-init (#524): the "
+        "admin token has not arrived yet, so the request 401s and its failure "
+        "handler wipes the lists the admin-connect frame delivered"
+    )
+
+
+def test_house_panel_does_not_fetch_entities_at_init() -> None:
+    """_initHouseToggles must not call the token-gated loader (#527)."""
+    body = _function_body(ADMIN_JS.read_text("utf-8"), "_initHouseToggles")
+    assert "_loadHouseEntities(" not in body, (
+        "_initHouseToggles() must not fetch entities at page-init (#527)"
+    )
+
+
+def test_ws_frame_remains_the_primary_population_path() -> None:
+    """The admin-connect frame must still populate both panels (#502).
+
+    Dropping the init fetch is only safe because the WebSocket carries the
+    lists; this pins that the consumer is still wired up.
+    """
+    js = ADMIN_JS.read_text("utf-8")
+    body = _function_body(js, "handleGameState")
+    assert "msg.tts_entities" in body and "msg.media_players" in body
+    assert "msg.house_entities" in body
+    # …and the HTTP loaders survive as the fallback for an older server, now
+    # reached only once the admin token is in hand.
+    assert "_loadTtsEntities(" in body
+    assert "_loadHouseEntities(" in body
+
+
+# --------------------------------------------------------------------------
+# #524 / #527 — a failed load never overwrites a successful one
+# --------------------------------------------------------------------------
+
+
+def test_tts_failure_branches_bail_out_when_already_loaded() -> None:
+    """Both the 401 branch and the .catch must respect _ttsEntitiesLoaded."""
+    body = _function_body(ADMIN_JS.read_text("utf-8"), "_loadTtsEntities")
+    guards = re.findall(r"if\s*\(\s*_ttsEntitiesLoaded\s*\)\s*return", body)
+    assert len(guards) >= 2, (
+        "_loadTtsEntities must bail out of BOTH the !data branch and the "
+        ".catch when the lists already loaded (#524)"
+    )
+    # Each wipe call must sit behind a guard: no `null` repaint may appear
+    # before the first guard in the function body.
+    first_guard = body.index("if (_ttsEntitiesLoaded) return")
+    head = body[:first_guard]
+    assert "_populateEntitySelect(_ttsEls.engine, null" not in head, (
+        "a 'None found' repaint must never run ahead of the loaded-guard"
+    )
+
+
+def test_house_failure_branches_bail_out_when_already_loaded() -> None:
+    """Same guarantee for the party-light list and the house pickers (#527)."""
+    body = _function_body(ADMIN_JS.read_text("utf-8"), "_loadHouseEntities")
+    guards = re.findall(r"if\s*\(\s*_houseEntitiesLoaded\s*\)\s*return", body)
+    assert len(guards) >= 2, (
+        "_loadHouseEntities must bail out of BOTH the !data branch and the "
+        ".catch when the lists already loaded (#527)"
+    )
+    first_guard = body.index("if (_houseEntitiesLoaded) return")
+    head = body[:first_guard]
+    assert "_renderHouseLightList(null" not in head, (
+        "the party-light list must never be wiped ahead of the loaded-guard"
+    )
+
+
+def test_successful_load_still_marks_loaded() -> None:
+    """The success paths must set the flags the guards read."""
+    js = ADMIN_JS.read_text("utf-8")
+    assert "_ttsEntitiesLoaded = true" in _function_body(js, "_loadTtsEntities")
+    assert "_houseEntitiesLoaded = true" in _function_body(js, "_populateHouseEntities")
+
+
+# --------------------------------------------------------------------------
+# #526 — switch/label gap
+# --------------------------------------------------------------------------
+
+
+def test_toggle_compact_carries_the_gap() -> None:
+    """The shared base supplies the switch↔label gap for every panel (#526)."""
+    block = _rule(STYLES.read_text("utf-8"), ".toggle-compact {")
+    m = re.search(r"gap:\s*(\d+)px", block)
+    assert m, ".toggle-compact must declare the switch/label gap (#526)"
+    assert int(m.group(1)) >= 8, "gap must be visible, not hairline"
+
+
+def test_gap_is_authored_in_the_css_source_not_only_the_build() -> None:
+    """styles.css is generated — the rule has to live in css/src/ too."""
+    block = _rule(SHARED_SRC.read_text("utf-8"), ".toggle-compact {")
+    assert re.search(r"gap:\s*\d+px", block), (
+        "the gap must be authored in css/src/02-shared.css, otherwise the "
+        "next build_css.py run drops it"
+    )
+
+
+def test_tts_toggles_inherit_the_gap() -> None:
+    """Step 7's rows must end up spaced like steps 6 and 8.
+
+    The TTS panel never declared a gap of its own — that WAS the bug — so the
+    guarantee is that it inherits one and that no later rule zeroes it.
+    """
+    css = STYLES.read_text("utf-8")
+    selectors = (
+        ".setup-tts-toggle",
+        ".setup-house-toggle",
+        ".setup-lightning-toggle",
+    )
+    for selector in selectors:
+        for m in re.finditer(re.escape(selector) + r"\s*\{([^}]*)\}", css):
+            assert not re.search(r"gap:\s*0", m.group(1)), (
+                f"{selector} must not cancel the inherited gap (#526)"
+            )

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"


### PR DESCRIPTION
Fixes #524, fixes #527, fixes #526.

## The bug

On every fresh admin tab `sessionStorage` is empty, so the page-init fetch to the admin-token-gated `/api/quizify/tts-entities` went out **without a token** and 401'd — not as a risk, but by construction. Its failure handler then repainted the `None found — configure in HA` fallback over the lists the admin-connect frame (#502) had already delivered. The dropdowns were correct for a moment and then wiped.

Remote hosts hit it reliably: the WebSocket is already open and pushes the admin frame at once, while the HTTP leg makes a fresh round-trip through the cloud relay — so the doomed 401 lands last and wins. On a LAN both legs are fast and the order flips, which is why this survived local testing.

#502 removed the race for the success path and left it standing in the failure path.

**#527 is the same defect** in the House Plays Along copy: the late 401 called `_renderHouseLightList(null, …)` and wiped the rendered checkbox list — which is why a host with 72 lights could not select a party light. The master-toggle theory originally filed there was wrong.

## The fix

Two changes, both load-bearing:

1. **No entity fetch at page-init.** Removed from `_initTtsToggles` and `_initHouseToggles`. It cannot succeed there, so its only observable effect was this bug. The WS frame is the documented primary path; the HTTP loaders stay as the fallback for an older server, reached from `handleGameState` once the token actually exists.
2. **A failed load never overwrites a successful one.** Every failure branch — the `!data` path *and* the `.catch` — now bails out when the list already loaded. A request that failed learned nothing about the host's entities and has no business overwriting an answer that did.

Both are needed: (1) removes the guaranteed-failing request, (2) closes the same hole for the fallback path and for reconnects.

## #526 — the toggle gap

The switch/label gap moves onto the shared `.toggle-compact` base. It had been declared per panel (`.setup-lightning-toggle`, `.setup-house-toggle`) and the TTS panel simply never got one, so step 7's labels butted against their switches while steps 6 and 8 looked right. Every `.toggle-compact` call site in the codebase also carries one of those three classes, so nothing relied on the previous zero gap — checked before moving it rather than assumed.

## Tests

9 new assertions in `tests/test_entity_picker_race_524.py`, text-level over the shipped `admin.js` and `styles.css` because the behaviour lives in the browser and this repo has no JS runner. They pin: no init fetch in either panel, the WS frame still wired as the primary path, both failure branches guarded, the success paths still setting the flags the guards read, and the gap authored in `css/src/` (not only in the generated file, which the next build would otherwise drop).

**Verified meaningful**: stashed the fix and re-ran — 6 of the 9 fail against the pre-fix tree. The 3 that pass either way assert invariants the change must not break.

- Full suite: **1214 passed / 9 skipped** (baseline 1205 + 9 new)
- `ruff check custom_components/`: clean
- `styles.css` rebuilt from `css/src/`; `player.bundle.js` byte-identical to HEAD
- `node --check` on `admin.js`: clean
- mypy unaffected — no Python changed under `custom_components/quizify` (its `files=` scope)

## Not verified on hardware

This is a UI change and has **not** run through the 390×844 mobile check on a live HA. It joins #494, #521 and #369 in that gap. The #526 part is visible on the screenshot that prompted the report, so a quick look at step 7 after deploying is the cheapest confirmation; #524/#527 need a fresh admin tab over a remote (Nabu Casa) connection, which is exactly the condition that made the race reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
