### PR TITLE
feat(admin): ask for one speaker instead of two

### DIFF
--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -378,13 +378,23 @@
                                 <option value="" data-i18n="setup.tts.usedefault">Use default</option>
                             </select>
                         </label>
-                        <label class="setup-tts-select" for="tts-speaker-select">
-                            <span class="setup-tts-select-label" data-i18n="setup.tts.speaker">Speaker</span>
-                            <select id="tts-speaker-select" class="setup-select">
-                                <option value="" data-i18n="setup.tts.usedefault">Use default</option>
-                            </select>
-                        </label>
                     </div>
+                    <!-- Game-wide speaker (#525). Deliberately OUTSIDE
+                         #tts-children: that container gets .is-disabled →
+                         pointer-events:none when narration is switched off, and
+                         this speaker also carries the House Plays Along sound
+                         effects — burying it behind the narration switch would
+                         make it unreachable for a host who wants effects but no
+                         quizmaster voice. Stored as quizify_tts.media_player,
+                         which stays the single source of truth; the house panel
+                         only holds an optional override. -->
+                    <label class="setup-audio-select" for="game-speaker-select">
+                        <span class="setup-audio-select-label" data-i18n="setup.audio.speaker">Speaker</span>
+                        <select id="game-speaker-select" class="setup-select">
+                            <option value="" data-i18n="setup.tts.usedefault">Use default</option>
+                        </select>
+                    </label>
+                    <div class="setup-audio-hint" data-i18n="setup.audio.speakerHint">Used for the narration and the sound effects.</div>
 
                     <!-- House Plays Along (#494), Variant D "Presets". Master
                          switch (default OFF — silent until enabled), then a
@@ -487,6 +497,20 @@
                                     <span class="toggle-switch-compact" aria-hidden="true"></span>
                                     <span class="toggle-label" data-i18n="setup.house.sfxWinner">Fanfare for the winner</span>
                                 </label>
+                                <!-- Optional split (#525): the game asks for ONE
+                                     speaker in step 7. A host who wants the
+                                     effects somewhere else sets it here — empty
+                                     means "follow the game speaker". admin.js
+                                     opens this disclosure automatically when a
+                                     stored setup already had two different
+                                     speakers, so the split is never carried
+                                     forward invisibly. -->
+                                <label class="setup-house-select" for="house-speaker-select">
+                                    <span class="setup-house-select-label" data-i18n="setup.house.speakerOverride">Different speaker for the effects</span>
+                                    <select id="house-speaker-select" class="setup-select">
+                                        <option value="" data-i18n="setup.house.speakerFollow">Same as the game speaker</option>
+                                    </select>
+                                </label>
                             </div>
 
                             <!-- Entity pickers. The light picker is a multi-choice,
@@ -498,12 +522,6 @@
                                 <legend class="setup-house-select-label" data-i18n="setup.house.lightsPicker">Party lights</legend>
                                 <div class="setup-house-lightlist" id="house-light-list"></div>
                             </fieldset>
-                            <label class="setup-house-select" for="house-speaker-select">
-                                <span class="setup-house-select-label" data-i18n="setup.house.speaker">Speaker</span>
-                                <select id="house-speaker-select" class="setup-select">
-                                    <option value="" data-i18n="setup.house.usedefault">Use default</option>
-                                </select>
-                            </label>
                             <label class="setup-house-select" for="house-scene-select">
                                 <span class="setup-house-select-label" data-i18n="setup.house.scene">Winner scene</span>
                                 <select id="house-scene-select" class="setup-select">

--- a/custom_components/quizify/www/css/src/07-player.css
+++ b/custom_components/quizify/www/css/src/07-player.css
@@ -1585,6 +1585,28 @@
     font-size: 0.82rem;
     color: var(--color-text-muted);
 }
+
+/* Game-wide speaker (#525) — same visual language as the narration dropdowns
+   above it, but a sibling of #tts-children rather than a child, so it keeps
+   full opacity and stays clickable when the narration switch is off. It also
+   drives the House sound effects, hence the hint line underneath. */
+.setup-audio-select {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding-left: 30px;
+    margin-top: 10px;
+}
+.setup-audio-select-label {
+    font-size: 0.82rem;
+    color: var(--color-text-muted);
+}
+.setup-audio-hint {
+    padding-left: 30px;
+    margin-top: 4px;
+    font-size: 0.78rem;
+    color: var(--color-text-muted);
+}
 .setup-select {
     width: 100%;
     padding: 8px 10px;

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -4685,6 +4685,28 @@ footer {
     font-size: 0.82rem;
     color: var(--color-text-muted);
 }
+
+/* Game-wide speaker (#525) — same visual language as the narration dropdowns
+   above it, but a sibling of #tts-children rather than a child, so it keeps
+   full opacity and stays clickable when the narration switch is off. It also
+   drives the House sound effects, hence the hint line underneath. */
+.setup-audio-select {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding-left: 30px;
+    margin-top: 10px;
+}
+.setup-audio-select-label {
+    font-size: 0.82rem;
+    color: var(--color-text-muted);
+}
+.setup-audio-hint {
+    padding-left: 30px;
+    margin-top: 4px;
+    font-size: 0.78rem;
+    color: var(--color-text-muted);
+}
 .setup-select {
     width: 100%;
     padding: 8px 10px;

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -391,7 +391,6 @@
       "join": "Neue Spieler begrüßen",
       "countdown": "Countdown ansagen",
       "engine": "TTS-Stimme",
-      "speaker": "Lautsprecher",
       "usedefault": "Standard verwenden",
       "noentities": "Keine gefunden – in HA einrichten"
     },
@@ -425,7 +424,13 @@
       "scene": "Sieger-Szene",
       "usedefault": "Standard verwenden",
       "noentities": "Keine gefunden – in HA einrichten",
-      "nolights": "Keine Lampen gefunden – in HA einrichten"
+      "nolights": "Keine Lampen gefunden – in HA einrichten",
+      "speakerOverride": "Anderer Lautsprecher für die Effekte",
+      "speakerFollow": "Wie der Spiel-Lautsprecher"
+    },
+    "audio": {
+      "speaker": "Lautsprecher",
+      "speakerHint": "Gilt für die Ansagen und die Soundeffekte."
     }
   },
   "featured": {

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -391,7 +391,6 @@
       "join": "Welcome players as they join",
       "countdown": "Call out the final countdown",
       "engine": "TTS engine",
-      "speaker": "Speaker",
       "usedefault": "Use default",
       "noentities": "None found — configure in HA"
     },
@@ -425,7 +424,13 @@
       "scene": "Winner scene",
       "usedefault": "Use default",
       "noentities": "None found — configure in HA",
-      "nolights": "No lights found — configure in HA"
+      "nolights": "No lights found — configure in HA",
+      "speakerOverride": "Different speaker for the effects",
+      "speakerFollow": "Same as the game speaker"
+    },
+    "audio": {
+      "speaker": "Speaker",
+      "speakerHint": "Used for the narration and the sound effects."
     }
   },
   "featured": {

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -391,7 +391,6 @@
       "join": "Dar la bienvenida a los jugadores",
       "countdown": "Anunciar la cuenta atrás final",
       "engine": "Motor de TTS",
-      "speaker": "Altavoz",
       "usedefault": "Usar predeterminado",
       "noentities": "Ninguno encontrado: configúralo en HA"
     },
@@ -425,7 +424,13 @@
       "scene": "Escena del ganador",
       "usedefault": "Usar predeterminado",
       "noentities": "Ninguno encontrado: configúralo en HA",
-      "nolights": "No se han encontrado luces: configúralas en HA"
+      "nolights": "No se han encontrado luces: configúralas en HA",
+      "speakerOverride": "Otro altavoz para los efectos",
+      "speakerFollow": "El mismo del juego"
+    },
+    "audio": {
+      "speaker": "Altavoz",
+      "speakerHint": "Se usa para la narración y los efectos de sonido."
     }
   },
   "featured": {

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -1848,7 +1848,12 @@
             join: document.getElementById('tts-announce-join'),
             countdown: document.getElementById('tts-announce-countdown'),
             engine: document.getElementById('tts-engine-select'),
-            speaker: document.getElementById('tts-speaker-select'),
+            // #525: one speaker for the whole game. The control moved out of
+            // #tts-children (that container goes pointer-events:none when
+            // narration is off, and this speaker also carries the House sound
+            // effects), but it is still stored as quizify_tts.media_player —
+            // the single source of truth both panels resolve against.
+            speaker: document.getElementById('game-speaker-select'),
         };
         var cfg = _loadTtsConfig();
         if (_ttsEls.enable) _ttsEls.enable.checked = cfg.enabled;
@@ -1901,7 +1906,16 @@
                             return typeof e === 'string' && e;
                         });
                     }
-                    if (typeof saved.media_player === 'string') cfg.media_player = saved.media_player;
+                    // #525: `media_player_override` is authoritative once it
+                    // exists. A setup written before this change only has the
+                    // legacy `media_player`, which held a resolved speaker —
+                    // read it as the candidate override and let
+                    // _migrateSpeakerSplit decide whether it means anything.
+                    if (typeof saved.media_player_override === 'string') {
+                        cfg.media_player = saved.media_player_override;
+                    } else if (typeof saved.media_player === 'string') {
+                        cfg.media_player = saved.media_player;
+                    }
                     if (typeof saved.winner_scene_entity === 'string') {
                         cfg.winner_scene_entity = saved.winner_scene_entity;
                     }
@@ -1918,7 +1932,16 @@
         var cfg = _readHouseConfig();
         _houseSaved = cfg;
         try {
-            localStorage.setItem(HOUSE_STORAGE_KEY, JSON.stringify(cfg));
+            // #525: persist the OVERRIDE, not the resolved speaker. Storing the
+            // resolved value would look like a deliberate second speaker on the
+            // next page load: change the game speaker afterwards and the two
+            // stored values diverge, so the migration would resurrect a split
+            // the host never asked for. `media_player` stays in the object for
+            // the server payload; `media_player_override` is what survives.
+            var stored = {};
+            Object.keys(cfg).forEach(function (k) { stored[k] = cfg[k]; });
+            stored.media_player_override = _rawHouseSpeakerOverride();
+            localStorage.setItem(HOUSE_STORAGE_KEY, JSON.stringify(stored));
         } catch (e) { /* storage unavailable — preference is session-only */ }
         // Push to the server too, so the effects are configured during the
         // pre-game lobby (before start_game) (#494).
@@ -2003,6 +2026,45 @@
         _saveHouseConfig();
     }
 
+    // #525: resolve the House speaker. An empty override follows the game-wide
+    // speaker (step 7); a non-empty one wins. Kept as a function rather than an
+    // inline `||` because both _readHouseConfig and the migration need the same
+    // rule, and getting the two out of step is precisely the class of bug this
+    // issue was about.
+    function _resolveHouseSpeaker(override) {
+        if (override) return override;
+        return _ttsEls && _ttsEls.speaker
+            ? _ttsEls.speaker.value
+            : (_loadTtsConfig().media_player || '');
+    }
+
+    // The RAW override, before _resolveHouseSpeaker folds in the game speaker.
+    // Restoring the picker must use this: feeding it the resolved value would
+    // pre-select the game speaker as an explicit override and turn "follow"
+    // into a split on the next save — the very divergence this issue removed.
+    function _rawHouseSpeakerOverride() {
+        if (_houseEntitiesLoaded && _houseEls.speaker) return _houseEls.speaker.value;
+        return (_houseSaved && _houseSaved.media_player) || '';
+    }
+
+    // #525 migration. Before this change the host answered the speaker question
+    // twice, so a stored setup can legitimately hold two different values.
+    // Folding the question into one control must not silently reassign one of
+    // them: an existing divergence is kept as the override AND the disclosure
+    // holding it is opened, so the split is visible rather than inherited in
+    // the dark. A stored value that merely repeats the game speaker carries no
+    // intent and is normalised to "follow".
+    function _migrateSpeakerSplit() {
+        if (!_houseEls.speaker) return;
+        var ttsSpeaker = _loadTtsConfig().media_player || '';
+        var houseSpeaker = (_houseSaved && _houseSaved.media_player) || '';
+        if (!houseSpeaker || houseSpeaker === ttsSpeaker) {
+            if (_houseSaved) _houseSaved.media_player = '';
+            return;
+        }
+        _toggleHouseAdvanced(true);
+    }
+
     function _toggleHouseAdvanced(force) {
         var btn = _houseEls.advBtn;
         var panel = _houseEls.advanced;
@@ -2027,9 +2089,15 @@
             light_entities: _houseLightsRendered
                 ? _readHouseLightEntities()
                 : (saved.light_entities || []).slice(),
-            media_player: _houseEntitiesLoaded && _houseEls.speaker
-                ? _houseEls.speaker.value
-                : saved.media_player,
+            // #525: quizify_house.media_player is now an *override*, not a
+            // second speaker question — empty means "follow the game speaker
+            // from step 7". The server keeps receiving one resolved entity id,
+            // so the wire format is unchanged; only the UI collapsed.
+            media_player: _resolveHouseSpeaker(
+                _houseEntitiesLoaded && _houseEls.speaker
+                    ? _houseEls.speaker.value
+                    : saved.media_player
+            ),
             winner_scene_entity: _houseEntitiesLoaded && _houseEls.scene
                 ? _houseEls.scene.value
                 : saved.winner_scene_entity,
@@ -2106,7 +2174,8 @@
         var data = payload || {};
         _renderHouseLightList(data.lights || [], cfg.light_entities);
         _houseEntitiesLoaded = true;
-        _populateEntitySelect(_houseEls.speaker, data.media_players || [], cfg.media_player, 'setup.house.noentities');
+        // #525: restore the raw override, never the resolved value.
+        _populateEntitySelect(_houseEls.speaker, data.media_players || [], _rawHouseSpeakerOverride(), 'setup.house.noentities');
         _populateEntitySelect(_houseEls.scene, data.scenes || [], cfg.winner_scene_entity, 'setup.house.noentities');
         _syncHouseChildState();
     }
@@ -2130,7 +2199,7 @@
                     // lights.
                     if (_houseEntitiesLoaded) return;
                     _renderHouseLightList(null, cfg.light_entities);
-                    _populateEntitySelect(_houseEls.speaker, null, cfg.media_player, 'setup.house.noentities');
+                    _populateEntitySelect(_houseEls.speaker, null, _rawHouseSpeakerOverride(), 'setup.house.noentities');
                     _populateEntitySelect(_houseEls.scene, null, cfg.winner_scene_entity, 'setup.house.noentities');
                     return;
                 }
@@ -2140,7 +2209,7 @@
                 console.warn('[quizify] house-entities fetch failed:', e);
                 if (_houseEntitiesLoaded) return;   // #524/#527, see above
                 _renderHouseLightList(null, cfg.light_entities);
-                _populateEntitySelect(_houseEls.speaker, null, cfg.media_player, 'setup.house.noentities');
+                _populateEntitySelect(_houseEls.speaker, null, _rawHouseSpeakerOverride(), 'setup.house.noentities');
                 _populateEntitySelect(_houseEls.scene, null, cfg.winner_scene_entity, 'setup.house.noentities');
             });
     }
@@ -2193,6 +2262,9 @@
         [_houseEls.speaker, _houseEls.scene].forEach(function (sel) {
             if (sel) on(sel, 'change', _saveHouseConfig);
         });
+        // #525: decide what a stored two-speaker setup means BEFORE the state
+        // sync, and open the disclosure if it holds a real divergence.
+        _migrateSpeakerSplit();
         // Reflect the master→children enabled/dimmed state.
         _syncHouseChildState();
         // NO entity fetch here — same reasoning as the TTS panel (#524/#527):

--- a/tests/test_one_speaker_525.py
+++ b/tests/test_one_speaker_525.py
@@ -1,0 +1,247 @@
+"""Guard the single game-wide speaker and its migration (#525).
+
+The setup screen used to ask for a speaker twice: once in step 7 ("Quizmaster
+voice?") for the narration and again in step 8 ("Does the house play along?")
+for the sound effects. Both were labelled "Speaker", both were fed from the same
+media_player list, and nothing said they were related.
+
+Decision: **one** speaker for the whole game, with the narration/effects split
+demoted into step 8's "Customise single effects" disclosure.
+
+Three things have to hold, and each of them is a way the change could go wrong:
+
+1. The shared control must sit **outside** ``#tts-children``. That container
+   gets ``.is-disabled`` → ``pointer-events: none`` when narration is switched
+   off, so a speaker parked inside it would be unreachable for a host who wants
+   house effects but no quizmaster voice.
+2. The house picker must sit **inside** ``#house-advanced`` — that is what
+   "behind the disclosure" means.
+3. A stored setup holding two *different* speakers must be carried forward with
+   the disclosure opened, never silently collapsed onto one value. And the
+   picker must be restored from the raw override, because restoring it from the
+   resolved value would pre-select the game speaker as an explicit override and
+   re-create the split on the next save.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+WWW = REPO / "custom_components" / "quizify" / "www"
+ADMIN_HTML = WWW / "admin.html"
+ADMIN_JS = WWW / "js" / "admin.js"
+I18N = WWW / "i18n"
+
+
+def _element_span(html: str, element_id: str) -> tuple[int, int]:
+    """Return (start, end) offsets of the <div> carrying ``element_id``."""
+    marker = f'id="{element_id}"'
+    at = html.index(marker)
+    start = html.rindex("<div", 0, at)
+    depth = 0
+    i = start
+    while i < len(html):
+        nxt_open = html.find("<div", i)
+        nxt_close = html.find("</div>", i)
+        if nxt_close == -1:
+            break
+        if nxt_open != -1 and nxt_open < nxt_close:
+            depth += 1
+            i = nxt_open + 4
+            continue
+        depth -= 1
+        i = nxt_close + 6
+        if depth == 0:
+            return start, i
+    raise AssertionError(f"unbalanced <div> while scanning #{element_id}")
+
+
+def _function_body(js: str, name: str) -> str:
+    m = re.search(r"function\s+" + re.escape(name) + r"\s*\([^)]*\)\s*\{", js)
+    assert m, f"{name}() not found in admin.js"
+    depth = 0
+    start = m.end() - 1
+    for i in range(start, len(js)):
+        if js[i] == "{":
+            depth += 1
+        elif js[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return js[start : i + 1]
+    raise AssertionError(f"unbalanced braces while scanning {name}()")
+
+
+# --------------------------------------------------------------------------
+# Placement
+# --------------------------------------------------------------------------
+
+
+def test_only_one_speaker_control_outside_the_disclosure() -> None:
+    """Exactly one speaker picker may be visible on the default path."""
+    html = ADMIN_HTML.read_text("utf-8")
+    _, adv_end = _element_span(html, "house-advanced")
+    adv_start, _ = _element_span(html, "house-advanced")
+    outside = html[:adv_start] + html[adv_end:]
+    selects = re.findall(r'<select id="([a-z-]*speaker[a-z-]*)"', outside)
+    assert selects == ["game-speaker-select"], (
+        "step 7 and step 8 must not both ask for a speaker outside the "
+        f"disclosure (#525); found {selects}"
+    )
+
+
+def test_game_speaker_is_not_inside_the_narration_children() -> None:
+    """It must survive the narration master switch being off (#525).
+
+    ``.setup-tts-children.is-disabled`` sets ``pointer-events: none``, so a
+    control parked in there cannot be operated — and this one also drives the
+    house sound effects.
+    """
+    html = ADMIN_HTML.read_text("utf-8")
+    start, end = _element_span(html, "tts-children")
+    assert 'id="game-speaker-select"' not in html[start:end], (
+        "the game-wide speaker must live outside #tts-children, otherwise it "
+        "goes pointer-events:none when narration is switched off (#525)"
+    )
+    assert 'id="game-speaker-select"' in html, "the shared picker must exist"
+
+
+def test_house_speaker_moved_into_the_disclosure() -> None:
+    """The split is available, but off the default path (#525)."""
+    html = ADMIN_HTML.read_text("utf-8")
+    start, end = _element_span(html, "house-advanced")
+    assert 'id="house-speaker-select"' in html[start:end], (
+        "the effects-speaker override belongs inside #house-advanced (#525)"
+    )
+
+
+def test_pointer_events_none_still_applies_to_the_narration_children() -> None:
+    """Pins the property the placement rule depends on."""
+    css = (WWW / "css" / "styles.css").read_text("utf-8")
+    block = css[css.index(".setup-tts-children.is-disabled") :]
+    block = block[block.index("{") + 1 : block.index("}")]
+    assert "pointer-events: none" in block, (
+        "if this ever stops being true, revisit test_game_speaker_is_not_"
+        "inside_the_narration_children — the placement rule exists because of it"
+    )
+
+
+# --------------------------------------------------------------------------
+# Resolution + migration
+# --------------------------------------------------------------------------
+
+
+def test_empty_override_follows_the_game_speaker() -> None:
+    body = _function_body(ADMIN_JS.read_text("utf-8"), "_resolveHouseSpeaker")
+    assert "if (override) return override" in body, (
+        "a set override must win over the game speaker"
+    )
+    assert "_ttsEls.speaker" in body and "_loadTtsConfig()" in body, (
+        "an empty override must fall through to the game-wide speaker (#525)"
+    )
+
+
+def test_migration_opens_the_disclosure_on_a_real_divergence() -> None:
+    body = _function_body(ADMIN_JS.read_text("utf-8"), "_migrateSpeakerSplit")
+    # equal or empty → normalised to "follow", and NOT opened
+    assert "houseSpeaker === ttsSpeaker" in body, (
+        "a stored value that merely repeats the game speaker carries no intent "
+        "and must be normalised to 'follow' (#525)"
+    )
+    assert "_toggleHouseAdvanced(true)" in body, (
+        "a genuine two-speaker setup must open the disclosure so the host sees "
+        "the split instead of inheriting it invisibly (#525)"
+    )
+    # the normalise branch must return before reaching the open call
+    norm = body.index("houseSpeaker === ttsSpeaker")
+    opened = body.index("_toggleHouseAdvanced(true)")
+    assert "return" in body[norm:opened], (
+        "the normalise branch must not fall through into opening the disclosure"
+    )
+
+
+def test_migration_runs_at_init() -> None:
+    body = _function_body(ADMIN_JS.read_text("utf-8"), "_initHouseToggles")
+    assert "_migrateSpeakerSplit()" in body, (
+        "the migration has to run when the panel initialises (#525)"
+    )
+
+
+def test_override_picker_is_restored_from_the_raw_value() -> None:
+    """Restoring from the resolved value would re-create the split (#525)."""
+    js = ADMIN_JS.read_text("utf-8")
+    for line in js.splitlines():
+        if "_populateEntitySelect(_houseEls.speaker" in line:
+            assert "_rawHouseSpeakerOverride()" in line, (
+                "the override picker must be restored from the raw override, "
+                f"not the resolved speaker (#525): {line.strip()}"
+            )
+    assert "_rawHouseSpeakerOverride" in js
+
+
+def test_storage_keeps_the_override_not_the_resolved_speaker() -> None:
+    """Persisting the resolved value would resurrect the split (#525).
+
+    Failure mode this pins: host follows the game speaker (override empty), a
+    save writes the *resolved* id into storage, the host later changes the game
+    speaker — now the two stored values differ, and on the next load the
+    migration reads that as a deliberate two-speaker setup and re-opens the
+    split the host never asked for.
+    """
+    body = _function_body(ADMIN_JS.read_text("utf-8"), "_saveHouseConfig")
+    assert "media_player_override" in body, (
+        "the stored object must carry the raw override (#525)"
+    )
+    assert "_rawHouseSpeakerOverride()" in body
+
+
+def test_legacy_storage_without_the_override_key_still_loads() -> None:
+    """Setups written before this change only have the legacy key (#525)."""
+    body = _function_body(ADMIN_JS.read_text("utf-8"), "_loadHouseConfig")
+    assert "saved.media_player_override" in body, (
+        "the new key must be preferred when present"
+    )
+    assert "saved.media_player" in body, (
+        "a pre-#525 setup only has the legacy key and must still be read"
+    )
+    new_at = body.index("saved.media_player_override")
+    legacy_at = body.index("else if (typeof saved.media_player === 'string')")
+    assert new_at < legacy_at, "the override key must take precedence"
+
+
+def test_house_config_sends_a_resolved_entity_id() -> None:
+    """The wire format is unchanged — the server still gets one entity id."""
+    body = _function_body(ADMIN_JS.read_text("utf-8"), "_readHouseConfig")
+    assert "_resolveHouseSpeaker(" in body, (
+        "configure_house must carry the resolved speaker, so collapsing the UI "
+        "does not change what the backend receives (#525)"
+    )
+
+
+# --------------------------------------------------------------------------
+# i18n
+# --------------------------------------------------------------------------
+
+
+def test_new_labels_exist_in_every_language() -> None:
+    for lang in ("en", "de", "es"):
+        data = json.loads((I18N / f"{lang}.json").read_text("utf-8"))
+        setup = data["setup"]
+        assert setup["audio"]["speaker"], f"{lang}: setup.audio.speaker missing"
+        assert setup["audio"]["speakerHint"], f"{lang}: setup.audio.speakerHint missing"
+        house = setup["house"]
+        assert house["speakerOverride"], f"{lang}: house.speakerOverride missing"
+        assert house["speakerFollow"], f"{lang}: house.speakerFollow missing"
+
+
+def test_retired_label_is_gone_everywhere() -> None:
+    """The old step-7 'Speaker' key must not linger unused."""
+    html = ADMIN_HTML.read_text("utf-8")
+    assert "setup.tts.speaker" not in html
+    for lang in ("en", "de", "es"):
+        data = json.loads((I18N / f"{lang}.json").read_text("utf-8"))
+        assert "speaker" not in data["setup"]["tts"], (
+            f"{lang}: setup.tts.speaker is no longer referenced by the markup"
+        )


### PR DESCRIPTION
Closes #525.

The setup screen asked the same question twice — step 7 for the narration speaker, step 8 for the effects speaker. Both labelled "Speaker", both fed from the same list, nothing saying they were related. Now there is **one** speaker for the whole game, and the split lives behind step 8's existing "Customise single effects" disclosure, per the decision on the issue.

## Placement is load-bearing

The shared control sits **outside** `#tts-children`. That container goes `.is-disabled` → `pointer-events: none` when narration is switched off — so a speaker parked inside it would be unreachable for a host who wants house effects but no quizmaster voice. A test pins the placement *and* the CSS property the rule depends on, so the two can't drift apart silently.

## The wire format did not change

`quizify_house.media_player` became an override where empty means "follow the game speaker"; `_readHouseConfig` resolves it before sending. `configure_house` still carries one concrete entity id and the backend sees nothing new. Collapsing the UI did not require collapsing the protocol.

## Migration

An existing divergence is carried forward, not collapsed: if a stored setup holds two different speakers, the second is kept as the override **and** the disclosure is opened, so the host sees the split rather than inheriting it in the dark. A stored value that merely repeats the game speaker carries no intent and is normalised to "follow".

## Two traps found while building

Both would have re-created the very split this issue removes, and both are now pinned by tests:

1. **Restoring the picker from the resolved value.** That pre-selects the game speaker as an explicit override, so the next save writes a split nobody asked for. It is restored from the raw override instead.
2. **Persisting the resolved value.** Same outcome, one reload later: follow the game speaker → save → change the game speaker → the two stored values now differ, and the migration reads that as a deliberate two-speaker setup. A new `media_player_override` key is what survives; the legacy key is still read for setups written before this change.

## Verification

- 13 new assertions in `tests/test_one_speaker_525.py`. **Verified meaningful** — 10 of 13 fail against the pre-change tree; the 3 that pass either way assert invariants the change must not break.
- Full suite: **1227 passed / 9 skipped**
- `ruff check custom_components/`: clean
- `styles.css` rebuilt from `css/src/`; `player.bundle.js` byte-identical
- `node --check` on `admin.js`: clean; all three i18n files parse
- mypy unaffected — no Python changed under its `files=` scope

## Not verified on hardware

UI change, no 390×844 mobile pass on a live HA. Two things are worth a look when it is deployed: that the new speaker row reads as belonging to the game rather than to step 7's narration block, and that the disclosure genuinely opens for a setup that already had two different speakers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
