### PR TITLE
fix(admin): keep the admin session token past the tab that earned it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to Quizify are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **The host could be locked out of their own admin page, permanently.** The
+  admin session token is a lasting credential — the server writes it to disk
+  and only ever issues a new one when no token exists at all. The browser,
+  though, kept its copy in `sessionStorage`, which is discarded the moment the
+  tab closes. So once a host closed the admin tab (or restarted Home Assistant
+  while it was closed), the credential was orphaned: no browser could present
+  it, and no browser could earn a replacement. Every admin tab opened after
+  that was refused, silently and for good.
+
+  What that looked like in practice was not an error message but an empty
+  setup screen: the rejected connection is the one that carries the lists of
+  TTS engines, speakers, lights and scenes, so the dropdowns in steps 7 and 8
+  stayed empty and offered nothing to choose. A host with 72 lights saw none
+  of them.
+
+  The token now lives in `localStorage`, which is the lifetime the server
+  already assumed it had. An admin tab that is still open keeps working —
+  its old per-tab token is carried over on first read, not discarded.
+
+  If you are locked out right now, the `quizify.reset_admin_session` service
+  clears the stranded token and the next admin page you open claims a fresh
+  one.
+
 ## [1.6.1-RC4] — 2026-07-30
 
 Fourth release candidate for 1.6.1. One change: the setup screen stops asking

--- a/custom_components/quizify/www/analytics.html
+++ b/custom_components/quizify/www/analytics.html
@@ -317,6 +317,9 @@
     </div>
 
     <script src="/quizify/static/js/i18n.js?v={{ASSET_VER}}"></script>
+    <!-- utils.js is loaded for QuizifyUtils.readAdminToken() — the single
+         source of truth for where the admin session token is stored. -->
+    <script src="/quizify/static/js/utils.js?v={{ASSET_VER}}"></script>
     <script>
     (function() {
         'use strict';
@@ -342,14 +345,15 @@
         });
 
         // #356: the analytics/flags endpoints are admin-token gated. The token
-        // is the admin session token the host holds; read it from this tab's
-        // sessionStorage (set by the admin page) or from a ?token= URL param so
-        // the dashboard keeps working when opened straight from the admin panel.
+        // is the admin session token the host holds; read it through
+        // QuizifyUtils (durable localStorage, with the legacy per-tab value as
+        // a migration fallback) or from a ?token= URL param so the dashboard
+        // keeps working when opened straight from the admin panel.
         function adminToken() {
             try {
                 var fromUrl = new URLSearchParams(window.location.search).get('token');
                 return fromUrl
-                    || sessionStorage.getItem('quizify_admin_session_token')
+                    || (window.QuizifyUtils && QuizifyUtils.readAdminToken())
                     || '';
             } catch (e) { return ''; }
         }

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -1044,7 +1044,7 @@
     // ---- WebSocket ----
     function connect() {
         var proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
-        var savedToken = sessionStorage.getItem('quizify_admin_session_token');
+        var savedToken = QuizifyUtils.readAdminToken();
         // #359: the admin session token used to be appended to the WS URL as
         // ?token=..., where it leaked into aiohttp / reverse-proxy access logs
         // and browser history. It is now sent as the FIRST WebSocket frame
@@ -1199,7 +1199,7 @@
     function handleGameState(msg) {
         currentPhase = msg.phase;
         if (msg.admin_session_token) {
-            sessionStorage.setItem('quizify_admin_session_token', msg.admin_session_token);
+            QuizifyUtils.writeAdminToken(msg.admin_session_token);
         }
         // The admin-connect frame now carries the TTS-engine + media-player
         // lists directly (server-side, over this already-authenticated socket),
@@ -1808,7 +1808,7 @@
     function _loadTtsEntities(cfg) {
         // #356: the tts-entities endpoint is admin-token gated. Send the
         // session token the admin page already holds.
-        var _tok = sessionStorage.getItem('quizify_admin_session_token');
+        var _tok = QuizifyUtils.readAdminToken();
         var _url = '/api/quizify/tts-entities'
             + (_tok ? '?token=' + encodeURIComponent(_tok) : '');
         fetch(_url)
@@ -2183,7 +2183,7 @@
     // HTTP fallback for an older server that doesn't put house_entities on the
     // admin frame. Admin-token gated like /api/quizify/tts-entities (#356).
     function _loadHouseEntities(cfg) {
-        var _tok = sessionStorage.getItem('quizify_admin_session_token');
+        var _tok = QuizifyUtils.readAdminToken();
         var _url = '/api/quizify/house-entities'
             + (_tok ? '?token=' + encodeURIComponent(_tok) : '');
         fetch(_url)
@@ -2358,7 +2358,7 @@
         // crown transfer from a stale (disconnected) admin slot — without it a
         // LAN client could seize the crown during a host reload.
         var _joinMsg = { name: name, is_admin: true };
-        var _adminTok = sessionStorage.getItem('quizify_admin_session_token');
+        var _adminTok = QuizifyUtils.readAdminToken();
         if (_adminTok) _joinMsg.admin_token = _adminTok;
         send('join', _joinMsg);
         closeAdminJoinModal();

--- a/custom_components/quizify/www/js/pack-submit.js
+++ b/custom_components/quizify/www/js/pack-submit.js
@@ -311,7 +311,7 @@ window.QuizifyPackSubmit = (function () {
         try {
             // #356: submissions list is admin-token gated; forward the token
             // the admin page holds.
-            var _tok = sessionStorage.getItem('quizify_admin_session_token');
+            var _tok = QuizifyUtils.readAdminToken();
             var _url = SUBMISSIONS_URL
                 + (_tok ? '?token=' + encodeURIComponent(_tok) : '');
             var resp = await fetch(_url);

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -105,7 +105,7 @@
                         // transfer from a stale admin slot. Optional + fail-soft
                         // — a missing token just means no auto-crown, never a
                         // rejected join, so the DESIGN.md trust model stands.
-                        var _at = sessionStorage.getItem('quizify_admin_session_token');
+                        var _at = QuizifyUtils.readAdminToken();
                         if (_at) joinMsg.admin_token = _at;
                     }
                     send('join', joinMsg);
@@ -1040,7 +1040,7 @@
                 joinMsg.is_admin = true;
                 // #358: attach the admin session token (fail-soft) so a crown
                 // transfer from a stale admin slot can be authorised.
-                var _at = sessionStorage.getItem('quizify_admin_session_token');
+                var _at = QuizifyUtils.readAdminToken();
                 if (_at) joinMsg.admin_token = _at;
             }
             send('join', joinMsg);

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -4504,7 +4504,7 @@
                         // transfer from a stale admin slot. Optional + fail-soft
                         // — a missing token just means no auto-crown, never a
                         // rejected join, so the DESIGN.md trust model stands.
-                        var _at = sessionStorage.getItem('quizify_admin_session_token');
+                        var _at = QuizifyUtils.readAdminToken();
                         if (_at) joinMsg.admin_token = _at;
                     }
                     send('join', joinMsg);
@@ -5439,7 +5439,7 @@
                 joinMsg.is_admin = true;
                 // #358: attach the admin session token (fail-soft) so a crown
                 // transfer from a stale admin slot can be authorised.
-                var _at = sessionStorage.getItem('quizify_admin_session_token');
+                var _at = QuizifyUtils.readAdminToken();
                 if (_at) joinMsg.admin_token = _at;
             }
             send('join', joinMsg);

--- a/custom_components/quizify/www/js/utils.js
+++ b/custom_components/quizify/www/js/utils.js
@@ -46,9 +46,53 @@
         return { valid: true, name: trimmed };
     }
 
+    // ---- Admin session token -------------------------------------------
+    //
+    // The admin session token is a PERSISTENT credential, and every reader
+    // must go through the two helpers below so the storage choice lives in
+    // exactly one place.
+    //
+    // It used to be kept in sessionStorage, which dies with the tab. The
+    // server, meanwhile, persists its copy to disk and only ever bootstraps
+    // a NEW token when no token exists at all (connection.py
+    // try_bootstrap_admin). Closing the tab — or restarting HA — therefore
+    // orphaned the credential: no client could present it, and no client
+    // could earn a replacement. Every fresh admin tab was refused with
+    // "Admin only", so the admin-connect frame never arrived and the setup
+    // panel's TTS/light/media_player dropdowns stayed empty (the symptom
+    // that surfaced this, 2026-08-05). localStorage gives the token the
+    // same lifetime the server already assumes it has.
+    var ADMIN_TOKEN_KEY = 'quizify_admin_session_token';
+
+    function writeAdminToken(token) {
+        if (!token) return;
+        try {
+            localStorage.setItem(ADMIN_TOKEN_KEY, token);
+        } catch (e) { /* storage disabled/full — the socket still works */ }
+    }
+
+    function readAdminToken() {
+        try {
+            var tok = localStorage.getItem(ADMIN_TOKEN_KEY);
+            if (tok) return tok;
+            // Migration: a tab opened before this change still holds the
+            // old per-tab token. Promote it to the durable store on first
+            // read so that tab's session survives its own closing.
+            var legacy = sessionStorage.getItem(ADMIN_TOKEN_KEY);
+            if (legacy) {
+                writeAdminToken(legacy);
+                return legacy;
+            }
+        } catch (e) { /* storage disabled — fall through to null */ }
+        return null;
+    }
+
     window.QuizifyUtils = {
         escapeHtml: escapeHtml,
         validateName: validateName,
         MAX_NAME_LENGTH: MAX_NAME_LENGTH,
+        readAdminToken: readAdminToken,
+        writeAdminToken: writeAdminToken,
+        ADMIN_TOKEN_KEY: ADMIN_TOKEN_KEY,
     };
 })();

--- a/tests/test_admin_token_durable_storage.py
+++ b/tests/test_admin_token_durable_storage.py
@@ -1,0 +1,101 @@
+"""Guard the durable admin-token storage fix (admin lockout, 2026-08-05).
+
+The admin session token is a *persistent* credential: the server writes its
+copy to ``quizify/admin_token.json`` and — see
+``ConnectionManager.try_bootstrap_admin`` — only ever mints a NEW one when no
+token exists at all. The client kept its copy in ``sessionStorage``, which dies
+with the tab. Closing the admin tab (or restarting HA while it was closed)
+therefore orphaned the credential: no browser could present it, and no browser
+could earn a replacement, so every fresh admin tab was refused with
+"Admin only" — permanently, and silently.
+
+The visible symptom was the setup panel: ``admin_connect`` is what triggers the
+admin-connect frame, and that frame is what carries the TTS / media_player /
+light / scene lists (#502, #494). Rejected connect → no frame → the dropdowns
+never populate and show only their authored "Use default" option. Note they do
+not even show the "None found" fallback, which is how this was told apart from
+an empty-list-from-the-server bug.
+
+Asserted over the shipped JS text because the behaviour lives in the browser
+and there is no JS test runner in this repo (same approach as
+``test_entity_picker_race_524.py``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+WWW = REPO / "custom_components" / "quizify" / "www"
+UTILS_JS = WWW / "js" / "utils.js"
+
+TOKEN_KEY = "quizify_admin_session_token"
+
+# Every file that reads or writes the admin token. utils.js is excluded: it is
+# the one place allowed to name the storage backend.
+CONSUMERS = [
+    WWW / "js" / "admin.js",
+    WWW / "js" / "pack-submit.js",
+    WWW / "js" / "player-core.js",
+    WWW / "js" / "player.bundle.js",
+    WWW / "analytics.html",
+]
+
+
+def test_token_key_named_only_in_utils() -> None:
+    """No consumer may name the storage key — they go through the helpers.
+
+    This is the property that keeps the fix from rotting: a future call site
+    that reaches for ``sessionStorage`` directly re-creates the lockout for
+    that one page, and nothing else in the suite would notice.
+    """
+    offenders = [p.name for p in CONSUMERS if TOKEN_KEY in p.read_text(encoding="utf-8")]
+    assert not offenders, (
+        f"{offenders} name the admin-token storage key directly. Read and write "
+        "it through QuizifyUtils.readAdminToken()/writeAdminToken() so the "
+        "storage choice stays in one place (utils.js)."
+    )
+
+
+def test_consumers_use_the_helper() -> None:
+    """Each consumer actually calls the accessor (it didn't just drop the read)."""
+    for path in CONSUMERS:
+        text = path.read_text(encoding="utf-8")
+        assert "readAdminToken()" in text, f"{path.name} never reads the admin token"
+
+
+def test_utils_persists_to_local_storage() -> None:
+    """The token is written to localStorage — the store that outlives the tab."""
+    utils = UTILS_JS.read_text(encoding="utf-8")
+    assert "localStorage.setItem(ADMIN_TOKEN_KEY" in utils
+    assert "localStorage.getItem(ADMIN_TOKEN_KEY)" in utils
+
+
+def test_utils_migrates_the_legacy_per_tab_token() -> None:
+    """A tab still holding the old sessionStorage token keeps working.
+
+    Without this, upgrading mid-session would drop a live admin's credential
+    and hand the crown to whoever connected next.
+    """
+    utils = UTILS_JS.read_text(encoding="utf-8")
+    assert "sessionStorage.getItem(ADMIN_TOKEN_KEY)" in utils, (
+        "the legacy per-tab token must still be read once, so an already-open "
+        "admin tab survives the upgrade"
+    )
+    read_fn = utils.split("function readAdminToken()", 1)[1].split("\n    }", 1)[0]
+    assert "writeAdminToken(legacy)" in read_fn, (
+        "a legacy token must be promoted to the durable store on first read"
+    )
+
+
+def test_storage_access_is_guarded() -> None:
+    """Storage can throw (Safari private mode, disabled cookies).
+
+    The helpers must degrade to "no token" rather than take the admin page
+    down with them — a missing token only costs the bootstrap path, an
+    exception costs the whole panel.
+    """
+    utils = UTILS_JS.read_text(encoding="utf-8")
+    for fn in ("readAdminToken", "writeAdminToken"):
+        body = utils.split(f"function {fn}(", 1)[1].split("\n    }", 1)[0]
+        assert "try {" in body and "catch" in body, f"{fn} must guard storage access"


### PR DESCRIPTION
## The bug

The admin session token is a lasting credential: the server persists it to `quizify/admin_token.json`, and `try_bootstrap_admin()` only mints a new one when **no** token exists at all. The client kept its copy in `sessionStorage`, which the browser discards when the tab closes.

Closing the admin tab — or restarting Home Assistant while it was closed — therefore orphaned the credential. No browser could present it, and no browser could earn a replacement, so every later `admin_connect` was answered with `"Admin only"`. Permanently, and with nothing surfaced to the host.

## Why it looked like a dropdown bug

`admin_connect` is what triggers the admin-connect frame, and that frame is what carries the TTS / media_player / light / scene lists (#502, #494). Rejected connect → no frame → the setup screen's step 7 and 8 dropdowns stay empty. On a host with 72 lights, the picker offered none of them.

The diagnostic tell: the selects showed only their authored "Use default" option and **not** the "None found" fallback. That is what distinguishes this from the server returning empty lists — with empty lists, `_populateEntitySelect` runs and paints the fallback. Here it never ran at all.

Reproduced against a live install: the WS frames are `admin_connect` out, `{"type":"error","code":"INVALID_ACTION","message":"Admin only"}` back. Planting the persisted token into `sessionStorage` by hand filled every picker, which located the fault in authorization rather than in the entity snapshot or the frontend populate path.

## The fix

Move the token to `localStorage`, whose lifetime is the one the server already assumes it has.

- All read/write sites go through `QuizifyUtils.readAdminToken()` / `writeAdminToken()`, so the storage backend is named in exactly one place.
- A first read still picks up a legacy `sessionStorage` token and promotes it, so an admin tab open across the upgrade keeps its session instead of handing the crown to whoever connects next.
- `analytics.html` now loads `utils.js` (it previously read the key inline); `player.bundle.js` regenerated.

## Verification

Live against the deployed build, at the URL a host actually uses:

- Fresh tab → bootstrap → 2 TTS engines, 23 media players, 4 scenes, 72 lights; token in `localStorage`, `sessionStorage` empty.
- A **second** tab with `sessionStorage` wiped → authenticates from `localStorage` alone and fills every picker identically. This is exactly the case that previously got `"Admin only"`.

Full suite: 1232 passed, 9 skipped (the skips are the HA-harness tests, which need a local Home Assistant install).

New regression test `tests/test_admin_token_durable_storage.py` forbids any call site from naming the storage key itself — that is precisely how the lockout would come back for a single page without anything else noticing.

## Note for anyone locked out today

Deleting `admin_token.json` is **not** enough: the running integration keeps an in-memory copy. Call the `quizify.reset_admin_session` service instead, then open the admin page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)