### PR TITLE
docs: refresh README, release notes and requirements for 1.6.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@
 # ---- Dev / build frameworks ----
 .claude/
 docs/
+# docs/ holds local working material (design shotguns, scratch), but the
+# release notes are a published artefact: they are the prose behind each
+# GitHub release and the only place that history is readable in the repo.
+# Keeping them ignored is why the directory sat with a single stale file.
+!docs/release-notes/
 .playwright-mcp/
 
 # ---- Config & tooling ----

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ No apps to download. No accounts to create. Just scan a QR code and play.
 
 **Works on Any Screen** — Dashboard mode for the TV. Players use their phones. Admin runs the show. No extra hardware needed.
 
-**Ten Themes, Two Languages** — 2,893 questions across 20 themed packs (Geography, Pop Culture, Animals & Nature, Sport, Music, Science, History, Food & Drink, Technology, World Cup) in German and English. Mix them, filter them, swap mid-session.
+**Eleven Themes, Three Languages** — 3,823 questions across 28 themed packs (Geography, Pop Culture, Animals & Nature, Sport, Music, Science, History, Food & Drink, Technology, World Cup, Estimation) in German, English and Spanish. Mix them, filter them, swap mid-session.
 
 ---
 
@@ -318,20 +318,23 @@ Then **"Start New Game"** (same settings, same players) or **Reset Game** (fresh
 
 ## Question Packs
 
-Quizify ships with **2,893 questions across 20 themed packs in 10 themes**, in both German and English.
+Quizify ships with **3,823 questions across 28 themed packs in 11 themes**, in German, English and Spanish.
 
-| Theme | 🇩🇪 Deutsch | 🇬🇧 English |
-|-------|-------------|-------------|
-| 🌍 **Geographie / Geography** | 149 | 150 |
-| 🦋 **Tiere & Natur / Animals & Nature** | 149 | 150 |
-| 🎬 **Popkultur / Pop Culture** | 149 | 150 |
-| ⚽ **Sport** | 148 | 150 |
-| 🎵 **Musik / Music** | 150 | 150 |
-| 🔬 **Wissenschaft / Science** | 150 | 150 |
-| 📜 **Geschichte / History** | 149 | 150 |
-| 🍔 **Essen & Trinken / Food & Drink** | 150 | 150 |
-| 💡 **Technik / Technology** | 150 | 150 |
-| 🏆 **Weltmeisterschaft / World Cup** | 99 | 100 |
+| Theme | 🇩🇪 Deutsch | 🇬🇧 English | 🇪🇸 Español |
+|-------|-------------|-------------|-------------|
+| 🌍 **Geographie / Geography / Geografía** | 149 | 150 | 150 |
+| 🦋 **Tiere & Natur / Animals & Nature / Naturaleza** | 149 | 150 | 150 |
+| 🎬 **Popkultur / Pop Culture / Cultura Pop** | 149 | 150 | 150 |
+| ⚽ **Sport / Deportes** | 148 | 150 | 150 |
+| 🎵 **Musik / Music** | 150 | 150 | — |
+| 🔬 **Wissenschaft / Science / Ciencia** | 150 | 150 | 150 |
+| 📜 **Geschichte / History / Historia** | 149 | 150 | 150 |
+| 🍔 **Essen & Trinken / Food & Drink** | 150 | 150 | — |
+| 💡 **Technik / Technology** | 150 | 150 | — |
+| 🏆 **Weltmeisterschaft / World Cup** | 99 | 100 | — |
+| 🎯 **Schätzfragen / Estimation** | 15 | 15 | — |
+
+Spanish arrived in 1.3.0 and grew through 1.6.1; music, food and technology are the three themes it is still missing. The two Estimation packs hold slider questions rather than multiple choice — see [How to Play](#the-experience).
 
 Pack selection lives on the **first screen**: a featured pack card (e.g. World Cup) up top, with every other pack as a tappable chip right beneath it — tap to select or deselect, mix several, then hit **Start Game**. Game settings (difficulty, rounds, timer) stay one tap away under **Adjust settings**. **Mixed mode** drops you a random question from every selected pack, so you can stir Geography + Pop + Sport together for chaos mode.
 
@@ -368,7 +371,7 @@ Pack files live in `custom_components/quizify/questions/`. Drop a JSON file in t
 - Exactly **3 answers** per question
 - Exactly **1 correct** answer
 - Per-question fields the loader reads: `id` (required), `question` (required), `answers` (required), `difficulty` (default `medium`), `fun_fact` (optional), `category` (optional, falls back to pack name)
-- Pack-level fields: `name`, `language` (`de` / `en` — only those are wired into the language chip; other ISO codes load but won't be selectable from the UI), `theme` (one of `geography`, `nature`, `popculture`, `sport`, `music`, `science`, `history`, `food`, `tech`, `worldcup` — drives the theme-tab filter and pack-card icon), `version`
+- Pack-level fields: `name`, `language` (`de` / `en` / `es` — only those are wired into the language chip; other ISO codes load but won't be selectable from the UI), `theme` (one of `geography`, `nature`, `popculture`, `sport`, `music`, `science`, `history`, `food`, `tech`, `worldcup`, `trivia` — drives the theme-tab filter and pack-card icon), `version`
 - File goes in the `questions/` directory — picked up automatically on next game start
 
 ---
@@ -535,7 +538,7 @@ Yes — see <a href="#custom-question-packs">Custom Question Packs</a>. Drop a J
 <details>
 <summary><strong>What languages are supported?</strong></summary>
 <br>
-German (🇩🇪) and English (🇬🇧) — for both the UI and the question packs. The UI follows the game language: pick German and the entire admin + player + dashboard + analytics surface flips to German. v1.1.24 closed the last hardcoded-locale leaks.
+German (🇩🇪), English (🇬🇧) and Spanish (🇪🇸) — for both the UI and the question packs. The UI follows the game language: pick German and the entire admin + player + dashboard + analytics surface flips to German. v1.1.24 closed the last hardcoded-locale leaks; Spanish landed in v1.3.0 and reached 6 packs in v1.6.1. Spoken narration (v1.4.0) covers the same three languages.
 </details>
 
 <details>
@@ -555,6 +558,37 @@ Yes. The QR code uses whatever URL the admin's browser sees, so opening <code>/q
 <br>
 
 ## What's New
+
+Full prose notes for every release since 1.4.0 live in [`docs/release-notes/`](docs/release-notes/); the complete history is in [`CHANGELOG.md`](CHANGELOG.md).
+
+### v1.6.1 — The Room Stops Giving It Away 📺
+- **The TV stopped parking the correct answer on tile A.** The big screen drew its grid in question-file order while the phones used the round's shuffle — on 16 of the 26 shipped packs that meant tile A, every question, every game (#521). Scoring was never affected; it simply leaked to everyone watching.
+- **The setup screen, three times over** — entity pickers no longer come up empty over a remote connection (#524, #527), the admin token survives closing the tab so a host can't be locked out for good (#530), and setup asks for one speaker instead of two (#525)
+- **"With kids" no longer ambushes you** — the preset switches the auto Lightning Round off (#513)
+- **Shareable result cards** on the end screen — rank, packs, hit rate, points, one glyph per round (#369)
+- **Two new Spanish packs** — Deportes (#515) and Cultura Pop (#517), 150 questions each
+
+### v1.6.0 — The House Plays Along 🏠
+- **Whole-home game-show mode** — lights react to the game and room sound effects punctuate it, all off by default and only as far as you take it
+- **HA services for voice and automations**, a freshness engine that stops repeating the same questions, colour-independent reveal for accessibility, and per-player language
+
+### v1.5.0 — Now It's Fluent in Spanish, and a Whole Lot Sturdier 🇪🇸
+- **Four Spanish packs, 600 questions**, and a fully translated UI
+- A security and accessibility sweep across the host and player surfaces
+
+### v1.4.1 — Android Companion Launcher Fix 📱
+- "Open Quizify" works inside the Android Home Assistant Companion app, whose WebView silently swallowed the old `target="_blank"` link (#348)
+
+### v1.4.0 — The Host Finds Its Voice, and Close Enough Counts 🗣️
+- **Spoken narration** — a Home Assistant speaker reads the questions, names the options, announces the answer and welcomes players as they join (#281). Silent until you switch it on.
+- **Estimation questions** — a slider instead of four buttons, closest guess takes the points, and a number-line reveal showing everyone's guess (#275)
+
+### v1.3.0 — Lightning Strikes, and Now It Speaks Spanish ⚡
+- **Lightning Round** — a fast bonus mode nobody sees coming
+- **Spanish**, **picture questions**, **lobby music**, auto-difficulty, community pack submission, and a reworked finale
+
+### v1.2.7 — Concurrency + Security Hardening 🔒
+- Backend-only release: concurrency fixes (#167) and a security pass (#168), with 17 new tests
 
 ### v1.2.6 — World Cup Night 🏆
 - **Two new World Cup packs** (🇬🇧 World Cup · 🇩🇪 Weltmeisterschaft, ~200 questions) — surprising, weird-but-true facts about football's biggest stage, generated and reviewed for accuracy. The library is now ~2,890 questions across 20 packs.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -25,18 +25,24 @@ questions — with a focus on fun, surprising "useless knowledge" facts.
 6. After all rounds: podium reveal with winner animation
 
 ### Scoring
-- **Correct answer:** Base points (e.g. 1000)
-- **Speed bonus:** Additional points for faster answers (linear decay over time limit)
-- **Streak bonus:** Multiplier for consecutive correct answers
+
+Values below are the shipped ones — see `game/scoring.py`. The scale was reduced
+from the original 1000/500 to keep round scores readable on a TV across a room.
+
+- **Correct answer:** 10 base points (`BASE_POINTS`)
+- **Speed bonus:** up to 5 additional points for faster answers (`MAX_SPEED_BONUS`, linear decay over the time limit)
+- **Streak multiplier:** ×1.0 + 0.1 per consecutive correct answer, capped at 5 stacks (×1.5)
+- **Streak milestones:** one-off bonus at exactly 3 / 5 / 10 / 15 / 20 / 25 in a row (20 / 50 / 100 / 150 / 250 / 400 points)
 - **Difficulty multiplier:** Easy ×1, Medium ×1.5, Hard ×2
+- Formula: `(base + speed) × difficulty × streak`, plus any milestone bonus
 
 ### Timer
-- **Per difficulty:**
-  - Easy: 20 seconds
-  - Medium: 15 seconds
-  - Hard: 10 seconds
+- **One timer per game, not per difficulty.** The host picks it in setup:
+  Quick Round 20 s · Classic 30 s · Marathon 45 s · With kids 180 s, or any
+  custom value. Default is 30 s (`DEFAULT_ROUND_DURATION`).
 - Timer is visible to all players (countdown bar)
 - No answer within time = 0 points for that round
+- The Lightning Round (1.3.0) runs its own fixed 15 s per question and ignores this setting
 
 ---
 

--- a/docs/release-notes/v1.4.0.md
+++ b/docs/release-notes/v1.4.0.md
@@ -1,0 +1,31 @@
+## v1.4.0 — The Host Finds Its Voice, and Close Enough Counts
+
+Two big things happen in this release. The TV stops being a screen you read off and becomes a host that talks — reading the questions, naming the options, calling the winner, welcoming people as they sit down. And a whole new kind of question lands: not "which of these four," but "how close can you get?" Both have been waiting in the wings since 1.3.0; now they're on the table.
+
+Pull up a chair — here's what's new.
+
+### 🗣️ The TV becomes a real quiz master
+
+Flip one switch in setup and your Home Assistant speaker takes over hosting duties. It reads each question aloud, runs through the options ("A, Paris… B, London…"), announces the right answer and who actually got it, calls out when someone takes the lead, welcomes each player as they join the lobby, and counts down when time's running low. Nobody has to read the screen anymore — you can keep your eyes on your friends instead of the TV, which turns out to be a real win for anyone who finds small text on a far-off screen hard going.
+
+It's yours to shape. A master toggle turns the whole thing on or off, and underneath it sits a row of switches for each moment — want it to read questions but stay quiet on the standings? One tap. Pick which voice engine and which speaker it comes out of, right in the setup screen. It speaks German and English, matching whatever language the game is in. And it stays completely silent until you ask for it, so nothing changes for anyone who'd rather keep the room quiet.
+
+### 🎯 How close can you get?
+
+Not every question has an answer you can list. "How tall is the Eiffel Tower?" "How many bones in the human body?" The new estimation round hands everyone a slider instead of four buttons, and you guess. The closest guess takes the points, the rest scale down by how near they landed, an exact hit earns a little bonus, and anyone who didn't guess gets nothing. The reveal is the best part: every player's guess plotted on a number line with the true value pinned, so you can see at a glance who was inches away and who was in another postcode — on both the phones and the TV.
+
+Two packs come in the box to play with right away — **Schätzfragen** in German and **Estimation** in English, fifteen questions each, full of the kind of "wait, really?" numbers that start arguments. Your existing multiple-choice packs don't change at all; estimation simply slots in alongside them.
+
+### 🔧 Polish and under the hood
+
+The estimation type actually shipped quietly just after 1.3.0, and a few rough edges got sanded down on the way here: a cache fix so the new question type reaches phones that already had Quizify open, a render fix so the slider and its picture show up correctly on the very first question, and a guard that keeps estimation out of the frantic Lightning Round, where there's no room for a slider. The test suite got steadier too, with the last of some order-dependent flakiness ironed out so every future change lands on solid ground.
+
+### 🙏 Thank you
+
+Both of these grew straight out of games played at real tables — someone wishing the host didn't have to read every question, someone wanting a round where "close" was good enough. Keep the notes coming. The arguments over whose guess was closer are exactly the point.
+
+---
+
+**A talking host · a brand-new guess-the-number round · two estimation packs · German + English narration**
+
+[Report a Bug](https://github.com/mholzi/quizify/issues) · [Discussions](https://github.com/mholzi/quizify/discussions) · [Full Changelog](https://github.com/mholzi/quizify/blob/main/CHANGELOG.md)

--- a/docs/release-notes/v1.4.1.md
+++ b/docs/release-notes/v1.4.1.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- **"Open Quizify" now works inside the Android Home Assistant Companion App (#348).** The launcher button was a plain `<a target="_blank">` link, which the Android Companion's embedded WebView silently swallows — no tab opened and the button appeared dead. The launcher now detects the Companion Android user-agent and, in that case only, navigates the panel frame straight to `/quizify/admin` instead, bypassing the dead `target="_blank"`. iOS Companion, desktop and standalone browsers are unchanged and keep the native fullscreen new-tab behaviour. (Ported from the matching Beatify fix.) www-only change.
+
+**Full Changelog**: https://github.com/mholzi/quizify/compare/v1.4.0...v1.4.1

--- a/docs/release-notes/v1.5.0.md
+++ b/docs/release-notes/v1.5.0.md
@@ -1,0 +1,34 @@
+## v1.5.0 — Now It's Fluent in Spanish, and a Whole Lot Sturdier
+
+Back in 1.3.0 the game learned to say *hola* — one Spanish pack, the menus half-translated, an honest start but clearly a work in progress. This release finishes the job. Spanish is no longer a preview; it's a full seat at the table, with four packs, six hundred questions, and every last button in its own language. And while the doors were open, we went through the whole house tightening hinges, fixing latches and turning on the lights in the corners nobody had reached yet.
+
+Pull up a chair — here's what's new.
+
+### 🇪🇸 Spanish, all the way through
+
+Spanish players used to get one pack and a menu that flickered between languages. Now there are **four native Spanish packs — Geografía, Naturaleza, Ciencia and Historia — six hundred questions in all**, written in Spanish from the ground up rather than run through a translator, so the phrasing and the fun facts read the way a Spanish speaker would actually say them. Every one was fact-checked before it shipped.
+
+And the interface finally keeps up: the whole player and host UI is now fully translated, right down to the newest bits like the talking-host setup. Pick Spanish and the game stays Spanish — no more English flashing through on the odd screen. Same for the packs you already know and love in German and English; nothing there changed, Spanish simply pulls up alongside them.
+
+### 🔒 A quieter, safer house
+
+A big sweep of the plumbing this time, most of it the kind you're glad you never notice. We closed a handful of doors that shouldn't have been open on your home network — a way a device on your Wi-Fi could have grabbed host controls in the middle of a game, an unauthenticated corner that exposed player names, a couple of endpoints that answered to anyone who asked. Host-only actions now properly check that they're really coming from the host, the flag button can't be hammered, and the admin key stopped leaking into places it didn't belong. Nothing you have to do; it's just tighter than it was this morning.
+
+### ✨ Easier on the eyes, kinder to the ears
+
+A whole pass of polish aimed at the people actually sitting in the room. The TV text scales up so the couch can read the reveal and the standings without squinting. Colours and contrast got fixed where the light theme washed things out, keyboard focus is visible again, screen readers get proper labels on the timer and the dialogs, and anyone who's set "reduce motion" on their phone finally gets a calmer ride. Touch targets grew to the size a thumb expects, the TV lobby now shows the join QR and the live roster together, and a batch of small snags — clipped labels, off-centre toggles, dead buttons — quietly disappeared.
+
+### 🔧 Under the hood
+
+The scoring edges got a good going-over: a fistful of fixes around Steal, estimation rounds and the Lightning Round so the points land where they should even in the odd corner cases, plus reconnection and roster handling made steadier. Several hot paths were made lighter — leaderboards, finale recomputes, analytics — so busier games stay smooth. The test suite grew to **a thousand passing tests**, which is the real reason a release this broad can go out with a straight face.
+
+### 🙏 Thank you
+
+Completing Spanish came straight out of watching the half-finished version go out and wanting to do right by the people using it. Keep the questions, the bug reports and the "wouldn't it be nice if…" notes coming — they're what turns a preview into the real thing.
+
+---
+
+**Four Spanish packs · 600 questions · fully translated UI · a security + accessibility sweep · 1,000 passing tests**
+
+[Report a Bug](https://github.com/mholzi/quizify/issues) · [Discussions](https://github.com/mholzi/quizify/discussions) · [Full Changelog](https://github.com/mholzi/quizify/blob/main/CHANGELOG.md)
+

--- a/docs/release-notes/v1.6.0.md
+++ b/docs/release-notes/v1.6.0.md
@@ -1,0 +1,50 @@
+## v1.6.0 — The House Plays Along
+
+Until now the game lived on two screens: the TV and the phones in everyone's hands. The room itself just sat there. This release changes that. When the answer comes in, the lamps react. When someone hits a streak, the speaker in the corner says so. In the last seconds of a question the light breathes faster, and when a winner is decided the house can drop into a scene you built yourself.
+
+It also went the other way. A party quiz is only fun if everyone in the room can actually play it, so this release quietly fixed a handful of things that were shutting people out — a reveal a colour-blind guest couldn't read, text too small for the far end of the sofa, a question timer too fast for a seven-year-old, and a menu that was always in the host's language whether you spoke it or not.
+
+Six release candidates went into this one. Pull up a chair.
+
+### 🏠 The house plays along
+
+**Off by default** — nothing changes until you switch it on, and then only as far as you take it.
+
+Underneath sits a new **event backbone**: Quizify now fires `quizify_*` events on the Home Assistant bus at every milestone of a game — question shown, answer revealed, streak hit, winner decided. If you already build automations, that alone is the feature; wire the events to whatever you like.
+
+On top of it come three layers you don't have to build yourself. **Light choreography** turns your party lights into a game-show rig, with transient accents on the game's beats and a countdown pulse that quickens in the final seconds. **Room sound effects** put the cues on a real speaker — correct, wrong, streak, winner — and four of them now ship with the integration, so the feature makes a sound out of the box instead of waiting for you to go hunting for audio files. A **finale scene selector** hands the moment of victory to a `scene.*` you built.
+
+All of it is set up from a panel of its own in the host screen: three one-tap presets — **Game Show**, **Cozy Glow**, **Events only** — and an advanced section underneath if you want per-effect control and your own entity picks.
+
+### 🎙️ Hands free
+
+Five new Home Assistant services — `start_game`, `next_round`, `pause`, `resume`, `end_game` — mean the host no longer has to be the person holding the tablet. Drive the game from Assist ("Hey Nabu, next question"), a Zigbee remote on the coffee table, a dashboard button, or an automation. Calls that arrive at the wrong moment fail with a clear message rather than doing something strange.
+
+### 🔀 Questions that stay fresh
+
+Play two game nights in a row and the second one used to feel familiar. Question selection now weighs against what you've recently seen — a decay curve plus a hard exclusion window, with a guard so small packs don't run dry. On by default; switch **Avoid recent repeats** off and the old ordering comes back exactly as it was.
+
+### ♿ Room for everyone
+
+The reveal **no longer depends on colour**. Right and wrong used to differ only in hue, and at Soft Parlor's soft saturations the sage and the dusty red collapse into nearly the same grey-green under red-green colour blindness — a guest could not read their own result on their own phone. The answer buttons now carry the same ★ and × the TV has always used. This one isn't a setting: a guest on a borrowed phone never finds a settings switch.
+
+Next to the speaker icon there's now an **accessibility toggle** — larger text, motion held still — remembered per phone. Handy for the far end of the sofa, and for anyone whose device never had "reduce motion" switched on in the first place.
+
+Each phone can also **pick its own language** now, from flag chips on the join screen. The questions stay in the pack language the host chose; the buttons and labels around them follow the player. A Spanish-speaking guest at a German host's party gets a Spanish interface without anyone changing the game.
+
+And for the youngest players: the timer picker now goes up to **180 seconds**, with a **"With kids"** preset (5 rounds, easy, 180 s) so you don't have to go hunting for it. That came from a host who told us three rounds in that their children simply could not read a question and four answers in 45 seconds.
+
+### 🔧 Under the hood
+
+The host's narration dropdowns — TTS engine and speaker — used to come up empty; they now arrive over the already-authenticated admin channel instead of racing a token, so they populate reliably. Screen readers stopped reading translation keys aloud. The test suite is at **1,084 tests**. And the repository finally carries the MIT licence its README has advertised since launch, plus the HACS and Home Assistant validation that Quizify had been shipping without.
+
+### 🙏 Thank you
+
+The best change in this release came from an external report — someone playing with small children who told us the clock was too fast. That is worth more than a feature request list. Keep them coming.
+
+---
+
+**Whole-home game-show mode · HA services for voice + automations · freshness engine · colour-independent reveal · per-player language · 1,084 passing tests**
+
+[Report a Bug](https://github.com/mholzi/quizify/issues) · [Discussions](https://github.com/mholzi/quizify/discussions) · [Full Changelog](https://github.com/mholzi/quizify/blob/main/CHANGELOG.md)
+

--- a/docs/release-notes/v1.6.1.md
+++ b/docs/release-notes/v1.6.1.md
@@ -1,0 +1,46 @@
+## v1.6.1 — The Room Stops Giving It Away
+
+1.6.0 handed the game to the whole house — the lights, the speaker, the television. Two weeks of living with it turned up what that had cost: a television quietly showing everyone the correct answer, a setup screen that argued with the house it was meant to configure, and a host who could be shut out of their own admin page for good. Five release candidates went into this one.
+
+Two things here are additions rather than repairs. The end screen now hands you something to take with you, and Spanish grew by two packs.
+
+### 📺 The television was telling everyone
+
+Quizify shuffles answers per round and again per phone, but the payload the big screen drew was built straight off the question file. In **16 of the 26 shipped packs** the correct answer sits at index 0 of every question — so on those packs it was tile A, every question, every game ([#521](https://github.com/mholzi/quizify/issues/521)). Nobody was mis-scored, because the phones always had a real shuffle. It simply leaked to everyone watching the TV.
+
+The same cause made the narrator speak the round's shuffle while the grid drew file order, so a spoken "B" pointed at a different tile. The fix threads the existing shuffle map through the dashboard payload, the reveal highlight, the distribution bars and both reconnect snapshots, falling back to file order if the map is unusable — a mislabelled grid is worse than an unshuffled one. The pack files are untouched: reordering them would have hidden the leak while leaving narration and reconnect broken.
+
+### 🔧 The setup screen, three times over
+
+**The entity pickers came up empty ([#524](https://github.com/mholzi/quizify/issues/524), [#527](https://github.com/mholzi/quizify/issues/527)).** Every fresh admin tab asked the server for its engines, speakers, lights and scenes *before* it held the token needed to ask, and the refusal then painted "None found" over lists the WebSocket had already delivered. Hosts reaching Home Assistant remotely hit it every time; on a local network the two requests land in either order, which is why testing never saw it. The reporting host had 2 engines, 23 media players and 72 lights, and the screen insisted there were none. The doomed request is gone, and a failed load may no longer overwrite a successful one.
+
+**The host could be locked out permanently ([#530](https://github.com/mholzi/quizify/issues/530)).** The admin token is a lasting credential — the server writes it to disk and only issues a new one when none exists. The browser kept its copy in `sessionStorage`, which dies with the tab. Close the admin tab once and the credential was orphaned: no browser could present it, none could earn a replacement. It now lives in `localStorage`, the lifetime the server always assumed. If you are locked out right now, call the `quizify.reset_admin_session` service and reopen the page.
+
+**The game asks for one speaker, not two ([#525](https://github.com/mholzi/quizify/issues/525)).** Step 7 asked for a narration speaker and step 8 asked again for effects — same label, same devices, nothing on screen saying they were related. Now it asks once; the split moved inside step 8's advanced panel, where an empty setting means "follow the game speaker". Already set two? Nothing is quietly reassigned — the second is kept and the panel opens by itself so you can decide.
+
+### 👨‍👩‍👧 For the youngest players
+
+The "With kids" preset bundles 5 rounds / easy / 180 s because a host told us their children could not read a question and four answers in 45 seconds. It never touched the lightning toggle, so those same hosts got an ambush round of five questions at 15 seconds each — the one setting they had asked for, overridden mid-game ([#513](https://github.com/mholzi/quizify/issues/513)). The preset now switches the Lightning Round off.
+
+### 🃏 Something to take with you
+
+The end screen carries a score slip — rank, packs, hit rate, points, and a strip of one glyph per round — with a **Share card** button behind it ([#369](https://github.com/mholzi/quizify/issues/369)). The text goes to `navigator.share` and falls back to the clipboard, because the OS share sheet needs HTTPS and plenty of Home Assistant installs run over plain HTTP.
+
+The card is a public claim once it lands in a group chat, so it refuses to flatter: a timeout keeps its own glyph instead of being folded into a wrong answer, a player who joined late reports only the rounds they played, tied players share a rank, and a player who never answered gets no card at all. Power-ups appear as a count rather than a mark on a round — the game does not record which round one was spent in, and placing it would be invented data.
+
+### 🇪🇸 Spanish grows
+
+Two new packs, 150 questions each, neither one a translated English pack: **sport** ([#515](https://github.com/mholzi/quizify/issues/515)) and **pop culture** ([#517](https://github.com/mholzi/quizify/issues/517)). Spanish now stands at 6 packs / 900 questions, the library at **28 packs / 3,823 questions**. Still missing in Spanish: music, food, technology.
+
+Three fun facts in the new pop culture pack were also corrected ([#519](https://github.com/mholzi/quizify/issues/519)) — the questions and answers were right, the trivia line was not. With narration on, the speaker states that line to the room as fact, so a wrong one is worse than none.
+
+### 🙏 Thank you
+
+The empty pickers and the locked-out admin page were both reported by hosts mid-party, and the kids preset those hosts were using exists because of an earlier report of the same kind. Neither of the first two would have surfaced in testing: one only shows up over a remote connection, the other only after you close the tab. Keep them coming.
+
+---
+
+**Correct answer no longer parked on tile A · shareable result cards · one speaker instead of two · admin lockout resolved · two new Spanish packs · 1,315 passing tests**
+
+[Report a Bug](https://github.com/mholzi/quizify/issues) · [Full Changelog](https://github.com/mholzi/quizify/blob/main/CHANGELOG.md)
+

--- a/tests/test_docs_pack_counts.py
+++ b/tests/test_docs_pack_counts.py
@@ -1,0 +1,81 @@
+"""Keep the README's library figures honest (docs refresh, 2026-08-09).
+
+The README claimed "2,893 questions across 20 themed packs ... in German and
+English" for months after that stopped being true: 1.3.0 added Spanish, 1.4.0
+added the two estimation packs, and 1.5.0/1.6.1 took Spanish to six packs. The
+numbers are quoted in two places and the language list in four, so every pack
+PR could — and did — leave them behind without anything failing.
+
+This test recomputes the figures from the shipped pack files and asserts the
+README quotes them. It fails the moment a pack is added or removed without the
+README being updated, which is exactly when a human would otherwise forget.
+
+``questions/community/`` is excluded on purpose: ``example-pack.json`` is the
+schema sample from the "Custom Question Packs" section, not something a host
+plays, and counting it would make the README quote 29 packs to a reader who can
+only ever select 28.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+QUESTIONS_DIR = REPO / "custom_components" / "quizify" / "questions"
+README = REPO / "README.md"
+
+
+def _shipped_packs() -> list[dict]:
+    """Load every shipped pack (top-level question files with a question list)."""
+    packs = []
+    for path in sorted(QUESTIONS_DIR.glob("*.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data.get("questions"), list):
+            packs.append(data)
+    return packs
+
+
+def test_readme_quotes_the_real_pack_and_question_counts() -> None:
+    packs = _shipped_packs()
+    pack_count = len(packs)
+    question_count = sum(len(p["questions"]) for p in packs)
+
+    readme = README.read_text(encoding="utf-8")
+
+    assert f"{pack_count} themed packs" in readme, (
+        f"README does not quote the real pack count ({pack_count}). "
+        "Update both the intro bullet and the Question Packs heading."
+    )
+    assert f"{question_count:,} questions" in readme, (
+        f"README does not quote the real question count ({question_count:,}). "
+        "Update both the intro bullet and the Question Packs heading."
+    )
+
+
+def test_readme_names_every_shipped_language() -> None:
+    """A new pack language must reach the README, not just the picker."""
+    languages = {p.get("language") for p in _shipped_packs()}
+    readme = README.read_text(encoding="utf-8").lower()
+
+    names = {"de": "german", "en": "english", "es": "spanish"}
+    for code in sorted(languages):
+        assert code in names, (
+            f"Pack language {code!r} has no README wording yet — add it to this "
+            "test's mapping and to the README language lists."
+        )
+        assert names[code] in readme, (
+            f"{names[code].title()} packs ship but the README never says so."
+        )
+
+
+def test_readme_names_every_shipped_theme() -> None:
+    """The theme list in the pack schema doc must cover what actually ships."""
+    themes = {p.get("theme") for p in _shipped_packs() if p.get("theme")}
+    readme = README.read_text(encoding="utf-8")
+
+    for theme in sorted(themes):
+        assert f"`{theme}`" in readme, (
+            f"Theme {theme!r} ships but is missing from the README's list of "
+            "valid `theme` values, so a pack author cannot discover it."
+        )


### PR DESCRIPTION
## What

The documentation had drifted roughly four minor releases behind the code. This brings it back to the shipped 1.6.1 state and adds a test so it cannot drift silently again.

## Why it mattered

The README is the HACS store page — `hacs.json` sets `render_readme: true`, so this text is what a prospective user reads before installing. It advertised **"2,893 questions across 20 themed packs ... in German and English"**. The real figures, recounted from the pack files:

| | README claimed | Actually ships |
|---|---|---|
| Packs | 20 | **28** |
| Questions | 2,893 | **3,823** |
| Themes | 10 | **11** |
| Languages | de, en | **de, en, es** |

Spanish has shipped since 1.3.0 and reached six packs in 1.6.1, and the README never mentioned it — including in the FAQ answer about supported languages and in the pack schema doc, which told pack authors that only `de` and `en` are wired into the language chip.

The **What's New** section ended at v1.1.31, so it omitted every headline feature of the last four minors: Lightning Round, picture questions, spoken narration, estimation questions, House Plays Along, shareable result cards.

## Changes

- **README** — intro bullet, Question Packs heading and table (new `es` column, new Estimation row), pack schema `language` / `theme` lists, FAQ language answer, and What's New entries for 1.2.7 → 1.6.1.
- **docs/release-notes/** — added `v1.4.1`, `v1.5.0`, `v1.6.0`, `v1.6.1`, taken verbatim from the published release bodies. Worth flagging: this directory **was never in the repo**. `docs/` is ignored wholesale in `.gitignore`, so even the single `v1.4.0.md` it contained was local-only and invisible to every clone. This PR negates the ignore for `docs/release-notes/` alone, leaving the rest of `docs/` (design shotguns, scratch) ignored as before.
- **REQUIREMENTS.md** — the scoring section still documented the pre-rescale 1000-point base; `game/scoring.py` has `BASE_POINTS = 10`, `MAX_SPEED_BONUS = 5` and a capped streak multiplier. The timer section described a per-difficulty timer (20/15/10 s) that no longer exists — the host picks one timer per game, and the Lightning Round ignores it.
- **tests/test_docs_pack_counts.py** — recomputes packs, questions, languages and themes from `questions/*.json` and asserts the README quotes them. A new pack, language or theme now fails CI until the README follows.

## Notes

- Documentation only — no runtime code touched.
- The counts exclude `questions/community/example-pack.json`: it is the schema sample from the README, not something a host can select, and counting it would have the README quote 29 packs to a reader who only ever sees 28.

Closes nothing — filed from the documentation audit after the 1.6.1 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)