### PR TITLE
feat(cards): quizify-host-card — host controls on a dashboard (#278)

### DIFF
--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -215,6 +215,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
     )
 
+    # Register the host card as a Lovelace resource (#278). Convenience only —
+    # the helper swallows every failure and logs the manual step instead, so a
+    # YAML-mode dashboard or a changed core API can't take setup down with it.
+    from .cards import async_register_card_resource  # noqa: PLC0415
+
+    await async_register_card_resource(hass, getattr(ctx, "version", None))
+
     # Register sidebar panel.
     async_register_built_in_panel(
         hass,

--- a/custom_components/quizify/cards.py
+++ b/custom_components/quizify/cards.py
@@ -1,0 +1,97 @@
+"""Lovelace resource registration for the Quizify custom cards (#278).
+
+A custom card only exists for a dashboard once its JavaScript is registered as
+a Lovelace *resource*. Doing that by hand means walking the host through
+Settings → Dashboards → Resources, which is exactly the kind of step people
+skip before reporting the card as broken. When Lovelace runs in storage mode
+(the default) we can add the resource ourselves.
+
+Two rules govern everything here:
+
+* **Setup must never fail because of this.** The card is a convenience; the
+  game does not depend on it. Every path is wrapped, and a failure downgrades
+  to a log line telling the host what to add manually.
+* **Never register twice.** The resource list is persisted, so an unguarded
+  add would append a duplicate on every restart.
+
+YAML-mode Lovelace has no writable resource store — there the host owns
+``configuration.yaml`` and we only log what to put in it.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+#: URL the card is served from. It lives under the existing static mount
+#: (``STATIC_URL_PREFIX`` + ``www/``), so no extra route is needed.
+CARD_URL = "/quizify/static/cards/quizify-host-card.js"
+
+
+def _resource_url(version: str | None) -> str:
+    """Return the card URL with the manifest version as a cache-buster.
+
+    Same trick the HTML pages use: a dashboard that cached the previous card
+    would otherwise keep it until the host cleared their browser.
+    """
+    return f"{CARD_URL}?v={version}" if version else CARD_URL
+
+
+async def async_register_card_resource(
+    hass: HomeAssistant, version: str | None = None
+) -> bool:
+    """Add the host card to Lovelace's resource list if it isn't there yet.
+
+    Returns ``True`` when the resource is present afterwards (either because we
+    added it or because it already was), ``False`` when the host has to add it
+    by hand. Never raises.
+    """
+    url = _resource_url(version)
+    try:
+        lovelace: Any = hass.data.get("lovelace")
+        resources: Any = getattr(lovelace, "resources", None)
+        if resources is None and isinstance(lovelace, dict):
+            # Older cores kept Lovelace's pieces in a plain dict.
+            resources = lovelace.get("resources")
+
+        if resources is None:
+            _LOGGER.info(
+                "Lovelace resources are not available (YAML mode?) — add %s "
+                "manually under Settings > Dashboards > Resources to use the "
+                "Quizify host card",
+                url,
+            )
+            return False
+
+        if not getattr(resources, "loaded", True):
+            await resources.async_load()
+            resources.loaded = True
+
+        for item in resources.async_items() or []:
+            existing = str(item.get("url", ""))
+            # Compare without the cache-buster so a version bump updates the
+            # entry instead of adding a second one.
+            if existing.split("?")[0] == CARD_URL:
+                if existing != url:
+                    await resources.async_update_item(
+                        item["id"], {"url": url, "res_type": "module"}
+                    )
+                    _LOGGER.debug("Updated Quizify card resource to %s", url)
+                return True
+
+        await resources.async_create_item({"res_type": "module", "url": url})
+        _LOGGER.info("Registered Quizify host card as a Lovelace resource (%s)", url)
+        return True
+    except Exception:  # noqa: BLE001 — a broken card must not break setup
+        _LOGGER.warning(
+            "Could not register the Quizify host card automatically. Add %s as a "
+            "JavaScript Module under Settings > Dashboards > Resources to use it.",
+            url,
+            exc_info=True,
+        )
+        return False

--- a/custom_components/quizify/www/cards/quizify-host-card.js
+++ b/custom_components/quizify/www/cards/quizify-host-card.js
@@ -1,0 +1,444 @@
+/*
+ * quizify-host-card — host controls as a native Lovelace card (#278).
+ *
+ * Two densities in one resource, per the locked design:
+ *   mode: compact  (default, "Remote Control") — one morphing button
+ *   mode: expanded ("Cockpit")                 — roster, QR, progress, all controls
+ *
+ * The card speaks the SAME WebSocket protocol as www/js/admin.js: connect to
+ * /api/quizify/ws?role=admin, send `admin_auth` as the FIRST frame (never
+ * ?token= in the URL, #359), then `admin_connect`, and render from the
+ * `game_state` broadcast. No new server endpoint and no new message type.
+ *
+ * Quizify is served from hass.http.app.router, i.e. the SAME origin as the
+ * Home Assistant frontend, so this card can read the very admin token the
+ * admin page stored. It does that through QuizifyUtils.readAdminToken() rather
+ * than touching localStorage directly — utils.js is the one place allowed to
+ * name the storage key (see tests/test_admin_token_durable_storage.py).
+ *
+ * That sharing has a consequence worth stating plainly: the token only exists
+ * once the admin page has run on this browser. On a tablet that never opened
+ * /quizify/admin the card cannot authenticate, so it renders an explicit link
+ * instead of dead buttons. #530 was exactly that failure mode — a silent empty
+ * surface — and it cost a release candidate.
+ */
+(function () {
+    'use strict';
+
+    var TAG = 'quizify-host-card';
+    if (window.customElements && window.customElements.get(TAG)) return;
+
+    var UTILS_URL = '/quizify/static/js/utils.js';
+    var QR_URL = '/quizify/static/js/vendor/qrcode.min.js';
+    var ADMIN_URL = '/quizify/admin';
+    var WS_PATH = '/api/quizify/ws?role=admin';
+
+    var MAX_RECONNECT = 10;
+
+    /*
+     * Phase -> primary action. Phase strings are GamePhase in game/state.py;
+     * every message here is one admin.js already sends for the same phase. The
+     * card must not invent transitions — an unknown phase falls through to a
+     * disabled button rather than guessing.
+     */
+    var PHASE_ACTIONS = {
+        LOBBY: { labelKey: 'start', msg: 'start_game' },
+        QUESTION_ACTIVE: { labelKey: 'skip', msg: 'admin_skip' },
+        ANSWER_REVEAL: { labelKey: 'next', msg: 'next_question' },
+        PAUSED: { labelKey: 'resume', msg: 'resume_game' },
+        FINALE: { labelKey: 'again', msg: 'play_again' },
+        LIGHTNING: { labelKey: 'skip', msg: 'admin_skip' },
+        LIGHTNING_RECAP: { labelKey: 'next', msg: 'next_question' }
+    };
+
+    var LABELS = {
+        en: {
+            title: 'Quizify', start: 'Start game', skip: 'Skip to answer',
+            next: 'Next question', resume: 'Resume', again: 'Play again',
+            reveal: 'Reveal', end: 'End game', reset: 'Reset', kick: 'Kick',
+            players: 'players', round: 'Round', join: 'Join',
+            waiting: 'Waiting for players', connecting: 'Connecting…',
+            offline: 'Connection lost — reconnecting',
+            noToken: 'Open Quizify once to link this dashboard',
+            openAdmin: 'Open Quizify', resetConfirm: 'Reset the game?'
+        },
+        de: {
+            title: 'Quizify', start: 'Spiel starten', skip: 'Zur Auflösung',
+            next: 'Nächste Frage', resume: 'Weiter', again: 'Nochmal spielen',
+            reveal: 'Auflösen', end: 'Spiel beenden', reset: 'Zurücksetzen', kick: 'Rauswerfen',
+            players: 'Spieler', round: 'Runde', join: 'Beitreten',
+            waiting: 'Warte auf Spieler', connecting: 'Verbinde…',
+            offline: 'Verbindung verloren — versuche erneut',
+            noToken: 'Öffne Quizify einmal, um dieses Dashboard zu verbinden',
+            openAdmin: 'Quizify öffnen', resetConfirm: 'Spiel zurücksetzen?'
+        },
+        es: {
+            title: 'Quizify', start: 'Empezar partida', skip: 'Ir a la respuesta',
+            next: 'Siguiente pregunta', resume: 'Continuar', again: 'Jugar otra vez',
+            reveal: 'Revelar', end: 'Terminar partida', reset: 'Reiniciar', kick: 'Expulsar',
+            players: 'jugadores', round: 'Ronda', join: 'Unirse',
+            waiting: 'Esperando jugadores', connecting: 'Conectando…',
+            offline: 'Conexión perdida — reintentando',
+            noToken: 'Abre Quizify una vez para enlazar este panel',
+            openAdmin: 'Abrir Quizify', resetConfirm: '¿Reiniciar la partida?'
+        }
+    };
+
+    var STYLE = [
+        ':host{display:block}',
+        'ha-card{padding:16px;display:flex;flex-direction:column;gap:12px}',
+        '.head{display:flex;align-items:baseline;justify-content:space-between;gap:8px}',
+        '.head .name{font-weight:600}',
+        '.head .meta{color:var(--secondary-text-color);font-size:.85em}',
+        '.primary{width:100%;min-height:48px;border:0;border-radius:10px;cursor:pointer;',
+        'font:inherit;font-weight:600;font-size:1.05em;padding:12px 16px;',
+        'background:var(--primary-color);color:var(--text-primary-color)}',
+        '.primary[disabled]{opacity:.5;cursor:default}',
+        '.row{display:flex;gap:8px;flex-wrap:wrap}',
+        '.row button{flex:1 1 auto;min-height:48px;min-width:88px;border-radius:10px;cursor:pointer;',
+        'font:inherit;padding:10px 12px;background:transparent;',
+        'border:1px solid var(--divider-color);color:var(--primary-text-color)}',
+        '.row button[disabled]{opacity:.5;cursor:default}',
+        '.foot{display:flex;justify-content:space-between;align-items:center;gap:8px;',
+        'color:var(--secondary-text-color);font-size:.85em}',
+        '.foot a{color:var(--primary-color)}',
+        '.split{display:flex;gap:16px;align-items:flex-start;flex-wrap:wrap}',
+        '.roster{flex:1 1 200px;display:flex;flex-direction:column;gap:2px;margin:0;padding:0;list-style:none}',
+        '.roster li{display:flex;align-items:center;gap:8px;padding:6px 0;',
+        'border-bottom:1px solid var(--divider-color)}',
+        '.roster li:last-child{border-bottom:0}',
+        '.roster .nm{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}',
+        '.roster .sc{font-variant-numeric:tabular-nums;color:var(--secondary-text-color)}',
+        '.dot{width:8px;height:8px;border-radius:50%;flex:none;background:var(--success-color,#4caf50)}',
+        '.dot.off{background:var(--disabled-text-color,#9e9e9e)}',
+        '.kick{border:0;background:transparent;cursor:pointer;color:var(--secondary-text-color);',
+        'font:inherit;min-height:32px;padding:0 6px}',
+        '.qr{flex:0 0 auto}',
+        '.qr img,.qr canvas{display:block;border-radius:6px}',
+        '.bar{height:4px;border-radius:999px;background:var(--divider-color);overflow:hidden}',
+        '.bar > i{display:block;height:100%;background:var(--primary-color)}',
+        '.note{color:var(--secondary-text-color);font-size:.9em;margin:0}',
+        '@media(prefers-reduced-motion:reduce){*{transition:none!important;animation:none!important}}'
+    ].join('');
+
+    function loadScript(url) {
+        return new Promise(function (resolve, reject) {
+            var existing = document.querySelector('script[data-quizify-src="' + url + '"]');
+            if (existing) {
+                if (existing.dataset.loaded === '1') return resolve();
+                existing.addEventListener('load', function () { resolve(); });
+                existing.addEventListener('error', reject);
+                return;
+            }
+            var s = document.createElement('script');
+            s.src = url;
+            s.dataset.quizifySrc = url;
+            s.addEventListener('load', function () { s.dataset.loaded = '1'; resolve(); });
+            s.addEventListener('error', reject);
+            document.head.appendChild(s);
+        });
+    }
+
+    function esc(text) {
+        return String(text == null ? '' : text)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
+    class QuizifyHostCard extends HTMLElement {
+        constructor() {
+            super();
+            this.attachShadow({ mode: 'open' });
+            this._config = { mode: 'compact' };
+            this._state = null;
+            this._ws = null;
+            this._status = 'connecting';
+            this._token = undefined;   // undefined = not looked up yet, null = none
+            this._attempts = 0;
+            this._retry = null;
+            this._lang = 'en';
+            this._qrDrawnFor = null;
+        }
+
+        // ---- Lovelace contract -------------------------------------------
+
+        setConfig(config) {
+            var mode = (config && config.mode) || 'compact';
+            if (mode !== 'compact' && mode !== 'expanded') {
+                throw new Error("quizify-host-card: mode must be 'compact' or 'expanded'");
+            }
+            this._config = {
+                mode: mode,
+                title: (config && config.title) || null
+            };
+            this._render();
+        }
+
+        getCardSize() {
+            return this._config.mode === 'expanded' ? 5 : 2;
+        }
+
+        static getStubConfig() {
+            return { type: 'custom:quizify-host-card', mode: 'compact' };
+        }
+
+        set hass(hass) {
+            // Only the display language is taken from hass; the game state comes
+            // from Quizify's own socket, which is the authority on the game.
+            var lang = (hass && (hass.language || (hass.locale && hass.locale.language))) || 'en';
+            lang = String(lang).slice(0, 2);
+            if (LABELS[lang] && lang !== this._lang) {
+                this._lang = lang;
+                this._render();
+            }
+        }
+
+        connectedCallback() {
+            this._connect();
+        }
+
+        disconnectedCallback() {
+            if (this._retry) { clearTimeout(this._retry); this._retry = null; }
+            this._attempts = MAX_RECONNECT;   // stop reconnecting once removed
+            if (this._ws) { try { this._ws.close(); } catch (e) { /* already gone */ } }
+            this._ws = null;
+        }
+
+        // ---- Wiring ------------------------------------------------------
+
+        get _t() { return LABELS[this._lang] || LABELS.en; }
+
+        _connect() {
+            var self = this;
+            var ensureUtils = window.QuizifyUtils
+                ? Promise.resolve()
+                : loadScript(UTILS_URL).catch(function () { /* fall through to no-token */ });
+
+            ensureUtils.then(function () {
+                self._token = (window.QuizifyUtils && window.QuizifyUtils.readAdminToken())
+                    ? window.QuizifyUtils.readAdminToken()
+                    : null;
+
+                if (!self._token) {
+                    // No credential on this browser yet. Say so — never render a
+                    // control surface that silently does nothing (#530).
+                    self._status = 'no-token';
+                    self._render();
+                    return;
+                }
+                self._open();
+            });
+        }
+
+        _open() {
+            var self = this;
+            var proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+            var ws;
+            try {
+                ws = new WebSocket(proto + '//' + location.host + WS_PATH);
+            } catch (e) {
+                this._scheduleRetry();
+                return;
+            }
+            this._ws = ws;
+
+            ws.onopen = function () {
+                self._attempts = 0;
+                self._status = 'online';
+                // Token first, out of the URL (#359), then the connect frame.
+                ws.send(JSON.stringify({ type: 'admin_auth', token: self._token }));
+                ws.send(JSON.stringify({ type: 'admin_connect' }));
+            };
+
+            ws.onmessage = function (evt) {
+                var msg;
+                try { msg = JSON.parse(evt.data); } catch (e) { return; }
+                if (msg.admin_session_token && window.QuizifyUtils) {
+                    window.QuizifyUtils.writeAdminToken(msg.admin_session_token);
+                    self._token = msg.admin_session_token;
+                }
+                if (msg.type === 'game_state') {
+                    self._state = msg;
+                    self._render();
+                }
+            };
+
+            ws.onclose = function () {
+                self._ws = null;
+                self._status = 'offline';
+                self._render();
+                self._scheduleRetry();
+            };
+
+            ws.onerror = function () { /* onclose does the reconnecting */ };
+        }
+
+        _scheduleRetry() {
+            if (this._attempts >= MAX_RECONNECT) return;
+            var self = this;
+            var delay = Math.min(1000 * Math.pow(2, this._attempts), 30000);
+            this._attempts += 1;
+            this._retry = setTimeout(function () { self._open(); }, delay);
+        }
+
+        _send(type, data) {
+            if (!this._ws || this._ws.readyState !== 1) return;
+            var payload = data || {};
+            payload.type = type;
+            this._ws.send(JSON.stringify(payload));
+        }
+
+        // ---- Rendering ---------------------------------------------------
+
+        _primary() {
+            var phase = this._state && this._state.phase;
+            var action = PHASE_ACTIONS[phase] || null;
+            var players = (this._state && this._state.players) || [];
+            // An empty lobby has nothing to start; say why rather than letting
+            // the host tap a button that refuses.
+            var blocked = phase === 'LOBBY' && players.length === 0;
+            return {
+                label: action ? this._t[action.labelKey] : this._t.connecting,
+                msg: action ? action.msg : null,
+                disabled: !action || blocked || this._status !== 'online',
+                blockedReason: blocked ? this._t.waiting : null
+            };
+        }
+
+        _render() {
+            if (!this.shadowRoot) return;
+            var t = this._t;
+            var s = this._state;
+            var expanded = this._config.mode === 'expanded';
+            var title = this._config.title || t.title;
+
+            if (this._status === 'no-token') {
+                this.shadowRoot.innerHTML =
+                    '<style>' + STYLE + '</style>' +
+                    '<ha-card>' +
+                    '<div class="head"><span class="name">' + esc(title) + '</span></div>' +
+                    '<p class="note">' + esc(t.noToken) + '</p>' +
+                    '<div class="foot"><a href="' + ADMIN_URL + '">' + esc(t.openAdmin) + '</a></div>' +
+                    '</ha-card>';
+                return;
+            }
+
+            var players = (s && s.players) || [];
+            var primary = this._primary();
+            var meta = s
+                ? t.round + ' ' + (s.round || 0) + '/' + (s.total_rounds || 0) +
+                  ' · ' + players.length + ' ' + t.players
+                : t.connecting;
+
+            var html = '<style>' + STYLE + '</style><ha-card>';
+            html += '<div class="head"><span class="name">' + esc(title) + '</span>' +
+                    '<span class="meta">' + esc(meta) + '</span></div>';
+
+            if (expanded) {
+                html += '<div class="split"><ul class="roster">';
+                if (players.length === 0) {
+                    html += '<li><span class="nm">' + esc(t.waiting) + '</span></li>';
+                }
+                for (var i = 0; i < players.length; i++) {
+                    var p = players[i];
+                    html += '<li>' +
+                        '<span class="dot' + (p.connected ? '' : ' off') + '"></span>' +
+                        '<span class="nm">' + esc(p.name) + '</span>' +
+                        '<span class="sc">' + esc(p.score != null ? p.score : '—') + '</span>' +
+                        '<button class="kick" data-kick="' + esc(p.name) + '" ' +
+                        'title="' + esc(t.kick) + '" aria-label="' + esc(t.kick) + ' ' + esc(p.name) + '">×</button>' +
+                        '</li>';
+                }
+                html += '</ul><div class="qr" id="qr"></div></div>';
+
+                var total = (s && s.total_rounds) || 0;
+                var done = (s && s.round) || 0;
+                var pct = total > 0 ? Math.min(100, Math.round((done / total) * 100)) : 0;
+                html += '<div class="bar"><i style="width:' + pct + '%"></i></div>';
+            }
+
+            html += '<button class="primary" id="primary"' + (primary.disabled ? ' disabled' : '') + '>' +
+                    esc(primary.label) + '</button>';
+
+            if (expanded) {
+                html += '<div class="row">' +
+                    // Reveal is admin_skip: it cuts the timer short and shows the
+                    // answer, which is what admin.js does behind the same label.
+                    '<button data-msg="admin_skip">' + esc(t.reveal) + '</button>' +
+                    '<button data-msg="end_game">' + esc(t.end) + '</button>' +
+                    '<button data-reset="1">' + esc(t.reset) + '</button>' +
+                    '</div>';
+            }
+
+            var joinUrl = (s && s.join_url) || '/quizify/player';
+            var footNote = primary.blockedReason
+                || (this._status === 'offline' ? t.offline : '');
+            html += '<div class="foot"><a href="' + esc(joinUrl) + '">' + esc(t.join) + '</a>' +
+                    '<span>' + esc(footNote) + '</span></div>';
+
+            html += '</ha-card>';
+            this.shadowRoot.innerHTML = html;
+            this._bind(primary);
+            if (expanded) this._drawQr(joinUrl);
+        }
+
+        _bind(primary) {
+            var self = this;
+            var t = this._t;
+            var btn = this.shadowRoot.getElementById('primary');
+            if (btn && primary.msg) {
+                btn.addEventListener('click', function () { self._send(primary.msg); });
+            }
+            var others = this.shadowRoot.querySelectorAll('[data-msg]');
+            for (var i = 0; i < others.length; i++) {
+                (function (el) {
+                    el.addEventListener('click', function () { self._send(el.dataset.msg); });
+                })(others[i]);
+            }
+            var reset = this.shadowRoot.querySelector('[data-reset]');
+            if (reset) {
+                // The one destructive control — always ask.
+                reset.addEventListener('click', function () {
+                    if (window.confirm(t.resetConfirm)) self._send('reset_game');
+                });
+            }
+            var kicks = this.shadowRoot.querySelectorAll('[data-kick]');
+            for (var k = 0; k < kicks.length; k++) {
+                (function (el) {
+                    el.addEventListener('click', function () {
+                        self._send('kick_player', { name: el.dataset.kick });
+                    });
+                })(kicks[k]);
+            }
+        }
+
+        _drawQr(joinUrl) {
+            var box = this.shadowRoot.getElementById('qr');
+            if (!box) return;
+            var absolute = new URL(joinUrl, location.origin).href;
+            var self = this;
+            loadScript(QR_URL).then(function () {
+                if (typeof QRCode === 'undefined') return;
+                if (self._qrDrawnFor === absolute && box.firstChild) return;
+                box.innerHTML = '';
+                new QRCode(box, {
+                    text: absolute, width: 96, height: 96,
+                    correctLevel: QRCode.CorrectLevel.M
+                });
+                self._qrDrawnFor = absolute;
+            }).catch(function () { /* no QR is survivable; the link stays */ });
+        }
+    }
+
+    window.customElements.define(TAG, QuizifyHostCard);
+
+    // Card picker entry, so the card is discoverable in the UI editor rather
+    // than only via YAML.
+    window.customCards = window.customCards || [];
+    window.customCards.push({
+        type: TAG,
+        name: 'Quizify Host',
+        description: 'Start, advance and end a Quizify game from a dashboard.',
+        preview: false
+    });
+})();

--- a/tests/test_host_card_278.py
+++ b/tests/test_host_card_278.py
@@ -1,0 +1,166 @@
+"""Guard the Lovelace host card (#278).
+
+The card is browser code and this repo has no JS test runner, so its contract
+is asserted over the shipped file text — the same approach as
+``test_admin_token_durable_storage.py`` and ``test_entity_picker_race_524.py``.
+
+Two things are worth pinning, and they are the two that would fail silently:
+
+1. **The phase → message map.** The card mirrors what ``admin.js`` sends for a
+   given ``GamePhase``. Rename a phase in ``game/state.py`` and the card would
+   simply stop offering a button — no error, just a dead card that looks fine
+   in a screenshot.
+2. **The no-token fallback.** #530 shipped a control surface that silently did
+   nothing because a credential was missing. The card must always name that
+   state and link out of it.
+
+``cards.py`` is tested for the promise it makes to setup: never raise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+COMPONENT = REPO / "custom_components" / "quizify"
+CARD_JS = COMPONENT / "www" / "cards" / "quizify-host-card.js"
+PHASES_PY = COMPONENT / "game" / "phase_controller.py"
+CARDS_PY = COMPONENT / "cards.py"
+
+# Phase -> the message the card must send. Keep in step with PHASE_ACTIONS in
+# the card and with what admin.js does for the same phase.
+EXPECTED_ACTIONS = {
+    "LOBBY": "start_game",
+    "QUESTION_ACTIVE": "admin_skip",
+    "ANSWER_REVEAL": "next_question",
+    "PAUSED": "resume_game",
+    "FINALE": "play_again",
+}
+
+
+def _card_text() -> str:
+    return CARD_JS.read_text(encoding="utf-8")
+
+
+def test_card_file_ships() -> None:
+    assert CARD_JS.is_file(), "the host card must ship inside www/ to be served"
+
+
+def test_every_phase_maps_to_the_expected_message() -> None:
+    text = _card_text()
+    for phase, message in EXPECTED_ACTIONS.items():
+        pattern = re.compile(
+            re.escape(phase) + r"\s*:\s*\{[^}]*msg\s*:\s*'" + re.escape(message) + r"'"
+        )
+        assert pattern.search(text), (
+            f"{phase} must trigger {message!r} in PHASE_ACTIONS — a phase whose "
+            "mapping is missing or wrong leaves the host with a dead button."
+        )
+
+
+def test_card_phases_exist_in_the_game() -> None:
+    """A phase the card knows must still exist in GamePhase."""
+    game_phases = set(re.findall(r"^\s+([A-Z_]+) = \"", PHASES_PY.read_text(), re.M))
+    assert game_phases, "could not read GamePhase from game/phase_controller.py"
+
+    card_phases = set(re.findall(r"^\s+([A-Z_]+): \{ labelKey", _card_text(), re.M))
+    assert card_phases, "could not read PHASE_ACTIONS from the card"
+
+    unknown = card_phases - game_phases
+    assert not unknown, (
+        f"the card handles phases the game no longer has: {sorted(unknown)}"
+    )
+
+
+def test_auth_frame_goes_first_and_never_into_the_url() -> None:
+    """#359: the admin token travels in a frame, not as ?token= in the URL."""
+    text = _card_text()
+    assert "'admin_auth'" in text, "the card must authenticate with an admin_auth frame"
+
+    ws_path = re.search(r"var WS_PATH = '([^']+)'", text)
+    assert ws_path, "the WebSocket path must be a single named constant"
+    assert ws_path.group(1) == "/api/quizify/ws?role=admin", (
+        "the admin token must never ride in the WebSocket URL — it leaks into "
+        f"proxy logs and browser history (#359); got {ws_path.group(1)!r}"
+    )
+    assert "'?token='" not in text and '"?token="' not in text
+    auth_at = text.index("'admin_auth'")
+    connect_at = text.index("'admin_connect'")
+    assert auth_at < connect_at, (
+        "admin_auth must be sent before admin_connect, or the server answers the "
+        "connect frame as a plain player"
+    )
+
+
+def test_missing_token_shows_a_way_out_rather_than_dead_controls() -> None:
+    """The #530 lesson, pinned: never render an empty control surface."""
+    text = _card_text()
+    assert "no-token" in text, "the card needs an explicit no-credential state"
+    assert "/quizify/admin" in text, (
+        "the no-credential state must link to the admin page — that is the only "
+        "way for the host to mint the token this card needs"
+    )
+
+
+def test_token_key_is_not_named_in_the_card() -> None:
+    """utils.js stays the one place that knows the storage key."""
+    text = _card_text()
+    assert "quizify_admin_session_token" not in text
+    assert "readAdminToken" in text, "the card must reuse the shared token helper"
+
+
+def test_reset_is_confirmed() -> None:
+    text = _card_text()
+    reset_at = text.index("'reset_game'")
+    window = text[max(0, reset_at - 400) : reset_at]
+    assert "confirm" in window, "reset wipes a running game — it must ask first"
+
+
+def test_config_rejects_an_unknown_mode() -> None:
+    text = _card_text()
+    assert "mode must be 'compact' or 'expanded'" in text, (
+        "an unknown mode must raise in setConfig so Lovelace shows a config "
+        "error instead of rendering an arbitrary density"
+    )
+    assert "mode: 'compact'" in text, "compact is the documented default"
+
+
+def test_resource_registration_never_raises() -> None:
+    """Setup must survive any Lovelace shape, including none at all."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("quizify_cards", CARDS_PY)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    class _Hass:
+        def __init__(self, data):
+            self.data = data
+
+    class _Explosive:
+        @property
+        def resources(self):
+            raise RuntimeError("core changed shape")
+
+    for data in ({}, {"lovelace": None}, {"lovelace": _Explosive()}):
+        result = asyncio.run(module.async_register_card_resource(_Hass(data), "1.6.1"))
+        assert result is False, "an unavailable resource store means 'not registered'"
+
+
+def test_resource_url_carries_the_cache_buster() -> None:
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("quizify_cards", CARDS_PY)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert module._resource_url("1.6.1").endswith("?v=1.6.1")
+    assert module._resource_url(None) == module.CARD_URL
+    assert module.CARD_URL.startswith("/quizify/static/"), (
+        "the card is served by the existing static mount; a different prefix "
+        "would need its own route"
+    )


### PR DESCRIPTION
Implements the design locked on #278: **B1 "Remote Control" as the default, B2 "Cockpit" as `mode: expanded`.** One resource, two densities.

```yaml
type: custom:quizify-host-card
mode: compact        # compact (default) | expanded
title: Quizify       # optional
```

## What it does

**`mode: compact`** — header (phase + player count), one full-width button that morphs with the phase, and a quiet footer with the join link. 48 px touch target, meant to be used one-handed while standing in the room.

**`mode: expanded`** — adds the roster with connection dots, the join QR, a round progress bar, and the `Reveal` / `End` / `Reset` row, plus a per-player kick. For a tablet that does nothing else.

A host who wants both places the card twice with different modes — which is why B3 "Two-Tile" needed no separate resource.

## What it deliberately does not do

**No `quizify-tv-card`.** Its only real justification was HA Cast, since the cast receiver renders neither a raw URL nor an `iframe` card. Markus does not cast, and `GET /quizify/dashboard` already serves that view — the card would have re-packaged existing output for the larger half of the L effort. Variants A1–A3 stay on the issue if casting ever becomes a requirement.

## Protocol reuse

No new endpoint and no new message type. The card opens `/api/quizify/ws?role=admin`, sends `admin_auth` as the **first frame** (#359 — the token never rides in the URL), then `admin_connect`, and renders from the `game_state` broadcast. Exactly what `admin.js` does.

| Phase | Button | Message |
|---|---|---|
| `LOBBY` | Start game | `start_game` |
| `QUESTION_ACTIVE` | Skip to answer | `admin_skip` |
| `ANSWER_REVEAL` | Next question | `next_question` |
| `PAUSED` | Resume | `resume_game` |
| `FINALE` | Play again | `play_again` |

An unrecognised phase yields a **disabled** button. The card never invents a transition it isn't sure `admin.js` would make.

## The token, and the trap it carries

Quizify is served from `hass.http.app.router` — the **same origin** as the HA frontend — so the card can read the very token the admin page stored. It goes through `QuizifyUtils.readAdminToken()` rather than touching `localStorage`, keeping `utils.js` the one place that names the key (`test_admin_token_durable_storage.py` enforces that).

The catch: that token only exists once the admin page has run on this browser. A tablet that never opened `/quizify/admin` cannot authenticate. There the card renders **"Open Quizify once to link this dashboard"** with a link — never an empty control surface. That silent-dead-surface is precisely #530, which cost a release candidate, so a test pins it.

## Resource registration

`cards.py` adds the card to Lovelace's resource list when Lovelace runs in storage mode, updates rather than duplicates the entry when the version cache-buster changes, and funnels every other outcome (YAML mode, changed core API, anything raising) into a log line naming the manual step. **Setup can never fail because of the card.** A test drives it through a missing store, a `None` store and a store that raises.

## Notes

- The card is served from the existing static mount at `/quizify/static/cards/quizify-host-card.js`. The spec comment said `/quizify/cards/…`; using the mount that already exists avoids a Python view for a plain static file, and the URL carries the manifest cache-buster like every other asset.
- There is no join **code** in Quizify — joining is by URL/QR — so the mockup's "Code 4271" became the join link plus QR.
- Labels ship in de/en/es, following `hass.language`.
- **Not verified on real hardware.** The LAN is currently unreachable from the build machine, so this has not been placed on a live dashboard. Worth doing before it is relied on at a party.

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)