### PR TITLE
fix(cards): the compact host card can end a game (#278)

### DIFF
--- a/custom_components/quizify/www/cards/quizify-host-card.js
+++ b/custom_components/quizify/www/cards/quizify-host-card.js
@@ -102,6 +102,13 @@
         '.foot{display:flex;justify-content:space-between;align-items:center;gap:8px;',
         'color:var(--secondary-text-color);font-size:.85em}',
         '.foot a{color:var(--primary-color)}',
+        '.foot .note{flex:1;text-align:center}',
+        // The compact card\'s only secondary action. Deliberately text-weight:
+        // ending a game is rare next to the primary button, and a second solid
+        // button would compete with it.
+        '.linky{border:0;background:none;padding:4px 0;cursor:pointer;font:inherit;',
+        'color:var(--secondary-text-color);text-decoration:underline}',
+        '.linky:hover{color:var(--primary-text-color)}',
         '.split{display:flex;gap:16px;align-items:flex-start;flex-wrap:wrap}',
         '.roster{flex:1 1 200px;display:flex;flex-direction:column;gap:2px;margin:0;padding:0;list-style:none}',
         '.roster li{display:flex;align-items:center;gap:8px;padding:6px 0;',
@@ -374,7 +381,15 @@
             var footNote = primary.blockedReason
                 || (this._status === 'offline' ? t.offline : '');
             html += '<div class="foot"><a href="' + esc(joinUrl) + '">' + esc(t.join) + '</a>' +
-                    '<span>' + esc(footNote) + '</span></div>';
+                    '<span class="note">' + esc(footNote) + '</span>';
+            // End game lives in the compact footer (#278 spec). Expanded already
+            // carries it in the control row, and there is nothing to end while
+            // the lobby is still open — so it appears only where it can act.
+            if (!expanded && s && s.phase && s.phase !== 'LOBBY') {
+                html += '<button class="linky" data-msg="end_game">' +
+                        esc(t.end) + '</button>';
+            }
+            html += '</div>';
 
             html += '</ha-card>';
             this.shadowRoot.innerHTML = html;

--- a/tests/test_host_card_278.py
+++ b/tests/test_host_card_278.py
@@ -111,6 +111,28 @@ def test_token_key_is_not_named_in_the_card() -> None:
     assert "readAdminToken" in text, "the card must reuse the shared token helper"
 
 
+def test_compact_footer_offers_end_game() -> None:
+    """The compact card must be able to END a game, not only run one.
+
+    The #278 spec puts a text-weight "End game" in the compact footer beside
+    the join link. The first implementation shipped the footer without it, so
+    a host on the compact card could start and advance a game but had to
+    switch to the cockpit or the admin page to finish it — found by rendering
+    every phase against the deployed 1.7.0-RC1 build.
+    """
+    text = _card_text()
+    foot_at = text.index('<div class="foot"><a href="\' + esc(joinUrl)')
+    footer = text[foot_at : foot_at + 700]
+    assert "end_game" in footer, (
+        "the compact footer must carry the end-game action; without it the "
+        "compact card cannot finish a game at all"
+    )
+    assert "expanded" in footer, (
+        "the end-game action belongs to the compact footer only — expanded "
+        "already has it in the control row"
+    )
+
+
 def test_reset_is_confirmed() -> None:
     text = _card_text()
     reset_at = text.index("'reset_game'")


### PR DESCRIPTION
## The gap

The [#278 spec](https://github.com/mholzi/quizify/issues/278#issuecomment-5233500746) describes the compact footer as *"join code, and a text-weight `End game` as the only secondary action"*. The card shipped that footer with the join link and the status note — and no end action.

The effect: a host using the compact card can **start** a game and **advance** it through every phase, but cannot **finish** it. They have to switch to `mode: expanded` or open `/quizify/admin`.

## How it surfaced

By rendering the **deployed** `1.7.0-RC1` card in every phase — lobby empty, lobby with players, question, reveal, paused, finale — and reading what each one actually offers. That is what the release candidate was for; the gap would otherwise have shown up mid-party.

## The fix

```
Beitreten                    Spiel beenden
```

The action appears only where it can act:

- **Not in `expanded`** — the control row already has End next to Reveal and Reset; a second one would be noise.
- **Not in `LOBBY`** — there is no game to end before it starts, and an end button in an empty lobby invites a confusing tap.

Styling is deliberately text-weight (`.linky`), matching the spec's wording: ending a game is rare next to the primary button, and a second solid button would compete with it for the eye.

## Test

`test_compact_footer_offers_end_game` pins the compact footer to contain `end_game` and to be conditioned on the mode, so the action cannot silently vanish again. The other ten card tests are unchanged and still pass.

## Notes

- Card-only change; no server code, no protocol change, no new config.
- No version bump — the next release is not due before 2026-08-24, so this rides along to the next candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)