### PR TITLE
feat(setup): saved game presets (#433)

### DIFF
--- a/custom_components/quizify/server/preset_store.py
+++ b/custom_components/quizify/server/preset_store.py
@@ -1,0 +1,172 @@
+"""Atomic JSON-on-disk store for saved game presets (#433).
+
+A host reconfigures the same two or three setups every session — packs,
+difficulty, rounds, timer, lightning. This keeps named copies of them so the
+setup screen collapses to one tap.
+
+The presets live on the **server**, not in the browser: a preset saved on the
+living-room tablet has to exist on the host's phone too, and a browser-local
+store fails that the first time a second device is used.
+
+Written in the shape of :mod:`server.token_store` — same executor-offloaded,
+atomic write-then-replace, same tolerance for a corrupt file (a broken presets
+file must never stop the game from starting; it degrades to "no presets").
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import secrets
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..runtime import Runtime
+
+_LOGGER = logging.getLogger(__name__)
+
+#: Hard caps. A JSON file that grows without limit is a slow leak, and the
+#: chip row stops being one-tap long before twenty entries.
+MAX_PRESETS = 20
+MAX_NAME_LENGTH = 40
+
+#: Fields a preset carries. Deliberately NOT the TTS / house settings: those
+#: belong to devices, not to the shape of an evening, and a preset that
+#: silently repoints a speaker surprises more than it helps.
+_INT_FIELDS = ("rounds", "timer")
+_STR_FIELDS = ("difficulty", "category")
+
+SCHEMA_VERSION = 1
+
+
+class PresetValidationError(ValueError):
+    """A preset was rejected — the message is safe to return to the caller."""
+
+
+class PresetStore:
+    """Named game setups, persisted as one small JSON file."""
+
+    def __init__(self, runtime: Runtime, filename: str = "presets.json") -> None:
+        self._runtime = runtime
+        self._path = runtime.data_dir / filename
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Disk
+    # ------------------------------------------------------------------
+
+    async def _read(self) -> list[dict[str, Any]]:
+        if not self._path.exists():
+            return []
+        try:
+            content = await self._runtime.run_in_executor(self._path.read_text)
+            data = json.loads(content)
+        except (OSError, json.JSONDecodeError) as err:
+            _LOGGER.warning("Preset store corrupt or unreadable: %s", err)
+            return []
+        presets = data.get("presets") if isinstance(data, dict) else None
+        return [p for p in presets if isinstance(p, dict)] if presets else []
+
+    async def _write(self, presets: list[dict[str, Any]]) -> None:
+        tmp = self._path.with_suffix(".tmp")
+        content = json.dumps({"version": SCHEMA_VERSION, "presets": presets})
+
+        def _do() -> None:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp.write_text(content)
+            os.replace(tmp, self._path)
+
+        try:
+            await self._runtime.run_in_executor(_do)
+        except OSError as err:
+            _LOGGER.warning("Failed to persist presets: %s", err)
+
+    # ------------------------------------------------------------------
+    # API
+    # ------------------------------------------------------------------
+
+    async def list(self) -> list[dict[str, Any]]:
+        """Return the saved presets in host order."""
+        return await self._read()
+
+    async def save(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Create or update one preset and return the stored record.
+
+        Raises :class:`PresetValidationError` for anything the caller can fix.
+        """
+        record = _validate(payload)
+        async with self._lock:
+            presets = await self._read()
+            existing = payload.get("id")
+            if existing:
+                for index, preset in enumerate(presets):
+                    if preset.get("id") == existing:
+                        record["id"] = existing
+                        record["created"] = preset.get("created", record["created"])
+                        presets[index] = record
+                        break
+                else:
+                    raise PresetValidationError("unknown preset id")
+            else:
+                if len(presets) >= MAX_PRESETS:
+                    raise PresetValidationError(
+                        f"at most {MAX_PRESETS} presets can be saved"
+                    )
+                presets.append(record)
+            await self._write(presets)
+        return record
+
+    async def delete(self, preset_id: str) -> bool:
+        """Remove a preset. Returns False when the id was unknown."""
+        async with self._lock:
+            presets = await self._read()
+            remaining = [p for p in presets if p.get("id") != preset_id]
+            if len(remaining) == len(presets):
+                return False
+            await self._write(remaining)
+        return True
+
+
+def _validate(payload: dict[str, Any]) -> dict[str, Any]:
+    """Normalise an incoming preset, raising on anything unusable."""
+    if not isinstance(payload, dict):
+        raise PresetValidationError("preset must be an object")
+
+    name = str(payload.get("name", "")).strip()
+    if not name:
+        raise PresetValidationError("name is required")
+    if len(name) > MAX_NAME_LENGTH:
+        raise PresetValidationError(
+            f"name must be at most {MAX_NAME_LENGTH} characters"
+        )
+
+    record: dict[str, Any] = {
+        "id": payload.get("id") or f"p_{secrets.token_hex(3)}",
+        "name": name,
+        "created": str(payload.get("created") or ""),
+    }
+
+    for field in _INT_FIELDS:
+        value = payload.get(field)
+        if value is None:
+            continue
+        try:
+            record[field] = int(value)
+        except (TypeError, ValueError):
+            raise PresetValidationError(f"{field} must be a number") from None
+
+    for field in _STR_FIELDS:
+        value = payload.get(field)
+        if value is not None:
+            record[field] = str(value)
+
+    if payload.get("lightning") is not None:
+        record["lightning"] = bool(payload["lightning"])
+
+    packs = payload.get("packs")
+    if isinstance(packs, list):
+        record["packs"] = [str(p) for p in packs]
+
+    return record

--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -29,6 +29,7 @@ from .pack_submission import (
     submit_config_view,
     submit_pack_view,
 )
+from .preset_store import PresetStore, PresetValidationError
 from .rate_limit import SlidingWindowLimiter
 from .serializers import (
     build_game_status_response,
@@ -909,6 +910,62 @@ async def analytics_data_view(request: web.Request) -> web.Response:
     return web.json_response(ctx.analytics.compute_metrics(period))
 
 
+_PRESET_STORE_KEY = "quizify_preset_store"
+
+
+def _preset_store(request: web.Request) -> PresetStore:
+    """Return the per-app preset store, creating it once.
+
+    Cached on the aiohttp application rather than rebuilt per request: the
+    store owns an ``asyncio.Lock`` that serialises read-modify-write, and a
+    fresh instance per request would lock nothing. Stashing it here (instead
+    of on ``AppContext``) keeps the HA and standalone entry points untouched.
+    """
+    store = request.app.get(_PRESET_STORE_KEY)
+    if store is None:
+        store = PresetStore(_get_ctx(request).runtime)
+        request.app[_PRESET_STORE_KEY] = store
+    return store
+
+
+async def presets_view(request: web.Request) -> web.Response:
+    """List saved game presets (#433)."""
+    if not _is_admin_authenticated(request):
+        return _unauthorized()
+    return web.json_response({"presets": await _preset_store(request).list()})
+
+
+async def preset_save_view(request: web.Request) -> web.Response:
+    """Create or update a saved preset (#433)."""
+    if not _is_admin_authenticated(request):
+        return _unauthorized()
+    try:
+        payload = await request.json()
+    except (json.JSONDecodeError, ValueError):
+        return web.json_response({"error": "invalid JSON"}, status=400)
+
+    try:
+        record = await _preset_store(request).save(payload)
+    except PresetValidationError as err:
+        # The message is authored for a caller, not a log line — the admin UI
+        # shows it verbatim, so "at most 20 presets can be saved" beats a bare
+        # 400 the host has to guess about.
+        return web.json_response({"error": str(err)}, status=400)
+    return web.json_response({"preset": record})
+
+
+async def preset_delete_view(request: web.Request) -> web.Response:
+    """Delete a saved preset by id (#433)."""
+    if not _is_admin_authenticated(request):
+        return _unauthorized()
+    preset_id = request.query.get("id", "")
+    if not preset_id:
+        return web.json_response({"error": "id is required"}, status=400)
+    if not await _preset_store(request).delete(preset_id):
+        return web.json_response({"error": "unknown preset id"}, status=404)
+    return web.json_response({"deleted": preset_id})
+
+
 async def question_stats_view(request: web.Request) -> web.Response:
     """Return per-question difficulty stats.
 
@@ -1239,6 +1296,12 @@ ROUTES: list[tuple[str, str, _RouteHandler]] = [
     ("GET", "/api/quizify/analytics/data", analytics_data_view),
     ("GET", "/api/quizify/all-time", all_time_leaderboard_view),
     ("GET", "/api/quizify/question-stats", question_stats_view),
+    # Saved game presets (#433) — all three gated on the admin token: they do
+    # not expose secrets, but they change what the next game will be, and
+    # these routes carry no HA auth.
+    ("GET", "/api/quizify/presets", presets_view),
+    ("POST", "/api/quizify/presets", preset_save_view),
+    ("DELETE", "/api/quizify/presets", preset_delete_view),
     ("GET", "/api/quizify/packs", pack_versions_view),
     ("GET", "/api/quizify/packs/updates", pack_update_check_view),
     ("POST", "/api/quizify/flag-question", flag_question_view),

--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -126,6 +126,15 @@
 
                 <h2 class="setup-detail-title" data-i18n="setup.pickMode">Pick a mode</h2>
 
+                <!-- #433: saved presets. Hidden entirely until the host has
+                     saved one — a labelled empty row is furniture that
+                     explains nothing. Populated by admin.js from
+                     GET /api/quizify/presets. -->
+                <div class="my-presets" id="my-presets" hidden>
+                    <p class="my-presets-label" data-i18n="setup.myPresets">My presets</p>
+                    <div class="my-presets-row" id="my-presets-row"></div>
+                </div>
+
                 <div class="setup-presets" id="setup-presets" role="radiogroup"
                      data-i18n-aria-label="setup.pickMode" aria-label="Pick a mode">
                     <button type="button" class="preset-card" data-preset="schnellrunde"

--- a/custom_components/quizify/www/css/src/07-player.css
+++ b/custom_components/quizify/www/css/src/07-player.css
@@ -3885,3 +3885,79 @@ body.is-admin .reaction-bar {
     color: var(--color-text-light);
     margin-top: 10px;
 }
+
+/* ── Saved presets (#433) ─────────────────────────────────────────────
+   Variant A of the design shotgun: a horizontally scrollable chip row
+   ABOVE the four built-in mode cards, which stay exactly as they are.
+   The last visible chip is deliberately allowed to clip at the viewport
+   edge — that is the scroll affordance; a row that fits tidily reads as
+   "that's all there is". No arrows, no dots.                          */
+
+.my-presets {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 14px;
+}
+.my-presets-label {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    margin: 0;
+}
+.my-presets-row {
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    padding: 2px 0 4px;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+}
+.my-presets-row::-webkit-scrollbar { display: none; }
+
+.preset-chip {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    /* 44px floor: these sit next to a delete affordance, and a miss there
+       is destructive rather than merely annoying. */
+    min-height: 44px;
+    padding: 10px 14px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 999px;
+    background: var(--color-bg-card-alt);
+    color: var(--color-text-primary);
+    font-family: var(--font-body);
+    font-size: 0.9rem;
+    white-space: nowrap;
+    cursor: pointer;
+}
+.preset-chip.is-active {
+    background: var(--color-accent-primary);
+    border-color: var(--color-accent-primary);
+    color: var(--color-text-on-accent, #43201B);
+    font-weight: 600;
+}
+.preset-chip--add {
+    border-style: dashed;
+    color: var(--color-text-muted);
+}
+.preset-chip-remove {
+    /* Its own hit area, or deleting becomes a lottery next to selecting. */
+    min-width: 32px;
+    min-height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin: -6px -8px -6px 0;
+    border: 0;
+    background: none;
+    color: inherit;
+    opacity: 0.55;
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+.preset-chip-remove:hover { opacity: 1; }

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -6985,6 +6985,82 @@ body.is-admin .reaction-bar {
     color: var(--color-text-light);
     margin-top: 10px;
 }
+
+/* ── Saved presets (#433) ─────────────────────────────────────────────
+   Variant A of the design shotgun: a horizontally scrollable chip row
+   ABOVE the four built-in mode cards, which stay exactly as they are.
+   The last visible chip is deliberately allowed to clip at the viewport
+   edge — that is the scroll affordance; a row that fits tidily reads as
+   "that's all there is". No arrows, no dots.                          */
+
+.my-presets {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 14px;
+}
+.my-presets-label {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    margin: 0;
+}
+.my-presets-row {
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    padding: 2px 0 4px;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+}
+.my-presets-row::-webkit-scrollbar { display: none; }
+
+.preset-chip {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    /* 44px floor: these sit next to a delete affordance, and a miss there
+       is destructive rather than merely annoying. */
+    min-height: 44px;
+    padding: 10px 14px;
+    border: 1px solid var(--color-border-light);
+    border-radius: 999px;
+    background: var(--color-bg-card-alt);
+    color: var(--color-text-primary);
+    font-family: var(--font-body);
+    font-size: 0.9rem;
+    white-space: nowrap;
+    cursor: pointer;
+}
+.preset-chip.is-active {
+    background: var(--color-accent-primary);
+    border-color: var(--color-accent-primary);
+    color: var(--color-text-on-accent, #43201B);
+    font-weight: 600;
+}
+.preset-chip--add {
+    border-style: dashed;
+    color: var(--color-text-muted);
+}
+.preset-chip-remove {
+    /* Its own hit area, or deleting becomes a lottery next to selecting. */
+    min-width: 32px;
+    min-height: 32px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin: -6px -8px -6px 0;
+    border: 0;
+    background: none;
+    color: inherit;
+    opacity: 0.55;
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+.preset-chip-remove:hover { opacity: 1; }
 /* ==========================================
    Responsive
    ========================================== */

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -431,7 +431,12 @@
     "audio": {
       "speaker": "Lautsprecher",
       "speakerHint": "Gilt für die Ansagen und die Soundeffekte."
-    }
+    },
+    "myPresets": "Meine Presets",
+    "savePreset": "Aktuelles speichern",
+    "savePresetPrompt": "Name für dieses Preset:",
+    "deletePreset": "Preset löschen",
+    "deletePresetConfirm": "Preset löschen:"
   },
   "featured": {
     "tag": "Neu",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -431,7 +431,12 @@
     "audio": {
       "speaker": "Speaker",
       "speakerHint": "Used for the narration and the sound effects."
-    }
+    },
+    "myPresets": "My presets",
+    "savePreset": "Save current",
+    "savePresetPrompt": "Name for this preset:",
+    "deletePreset": "Delete preset",
+    "deletePresetConfirm": "Delete preset:"
   },
   "featured": {
     "tag": "New",

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -431,7 +431,12 @@
     "audio": {
       "speaker": "Altavoz",
       "speakerHint": "Se usa para la narración y los efectos de sonido."
-    }
+    },
+    "myPresets": "Mis ajustes",
+    "savePreset": "Guardar actual",
+    "savePresetPrompt": "Nombre para este ajuste:",
+    "deletePreset": "Eliminar ajuste",
+    "deletePresetConfirm": "¿Eliminar el ajuste:"
   },
   "featured": {
     "tag": "Nuevo",

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -750,20 +750,47 @@
         { id: 'marathon',     rounds: 20, difficulty: 'hard',   timer: 45, lightning: true,  labelKey: 'setup.preset.marathonName' },
     ];
 
+    // #433: the host's own saved presets, loaded from the server so a preset
+    // saved on the tablet exists on the phone too.
+    var _customPresets = [];
+    var _presetsLoaded = false;
+
+    function _sameBundle(p) {
+        // Lightning is part of the bundle (#513) — flipping the toggle by
+        // hand makes the run "Eigene" again, same as picking own topics.
+        return p.rounds === selectedRounds && p.difficulty === selectedDifficulty
+            && p.timer === selectedTimer && p.lightning === selectedLightning;
+    }
+
+    function _samePacks(packs) {
+        var mine = selectedCategories || [];
+        var theirs = packs || [];
+        if (mine.length !== theirs.length) return false;
+        var a = mine.slice().sort(), b = theirs.slice().sort();
+        for (var i = 0; i < a.length; i++) { if (a[i] !== b[i]) return false; }
+        return true;
+    }
+
     function _matchingPreset() {
-        // A preset (Schnellrunde / Klassiker / Marathon) is a full bundle that
-        // implies mixed topics. Once the host picks specific topics it is no
-        // longer that preset — it's custom (Eigene). So a non-mixed category
-        // selection never matches a preset, which stops the ready screen from
-        // mislabelling a custom topic run as "Klassiker".
-        if (selectedCategory !== 'mixed') return null;
-        for (var i = 0; i < _PRESETS.length; i++) {
-            var p = _PRESETS[i];
-            // Lightning is part of the bundle (#513) — flipping the toggle by
-            // hand makes the run "Eigene" again, same as picking own topics.
-            if (p.rounds === selectedRounds && p.difficulty === selectedDifficulty
-                && p.timer === selectedTimer && p.lightning === selectedLightning) {
-                return { id: p.id, label: _t(p.labelKey) };
+        // A built-in preset (Schnellrunde / Klassiker / Marathon) is a full
+        // bundle that implies mixed topics. Once the host picks specific
+        // topics it is no longer that preset — it's custom (Eigene). So a
+        // non-mixed category selection never matches a BUILT-IN preset, which
+        // stops the ready screen from mislabelling a custom topic run as
+        // "Klassiker".
+        if (selectedCategory === 'mixed') {
+            for (var i = 0; i < _PRESETS.length; i++) {
+                var p = _PRESETS[i];
+                if (_sameBundle(p)) return { id: p.id, label: _t(p.labelKey) };
+            }
+        }
+        // #433: saved presets CAN express a pack choice, so they are matched
+        // on packs as well — checked after the built-ins so a saved preset
+        // that happens to equal Klassiker still reads as Klassiker.
+        for (var j = 0; j < _customPresets.length; j++) {
+            var c = _customPresets[j];
+            if (_sameBundle(c) && _samePacks(c.packs)) {
+                return { id: c.id, label: c.name, custom: true };
             }
         }
         return null;
@@ -777,6 +804,142 @@
             var active = match ? (id === match.id) : (id === 'eigene');
             card.classList.toggle('is-active', active);
         });
+    }
+
+    // ── Saved presets (#433) ──────────────────────────────────────────
+    // Server-stored, so a preset saved on the living-room tablet is there on
+    // the host's phone too. The four built-in cards below are untouched by
+    // all of this; this only adds a chip row above them.
+
+    function _presetFetch(opts) {
+        // Header rather than ?token= — #359 moved the token out of URLs, and
+        // new call sites should not put it back in.
+        var tok = QuizifyUtils.readAdminToken();
+        var init = opts || {};
+        init.headers = init.headers || {};
+        if (tok) init.headers['X-Quizify-Token'] = tok;
+        return fetch('/api/quizify/presets' + (init._q || ''), init);
+    }
+
+    function _loadCustomPresets() {
+        return _presetFetch({ method: 'GET' })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (data) {
+                _customPresets = (data && data.presets) || [];
+                _renderCustomPresets();
+            })
+            .catch(function () { /* no presets is a fine steady state */ });
+    }
+
+    function _renderCustomPresets() {
+        var wrap = document.getElementById('my-presets');
+        var row = document.getElementById('my-presets-row');
+        if (!wrap || !row) return;
+
+        row.innerHTML = '';
+        var match = _matchingPreset();
+
+        _customPresets.forEach(function (p) {
+            var chip = document.createElement('button');
+            chip.type = 'button';
+            chip.className = 'preset-chip'
+                + (match && match.custom && match.id === p.id ? ' is-active' : '');
+            chip.setAttribute('data-preset-id', p.id);
+
+            var label = document.createElement('span');
+            label.textContent = p.name;
+            chip.appendChild(label);
+
+            var del = document.createElement('button');
+            del.type = 'button';
+            del.className = 'preset-chip-remove';
+            del.textContent = '×';
+            del.setAttribute('aria-label', _t('setup.deletePreset') + ' ' + p.name);
+            del.addEventListener('click', function (ev) {
+                ev.stopPropagation();   // deleting must never also select
+                _deleteCustomPreset(p);
+            });
+            chip.appendChild(del);
+
+            chip.addEventListener('click', function () { _applyCustomPreset(p); });
+            row.appendChild(chip);
+        });
+
+        var add = document.createElement('button');
+        add.type = 'button';
+        add.className = 'preset-chip preset-chip--add';
+        add.textContent = '+ ' + _t('setup.savePreset');
+        add.addEventListener('click', _saveCurrentPreset);
+        row.appendChild(add);
+
+        // Hidden entirely while nothing is saved: the label plus a lone
+        // "save" chip would be furniture explaining nothing. The save chip
+        // still needs a home, so the row shows as soon as the host has
+        // anything — and before that it lives in the Eigene panel's flow.
+        wrap.hidden = _customPresets.length === 0;
+    }
+
+    function _applyCustomPreset(p) {
+        _applyPreset(p.rounds, p.difficulty, p.timer, p.lightning);
+        _applyPacks(p.packs || []);
+        markActivePreset();
+        _renderCustomPresets();
+    }
+
+    function _applyPacks(packs) {
+        var container = document.getElementById('category-chips');
+        if (!container) return;
+        var wanted = packs.slice();
+        container.querySelectorAll('.chip').forEach(function (c) {
+            var v = c.dataset.value;
+            c.classList.toggle('active',
+                wanted.length ? wanted.indexOf(v) !== -1 : v === 'mixed');
+        });
+        selectedCategories = wanted;
+        selectedCategory = wanted.length === 0 ? 'mixed'
+            : (wanted.length === 1 ? wanted[0] : 'multi');
+        if (typeof updateCategorySummary === 'function') updateCategorySummary();
+    }
+
+    function _saveCurrentPreset() {
+        var name = window.prompt(_t('setup.savePresetPrompt'));
+        if (name === null) return;
+        name = name.trim();
+        if (!name) return;
+
+        _presetFetch({
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                name: name,
+                rounds: selectedRounds,
+                difficulty: selectedDifficulty,
+                timer: selectedTimer,
+                lightning: selectedLightning,
+                category: selectedCategory,
+                packs: selectedCategories || []
+            })
+        })
+            .then(function (r) {
+                return r.json().then(function (body) {
+                    // The server's message is written for a person ("at most
+                    // 20 presets can be saved"), so show it rather than a
+                    // generic failure the host has to guess about.
+                    if (!r.ok) throw new Error(body.error || 'save failed');
+                    return body;
+                });
+            })
+            .then(_loadCustomPresets)
+            .catch(function (err) { window.alert(err.message); });
+    }
+
+    function _deleteCustomPreset(p) {
+        if (!window.confirm(_t('setup.deletePresetConfirm') + ' „' + p.name + '"')) {
+            return;
+        }
+        _presetFetch({ method: 'DELETE', _q: '?id=' + encodeURIComponent(p.id) })
+            .then(_loadCustomPresets)
+            .catch(function () { /* stays on screen; next load reconciles */ });
     }
 
     // Apply preset: write to the active-chip state AND to the typed vars
@@ -1200,6 +1363,13 @@
         currentPhase = msg.phase;
         if (msg.admin_session_token) {
             QuizifyUtils.writeAdminToken(msg.admin_session_token);
+            // #433: load the saved presets once the token exists. Doing it on
+            // page load instead would race the token's arrival and 401 —
+            // exactly the failure #501 chased for the entity dropdowns.
+            if (!_presetsLoaded) {
+                _presetsLoaded = true;
+                _loadCustomPresets();
+            }
         }
         // The admin-connect frame now carries the TTS-engine + media-player
         // lists directly (server-side, over this already-authenticated socket),

--- a/tests/test_kids_preset_lightning_513.py
+++ b/tests/test_kids_preset_lightning_513.py
@@ -106,9 +106,18 @@ def test_apply_preset_writes_the_checkbox_not_just_the_variable() -> None:
 
 
 def test_matching_preset_compares_lightning() -> None:
-    """Otherwise a kids run with Lightning switched back on still reads "Mit Kindern"."""
-    body = _fn_body("_matchingPreset")
+    """Otherwise a kids run with Lightning switched back on still reads "Mit Kindern".
+
+    #433 moved the field-by-field comparison out of ``_matchingPreset`` into
+    ``_sameBundle``, which both the built-in and the saved presets go through
+    — so that is where the lightning check now has to be. The invariant is
+    unchanged: lightning is part of the bundle, and flipping it by hand must
+    stop the run from matching the preset.
+    """
+    body = _fn_body("_sameBundle")
     assert "p.lightning === selectedLightning" in body
+    # …and the matcher must actually route through that helper.
+    assert "_sameBundle(" in _fn_body("_matchingPreset")
 
 
 def test_toggling_lightning_by_hand_refreshes_the_active_card() -> None:

--- a/tests/test_saved_presets_433.py
+++ b/tests/test_saved_presets_433.py
@@ -1,0 +1,237 @@
+"""Saved game presets (#433).
+
+Two halves, matching where the feature can break:
+
+* the store — a small JSON file that must survive a reload, refuse the
+  things the spec caps, and never hand the caller a half-written file;
+* the admin UI — asserted over the shipped JS/CSS text, because the browser
+  half has no test runner here (same approach as the host-card tests).
+
+The UI assertions are not decoration. `_matchingPreset()` deciding only over
+the four built-in bundles is precisely what would make a freshly saved preset
+read back as "Eigene", and that failure is silent: nothing errors, the host
+just sees their preset not being recognised.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from custom_components.quizify.server.preset_store import (  # noqa: E402
+    MAX_NAME_LENGTH,
+    MAX_PRESETS,
+    PresetStore,
+    PresetValidationError,
+)
+
+WWW = REPO / "custom_components" / "quizify" / "www"
+ADMIN_JS = WWW / "js" / "admin.js"
+ADMIN_HTML = WWW / "admin.html"
+CSS = WWW / "css" / "src" / "07-player.css"
+VIEWS = REPO / "custom_components" / "quizify" / "server" / "views.py"
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+
+def _store(tmp_path: Path) -> PresetStore:
+    return PresetStore(_FakeRuntime(tmp_path))
+
+
+FAMILY = {
+    "name": "Familienabend",
+    "rounds": 5,
+    "difficulty": "easy",
+    "timer": 180,
+    "lightning": False,
+    "category": "multi",
+    "packs": ["geographie", "tiere-natur"],
+}
+
+
+# ---------------------------------------------------------------- store
+
+
+def test_round_trip_survives_a_reload(tmp_path: Path) -> None:
+    async def go() -> None:
+        store = _store(tmp_path)
+        saved = await store.save(dict(FAMILY))
+        assert saved["id"]
+        # A second store over the same directory is what a restart looks like.
+        again = await _store(tmp_path).list()
+        assert [p["name"] for p in again] == ["Familienabend"]
+        assert again[0]["packs"] == ["geographie", "tiere-natur"]
+        assert again[0]["lightning"] is False
+
+    asyncio.run(go())
+
+
+def test_saving_with_an_id_updates_instead_of_duplicating(tmp_path: Path) -> None:
+    async def go() -> None:
+        store = _store(tmp_path)
+        first = await store.save(dict(FAMILY))
+        renamed = dict(FAMILY, id=first["id"], name="Familienabend XL", rounds=10)
+        await store.save(renamed)
+        presets = await store.list()
+        assert len(presets) == 1, "an id must update in place, not append"
+        assert presets[0]["name"] == "Familienabend XL"
+        assert presets[0]["rounds"] == 10
+        assert presets[0]["created"] == first["created"]
+
+    asyncio.run(go())
+
+
+def test_delete_removes_and_reports_unknown_ids(tmp_path: Path) -> None:
+    async def go() -> None:
+        store = _store(tmp_path)
+        saved = await store.save(dict(FAMILY))
+        assert await store.delete(saved["id"]) is True
+        assert await store.list() == []
+        assert await store.delete(saved["id"]) is False
+
+    asyncio.run(go())
+
+
+def test_caps_are_enforced(tmp_path: Path) -> None:
+    """Without caps the file is a slow leak and the chip row stops being one tap."""
+
+    async def go() -> None:
+        store = _store(tmp_path)
+        for i in range(MAX_PRESETS):
+            await store.save(dict(FAMILY, name=f"P{i}"))
+        with pytest.raises(PresetValidationError):
+            await store.save(dict(FAMILY, name="one too many"))
+
+        with pytest.raises(PresetValidationError):
+            await store.save(dict(FAMILY, name="x" * (MAX_NAME_LENGTH + 1)))
+        with pytest.raises(PresetValidationError):
+            await store.save(dict(FAMILY, name="   "))
+
+    asyncio.run(go())
+
+
+def test_a_corrupt_file_degrades_to_no_presets(tmp_path: Path) -> None:
+    """A broken presets file must never stop a game from being set up."""
+    (tmp_path / "presets.json").write_text("{not json at all")
+
+    async def go() -> None:
+        assert await _store(tmp_path).list() == []
+        # …and it stays usable afterwards.
+        await _store(tmp_path).save(dict(FAMILY))
+        assert len(await _store(tmp_path).list()) == 1
+
+    asyncio.run(go())
+
+
+def test_tts_and_house_settings_are_not_persisted(tmp_path: Path) -> None:
+    """Presets describe an evening, not which speaker is in the room."""
+
+    async def go() -> None:
+        store = _store(tmp_path)
+        await store.save(dict(FAMILY, tts_entity="tts.google", house_enabled=True))
+        stored = (await store.list())[0]
+        assert "tts_entity" not in stored
+        assert "house_enabled" not in stored
+
+    asyncio.run(go())
+
+
+# ---------------------------------------------------------------- wiring
+
+
+def test_all_three_verbs_are_admin_gated() -> None:
+    text = VIEWS.read_text(encoding="utf-8")
+    for verb in ("GET", "POST", "DELETE"):
+        assert f'("{verb}", "/api/quizify/presets"' in text, f"{verb} route missing"
+    for view in ("presets_view", "preset_save_view", "preset_delete_view"):
+        body = text.split(f"async def {view}")[1].split("async def ")[0]
+        assert "_is_admin_authenticated" in body, (
+            f"{view} must be gated — these routes carry no HA auth and they "
+            "change what the next game will be"
+        )
+
+
+def test_matching_preset_considers_saved_presets_and_packs() -> None:
+    """The silent-failure pin: without this a saved preset reads as "Eigene"."""
+    text = ADMIN_JS.read_text(encoding="utf-8")
+    body = text.split("function _matchingPreset()")[1].split("\n    function ")[0]
+    assert "_customPresets" in body, (
+        "_matchingPreset must iterate the saved presets, not only _PRESETS"
+    )
+    assert "_samePacks" in body, (
+        "saved presets can express a pack choice, so packs must be compared"
+    )
+    built_in = body.index("_PRESETS")
+    custom = body.index("_customPresets")
+    assert built_in < custom, (
+        "built-ins are checked first so a saved preset equal to Klassiker "
+        "still reads as Klassiker"
+    )
+
+
+def test_delete_does_not_also_select() -> None:
+    text = ADMIN_JS.read_text(encoding="utf-8")
+    remove = text.split("preset-chip-remove")[1][:600]
+    assert "stopPropagation" in remove, (
+        "the × sits inside the chip; without stopPropagation deleting also "
+        "applies the preset being deleted"
+    )
+
+
+def test_presets_load_only_once_a_token_exists() -> None:
+    """#501's lesson: an admin-gated fetch on page load races the token."""
+    text = ADMIN_JS.read_text(encoding="utf-8")
+    handler = text.split("function handleGameState")[1][:900]
+    assert "_loadCustomPresets" in handler
+    assert "admin_session_token" in handler
+
+
+def test_row_is_hidden_until_something_is_saved() -> None:
+    assert 'id="my-presets"' in ADMIN_HTML.read_text(encoding="utf-8")
+    text = ADMIN_JS.read_text(encoding="utf-8")
+    assert "_customPresets.length === 0" in text, (
+        "an empty labelled row is furniture that explains nothing"
+    )
+
+
+def test_chip_touch_targets_are_at_least_44px() -> None:
+    css = CSS.read_text(encoding="utf-8")
+    chip = css.split(".preset-chip {")[1].split("}")[0]
+    match = re.search(r"min-height:\s*(\d+)px", chip)
+    assert match and int(match.group(1)) >= 44, (
+        "chips carry a destructive × — 44px is the floor"
+    )
+    remove = css.split(".preset-chip-remove {")[1].split("}")[0]
+    assert re.search(r"min-width:\s*(\d+)px", remove), (
+        "the × needs its own hit area or deleting is a lottery"
+    )
+
+
+def test_built_in_preset_cards_are_untouched() -> None:
+    """The feature adds a row; it does not restyle the mode chooser."""
+    html = ADMIN_HTML.read_text(encoding="utf-8")
+    for preset in ("schnellrunde", "klassiker", "kinder", "marathon", "eigene"):
+        assert f'data-preset="{preset}"' in html
+
+
+def test_i18n_keys_exist_in_every_shipped_language() -> None:
+    for lang in ("de", "en", "es"):
+        data = json.loads((WWW / "i18n" / f"{lang}.json").read_text(encoding="utf-8"))
+        setup = data["setup"]
+        for key in ("myPresets", "savePreset", "savePresetPrompt",
+                    "deletePreset", "deletePresetConfirm"):
+            assert setup.get(key), f"{lang}.json is missing setup.{key}"


### PR DESCRIPTION
Implements the spec and the locked UI variant from #433.

## Why it is server-side

A preset saved on the living-room tablet has to be there on the host's phone. `localStorage` fails that the first time a second device is used, and silently. So: `presets.json` in `runtime.data_dir`, written through the same atomic write-then-replace as `server/token_store.py`, which `analytics.py` already uses the same directory for.

A corrupt file degrades to "no presets" rather than blocking setup — a broken JSON file must never stand between a host and starting a game.

## API

`GET` / `POST` / `DELETE` on `/api/quizify/presets`, all three behind `_is_admin_authenticated`. Presets hold nothing secret; the gate is there because these routes carry **no HA auth** and a preset changes what the next game will be.

Caps: 20 presets, 40-character names, enforced server-side. The refusal message is written for a person ("at most 20 presets can be saved") because the admin UI shows it verbatim.

## UI — variant A

A horizontally scrollable chip row above the four built-in mode cards, which are **untouched** in markup, order and styling.

- The last visible chip is allowed to clip at the viewport edge. That is the affordance; a row that fits tidily reads as "that's all". No arrows, no dots.
- Chips are **44 px** and the `×` has its own hit area — a miss there deletes rather than merely annoying.
- The row is **hidden entirely** until something is saved. A labelled empty row is furniture that explains nothing.
- Labels ship in de/en/es.

## The bug this would otherwise have shipped with

`_matchingPreset()` decided the screen's label by walking the four hard-coded bundles and falling back to "Eigene". Left alone, a freshly saved preset reads back as **"Eigene"** the moment it is re-applied — nothing errors, the host simply sees their own preset not being recognised.

It now walks the saved presets as well, **after** the built-ins so a saved preset that happens to equal Klassiker still says Klassiker, and compares `packs`. That comparison is why the old "mixed topics only" guard had to be scoped to built-ins: it exists precisely because a built-in preset cannot express a pack choice, and a saved one can.

Loading waits for `admin_session_token` to arrive over the socket rather than firing on page load — the same race #501 chased for the entity dropdowns.

## Tests

`tests/test_saved_presets_433.py`, split the way the feature can break:

- **Store**: round-trip across a simulated restart, update-in-place on an id, delete including the unknown-id path, both caps, a corrupt file, and that TTS/house keys are dropped rather than persisted.
- **Wiring**: every verb gated; `_matchingPreset` references the saved list *and* packs, built-ins first; the `×` calls `stopPropagation` (without it, deleting also applies the preset being deleted); the load is token-triggered; the row hides when empty; chips measure ≥ 44 px; the four built-in cards still exist untouched; all five i18n keys present in de/en/es.

## Notes

- `styles.css` regenerated via `scripts/build_css.py` from the `src/` module, as required.
- No version bump — next release is not due before 2026-08-24.
- Not verified on hardware yet; the RC on Markus' HA is 1.7.0-RC2, which predates this.

Closes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)