### PR TITLE
fix(setup): keep the preset chips and cards in step (#433)

### DIFF
--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -800,10 +800,19 @@
         var match = _matchingPreset();
         document.querySelectorAll('.preset-card[data-preset]').forEach(function (card) {
             var id = card.getAttribute('data-preset');
-            // "Eigene" is active only when no real preset matches.
-            var active = match ? (id === match.id) : (id === 'eigene');
+            // "Eigene" is active when no built-in preset matches — including
+            // when a SAVED preset does (#433). A saved preset has no card of
+            // its own, so without this branch the whole card row ends up with
+            // nothing highlighted, which reads as "no mode selected".
+            var active = (match && !match.custom)
+                ? (id === match.id)
+                : (id === 'eigene');
             card.classList.toggle('is-active', active);
         });
+        // The chips answer the same question as the cards, so they have to be
+        // repainted from the same place. Rendering them only on load/save/apply
+        // left a chip lit after the host changed a setting afterwards.
+        _renderCustomPresets();
     }
 
     // ── Saved presets (#433) ──────────────────────────────────────────
@@ -882,8 +891,8 @@
     function _applyCustomPreset(p) {
         _applyPreset(p.rounds, p.difficulty, p.timer, p.lightning);
         _applyPacks(p.packs || []);
+        // markActivePreset repaints the chips too, so no separate call here.
         markActivePreset();
-        _renderCustomPresets();
     }
 
     function _applyPacks(packs) {

--- a/tests/test_saved_presets_433.py
+++ b/tests/test_saved_presets_433.py
@@ -200,6 +200,32 @@ def test_presets_load_only_once_a_token_exists() -> None:
     assert "admin_session_token" in handler
 
 
+def test_chips_repaint_whenever_the_cards_do() -> None:
+    """Found in the browser, not by the suite: a chip stayed lit after the
+    host changed a setting, because the chips were only drawn on
+    load/save/apply while the cards were repainted on every change."""
+    text = ADMIN_JS.read_text(encoding="utf-8")
+    body = text.split("function markActivePreset()")[1].split("\n    function ")[0]
+    assert "_renderCustomPresets()" in body, (
+        "the chips answer the same question as the cards and must be "
+        "repainted from the same place"
+    )
+
+
+def test_a_matching_saved_preset_lights_the_custom_card() -> None:
+    """Otherwise the whole card row shows nothing selected.
+
+    A saved preset has no card of its own, so `match.id` matches no card and
+    the "Eigene" fallback is skipped because a match exists — leaving every
+    card unhighlighted, which reads as "no mode chosen".
+    """
+    text = ADMIN_JS.read_text(encoding="utf-8")
+    body = text.split("function markActivePreset()")[1].split("\n    function ")[0]
+    assert "!match.custom" in body, (
+        "a saved-preset match must fall through to the Eigene card"
+    )
+
+
 def test_row_is_hidden_until_something_is_saved() -> None:
     assert 'id="my-presets"' in ADMIN_HTML.read_text(encoding="utf-8")
     text = ADMIN_JS.read_text(encoding="utf-8")


### PR DESCRIPTION
Two display defects in the saved presets shipped by #534. Both were found by driving the real admin page at phone width on the live 1.7.0-RC3 install — neither showed up in the 1,343-test suite, because both are about what the screen *keeps* showing rather than what the code computes.

## 1. A chip stayed lit after the settings changed

Save a preset, then change rounds/difficulty/timer. The mode cards correctly moved to Marathon; the chip still read as the active preset.

The chips were rendered on load, save and apply. The cards were repainted on every settings change through `markActivePreset()`. Two paints, one question. `markActivePreset()` now repaints both.

## 2. No card was highlighted while a saved preset matched

`active = match ? (id === match.id) : (id === 'eigene')`

A saved preset has no card of its own, so `match.id` matched nothing — and the `Eigene` fallback was skipped precisely because a match existed. Result: the whole card row showed nothing selected, which reads as "no mode chosen" while a mode was very much chosen.

A saved-preset match now falls through to **Eigene**, which is what it is relative to the four built-in modes.

## Tests

Two additions to `tests/test_saved_presets_433.py`, both stating the symptom they prevent rather than the line they pin: that `markActivePreset` repaints the chips, and that a custom match falls through to the Eigene card.

## Notes

- Display only. Nothing was ever lost or mis-saved by either defect; the settings themselves round-tripped correctly, which the live test also confirmed (`Testabend · 5 Rounds · Easy · 180 s` came back exactly).
- No version bump in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)