### PR TITLE
feat(questions): let image_url point at images shipped with the integration (#536)

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ Pack files live in `custom_components/quizify/questions/`. Drop a JSON file in t
 **Rules:**
 - Exactly **3 answers** per question
 - Exactly **1 correct** answer
-- Per-question fields the loader reads: `id` (required), `question` (required), `answers` (required), `difficulty` (default `medium`), `fun_fact` (optional), `category` (optional, falls back to pack name)
+- Per-question fields the loader reads: `id` (required), `question` (required), `answers` (required), `difficulty` (default `medium`), `fun_fact` (optional), `category` (optional, falls back to pack name), `image_url` (optional — an `https://` URL, or a path under `/quizify/static/` for an image shipped with the pack; anything else is ignored)
 - Pack-level fields: `name`, `language` (`de` / `en` / `es` — only those are wired into the language chip; other ISO codes load but won't be selectable from the UI), `theme` (one of `geography`, `nature`, `popculture`, `sport`, `music`, `science`, `history`, `food`, `tech`, `worldcup`, `trivia` — drives the theme-tab filter and pack-card icon), `version`
 - File goes in the `questions/` directory — picked up automatically on next game start
 

--- a/custom_components/quizify/game/questions.py
+++ b/custom_components/quizify/game/questions.py
@@ -130,13 +130,34 @@ class Question:
         return self.type == QUESTION_TYPE_ESTIMATE
 
 
-def _sanitize_image_url(raw: object, question_id: str) -> str:
-    """Return a safe http(s) image URL, or "" if absent/invalid.
+#: The one local location a pack may point at: the integration's own static
+#: mount (#536). Anything shipped with the integration lives under here, and
+#: it is served read-only, so a pack can reference its own images without
+#: depending on a third-party host that may vanish and break every install at
+#: once. This is a PREFIX ALLOWLIST, not "relative paths are fine" — see
+#: ``_sanitize_image_url``.
+LOCAL_IMAGE_PREFIX = "/quizify/static/"
 
-    Only absolute http/https URLs are allowed. A relative path, a
-    ``javascript:``/``data:`` scheme, or a non-string is dropped (and
-    logged) so a malformed or hostile pack can't break the dashboard
-    render or smuggle markup through the field.
+#: Traversal markers rejected inside an otherwise-allowed local path. The
+#: percent-encoded form is listed because the browser, not this code, is what
+#: finally resolves the path.
+_TRAVERSAL_MARKERS = ("..", "%2e%2e")
+
+
+def _sanitize_image_url(raw: object, question_id: str) -> str:
+    """Return a safe image URL, or "" if absent/invalid.
+
+    Two forms are accepted:
+
+    * an absolute ``http``/``https`` URL, and
+    * a path under :data:`LOCAL_IMAGE_PREFIX`, i.e. an image shipped inside
+      the integration (#536).
+
+    Everything else — any other relative path, ``javascript:``/``data:``, a
+    non-string — is dropped (and logged) so a malformed or hostile pack can't
+    break the dashboard render or smuggle markup through the field. The local
+    form additionally refuses traversal, so a pack cannot climb out of the
+    static mount and point at, say, a config file.
     """
     if not raw:
         return ""
@@ -149,6 +170,16 @@ def _sanitize_image_url(raw: object, question_id: str) -> str:
         return ""
     url = raw.strip()
     if url.lower().startswith(("http://", "https://")):
+        return url
+    if url.startswith(LOCAL_IMAGE_PREFIX):
+        lowered = url.lower()
+        if any(marker in lowered for marker in _TRAVERSAL_MARKERS):
+            _LOGGER.warning(
+                "Question '%s': ignoring image_url with path traversal: %r",
+                question_id,
+                url[:60],
+            )
+            return ""
         return url
     _LOGGER.warning(
         "Question '%s': ignoring image_url with unsupported scheme: %r",

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -372,6 +372,41 @@ class TestQuestionImage:
         assert q is not None
         assert q.image_url == ""
 
+    def test_parse_question_keeps_integration_static_path(self) -> None:
+        """#536: a pack may reference an image it ships with.
+
+        Without this the only way to ship a picture round is to point every
+        question at somebody else's server, which breaks on every install at
+        once the day that server changes a path.
+        """
+        url = "/quizify/static/img/packs/picture-round/eiffel.webp"
+        q = _parse_question(_valid_question_dict(image_url=url), "Test")
+        assert q is not None
+        assert q.image_url == url
+
+    def test_parse_question_drops_traversal_out_of_static(self) -> None:
+        """The prefix is an allowlist, not a door held open."""
+        for url in (
+            "/quizify/static/../../config/secrets.yaml",
+            "/quizify/static/img/../../../etc/passwd",
+            "/quizify/static/%2e%2e/%2e%2e/secrets.yaml",
+        ):
+            q = _parse_question(_valid_question_dict(image_url=url), "Test")
+            assert q is not None
+            assert q.image_url == "", url
+
+    def test_parse_question_drops_lookalike_prefixes(self) -> None:
+        """Only that exact prefix — not anything merely starting similarly."""
+        for url in (
+            "/quizify/staticx/p.png",
+            "/quizify/admin",
+            "//evil.example/p.png",
+            "/local/p.png",
+        ):
+            q = _parse_question(_valid_question_dict(image_url=url), "Test")
+            assert q is not None
+            assert q.image_url == "", url
+
     def test_parse_question_drops_javascript_scheme(self) -> None:
         q = _parse_question(
             _valid_question_dict(image_url="javascript:alert(1)"), "Test"


### PR DESCRIPTION
## Why

`_sanitize_image_url` accepted **absolute `http(s)` URLs only**. A pack shipping inside the integration could therefore only point at somebody else's server — and the day that server moves a path, every installation's picture questions break at once, fixable only by shipping a new pack.

## What changes

Paths under `/quizify/static/` are accepted as well:

```json
{ "image_url": "/quizify/static/img/packs/picture-round/eiffel.webp" }
```

That is the integration's own read-only static mount, so a pack can reference images it ships with. It also keeps working whether the host reaches Home Assistant over the LAN tonight and Nabu Casa tomorrow — something an absolute URL only manages by living on the public internet.

## What deliberately does not change

This is a **prefix allowlist**, not a relaxation:

| Input | Result |
|---|---|
| `https://…`, `http://…` | accepted (unchanged) |
| `/quizify/static/…` | **accepted (new)** |
| `/quizify/static/../../config/secrets.yaml` | dropped |
| `/quizify/static/%2e%2e/%2e%2e/…` | dropped |
| `/quizify/staticx/p.png` | dropped |
| `//evil.example/p.png`, `/local/p.png` | dropped |
| `javascript:`, `data:`, non-string | dropped |

Traversal is refused **inside** the allowed prefix too, in both plain and percent-encoded form — the browser, not this code, is what finally resolves the path, so rejecting only the literal `..` would be checking the wrong thing.

## Tests

Three added to `TestQuestionImage`: the new form is accepted; three traversal shapes are refused; four lookalike prefixes are refused. The existing rejections all keep their tests unchanged, which is the point — this PR should be provably additive.

## Notes

- README's pack-schema list now documents `image_url` and both accepted forms; it had never mentioned the field at all.
- Prerequisite for #537 (picture-round pack), which in turn is what would give #434's progressive reveal something to reveal.

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)