### PR TITLE
fix(frontend): accept local /quizify/static/ image URLs on the client (#540)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to Quizify are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **Picture questions rendered without the picture (#540).** Every question in
+  the packs from #537 arrived with a `/quizify/static/…` image URL that the
+  browser then discarded: the dashboard, the player and the lightning round
+  each carried their own `^https?://`-only check, so the local form #536 had
+  just taught the server to accept was dropped on the client. Both the TV and
+  the phone showed the question text with no image.
+
+  The rule now lives once, in `QuizifyUtils.safeImageUrl()`, mirroring the
+  server's `_sanitize_image_url` — absolute `http(s)`, or a path under
+  `/quizify/static/` with no traversal — and the three render sites call it.
+  Found by playing a round rather than by re-reading the server tests, which
+  were green throughout.
+
 ## [1.7.0-RC5] — 2026-08-11
 
 Fifth release candidate for 1.7.0. Content, not code.

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -1499,9 +1499,10 @@
         }
 
         // Issue #25 + #183 (Variant 1 split layout): render the optional
-        // question image as a side-by-side focal point. Only absolute
-        // http(s) URLs are accepted (the server already sanitises; this is
-        // defence-in-depth). Absent/invalid → the image pane is hidden and
+        // question image as a side-by-side focal point. Which URLs count as
+        // safe is decided in one place, QuizifyUtils.safeImageUrl (#540) —
+        // absolute http(s), or the integration's own static mount (#536).
+        // Absent/invalid → the image pane is hidden and
         // .has-image is removed, so the column collapses cleanly to the
         // original full-width text-only layout. If the image fails to load
         // we fall back to the same text-only layout (graceful fallback).
@@ -1512,7 +1513,8 @@
         function renderQuestionImage(url) {
             var img = els.questionImage;
             if (!img) return;
-            var safe = (typeof url === 'string' && /^https?:\/\//i.test(url)) ? url : '';
+            var safe = (window.QuizifyUtils && window.QuizifyUtils.safeImageUrl)
+                ? window.QuizifyUtils.safeImageUrl(url) : '';
             img.onerror = function() {
                 // Image failed → collapse to text-only, no broken-image icon.
                 img.removeAttribute('src');

--- a/custom_components/quizify/www/js/player-game.js
+++ b/custom_components/quizify/www/js/player-game.js
@@ -239,7 +239,11 @@
         var media = document.getElementById('question-media');
         var img = document.getElementById('question-image');
         if (!media || !img) return;
-        var safeImg = (typeof imgUrl === 'string' && /^https?:\/\//i.test(imgUrl)) ? imgUrl : '';
+        // Allowed forms live in QuizifyUtils.safeImageUrl, mirroring the
+        // server's sanitizer — absolute http(s) or the integration's own
+        // static mount (#536/#540).
+        var safeImg = (window.QuizifyUtils && window.QuizifyUtils.safeImageUrl)
+            ? window.QuizifyUtils.safeImageUrl(imgUrl) : '';
         img.onerror = function() {
             // Image failed → hide the banner, fall back to text-only.
             img.removeAttribute('src');

--- a/custom_components/quizify/www/js/player-lightning.js
+++ b/custom_components/quizify/www/js/player-lightning.js
@@ -67,11 +67,12 @@
 
         var img = document.getElementById('lightning-image');
         if (img) {
-            // Same http(s)-only guard as player-game.js renderQuestion
-            // (issue #257) — reject javascript:/data: and other schemes
-            // before they reach img.src.
-            var safeImg = (typeof msg.image_url === 'string' && /^https?:\/\//i.test(msg.image_url))
-                ? msg.image_url : '';
+            // Same guard as player-game.js renderQuestion (issue #257),
+            // now shared via QuizifyUtils.safeImageUrl (#540) — rejects
+            // javascript:/data: and other schemes before they reach
+            // img.src, while allowing the local static mount (#536).
+            var safeImg = (window.QuizifyUtils && window.QuizifyUtils.safeImageUrl)
+                ? window.QuizifyUtils.safeImageUrl(msg.image_url) : '';
             if (safeImg) {
                 // #467: localized generic alt for the lightning image question.
                 var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -3014,11 +3014,12 @@
 
         var img = document.getElementById('lightning-image');
         if (img) {
-            // Same http(s)-only guard as player-game.js renderQuestion
-            // (issue #257) — reject javascript:/data: and other schemes
-            // before they reach img.src.
-            var safeImg = (typeof msg.image_url === 'string' && /^https?:\/\//i.test(msg.image_url))
-                ? msg.image_url : '';
+            // Same guard as player-game.js renderQuestion (issue #257),
+            // now shared via QuizifyUtils.safeImageUrl (#540) — rejects
+            // javascript:/data: and other schemes before they reach
+            // img.src, while allowing the local static mount (#536).
+            var safeImg = (window.QuizifyUtils && window.QuizifyUtils.safeImageUrl)
+                ? window.QuizifyUtils.safeImageUrl(msg.image_url) : '';
             if (safeImg) {
                 // #467: localized generic alt for the lightning image question.
                 var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
@@ -3453,7 +3454,11 @@
         var media = document.getElementById('question-media');
         var img = document.getElementById('question-image');
         if (!media || !img) return;
-        var safeImg = (typeof imgUrl === 'string' && /^https?:\/\//i.test(imgUrl)) ? imgUrl : '';
+        // Allowed forms live in QuizifyUtils.safeImageUrl, mirroring the
+        // server's sanitizer — absolute http(s) or the integration's own
+        // static mount (#536/#540).
+        var safeImg = (window.QuizifyUtils && window.QuizifyUtils.safeImageUrl)
+            ? window.QuizifyUtils.safeImageUrl(imgUrl) : '';
         img.onerror = function() {
             // Image failed → hide the banner, fall back to text-only.
             img.removeAttribute('src');

--- a/custom_components/quizify/www/js/utils.js
+++ b/custom_components/quizify/www/js/utils.js
@@ -46,6 +46,37 @@
         return { valid: true, name: trimmed };
     }
 
+    // ---- Question image URLs -------------------------------------------
+    //
+    // Mirror of the server's _sanitize_image_url (game/questions.py). Two
+    // forms are allowed: an absolute http(s) URL, and a path under the
+    // integration's own static mount (#536). Everything else — any other
+    // relative path, javascript:/data:, a non-string — renders text-only.
+    //
+    // The server already sanitises; this stays as defence-in-depth for a
+    // payload that never went through it. It lives here, in one place, so
+    // the rule can't drift per view again: the dashboard, the player and
+    // the lightning round each carried their own copy of an http(s)-only
+    // test, which silently dropped every image the packs from #537 ship
+    // (#540).
+    var LOCAL_IMAGE_PREFIX = '/quizify/static/';
+    var TRAVERSAL_MARKERS = ['..', '%2e%2e'];
+
+    function safeImageUrl(url) {
+        if (typeof url !== 'string') return '';
+        var trimmed = url.trim();
+        if (!trimmed) return '';
+        if (/^https?:\/\//i.test(trimmed)) return trimmed;
+        if (trimmed.indexOf(LOCAL_IMAGE_PREFIX) === 0) {
+            var lowered = trimmed.toLowerCase();
+            for (var i = 0; i < TRAVERSAL_MARKERS.length; i++) {
+                if (lowered.indexOf(TRAVERSAL_MARKERS[i]) !== -1) return '';
+            }
+            return trimmed;
+        }
+        return '';
+    }
+
     // ---- Admin session token -------------------------------------------
     //
     // The admin session token is a PERSISTENT credential, and every reader
@@ -89,6 +120,7 @@
 
     window.QuizifyUtils = {
         escapeHtml: escapeHtml,
+        safeImageUrl: safeImageUrl,
         validateName: validateName,
         MAX_NAME_LENGTH: MAX_NAME_LENGTH,
         readAdminToken: readAdminToken,

--- a/tests/test_question_image_url_540.py
+++ b/tests/test_question_image_url_540.py
@@ -1,0 +1,203 @@
+"""Guard the client-side question-image URL check (#540).
+
+#536/#538 taught the *server* sanitizer (``_sanitize_image_url``) that a pack
+may point at an image shipped inside the integration, i.e. a path under
+``/quizify/static/``. The *clients* kept their own defence-in-depth copy of an
+``^https?://``-only test, so every question in the picture packs from #537
+arrived with a URL the browser then threw away: the dashboard and the player
+both rendered the question text with no image, and nothing in the suite
+noticed because the server-side tests were all green.
+
+Two properties keep that from happening again:
+
+1. The rule exists once, in ``QuizifyUtils.safeImageUrl``, and behaves like the
+   Python sanitizer — asserted by running the real shipped JS under node
+   against the same cases as ``test_local_image_urls_536`` style inputs.
+2. No view re-implements it. A future call site that inlines its own regex
+   would drift away from the server the same way this one did.
+
+The node half follows ``test_worker_contract_256.py``: skip locally when node
+is absent, hard-fail in CI where ``QUIZIFY_REQUIRE_NODE=1`` is set.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from custom_components.quizify.game.questions import _sanitize_image_url
+
+REPO = Path(__file__).resolve().parent.parent
+WWW = REPO / "custom_components" / "quizify" / "www"
+UTILS_JS = WWW / "js" / "utils.js"
+
+# Every place that turns an ``image_url`` from the wire into an ``img.src``.
+# utils.js is excluded — it is the one file allowed to spell out the rule.
+RENDER_SITES = [
+    WWW / "dashboard.html",
+    WWW / "js" / "player-game.js",
+    WWW / "js" / "player-lightning.js",
+    WWW / "js" / "player.bundle.js",
+]
+
+# (url, expected) — expected "" means "render text-only". Kept deliberately in
+# lock-step with the server cases so the two can be diffed by eye.
+CASES: list[tuple[object, str]] = [
+    ("https://example.com/a.jpg", "https://example.com/a.jpg"),
+    ("http://example.com/a.jpg", "http://example.com/a.jpg"),
+    # The form the picture packs actually ship (#537) — the regression.
+    (
+        "/quizify/static/img/packs/picture-round/great-wave.webp",
+        "/quizify/static/img/packs/picture-round/great-wave.webp",
+    ),
+    # Traversal out of the static mount stays refused, in both spellings.
+    ("/quizify/static/../../secrets.yaml", ""),
+    ("/quizify/static/%2e%2e/%2e%2e/secrets.yaml", ""),
+    # Other local paths are not a general "relative paths are fine" licence.
+    ("/local/somefile.png", ""),
+    ("img/packs/x.webp", ""),
+    # Schemes that must never reach img.src.
+    ("javascript:alert(1)", ""),
+    ("data:image/png;base64,AAAA", ""),
+    # Absent / malformed.
+    ("", ""),
+    ("   ", ""),
+]
+
+_NODE_HARNESS = """
+const fs = require('fs');
+global.window = {};
+// argv[0] is node, argv[1] this harness — the utils path is argv[2].
+eval(fs.readFileSync(process.argv[2], 'utf8'));
+const cases = JSON.parse(process.argv[3]);
+const out = cases.map((u) => global.window.QuizifyUtils.safeImageUrl(u));
+process.stdout.write(JSON.stringify(out));
+"""
+
+
+def _require_node() -> None:
+    """Skip locally when node is missing; fail in CI, which pins node 20."""
+    if shutil.which("node") is not None:
+        return
+    msg = "node not available — the safeImageUrl behaviour check cannot run"
+    if os.environ.get("QUIZIFY_REQUIRE_NODE") == "1":
+        pytest.fail(msg)
+    pytest.skip(msg)
+
+
+def test_safe_image_url_behaviour_matches_server(tmp_path: Path) -> None:
+    """The shipped helper accepts and rejects exactly what the server does."""
+    _require_node()
+    harness = tmp_path / "harness.js"
+    harness.write_text(_NODE_HARNESS, encoding="utf-8")
+    urls = [u for u, _ in CASES]
+    result = subprocess.run(
+        ["node", str(harness), str(UTILS_JS), json.dumps(urls)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"node harness failed:\n{result.stderr}"
+    got = json.loads(result.stdout)
+    mismatches = [
+        (url, expected, actual)
+        for (url, expected), actual in zip(CASES, got, strict=True)
+        if actual != expected
+    ]
+    assert not mismatches, f"safeImageUrl disagrees with the spec: {mismatches}"
+
+
+def test_client_agrees_with_python_sanitizer(tmp_path: Path) -> None:
+    """Client and server verdicts agree on every case.
+
+    Asserted as "same verdict", not "same string": what matters is that an
+    image the server hands out is one the browser will actually load, and that
+    neither side alone decides an image is fine.
+    """
+    _require_node()
+    harness = tmp_path / "harness.js"
+    harness.write_text(_NODE_HARNESS, encoding="utf-8")
+    urls = [u for u, _ in CASES]
+    result = subprocess.run(
+        ["node", str(harness), str(UTILS_JS), json.dumps(urls)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"node harness failed:\n{result.stderr}"
+    client = json.loads(result.stdout)
+    server = [_sanitize_image_url(u, "test-q") for u in urls]
+    disagreements = [
+        (url, srv, cli)
+        for url, srv, cli in zip(urls, server, client, strict=True)
+        if bool(srv) != bool(cli)
+    ]
+    assert not disagreements, (
+        "client and server disagree on whether these images may render "
+        f"(url, server, client): {disagreements}"
+    )
+
+
+def test_render_sites_use_the_helper() -> None:
+    """Every render site routes through the shared helper."""
+    missing = [
+        p.name for p in RENDER_SITES if "QuizifyUtils.safeImageUrl" not in p.read_text(encoding="utf-8")
+    ]
+    assert not missing, (
+        f"{missing} do not call QuizifyUtils.safeImageUrl(). Route image URLs "
+        "through it so the accepted forms stay in one place (utils.js)."
+    )
+
+
+def test_no_render_site_reimplements_the_scheme_test() -> None:
+    """No view carries its own http(s)-only regex.
+
+    This is the exact shape of the #540 bug: three copies of
+    ``/^https?:\\/\\//i`` that the server-side change in #536 could not reach.
+    """
+    needle = "^https?:"
+    offenders = [p.name for p in RENDER_SITES if needle in p.read_text(encoding="utf-8")]
+    assert not offenders, (
+        f"{offenders} test the URL scheme inline. A local copy drifts away "
+        "from the server sanitizer the moment the allowed forms change "
+        "(#540) — call QuizifyUtils.safeImageUrl() instead."
+    )
+
+
+def test_picture_packs_ship_urls_the_client_accepts() -> None:
+    """End-to-end on the real content: every shipped image URL survives both.
+
+    The packs from #537 are the reason this bug was visible at all, so assert
+    against them directly rather than against a hand-written sample.
+    """
+    _require_node()
+    questions_dir = REPO / "custom_components" / "quizify" / "questions"
+    urls: list[str] = []
+    for pack in ("bilderraetsel-de.json", "picture-round-en.json"):
+        data = json.loads((questions_dir / pack).read_text(encoding="utf-8"))
+        questions = data["questions"] if isinstance(data, dict) else data
+        urls.extend(q["image_url"] for q in questions if q.get("image_url"))
+    assert urls, "expected the picture packs to ship image_url values"
+
+    harness = REPO / "tests" / "_tmp_harness.js"
+    harness.write_text(_NODE_HARNESS, encoding="utf-8")
+    try:
+        result = subprocess.run(
+            ["node", str(harness), str(UTILS_JS), json.dumps(urls)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    finally:
+        harness.unlink(missing_ok=True)
+    assert result.returncode == 0, f"node harness failed:\n{result.stderr}"
+    dropped = [u for u, safe in zip(urls, json.loads(result.stdout), strict=True) if not safe]
+    assert not dropped, (
+        f"{len(dropped)} shipped picture-pack images would render text-only "
+        f"in the browser, e.g. {dropped[:3]}"
+    )


### PR DESCRIPTION
Fixes #540.

## The bug

Every question in the picture packs from #537 rendered **text-only** — on the TV dashboard and on the player phone. #536/#538 relaxed the server-side `_sanitize_image_url` to accept paths under `/quizify/static/`, but each client render site carried its own defence-in-depth copy of an `^https?://`-only test and dropped exactly that form.

Found by playing a round on the RC5 tree, not by re-reading the server tests — those were green throughout, because nothing exercised the render path.

Evidence from that run:

* `#question-media` stayed `hidden`, `#question-image` never got a `src`, on both views.
* The server access log recorded **zero** requests for `/quizify/static/img/packs/...` for the whole round.

## The change

The accepted forms now live in one place, `QuizifyUtils.safeImageUrl()` in `utils.js` (already loaded by player, dashboard and admin), mirroring the Python sanitizer: absolute `http(s)`, or a path under `/quizify/static/` with no `..` / `%2e%2e`. Three call sites now route through it:

* `www/dashboard.html` (TV)
* `www/js/player-game.js` (phone)
* `www/js/player-lightning.js` (lightning round)

`player.bundle.js` is rebuilt via `scripts/build_bundle.py`.

## Tests

`tests/test_question_image_url_540.py`, five tests — all five fail on the pre-fix tree:

1. The shipped helper, run under node, accepts and rejects the expected set (including both traversal spellings and `javascript:` / `data:`).
2. Client and server agree on the verdict for every case — the property that actually broke.
3. Every real URL in `bilderraetsel-de` / `picture-round-en` survives the client check.
4. Every render site calls the helper.
5. No render site re-inlines a scheme test — the drift that caused this.

The node half follows `test_worker_contract_256.py`: skip locally when node is absent, hard-fail under `QUIZIFY_REQUIRE_NODE=1`, which CI sets.

Full suite locally: **1,279 passed, 9 skipped** (the skips are the HA-dependent tests; that env has no `homeassistant` installed).

## Verified live

Second game on the dev server after the fix, same pack:

* TV (1920×1080): image renders in the split layout, `src=/quizify/static/img/packs/picture-round/harvesters.webp`, `naturalWidth` 1200, question and answers intact beside it.
* Phone (390×844): same image above the question text, zoom control present.
* Access log now records the `.webp` request that was missing before.

No release artefacts touched — no version bump, no tag.
