### PR TITLE
fix(server): prime the UI-language cache off the event loop (#542)

### DIFF
--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -88,6 +88,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         read_manifest_version,
     )
     from .server.views import (  # noqa: PLC0415
+        prime_ui_languages,
         refresh_live_version,
         register_routes,
     )
@@ -136,6 +137,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # result in explicitly (instead of relying on AppContext's synchronous
     # default_factory) keeps the loop clean.
     version = await hass.async_add_executor_job(read_manifest_version)
+
+    # Same treatment for the UI-language chips (#542): the set is derived from
+    # the shipped www/i18n/*.json bundles, which means a directory scan. It is
+    # lru_cached, so leaving it lazy cost exactly one blocking scandir per HA
+    # start — on the first player render, where the loop-watcher flagged it.
+    # Priming here moves that one scan into an executor thread.
+    await hass.async_add_executor_job(prime_ui_languages)
 
     ctx = AppContext(
         runtime=runtime,

--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -586,6 +586,21 @@ def _available_ui_languages() -> tuple[str, ...]:
     return tuple(known + extra)
 
 
+def prime_ui_languages() -> tuple[str, ...]:
+    """Warm :func:`_available_ui_languages` so the request path stays clean.
+
+    BLOCKING (``os.scandir`` via ``glob``) — must run OFF the event loop, i.e.
+    in an executor (``__init__.py`` does this at setup), in the standalone dev
+    server which has no HA loop, or in tests. Same treatment #343 gave the
+    manifest read; the language chips arrived later (#492) and were left on the
+    loop, where HA's watcher flagged them on the first player render (#542).
+
+    The lazy path stays intact: an un-primed process still resolves the set on
+    first use, it just does the scan wherever it happens to be called.
+    """
+    return _available_ui_languages()
+
+
 def _render_ui_language_chips(default_lang: str) -> str:
     """Render the player's UI-language chips (#492).
 

--- a/tests/test_ui_language_scandir_542.py
+++ b/tests/test_ui_language_scandir_542.py
@@ -1,0 +1,74 @@
+"""Keep the UI-language directory scan off the event loop (#542).
+
+``_available_ui_languages`` derives the player's language chips from the
+``www/i18n/*.json`` bundles actually shipped, which means a directory scan. It
+is ``lru_cache``d, so the cost was exactly one blocking ``scandir`` per HA
+start — but it landed on the first player render, inside the loop, where HA's
+watcher flagged it and asked for a bug report.
+
+#343 had already moved the other two disk reads in ``views.py`` (manifest,
+HTML) into an executor; the language chips arrived later (#492) and missed the
+pattern. The fix primes the cache at setup via ``prime_ui_languages``.
+
+Asserted two ways: the priming helper really fills the cache, and setup really
+calls it off the loop. The second half is a source-text assertion because
+exercising ``async_setup_entry`` needs the full HA harness, which is
+``importorskip``-gated in this repo.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from custom_components.quizify.server.views import (
+    _available_ui_languages,
+    prime_ui_languages,
+)
+
+REPO = Path(__file__).resolve().parent.parent
+INIT_PY = REPO / "custom_components" / "quizify" / "__init__.py"
+
+
+def test_priming_fills_the_cache() -> None:
+    """After priming, the request path can resolve languages with no I/O."""
+    _available_ui_languages.cache_clear()
+    assert _available_ui_languages.cache_info().currsize == 0
+
+    primed = prime_ui_languages()
+
+    assert _available_ui_languages.cache_info().currsize == 1
+    assert primed == _available_ui_languages()
+    # A cache hit, not a second scan.
+    assert _available_ui_languages.cache_info().hits >= 1
+
+
+def test_priming_returns_the_shipped_bundles() -> None:
+    """The primed value is the real bundle set, not a placeholder.
+
+    Guards against a "fix" that satisfies the loop watcher by no longer
+    reading the directory at all — the data-driven behaviour from #492 is the
+    point of the function.
+    """
+    _available_ui_languages.cache_clear()
+    i18n_dir = REPO / "custom_components" / "quizify" / "www" / "i18n"
+    shipped = {p.stem for p in i18n_dir.glob("*.json")}
+    assert shipped, "expected www/i18n/ to ship language bundles"
+    assert set(prime_ui_languages()) == shipped
+
+
+def test_setup_primes_it_in_an_executor() -> None:
+    """Setup must prime it OFF the loop, or the warning simply moves.
+
+    ``async_add_executor_job`` is what makes this a fix rather than a
+    relocation: calling ``prime_ui_languages()`` directly in ``async_setup``
+    would run the same scandir on the same loop, just earlier.
+    """
+    source = INIT_PY.read_text(encoding="utf-8")
+    assert "prime_ui_languages" in source, (
+        "__init__.py does not prime the UI-language cache — the first player "
+        "render will do the scandir on the event loop again (#542)."
+    )
+    assert "async_add_executor_job(prime_ui_languages)" in source, (
+        "prime_ui_languages() must be handed to async_add_executor_job; "
+        "calling it directly keeps the blocking scan on the loop."
+    )


### PR DESCRIPTION
Fixes #542.

## The bug

HA's loop watcher flags the first player render after every start:

```
Detected blocking call to scandir with args ('/config/custom_components/quizify/www/i18n/',)
inside the event loop by custom integration 'quizify' at server/views.py, line 579
```

`player_view` → `_serve_html` → `_render_ui_language_chips` → `_available_ui_languages`. Seen on a real install running v1.7.0-RC6.

## Scope, stated honestly

`_available_ui_languages` is `@lru_cache(maxsize=1)`, so this is **one** blocking `scandir` per HA start, not one per request — verified against the log, where the warning appears exactly once after each restart even though many player pages were served in between.

Worth fixing anyway: HA asks for it explicitly, and #343 already moved this file's other two disk reads (the manifest, the HTML `read_text`) off the loop. The language chips landed later in #492 and missed the pattern; this closes it.

## The change

`prime_ui_languages()` warms the cache, and `async_setup_entry` calls it through `hass.async_add_executor_job` right next to the existing `read_manifest_version` priming. The request path then resolves languages with no I/O.

The lazy path stays: `scripts/dev_server.py` has no HA executor, and the function must keep working un-primed.

## Tests

`tests/test_ui_language_scandir_542.py`:

1. Priming fills the cache, and the following call is a hit rather than a second scan.
2. The primed value is the real set of shipped bundles — so a "fix" that satisfies the watcher by not reading the directory at all fails here. The data-driven behaviour from #492 is the point of the function.
3. Setup hands the helper to `async_add_executor_job`. Calling it inline would move the same blocking scan earlier on the same loop, not remove it — this is the assertion that separates a fix from a relocation.

Full suite locally: **1,282 passed, 9 skipped** (skips are the HA-gated tests, no `homeassistant` in that env). `ruff==0.15.17 check custom_components/` clean.

No release artefacts touched.
