### PR TITLE
fix(lightning): don't spend the main game's questions (#544)

### DIFF
--- a/custom_components/quizify/game/lightning.py
+++ b/custom_components/quizify/game/lightning.py
@@ -135,8 +135,15 @@ class LightningRound:
     # Setup
     # ------------------------------------------------------------------
 
-    def start(self) -> bool:
+    def start(self, *, reserve: int = 0) -> bool:
         """Build the question queue and arm the first question.
+
+        ``reserve`` is how many questions the *main* game still needs (its
+        remaining rounds). Questions the main queue is holding are only
+        claimed while more than ``reserve`` of them remain — see #544, where a
+        5-round Easy game on the 17-question picture pack (7 easy) had its
+        last five easy questions taken by this detour and ended after round 2.
+        Lightning is a bonus; it must not spend the main game's questions.
 
         Returns False if no questions are available (caller should abort).
         """
@@ -177,11 +184,24 @@ class LightningRound:
         # slider, so an estimate question would render as an empty card —
         # skip them. Iterating a finite pool can't spin, so no attempt bound
         # is needed (an all-estimate pool simply yields no questions).
+        # How much of the main game's pending queue may be spent here (#544).
+        # Questions outside that queue are free — they were never promised to
+        # a later round. ``spare`` is computed once, before anything is taken,
+        # so the budget can't drift as the loop consumes.
+        queued_ids = self._bank.remaining_queue_ids()
+        spare = max(0, len(queued_ids) - reserve)
+        claimed_from_queue = 0
+
         for q in pool:
             if len(self._questions) >= self.num_questions:
                 break
             if getattr(q, "is_estimate", False):
                 continue
+            if q.id in queued_ids:
+                if claimed_from_queue >= spare:
+                    # The main game needs this one for a later round.
+                    continue
+                claimed_from_queue += 1
             self._questions.append(q)
             self._bank.record_shown(q.id)
 
@@ -193,7 +213,18 @@ class LightningRound:
             self._bank.drop_from_queue({q.id for q in self._questions})
 
         if not self._questions:
-            _LOGGER.warning("Lightning round: no questions available")
+            if pool and spare == 0:
+                # Distinct from an empty pool: questions exist, they are just
+                # spoken for by the main game's remaining rounds (#544). The
+                # caller treats False as "skip the detour, play on".
+                _LOGGER.info(
+                    "Lightning round skipped: all %d pending questions are "
+                    "reserved for the main game's remaining %d rounds",
+                    len(queued_ids),
+                    reserve,
+                )
+            else:
+                _LOGGER.warning("Lightning round: no questions available")
             return False
 
         self.num_questions = len(self._questions)

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -1546,7 +1546,11 @@ class QuizifyGameState:
             ),
             difficulty=difficulty,
         )
-        if not lr.start():
+        # Reserve the questions the main game still owes the host (#544). Only
+        # the auto path detours out of a running game; the lobby/finale entries
+        # have no remaining rounds to protect.
+        reserve = max(0, self.total_rounds - self.round) if auto else 0
+        if not lr.start(reserve=reserve):
             return False
 
         if auto:

--- a/tests/test_lightning_reserve_544.py
+++ b/tests/test_lightning_reserve_544.py
@@ -1,0 +1,197 @@
+"""The auto Lightning Round must not spend the main game's questions (#544).
+
+Observed on a real install (v1.7.0-RC7): a 5-round Easy game on
+``picture-round-en`` ended after round 2. The pack ships 17 questions, 7 of
+them easy; rounds 1 and 2 took two, the lightning detour took the remaining
+five and claimed them out of the main queue (``drop_from_queue``, #350), and
+the next normal round found an empty queue. With a fixed difficulty there is
+no ladder fallback, so ``state.py`` logged "No more questions available" and
+ended the game — the host asked for five rounds and got two, with nothing in
+the UI to explain it.
+
+The fix reserves what the main game still owes: lightning claims a queued
+question only while more than ``total_rounds - round`` of them remain, and
+declines to start when nothing is spare (the caller already falls back to a
+normal round when ``start()`` returns False).
+
+These tests drive ``LightningRound.start(reserve=...)`` against a stub bank so
+the arithmetic is visible, and then re-run the real scenario end-to-end
+through the game state.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.lightning import LightningRound  # noqa: E402
+from custom_components.quizify.game.questions import Question  # noqa: E402
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+
+
+def _q(idx: int, difficulty: str = "easy") -> Question:
+    return Question(
+        id=f"q{idx}",
+        question=f"Question {idx}?",
+        answers=[],
+        category="picture-round-en",
+        difficulty=difficulty,
+        language="en",
+    )
+
+
+class _StubBank:
+    """Minimal QuestionBank stand-in exposing only what start() touches."""
+
+    def __init__(self, pool: list[Question], queued: list[Question]) -> None:
+        self._pool = pool
+        self._queued = {q.id for q in queued}
+        self.shown: list[str] = []
+        self.dropped: set[str] = set()
+
+    def load_all_categories(self) -> None:
+        return None
+
+    def build_pool(self, **_kwargs: object) -> list[Question]:
+        return list(self._pool)
+
+    def shown_this_game_ids(self) -> set[str]:
+        return set(self.shown)
+
+    def remaining_queue_ids(self) -> set[str]:
+        return set(self._queued)
+
+    def record_shown(self, qid: str) -> None:
+        self.shown.append(qid)
+
+    def drop_from_queue(self, ids: set[str]) -> None:
+        self.dropped |= ids
+        self._queued -= ids
+
+
+def _round(pool: list[Question], queued: list[Question]) -> LightningRound:
+    return LightningRound(_StubBank(pool, queued), ["A"], category="picture-round-en")
+
+
+def test_leaves_the_main_game_its_remaining_rounds() -> None:
+    """The exact #544 arithmetic: 5 queued, 3 rounds left → 2 claimable."""
+    pool = [_q(i) for i in range(1, 6)]
+    lr = _round(pool, pool)
+
+    assert lr.start(reserve=3) is True
+
+    assert len(lr._questions) == 2, "lightning took questions the main game needs"
+    assert len(lr._bank.remaining_queue_ids()) == 3
+
+
+def test_skips_itself_when_nothing_is_spare() -> None:
+    """Every pending question is owed to a later round → no detour at all.
+
+    ``False`` is not a failure here: ``_start_auto_lightning`` treats it as
+    "play on", which is the whole point — a missing bonus round beats a game
+    that stops three rounds early.
+    """
+    pool = [_q(i) for i in range(1, 4)]
+    lr = _round(pool, pool)
+
+    assert lr.start(reserve=3) is False
+    assert lr._bank.dropped == set()
+    assert len(lr._bank.remaining_queue_ids()) == 3
+
+
+def test_unqueued_questions_are_free() -> None:
+    """Questions outside the main queue were never promised to a round.
+
+    A big pack has plenty the main game is not holding; lightning should still
+    get its full five there rather than being throttled by the reserve.
+    """
+    queued = [_q(i) for i in range(1, 4)]
+    pool = queued + [_q(i) for i in range(10, 20)]
+    lr = _round(pool, queued)
+
+    assert lr.start(reserve=3) is True
+    assert len(lr._questions) == 5
+    # The three queued ones stayed put; the five came from the free pool.
+    assert len(lr._bank.remaining_queue_ids()) == 3
+
+
+def test_reserve_zero_keeps_the_old_behaviour() -> None:
+    """From the lobby there is no round in flight, so nothing is reserved."""
+    pool = [_q(i) for i in range(1, 8)]
+    lr = _round(pool, pool)
+
+    assert lr.start(reserve=0) is True
+    assert len(lr._questions) == 5
+
+
+class _Runtime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+    def create_task(self, coro):  # noqa: ANN001
+        import asyncio
+
+        return asyncio.ensure_future(coro)
+
+
+@pytest.fixture
+def state(tmp_path: Path) -> QuizifyGameState:
+    ws = MagicMock()
+    ws.closed = False
+    st = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="test")
+    st.add_player("A", ws)
+    return st
+
+
+def test_real_pack_five_round_easy_game_keeps_its_rounds(
+    state: QuizifyGameState,
+) -> None:
+    """End-to-end on the pack that surfaced this: 5 rounds must stay 5.
+
+    Drives the real question bank, the real picture pack and the real
+    ``start_lightning_round`` entry, then walks the remaining rounds. Before
+    the fix the queue was empty here and the game ended at round 2.
+    """
+    state.start_game(
+        category="picture-round-en",
+        difficulty="easy",
+        num_rounds=5,
+        language="en",
+    )
+    for _ in range(2):
+        assert state.start_next_question() is not None
+        # Stand in for the round timer + evaluation, which the fast loop does
+        # in production; this test is about question supply, not timing.
+        state.phase = GamePhase.ANSWER_REVEAL
+
+    assert state.round == 2
+    state.phase = GamePhase.ANSWER_REVEAL
+    state.start_lightning_round(
+        category="picture-round-en", difficulty="easy", auto=True
+    )
+
+    # Whatever lightning did or didn't take, the main game must still be able
+    # to serve every round the host asked for.
+    served = 0
+    while state.round < state.total_rounds:
+        state.phase = GamePhase.ANSWER_REVEAL
+        q = state.start_next_question()
+        if q is None:
+            break
+        served += 1
+    assert state.round == 5, (
+        f"game stranded after round {state.round}; only {served} further "
+        "questions were available (#544)"
+    )


### PR DESCRIPTION
Fixes #544.

## The bug

A 5-round Easy game on **Picture Round** ends after round 2. Seen on a real install (v1.7.0-RC7):

```
Round 1/5 started: pic-en-014
Round 2/5 started: pic-en-016
Lightning round started: 5 questions
Lightning round finished
WARNING No more questions available
Game ended after 2 rounds
```

The arithmetic is exact: the pack ships 17 questions, **7 easy**. Rounds 1 and 2 took two; the auto lightning detour (#285) built its pool at the same difficulty, took the remaining five, and claimed them out of the main queue via `drop_from_queue` (#350). The next normal round found an empty queue, and a fixed difficulty has no ladder fallback — so `end_game()`. The host asked for five rounds, got two, and the UI said nothing about why (the TV shows the result with "Question 2 / 5" still in the header).

Also hits the **"With kids"** preset (#513): same 5 rounds at Easy.

## The change

`LightningRound.start(reserve=N)`. Before taking anything it computes

```python
spare = max(0, len(bank.remaining_queue_ids()) - reserve)
```

and then claims a *queued* question only while `claimed < spare`. Questions outside the main queue were never promised to a round, so they stay free — a large pack still yields the full five. `start_lightning_round(auto=True)` passes `total_rounds - round`; the lobby / finale entries pass `0`, exactly today's behaviour.

When nothing is spare, `start()` returns False and `_start_auto_lightning` already falls back to a normal round. A missing bonus round beats a game that stops three rounds early. That case logs at INFO with the reason, distinct from the existing "no questions available" warning.

**Deliberately not done:** letting a fixed-difficulty game drift onto a neighbouring rung to refill the queue. It would keep the round count up, but it would also put a hard question in front of the kids preset — worse than a short game. The ladder stays where it belongs, in the adaptive mode (#40).

Still out of scope: a pack genuinely smaller than the requested round count ends early with nothing in the UI explaining it. That is a separate issue — this one is about questions that existed and were taken away.

## Tests

`tests/test_lightning_reserve_544.py`:

1. The exact #544 arithmetic against a stub bank — 5 queued, 3 rounds left, 2 claimable.
2. Nothing spare → the detour declines and leaves the queue untouched.
3. Unqueued questions stay free, so a big pack still gets five.
4. `reserve=0` (lobby entry) behaves as before.
5. End-to-end through the real pack and real game state: after two rounds and a lightning detour, all five rounds are still servable. On the pre-fix tree this one fails with the production log line, `No more questions available`.

Full suite locally: **1,287 passed, 9 skipped**. `ruff==0.15.17 check custom_components/` clean.

No release artefacts touched.
