### PR TITLE
fix(player): stop the end screen throwing on its admin gate (#546)

### DIFF
--- a/custom_components/quizify/www/js/player-end.js
+++ b/custom_components/quizify/www/js/player-end.js
@@ -84,7 +84,13 @@
         // signal is now sufficient — but local state is authoritative.
         var adminControls = document.getElementById('end-admin-controls');
         var playerMessage = document.getElementById('end-player-message');
-        var amAdmin = !!state.isAdmin || !!(currentPlayer && currentPlayer.is_admin);
+        // #546: the second signal used to read a free ``currentPlayer``, which
+        // only exists as a local inside player-reveal.js / player-lobby.js —
+        // each module is its own IIFE, so this threw a ReferenceError and took
+        // the rest of this function with it, leaving BOTH blocks hidden. The
+        // viewer's own row is already marked ``is_current`` above; use that.
+        var me = leaderboard.find(function (p) { return p.is_current; });
+        var amAdmin = !!state.isAdmin || !!(me && me.is_admin);
 
         if (amAdmin) {
             if (adminControls) adminControls.classList.remove('hidden');

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -2447,7 +2447,13 @@
         // signal is now sufficient — but local state is authoritative.
         var adminControls = document.getElementById('end-admin-controls');
         var playerMessage = document.getElementById('end-player-message');
-        var amAdmin = !!state.isAdmin || !!(currentPlayer && currentPlayer.is_admin);
+        // #546: the second signal used to read a free ``currentPlayer``, which
+        // only exists as a local inside player-reveal.js / player-lobby.js —
+        // each module is its own IIFE, so this threw a ReferenceError and took
+        // the rest of this function with it, leaving BOTH blocks hidden. The
+        // viewer's own row is already marked ``is_current`` above; use that.
+        var me = leaderboard.find(function (p) { return p.is_current; });
+        var amAdmin = !!state.isAdmin || !!(me && me.is_admin);
 
         if (amAdmin) {
             if (adminControls) adminControls.classList.remove('hidden');

--- a/tests/test_end_screen_admin_gate_546.py
+++ b/tests/test_end_screen_admin_gate_546.py
@@ -1,0 +1,223 @@
+"""The end screen must not throw on its admin gate (#546).
+
+``player-end.js`` read a free ``currentPlayer`` when deciding whether to show
+the host's "Start New Game" block. That identifier only exists as a local
+inside ``player-reveal.js`` / ``player-lobby.js``, and every player module is
+its own IIFE — so the read threw a ReferenceError in the middle of
+``updateEndView``. Everything before it (winner hero, highlights, scoreboard,
+share card) had already rendered, which is why the screen looked healthy;
+everything from that line on did not run, so ``end-admin-controls`` and
+``end-player-message`` both kept their ``hidden`` class. The host lost the
+button, the player lost the explanation, and the message handler swallowed the
+error.
+
+Two tests, because either alone would be weak:
+
+* the shipped module is executed under node against a DOM stub and must
+  un-hide the right block — that is the behaviour that broke;
+* no player module may read an identifier that another module declares
+  locally — that is the shape of the bug, and it would come back the next
+  time someone copies a line between modules.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+JS_DIR = REPO / "custom_components" / "quizify" / "www" / "js"
+END_JS = JS_DIR / "player-end.js"
+BUNDLE_JS = JS_DIR / "player.bundle.js"
+
+# Modules that declare `currentPlayer` as their own local. A reader outside
+# these files is looking at a variable that does not exist for it.
+_OWNERS = {"player-reveal.js", "player-lobby.js"}
+
+_HARNESS = r"""
+const fs = require('fs');
+
+// --- minimal DOM ---------------------------------------------------------
+function el(id) {
+  return {
+    id, textContent: '', innerHTML: '', hidden: false, style: {},
+    _classes: new Set(id === 'end-admin-controls' || id === 'end-player-message' ? ['hidden'] : []),
+    classList: {
+      add(c) { this._o._classes.add(c); },
+      remove(c) { this._o._classes.delete(c); },
+      contains(c) { return this._o._classes.has(c); },
+      toggle(c, on) { on ? this._o._classes.add(c) : this._o._classes.delete(c); },
+    },
+    appendChild() {}, removeChild() {}, setAttribute() {}, removeAttribute() {},
+    getAttribute() { return null; }, addEventListener() {},
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    insertAdjacentHTML() {}, focus() {}, cloneNode() { return el(id); },
+  };
+}
+const nodes = {};
+function get(id) {
+  if (!nodes[id]) { const e = el(id); e.classList._o = e; nodes[id] = e; }
+  return nodes[id];
+}
+global.document = {
+  getElementById: get,
+  createElement: (t) => get('created-' + t),
+  querySelector: () => null,
+  querySelectorAll: () => [],
+  addEventListener() {},
+  body: get('body'),
+};
+global.window = {
+  scrollTo() {},
+  addEventListener() {},
+  setTimeout: (f) => f && 0,
+  QuizifyPlayerUtils: {
+    state: { playerName: 'Host', isAdmin: false },
+    escapeHtml: (s) => String(s == null ? '' : s),
+    formatPoints: (n) => String(n),
+    showView() {},
+    paintUiIcons() {},
+    feedbackIconHtml: () => '',
+    animateValue() {},
+    renderLeaderboard() {},
+    setupCollapsibles() {},
+  },
+  QuizifyUtils: { escapeHtml: (s) => String(s == null ? '' : s) },
+};
+global.requestAnimationFrame = (f) => f && 0;
+global.setTimeout = (f) => f && 0;
+
+eval(fs.readFileSync(process.argv[2], 'utf8'));
+
+const api = global.window.QuizifyPlayerEnd;
+const payload = JSON.parse(process.argv[3]);
+global.window.QuizifyPlayerUtils.state.isAdmin = payload.stateIsAdmin;
+
+let threw = null;
+try {
+  (api.updateEndView || api.render || api.update)(payload.data);
+} catch (e) {
+  threw = String(e && e.message || e);
+}
+process.stdout.write(JSON.stringify({
+  threw,
+  adminHidden: get('end-admin-controls').classList.contains('hidden'),
+  messageHidden: get('end-player-message').classList.contains('hidden'),
+}));
+"""
+
+
+def _require_node() -> None:
+    if shutil.which("node") is not None:
+        return
+    msg = "node not available — the end-screen render check cannot run"
+    if os.environ.get("QUIZIFY_REQUIRE_NODE") == "1":
+        pytest.fail(msg)
+    pytest.skip(msg)
+
+
+def _strip_comments(src: str) -> str:
+    """Drop // and /* */ comments so prose about a bug isn't mistaken for it."""
+    src = re.sub(r"/\*.*?\*/", "", src, flags=re.S)
+    return re.sub(r"(?m)^\s*//.*$|(?<=[;\s)])//.*$", "", src)
+
+
+def _run(tmp_path: Path, *, state_is_admin: bool, row_is_admin: bool) -> dict:
+    harness = tmp_path / "end-harness.js"
+    harness.write_text(_HARNESS, encoding="utf-8")
+    payload = {
+        "stateIsAdmin": state_is_admin,
+        "data": {
+            "leaderboard": [
+                {"name": "Host", "rank": 1, "score": 20, "is_admin": row_is_admin},
+                {"name": "Guest", "rank": 2, "score": 10},
+            ],
+            "superlatives": [],
+            "total_rounds": 5,
+        },
+    }
+    result = subprocess.run(
+        ["node", str(harness), str(END_JS), json.dumps(payload)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"node harness failed:\n{result.stderr}"
+    return json.loads(result.stdout)
+
+
+def test_end_screen_renders_without_throwing(tmp_path: Path) -> None:
+    """The render completes — this is what the ReferenceError prevented.
+
+    Deliberately with ``state.isAdmin`` false: the broken expression was
+    ``!!state.isAdmin || !!(currentPlayer && …)``, so a true left side
+    short-circuited past the bad read. The throw only ever happened when the
+    fallback was actually consulted — a host whose page reloaded, and every
+    non-host player.
+    """
+    _require_node()
+    out = _run(tmp_path, state_is_admin=False, row_is_admin=False)
+    assert out["threw"] is None, f"updateEndView threw: {out['threw']}"
+
+
+def test_host_gets_the_controls(tmp_path: Path) -> None:
+    """``state.isAdmin`` alone must reveal the host block and hide the note."""
+    _require_node()
+    out = _run(tmp_path, state_is_admin=True, row_is_admin=False)
+    assert out["adminHidden"] is False, "host sees no Start New Game block"
+    assert out["messageHidden"] is True
+
+
+def test_leaderboard_flag_also_counts(tmp_path: Path) -> None:
+    """The second signal still works: is_admin on the viewer's own row.
+
+    Keeping it is the point — the fix removes a broken read, not a feature.
+    """
+    _require_node()
+    out = _run(tmp_path, state_is_admin=False, row_is_admin=True)
+    assert out["adminHidden"] is False
+    assert out["messageHidden"] is True
+
+
+def test_plain_player_gets_the_message(tmp_path: Path) -> None:
+    """Neither signal → the waiting note shows and the host block stays away."""
+    _require_node()
+    out = _run(tmp_path, state_is_admin=False, row_is_admin=False)
+    assert out["adminHidden"] is True
+    assert out["messageHidden"] is False, "player sees neither controls nor note"
+
+
+def test_no_module_reads_another_modules_local() -> None:
+    """Guard the shape of the bug, not just this one line.
+
+    ``currentPlayer`` is a local of player-reveal.js / player-lobby.js. Any
+    other module reading it is reading a variable that does not exist there —
+    which is a ReferenceError at runtime, not a quiet ``undefined``.
+    """
+    offenders = []
+    for path in sorted(JS_DIR.glob("player-*.js")):
+        if path.name in _OWNERS:
+            continue
+        code = _strip_comments(path.read_text(encoding="utf-8"))
+        if re.search(r"\bcurrentPlayer\b", code):
+            offenders.append(path.name)
+    assert not offenders, (
+        f"{offenders} read `currentPlayer`, which only exists inside "
+        f"{sorted(_OWNERS)}. Each player module is its own IIFE, so this "
+        "throws (#546) — resolve the viewer's row from the leaderboard instead."
+    )
+
+
+def test_bundle_matches_the_fixed_source() -> None:
+    """The shipped bundle must carry the fix, not a stale copy."""
+    code = _strip_comments(BUNDLE_JS.read_text(encoding="utf-8"))
+    assert "!!(me && me.is_admin)" in code, (
+        "player.bundle.js does not contain the fixed admin gate — "
+        "run scripts/build_bundle.py"
+    )


### PR DESCRIPTION
Fixes #546.

## The bug

`player-end.js:87` read a free `currentPlayer` when deciding whether to show the host's "Start New Game" block:

```js
var amAdmin = !!state.isAdmin || !!(currentPlayer && currentPlayer.is_admin);
```

That identifier is a local of `player-reveal.js` / `player-lobby.js`, and each player module is its own IIFE — so the read throws a ReferenceError rather than yielding `undefined`.

The `||` short-circuits, so a truthy `state.isAdmin` never reaches it. It bit exactly when the fallback was needed: a host whose page reloaded (the flag comes from the URL and the `joined` reply), and **every** non-host player.

The throw then took the rest of `updateEndView` with it, and that line is the one that toggles the two end-screen blocks. Both kept their `hidden` class:

* the host got **no "Start New Game"**,
* a plain player got **no "wait for the host"** line either.

Everything before it — winner hero, highlights, scoreboard, share card — had already rendered, which is why the screen looks healthy. The message handler catches the error and logs `[Quizify] Bad message: …`, so nothing surfaces.

Observed on a real install at the end of a five-round game; both elements still carried `hidden`.

The comment directly above the line records that this block was moved to `state.isAdmin` *because* relying on `currentPlayer.is_admin` had caused a "chronic lockout" of the host button. The leftover fallback reintroduced it as an exception.

## The change

The viewer's own row is stamped `is_current` a few lines earlier. Use it:

```js
var me = leaderboard.find(function (p) { return p.is_current; });
var amAdmin = !!state.isAdmin || !!(me && me.is_admin);
```

Both signals survive — this removes a broken read, not a feature.

## Tests

`tests/test_end_screen_admin_gate_546.py` runs the **shipped** module under node against a small DOM stub and asserts what each audience actually sees:

1. The render completes with `state.isAdmin` false — the path that threw.
2. `state.isAdmin` alone reveals the host block and hides the note.
3. `is_admin` on the viewer's own row does the same — the second signal still counts.
4. Neither signal → the note shows, the host block stays away.
5. No player module reads an identifier another module declares locally — the shape of the bug, so it can't return by copy-paste.
6. The committed bundle carries the fix (a stale `player.bundle.js` would ship the old line).

Five of the six fail on the pre-fix tree. The one that passes is the `state.isAdmin=true` case — correctly, since short-circuiting kept it working all along.

Full suite locally: **1,293 passed, 9 skipped**. `ruff==0.15.17 check custom_components/` clean.

No release artefacts touched.
