### PR TITLE
polish: pack names on the share card, an icon for trivia packs, a lighter zoom control

### DIFF
--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -469,6 +469,11 @@ _THEME_ICONS = {
     "food": "🍔",
     "tech": "💡",
     "worldcup": "🏆",
+    # Picture rounds and estimation (#537, #275) ship ``theme: trivia``.
+    # Without an entry they fell back to the generic 🎲, which is also what an
+    # unknown theme gets — so a shipped pack was indistinguishable from a
+    # broken one.
+    "trivia": "🖼️",
 }
 
 # ---------------------------------------------------------------------------

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -3176,6 +3176,15 @@ class QuizifyWebSocketHandler:
         packs = list(getattr(game_state, "categories", None) or [])
         if not packs and getattr(game_state, "category", None):
             packs = [game_state.category]
+        # Slug -> display name. The card is written to be pasted into a group
+        # chat, and "picture-round-en" reads like a filename; the picker calls
+        # the same pack "Picture Round". Unknown slugs (a pack removed
+        # mid-game) fall back to the slug rather than vanishing from the line.
+        try:
+            _meta = game_state.question_bank.get_pack_versions()
+            packs = [(_meta.get(slug) or {}).get("name") or slug for slug in packs]
+        except (AttributeError, TypeError):  # pragma: no cover - defensive
+            pass
         finale_msg = serialize_finale(
             podium, all_players, superlatives=awards, packs=packs
         )

--- a/custom_components/quizify/www/css/src/03-question.css
+++ b/custom_components/quizify/www/css/src/03-question.css
@@ -111,17 +111,27 @@
     height: 100%;
     object-fit: contain;
 }
+/* A round, light control rather than a dark grey square.
+   The button is anchored to the media box, not to the picture — with
+   ``object-fit: contain`` a portrait image leaves wide pale margins, and the
+   old dark rectangle sat in one of them looking like a piece of the layout
+   that had come loose. Light glass reads as a control on both surfaces: a
+   soft white disc on the pale backing, and still a button over a dark
+   photograph, where the shadow and ring separate it from the image. */
 .question-image-zoom {
     position: absolute;
     top: 8px;
     right: 8px;
     width: 34px;
     height: 34px;
-    border: none;
-    border-radius: 8px;
-    background: rgba(42, 40, 32, 0.55);
-    color: #fff;
-    font-size: 16px;
+    border: 1px solid rgba(42, 40, 32, 0.16);
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.78);
+    -webkit-backdrop-filter: blur(6px);
+    backdrop-filter: blur(6px);
+    box-shadow: 0 1px 4px rgba(42, 40, 32, 0.18);
+    color: var(--color-text, #2a2820);
+    font-size: 15px;
     line-height: 1;
     cursor: pointer;
     display: flex;
@@ -135,7 +145,7 @@
     position: absolute;
     inset: -5px;
 }
-.question-image-zoom:hover { background: rgba(42, 40, 32, 0.75); }
+.question-image-zoom:hover { background: rgba(255, 255, 255, 0.92); }
 
 /* Fullscreen zoom overlay */
 .image-zoom-overlay {

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -1654,17 +1654,27 @@ button, .btn {
     height: 100%;
     object-fit: contain;
 }
+/* A round, light control rather than a dark grey square.
+   The button is anchored to the media box, not to the picture — with
+   ``object-fit: contain`` a portrait image leaves wide pale margins, and the
+   old dark rectangle sat in one of them looking like a piece of the layout
+   that had come loose. Light glass reads as a control on both surfaces: a
+   soft white disc on the pale backing, and still a button over a dark
+   photograph, where the shadow and ring separate it from the image. */
 .question-image-zoom {
     position: absolute;
     top: 8px;
     right: 8px;
     width: 34px;
     height: 34px;
-    border: none;
-    border-radius: 8px;
-    background: rgba(42, 40, 32, 0.55);
-    color: #fff;
-    font-size: 16px;
+    border: 1px solid rgba(42, 40, 32, 0.16);
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.78);
+    -webkit-backdrop-filter: blur(6px);
+    backdrop-filter: blur(6px);
+    box-shadow: 0 1px 4px rgba(42, 40, 32, 0.18);
+    color: var(--color-text, #2a2820);
+    font-size: 15px;
     line-height: 1;
     cursor: pointer;
     display: flex;
@@ -1678,7 +1688,7 @@ button, .btn {
     position: absolute;
     inset: -5px;
 }
-.question-image-zoom:hover { background: rgba(42, 40, 32, 0.75); }
+.question-image-zoom:hover { background: rgba(255, 255, 255, 0.92); }
 
 /* Fullscreen zoom overlay */
 .image-zoom-overlay {

--- a/custom_components/quizify/www/js/icons.js
+++ b/custom_components/quizify/www/js/icons.js
@@ -28,7 +28,14 @@
         history: '<path d="M7 4h9a2 2 0 0 1 2 2v12a2 2 0 0 0 2 2H8a2 2 0 0 1-2-2V6"/><path d="M6 6a2 2 0 0 0-2 2v1h2"/><path d="M10 9h5M10 13h5"/>',
         food: '<path d="M7 3v18M5 3v6a2 2 0 0 0 4 0V3"/><path d="M16 3c-1.6 0-2.5 2.2-2.5 5s1 4 2.5 4 2.5-1.2 2.5-4-.9-5-2.5-5zM16 12v9"/>',
         tech: '<path d="M9.5 18h5M11 21h2"/><path d="M12 3a6 6 0 0 0-3.8 10.6c.8.7 1.3 1.5 1.3 2.4h5c0-.9.5-1.7 1.3-2.4A6 6 0 0 0 12 3z"/>',
-        worldcup: '<path d="M7 4h10v4a5 5 0 0 1-10 0V4z"/><path d="M7 6H4v1a3.5 3.5 0 0 0 3.5 3.5M17 6h3v1a3.5 3.5 0 0 1-3.5 3.5"/><path d="M12 13v4M9 20h6M10 20a2 2 0 0 1 2-2 2 2 0 0 1 2 2"/>'
+        worldcup: '<path d="M7 4h10v4a5 5 0 0 1-10 0V4z"/><path d="M7 6H4v1a3.5 3.5 0 0 0 3.5 3.5M17 6h3v1a3.5 3.5 0 0 1-3.5 3.5"/><path d="M12 13v4M9 20h6M10 20a2 2 0 0 1 2-2 2 2 0 0 1 2 2"/>',
+        // The packs that don't fit a subject theme — picture rounds and
+        // estimation (#537, #275). Without an entry they fell through to
+        // ``mixed``, so "Bilderrätsel", "Schätzfragen" and "Gemischt" wore
+        // the same glyph, and "Mixed" means something else entirely (every
+        // pack at once). A framed picture reads for both: the estimation
+        // packs are the other kind of "look at this and judge".
+        trivia: '<rect x="3" y="5" width="18" height="14" rx="2"/><circle class="d" cx="8.5" cy="10" r="1.3"/><path d="M4 17l4.5-4.5 3 3L15 11l5 5"/>'
     };
 
     // UI line icons keyed by a semantic name (NOT a theme). Used for the
@@ -82,7 +89,7 @@
     var CATEGORY_TINT = {
         mixed: 'mix', geography: 'coral', nature: 'sage', popculture: 'sky',
         sport: 'sun', music: 'coral', science: 'sage', history: 'sky',
-        food: 'sun', tech: 'coral', worldcup: 'sun'
+        food: 'sun', tech: 'coral', worldcup: 'sun', trivia: 'sage'
     };
 
     // Returns the inner SVG markup (paths only) for a theme, or the mixed

--- a/tests/test_pack_labels_and_icons.py
+++ b/tests/test_pack_labels_and_icons.py
@@ -1,0 +1,99 @@
+"""Packs must be named and marked the way the picker names and marks them.
+
+Two small things a full browser pass turned up, both cosmetic and both the
+kind that only shows up when you look at the screen:
+
+* the shareable result card printed the pack **slug** (``picture-round-en``),
+  while every other surface shows the display name ("Picture Round"). The card
+  exists to be pasted into a group chat, so it reads like a filename there.
+* the four packs that ship ``theme: trivia`` (the picture rounds from #537 and
+  the estimation packs from #275) had no icon of their own, so they fell back
+  to the ``mixed`` glyph — the same mark "Gemischt" uses, which means every
+  pack at once, and the same 🎲 an *unknown* theme gets.
+
+The icon test is written against the packs actually shipped rather than a
+hard-coded theme list: a new pack with a new theme should fail here, not paint
+a fallback glyph in the picker.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+QUESTIONS = REPO / "custom_components" / "quizify" / "questions"
+ICONS_JS = REPO / "custom_components" / "quizify" / "www" / "js" / "icons.js"
+VIEWS_PY = REPO / "custom_components" / "quizify" / "server" / "views.py"
+WS_PY = REPO / "custom_components" / "quizify" / "server" / "websocket.py"
+
+
+def _shipped_themes() -> set[str]:
+    themes = set()
+    for path in QUESTIONS.glob("*.json"):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            theme = data.get("theme")
+            if isinstance(theme, str) and theme:
+                themes.add(theme)
+    return themes
+
+
+def _js_map_keys(name: str) -> set[str]:
+    """Keys of an object literal in icons.js.
+
+    Matches ``key: '…'`` anywhere, not just at the start of a line — the tint
+    map packs several entries per line, and a line-anchored pattern silently
+    saw only the first of each, which read as "nine themes have no tint".
+    """
+    src = ICONS_JS.read_text(encoding="utf-8")
+    match = re.search(rf"{name}\s*=\s*\{{(.*?)\n\s*\}};", src, re.S)
+    assert match, f"could not find {name} in icons.js"
+    return set(re.findall(r"([a-z]+)\s*:\s*'", match.group(1)))
+
+
+def test_every_shipped_theme_has_a_line_icon() -> None:
+    """No shipped pack may fall through to the ``mixed`` glyph."""
+    missing = sorted(_shipped_themes() - _js_map_keys("CATEGORY_ICON_SVG"))
+    assert not missing, (
+        f"themes {missing} ship in a pack but have no icon in icons.js, so the "
+        "picker draws the 'mixed' glyph — the mark that means *all* packs."
+    )
+
+
+def test_every_shipped_theme_has_a_tint() -> None:
+    """A themed icon without a tint gets the neutral mixed disc."""
+    missing = sorted(_shipped_themes() - _js_map_keys("CATEGORY_TINT"))
+    assert not missing, f"themes {missing} have an icon but no tint in icons.js"
+
+
+def test_every_shipped_theme_has_a_server_emoji() -> None:
+    """The server-rendered chips must not fall back to the unknown-theme 🎲."""
+    src = VIEWS_PY.read_text(encoding="utf-8")
+    match = re.search(r"_THEME_ICONS\s*=\s*\{(.*?)\n\}", src, re.S)
+    assert match, "could not find _THEME_ICONS in views.py"
+    keys = set(re.findall(r'"([a-z]+)"\s*:', match.group(1)))
+    missing = sorted(_shipped_themes() - keys)
+    assert not missing, (
+        f"themes {missing} have no entry in _THEME_ICONS, so a shipped pack "
+        "is drawn with the same 🎲 an unknown/broken theme gets."
+    )
+
+
+def test_share_card_gets_display_names_not_slugs() -> None:
+    """The finale maps pack slugs through the bank before sending them.
+
+    Asserted on the source because building a finale payload needs a live
+    game state; what matters is that the mapping happens at all, and that it
+    keeps the slug when a pack is unknown rather than dropping the line.
+    """
+    src = WS_PY.read_text(encoding="utf-8")
+    assert "get_pack_versions()" in src, (
+        "the finale no longer resolves pack display names — the share card "
+        "will print slugs like 'picture-round-en' again."
+    )
+    assert 'or slug for slug in packs' in src, (
+        "the slug fallback is gone; an unknown pack would vanish from the "
+        "card's Packs line instead of appearing under its slug."
+    )


### PR DESCRIPTION
Three cosmetic findings from the full browser pass on 1.7.0. No issue filed for these — they are visible-but-harmless, and the fix is smaller than the ticket would have been.

## 1. The share card printed a slug

The end-screen card showed `Packs: picture-round-en`; every other surface calls that pack "Picture Round". The card exists to be pasted into a group chat, where a slug reads like a filename someone forgot to translate.

The finale now maps the slugs through `question_bank.get_pack_versions()` before they go on the wire, keeping the slug as a fallback so a pack that was removed mid-game still appears on the line instead of silently dropping out of it.

## 2. Trivia packs had no icon

Four shipped packs carry `theme: trivia` — the two picture rounds (#537) and the two estimation packs (#275). `icons.js` had no entry, so they fell through to the `mixed` glyph, which is the mark **"Gemischt"** uses and means *every pack at once*; server-side they got the 🎲 that an *unknown* theme gets. Three different things wearing one mark.

They now have their own frame glyph, tint and emoji. Picture and estimation still share it — splitting them needs a new theme key, a theme tab, an i18n label and a README change, which is past cosmetics and worth its own decision.

## 3. The zoom button looked like a loose panel

`.question-image-zoom` was a dark grey rectangle anchored to the **media box**, not to the picture. With `object-fit: contain` a portrait image leaves wide pale margins, so on the picture packs the button usually sat in one of them — a hard-edged dark rectangle on cream, reading as a stray piece of layout rather than a control.

It is now a round, light-glass control with a ring and a soft shadow, which reads as a button both on the pale backing and over a dark photograph. The 44 px tap target from #423 is untouched.

## Tests

`tests/test_pack_labels_and_icons.py` — four, all failing on the pre-fix tree:

- every theme a **shipped pack actually uses** has a line icon, a tint and a server emoji. Written against the packs on disk rather than a hard-coded list, so the next pack with a new theme fails here instead of quietly painting a fallback.
- the finale still resolves display names, and still falls back to the slug.

Full suite: **1,297 passed, 9 skipped**. `ruff==0.15.17 check custom_components/` clean.

## What I did not verify

The zoom button is CSS only. I confirmed the computed style on the running player view and the placement, but I do not have a before/after screenshot of the final light variant — the dev-server game had moved past the question by the time the stylesheet was rebuilt. If it looks wrong on your phone, that is the one thing here I cannot claim to have seen.

No release artefacts touched.
