### PR TITLE
feat(#434): progressive image reveal — the picture sharpens as the clock runs

### DIFF
--- a/custom_components/quizify/game/questions.py
+++ b/custom_components/quizify/game/questions.py
@@ -87,6 +87,14 @@ QUESTION_TYPE_MULTIPLE_CHOICE = "multiple_choice"
 QUESTION_TYPE_ESTIMATE = "estimate"
 VALID_QUESTION_TYPES = (QUESTION_TYPE_MULTIPLE_CHOICE, QUESTION_TYPE_ESTIMATE)
 
+#: Image reveal styles (#434). ``""`` shows the picture outright, the way
+#: every image question behaved before. ``"progressive"`` starts it heavily
+#: blurred and sharpens it as the round timer runs down, so guessing early is
+#: worth more than guessing late.
+REVEAL_STYLE_NONE = ""
+REVEAL_STYLE_PROGRESSIVE = "progressive"
+VALID_REVEAL_STYLES = (REVEAL_STYLE_NONE, REVEAL_STYLE_PROGRESSIVE)
+
 
 @dataclass
 class Question:
@@ -112,6 +120,11 @@ class Question:
     # anything else is dropped at parse time so a malformed pack can't
     # inject markup or point at a local path.
     image_url: str = ""
+    # How the image is revealed (#434). Empty means "show it outright", which
+    # is what every pack did before this field existed. See
+    # ``_sanitize_reveal_style`` — a style without an image is dropped, since
+    # unblurring nothing is an effect with no subject.
+    reveal_style: str = REVEAL_STYLE_NONE
     # Question type (#275). Defaults to multiple_choice so every pack without
     # a ``type`` field behaves exactly as before.
     type: str = QUESTION_TYPE_MULTIPLE_CHOICE
@@ -187,6 +200,45 @@ def _sanitize_image_url(raw: object, question_id: str) -> str:
         url[:60],
     )
     return ""
+
+
+def _sanitize_reveal_style(
+    raw: object, image_url: str, question_id: str
+) -> str:
+    """Return a valid reveal style, or "" if absent/invalid/pointless (#434).
+
+    Two things are refused, both quietly falling back to "show the image
+    outright" rather than to an error:
+
+    * an unknown style — a typo'd ``"progresive"`` must not leave the picture
+      permanently blurred, which is what an unrecognised value keyed straight
+      into a CSS class would do; and
+    * a style on a question with **no image**, because a reveal with nothing
+      to reveal is the exact trap this issue was blocked on for months.
+    """
+    if not raw:
+        return REVEAL_STYLE_NONE
+    if not isinstance(raw, str):
+        _LOGGER.warning(
+            "Question '%s': ignoring non-string reveal_style (%s)",
+            question_id,
+            type(raw).__name__,
+        )
+        return REVEAL_STYLE_NONE
+    style = raw.strip().lower()
+    if style not in VALID_REVEAL_STYLES:
+        _LOGGER.warning(
+            "Question '%s': ignoring unknown reveal_style %r", question_id, style[:40]
+        )
+        return REVEAL_STYLE_NONE
+    if not image_url:
+        _LOGGER.warning(
+            "Question '%s': reveal_style %r has no image to reveal, ignoring",
+            question_id,
+            style,
+        )
+        return REVEAL_STYLE_NONE
+    return style
 
 
 def _normalize_season(raw: object) -> dict | None:
@@ -274,6 +326,8 @@ def _parse_estimate_question(data: dict, category_name: str) -> Question | None:
     unit_raw = data.get("unit", "")
     unit_val = unit_raw if isinstance(unit_raw, str) else ""
 
+    image_url = _sanitize_image_url(data.get("image_url"), data["id"])
+
     return Question(
         id=data["id"],
         question=data["question"],
@@ -281,7 +335,10 @@ def _parse_estimate_question(data: dict, category_name: str) -> Question | None:
         difficulty=data.get("difficulty", "medium"),
         fun_fact=data.get("fun_fact", ""),
         category=data.get("category", category_name),
-        image_url=_sanitize_image_url(data.get("image_url"), data["id"]),
+        image_url=image_url,
+        reveal_style=_sanitize_reveal_style(
+            data.get("reveal_style"), image_url, data["id"]
+        ),
         type=QUESTION_TYPE_ESTIMATE,
         estimate_answer=answer_val,
         estimate_min=min_val,
@@ -353,6 +410,8 @@ def _parse_question(data: dict, category_name: str) -> Question | None:
         for a in answers_raw
     ]
 
+    image_url = _sanitize_image_url(data.get("image_url"), data["id"])
+
     return Question(
         id=data["id"],
         question=data["question"],
@@ -360,7 +419,10 @@ def _parse_question(data: dict, category_name: str) -> Question | None:
         difficulty=data.get("difficulty", "medium"),
         fun_fact=data.get("fun_fact", ""),
         category=data.get("category", category_name),
-        image_url=_sanitize_image_url(data.get("image_url"), data["id"]),
+        image_url=image_url,
+        reveal_style=_sanitize_reveal_style(
+            data.get("reveal_style"), image_url, data["id"]
+        ),
     )
 
 

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -2013,6 +2013,10 @@ class QuizifyGameState:
                 "difficulty": q.difficulty,
                 "category": q.category,
                 "image_url": q.image_url,
+                # #434: a dashboard that reconnects mid-question needs both the
+                # style and the remaining time below to resume the blur at the
+                # right point instead of snapping to sharp.
+                "reveal_style": q.reveal_style,
                 "time_limit": self._round_duration,
                 "time_remaining": round(remaining, 1),
             }

--- a/custom_components/quizify/questions/bilderraetsel-de.json
+++ b/custom_components/quizify/questions/bilderraetsel-de.json
@@ -23,7 +23,8 @@
       ],
       "difficulty": "medium",
       "fun_fact": "Cézanne malte das Motiv fünfmal; eine Fassung gilt als eines der teuersten je verkauften Gemälde.",
-      "image_url": "/quizify/static/img/packs/picture-round/card-players.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/card-players.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-de-002",
@@ -44,7 +45,8 @@
       ],
       "difficulty": "medium",
       "fun_fact": "Ein Daishō ist das Paar aus langem und kurzem Schwert — das Vorrecht, beide zu tragen, hatten nur Samurai.",
-      "image_url": "/quizify/static/img/packs/picture-round/daisho-swords.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/daisho-swords.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-de-003",
@@ -65,7 +67,8 @@
       ],
       "difficulty": "easy",
       "fun_fact": "Der „Erdaufgang\" von Apollo 8 gilt als eines der einflussreichsten Fotos der Umweltbewegung.",
-      "image_url": "/quizify/static/img/packs/picture-round/earthrise.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/earthrise.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-de-004",
@@ -86,7 +89,8 @@
       ],
       "difficulty": "easy",
       "fun_fact": "Die aufgemalten Augen an der Seite sollten dem Toten erlauben, aus dem Sarg nach draußen zu blicken.",
-      "image_url": "/quizify/static/img/packs/picture-round/egyptian-coffin.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/egyptian-coffin.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-de-005",
@@ -107,7 +111,8 @@
       ],
       "difficulty": "hard",
       "fun_fact": "Gauguin verlegte die christliche Verkündigung nach Polynesien — Titel und Bildsprache mischen beide Welten.",
-      "image_url": "/quizify/static/img/packs/picture-round/gauguin-ia-orana-maria.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/gauguin-ia-orana-maria.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-de-006",
@@ -128,7 +133,8 @@
       ],
       "difficulty": "easy",
       "fun_fact": "Es ist ein Holzschnitt, kein Gemälde — gedruckt wurden zu Hokusais Zeit mehrere tausend Abzüge.",
-      "image_url": "/quizify/static/img/packs/picture-round/great-wave.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/great-wave.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-de-007",
@@ -149,7 +155,8 @@
       ],
       "difficulty": "medium",
       "fun_fact": "Amphoren transportierten Wein und Öl — bemalte Stücke wie dieses waren zugleich Preise bei Wettkämpfen.",
-      "image_url": "/quizify/static/img/packs/picture-round/greek-amphora.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/greek-amphora.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-de-008",
@@ -170,7 +177,8 @@
       ],
       "difficulty": "medium",
       "fun_fact": "Bruegels „Kornernte\" von 1565 gehört zu einer Folge von sechs Bildern über die Jahreszeiten.",
-      "image_url": "/quizify/static/img/packs/picture-round/harvesters.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/harvesters.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-de-009",
@@ -191,7 +199,8 @@
       ],
       "difficulty": "easy",
       "fun_fact": "Eine vollständige Plattenrüstung wog etwa 25 Kilo — verteilt auf den ganzen Körper, nicht auf den Schultern.",
-      "image_url": "/quizify/static/img/packs/picture-round/knight-armor.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/knight-armor.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-de-010",
@@ -212,7 +221,8 @@
       ],
       "difficulty": "hard",
       "fun_fact": "Der Skandal drehte sich um einen herabgerutschten Träger — Sargent übermalte ihn später.",
-      "image_url": "/quizify/static/img/packs/picture-round/madame-x.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/madame-x.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-de-011",
@@ -233,7 +243,8 @@
       ],
       "difficulty": "easy",
       "fun_fact": "Ohne Wind und Wasser bleibt der Abdruck dort vermutlich Millionen Jahre erhalten.",
-      "image_url": "/quizify/static/img/packs/picture-round/moon-footprint.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/moon-footprint.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-de-012",
@@ -254,7 +265,8 @@
       ],
       "difficulty": "hard",
       "fun_fact": "Die Seite stammt aus der „Sprache der Vögel\", einem persischen Gedicht über eine Vogelversammlung.",
-      "image_url": "/quizify/static/img/packs/picture-round/persian-birds-folio.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/persian-birds-folio.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-de-013",
@@ -275,7 +287,8 @@
       ],
       "difficulty": "hard",
       "fun_fact": "Rembrandt malte seine Frau Saskia mehrfach als Blumengöttin Flora.",
-      "image_url": "/quizify/static/img/packs/picture-round/rembrandt-flora.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/rembrandt-flora.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-de-014",
@@ -296,7 +309,8 @@
       ],
       "difficulty": "easy",
       "fun_fact": "Van Gogh malte über 35 Selbstporträts — meist, weil er sich kein Modell leisten konnte.",
-      "image_url": "/quizify/static/img/packs/picture-round/self-portrait-straw-hat.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/self-portrait-straw-hat.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-de-015",
@@ -317,7 +331,8 @@
       ],
       "difficulty": "medium",
       "fun_fact": "Gemalt wurde es 1851 in Düsseldorf — der Fluss im Hintergrund ist eigentlich der Rhein.",
-      "image_url": "/quizify/static/img/packs/picture-round/washington-crossing.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/washington-crossing.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-de-016",
@@ -338,7 +353,8 @@
       ],
       "difficulty": "easy",
       "fun_fact": "Van Gogh malte die Zypressen im Sommer 1889, während er in der Anstalt von Saint-Rémy lebte.",
-      "image_url": "/quizify/static/img/packs/picture-round/wheat-field-cypresses.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/wheat-field-cypresses.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-de-017",
@@ -359,7 +375,8 @@
       ],
       "difficulty": "medium",
       "fun_fact": "Von Vermeer sind nur etwa 35 Werke bekannt — dieses war das erste, das in eine amerikanische Sammlung kam.",
-      "image_url": "/quizify/static/img/packs/picture-round/young-woman-water-pitcher.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/young-woman-water-pitcher.webp",
+      "reveal_style": "progressive"
     }
   ]
 }

--- a/custom_components/quizify/questions/picture-round-en.json
+++ b/custom_components/quizify/questions/picture-round-en.json
@@ -23,7 +23,8 @@
       ],
       "difficulty": "medium",
       "fun_fact": "Cézanne painted the subject five times; one version counts among the most expensive paintings ever sold.",
-      "image_url": "/quizify/static/img/packs/picture-round/card-players.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/card-players.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-en-002",
@@ -44,7 +45,8 @@
       ],
       "difficulty": "medium",
       "fun_fact": "A daishō is the pairing of long and short sword — only samurai were allowed to wear both.",
-      "image_url": "/quizify/static/img/packs/picture-round/daisho-swords.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/daisho-swords.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-en-003",
@@ -65,7 +67,8 @@
       ],
       "difficulty": "easy",
       "fun_fact": "Apollo 8's Earthrise is counted among the most influential photographs of the environmental movement.",
-      "image_url": "/quizify/static/img/packs/picture-round/earthrise.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/earthrise.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-en-004",
@@ -86,7 +89,8 @@
       ],
       "difficulty": "easy",
       "fun_fact": "The eyes painted on the side let the dead look out of the coffin.",
-      "image_url": "/quizify/static/img/packs/picture-round/egyptian-coffin.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/egyptian-coffin.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-en-005",
@@ -107,7 +111,8 @@
       ],
       "difficulty": "hard",
       "fun_fact": "Gauguin moved the Christian Annunciation to Polynesia — the title and imagery mix both worlds.",
-      "image_url": "/quizify/static/img/packs/picture-round/gauguin-ia-orana-maria.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/gauguin-ia-orana-maria.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-en-006",
@@ -128,7 +133,8 @@
       ],
       "difficulty": "easy",
       "fun_fact": "It is a woodblock print, not a painting — several thousand impressions were pulled in Hokusai's day.",
-      "image_url": "/quizify/static/img/packs/picture-round/great-wave.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/great-wave.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-en-007",
@@ -149,7 +155,8 @@
       ],
       "difficulty": "medium",
       "fun_fact": "Amphorae carried wine and oil — painted ones like this doubled as prizes at games.",
-      "image_url": "/quizify/static/img/packs/picture-round/greek-amphora.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/greek-amphora.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-en-008",
@@ -170,7 +177,8 @@
       ],
       "difficulty": "medium",
       "fun_fact": "Bruegel's Harvesters of 1565 belongs to a series of six pictures about the seasons.",
-      "image_url": "/quizify/static/img/packs/picture-round/harvesters.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/harvesters.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-en-009",
@@ -191,7 +199,8 @@
       ],
       "difficulty": "easy",
       "fun_fact": "A full suit of plate weighed about 25 kilos — spread over the whole body, not hanging from the shoulders.",
-      "image_url": "/quizify/static/img/packs/picture-round/knight-armor.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/knight-armor.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-en-010",
@@ -212,7 +221,8 @@
       ],
       "difficulty": "hard",
       "fun_fact": "The scandal was about one fallen shoulder strap — Sargent later repainted it upright.",
-      "image_url": "/quizify/static/img/packs/picture-round/madame-x.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/madame-x.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-en-011",
@@ -233,7 +243,8 @@
       ],
       "difficulty": "easy",
       "fun_fact": "With no wind or water, it will probably stay there for millions of years.",
-      "image_url": "/quizify/static/img/packs/picture-round/moon-footprint.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/moon-footprint.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-en-012",
@@ -254,7 +265,8 @@
       ],
       "difficulty": "hard",
       "fun_fact": "The page comes from the Language of the Birds, a Persian poem about an assembly of birds.",
-      "image_url": "/quizify/static/img/packs/picture-round/persian-birds-folio.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/persian-birds-folio.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-en-013",
@@ -275,7 +287,8 @@
       ],
       "difficulty": "hard",
       "fun_fact": "Rembrandt painted his wife Saskia as Flora, goddess of flowers, more than once.",
-      "image_url": "/quizify/static/img/packs/picture-round/rembrandt-flora.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/rembrandt-flora.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-en-014",
@@ -296,7 +309,8 @@
       ],
       "difficulty": "easy",
       "fun_fact": "Van Gogh painted more than 35 self-portraits — mostly because he could not afford a model.",
-      "image_url": "/quizify/static/img/packs/picture-round/self-portrait-straw-hat.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/self-portrait-straw-hat.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-en-015",
@@ -317,7 +331,8 @@
       ],
       "difficulty": "medium",
       "fun_fact": "It was painted in Düsseldorf in 1851 — the river in the background is really the Rhine.",
-      "image_url": "/quizify/static/img/packs/picture-round/washington-crossing.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/washington-crossing.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-en-016",
@@ -338,7 +353,8 @@
       ],
       "difficulty": "easy",
       "fun_fact": "Van Gogh painted the cypresses in the summer of 1889, while living at the asylum in Saint-Rémy.",
-      "image_url": "/quizify/static/img/packs/picture-round/wheat-field-cypresses.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/wheat-field-cypresses.webp",
+      "reveal_style": "progressive"
     },
     {
       "id": "pic-en-017",
@@ -359,7 +375,8 @@
       ],
       "difficulty": "medium",
       "fun_fact": "Only about 35 works by Vermeer are known — this was the first to enter an American collection.",
-      "image_url": "/quizify/static/img/packs/picture-round/young-woman-water-pitcher.webp"
+      "image_url": "/quizify/static/img/packs/picture-round/young-woman-water-pitcher.webp",
+      "reveal_style": "progressive"
     }
   ]
 }

--- a/custom_components/quizify/server/protocol.py
+++ b/custom_components/quizify/server/protocol.py
@@ -84,6 +84,9 @@ class QuestionStartedMessage:
     # Optional image URL for the question (issue #25). Empty string when
     # the question carries no image.
     image_url: str = ""
+    # How that image is uncovered (#434): "" shows it outright, "progressive"
+    # starts it blurred and sharpens it as the timer runs down.
+    reveal_style: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -256,7 +259,8 @@ TYPESCRIPT_DECLARATIONS = """
 //   | { type: 'player_joined' | 'player_left'; players: Player[]; }
 //   | { type: 'question_started'; question_text: string; answers: string[];
 //       timer_duration: number; round_num: number; total_rounds: number;
-//       category: string; difficulty: string; image_url?: string; }
+//       category: string; difficulty: string; image_url?: string;
+//       reveal_style?: '' | 'progressive'; }
 //   | { type: 'timer_tick'; remaining: number; }
 //   | { type: 'answer_result'; correct: boolean; points_earned: number;
 //       speed_bonus: number; streak_bonus: number; difficulty_multiplier: number;

--- a/custom_components/quizify/server/serializers.py
+++ b/custom_components/quizify/server/serializers.py
@@ -138,6 +138,8 @@ def serialize_question_for_player(
         "category": question.category,
         "difficulty": question.difficulty,
         "image_url": question.image_url,
+        # #434: how the dashboard/player should uncover that image.
+        "reveal_style": question.reveal_style,
         "is_final_round": is_final_round,
         "player_score": player_score,
         "question_type": question.type,
@@ -210,6 +212,7 @@ def serialize_question_for_admin(
         "category": question.category,
         "difficulty": question.difficulty,
         "image_url": question.image_url,
+        "reveal_style": question.reveal_style,
         "question_type": question.type,
     }
     # Estimate questions (#275): the admin/TV gets the slider range + the true

--- a/custom_components/quizify/www/css/src/03-question.css
+++ b/custom_components/quizify/www/css/src/03-question.css
@@ -111,6 +111,23 @@
     height: 100%;
     object-fit: contain;
 }
+/* #434 progressive reveal, player side. Same mechanic as the dashboard, at a
+   smaller radius because the banner is a fraction of the size — the TV's 28px
+   on a 200px-tall banner is a grey rectangle, not a puzzle.
+
+   The zoom overlay carries the class too (see _revealTargets in
+   player-game.js): it renders a second <img> from the same src, so without
+   this a single tap on the magnifier would hand out the sharp picture. */
+.question-image.progressive-reveal,
+.image-zoom-img.progressive-reveal {
+    filter: blur(var(--reveal-blur, 0px));
+    transform: scale(1.06);
+    transition: filter 0.45s linear;
+}
+.question-media { overflow: hidden; }
+/* No reduced-motion override on purpose — see the note on the dashboard rule.
+   The global block stills the easing; the blur itself has to stay, or the
+   accessibility setting would quietly become an advantage. */
 /* A round, light control rather than a dark grey square.
    The button is anchored to the media box, not to the picture — with
    ``object-fit: contain`` a portrait image leaves wide pale margins, and the

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -1654,6 +1654,23 @@ button, .btn {
     height: 100%;
     object-fit: contain;
 }
+/* #434 progressive reveal, player side. Same mechanic as the dashboard, at a
+   smaller radius because the banner is a fraction of the size — the TV's 28px
+   on a 200px-tall banner is a grey rectangle, not a puzzle.
+
+   The zoom overlay carries the class too (see _revealTargets in
+   player-game.js): it renders a second <img> from the same src, so without
+   this a single tap on the magnifier would hand out the sharp picture. */
+.question-image.progressive-reveal,
+.image-zoom-img.progressive-reveal {
+    filter: blur(var(--reveal-blur, 0px));
+    transform: scale(1.06);
+    transition: filter 0.45s linear;
+}
+.question-media { overflow: hidden; }
+/* No reduced-motion override on purpose — see the note on the dashboard rule.
+   The global block stills the easing; the blur itself has to stay, or the
+   accessibility setting would quietly become an advantage. */
 /* A round, light control rather than a dark grey square.
    The button is anchored to the media box, not to the picture — with
    ``object-fit: contain`` a portrait image leaves wide pale margins, and the

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -412,6 +412,26 @@
             border: 1px solid var(--dash-border-neon);
             object-fit: contain;
         }
+        /* #434 progressive reveal. The blur amount is a custom property the
+           timer writes on every tick; the transition only has to smooth the
+           step between two ticks, so it is kept just under the tick interval.
+
+           `scale` is not cosmetic: a CSS blur samples beyond the element's
+           box and would otherwise fade the picture's own edges into the page,
+           making the frame look broken rather than obscured. Scaling up and
+           clipping in the parent keeps a clean edge at every blur radius. */
+        .dashboard-question-image.progressive-reveal {
+            filter: blur(var(--reveal-blur, 0px));
+            transform: scale(1.06);
+            transition: filter 0.45s linear;
+        }
+        .dashboard-question-media { overflow: hidden; }
+        /* Reduced motion needs no rule of its own here: the global
+           `prefers-reduced-motion` block in 00-tokens.css already collapses
+           every transition-duration, which stills the tick-to-tick easing.
+           What must NOT happen is the blur being switched off with it — that
+           would hand the answer to exactly the players who asked for calmer
+           motion. `filter` is a paint, not an animation, so it survives. */
 
         /* 3-column answer row (questions have exactly 3 answers) */
         .dashboard-answers {
@@ -1510,11 +1530,52 @@
             if (els.dashboardLeft) els.dashboardLeft.classList.toggle('has-image', !!on);
             if (els.questionMedia) els.questionMedia.hidden = !on;
         }
-        function renderQuestionImage(url) {
+        // #434: progressive reveal. The picture starts blurred and sharpens as
+        // the round timer drains, so an early guess is worth more than a late
+        // one. Driven entirely off `timer_tick` — the countdown the board
+        // already receives — so the mechanic needs no message of its own.
+        //
+        // The blur is written as a CSS custom property rather than a class per
+        // step: the value has to move every tick, and 30 discrete classes would
+        // fight the transition instead of riding it.
+        var REVEAL_MAX_BLUR_PX = 28;
+        var revealActive = false;
+
+        // Blur for a given point in the round. Full at the start, zero once
+        // the clock runs out — a question nobody answered still ends up
+        // readable on the board, which is what the reveal needs anyway.
+        function setRevealBlur(remaining, duration) {
+            var img = els.questionImage;
+            if (!img || !revealActive) return;
+            var frac = (duration > 0) ? Math.max(0, Math.min(1, remaining / duration)) : 0;
+            img.style.setProperty('--reveal-blur', (REVEAL_MAX_BLUR_PX * frac).toFixed(2) + 'px');
+        }
+
+        // Drop the blur entirely. Called at reveal — and it must be called
+        // there, because the summary view keeps the question view's image
+        // element instead of re-rendering it. Without this the correct answer
+        // would appear next to a picture nobody can make out.
+        function clearRevealBlur() {
+            var img = els.questionImage;
+            revealActive = false;
+            if (!img) return;
+            img.classList.remove('progressive-reveal');
+            img.style.removeProperty('--reveal-blur');
+        }
+
+        function renderQuestionImage(url, revealStyle) {
             var img = els.questionImage;
             if (!img) return;
             var safe = (window.QuizifyUtils && window.QuizifyUtils.safeImageUrl)
                 ? window.QuizifyUtils.safeImageUrl(url) : '';
+            // Reset first: the element is reused across rounds, so a stale
+            // blur from the previous question must not survive into this one.
+            clearRevealBlur();
+            if (safe && revealStyle === 'progressive') {
+                revealActive = true;
+                img.classList.add('progressive-reveal');
+                img.style.setProperty('--reveal-blur', REVEAL_MAX_BLUR_PX + 'px');
+            }
             img.onerror = function() {
                 // Image failed → collapse to text-only, no broken-image icon.
                 img.removeAttribute('src');
@@ -1646,6 +1707,8 @@
                             total_rounds: msg.total_rounds,
                             category: msg.question.category,
                             image_url: msg.question.image_url,
+                            reveal_style: msg.question.reveal_style,
+                            time_remaining: msg.question.time_remaining,
                             question_type: msg.question.question_type,
                             estimate: msg.question.estimate,
                         });
@@ -1832,10 +1895,17 @@
                 : 'Question ' + msg.round_num + ' / ' + msg.total_rounds;
             els.questionCategory.textContent = msg.category || '';
             els.questionText.textContent = msg.question_text;
-            renderQuestionImage(msg.image_url);
+            renderQuestionImage(msg.image_url, msg.reveal_style);
 
             timerDuration = msg.timer_duration || 30;
             timerRemaining = timerDuration;
+            // #434: a board that (re)connects mid-question gets its remaining
+            // time in the snapshot, so the blur resumes where the round
+            // actually is instead of restarting from opaque.
+            setRevealBlur(
+                (typeof msg.time_remaining === 'number') ? msg.time_remaining : timerDuration,
+                timerDuration
+            );
             els.timerFill.style.width = '100%';
             els.timerFill.className = 'dashboard-timer-fill';
 
@@ -1892,6 +1962,7 @@
             // late/in-flight tick that would otherwise resume the drain.)
             if (isPaused) return;
             timerRemaining = msg.remaining;
+            setRevealBlur(timerRemaining, timerDuration);
             var pct = timerDuration > 0 ? (timerRemaining / timerDuration) * 100 : 0;
             els.timerFill.style.width = pct + '%';
 
@@ -1905,6 +1976,11 @@
 
         function handleRoundSummary(msg) {
             var summary = msg.round_summary || msg;
+
+            // #434: the summary keeps the question view's image element, so
+            // the blur has to come off here or the answer is revealed beside a
+            // picture that is still unreadable.
+            clearRevealBlur();
 
             // #460: reset the timer bar at reveal. A skipped/timed-out question
             // otherwise leaves a stalled red/pulsing bar during the summary.

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -715,6 +715,10 @@
         // (and its timer) so it can never bleed onto the result screen.
         game.stopFrozenOverlay();
         _clearFinaleCountdown();
+        // #434: the round is over, so the picture stops hiding. The reveal
+        // view reuses the banner element, so leaving the blur on would show
+        // the correct answer next to an image nobody can read.
+        if (game.clearRevealBlur) game.clearRevealBlur();
         pu.showView('reveal-view');
 
         // Pass question context to reveal

--- a/custom_components/quizify/www/js/player-game.js
+++ b/custom_components/quizify/www/js/player-game.js
@@ -206,6 +206,9 @@
         // Soft tick in the last 5 seconds (one per whole second).
         if (window.QuizifyPlayerSound) window.QuizifyPlayerSound.tickFromRemaining(remaining);
 
+        // #434: same clock, same sharpening as the board.
+        setRevealBlur(remaining);
+
         if (remaining <= 5) {
             timerElement.classList.remove('timer--warning');
             timerElement.classList.add('timer--critical');
@@ -234,8 +237,45 @@
     // commit to a bet — which would defeat the Jeopardy-final tension.
     var _wagerGate = { active: false, submitted: false };
 
+    // #434: progressive reveal on the player's banner. The dashboard blurs
+    // the picture as the timer drains; the phone has to do the same, or a
+    // player simply reads the sharp copy in their hand and the mechanic on the
+    // TV is decoration.
+    var REVEAL_MAX_BLUR_PX = 14;   // smaller canvas than the TV, same feel
+    var _revealActive = false;
+    var _revealDuration = 0;
+
+    function _revealTargets() {
+        // The zoom overlay renders a SECOND <img> from the same src, so it has
+        // to carry the blur too — otherwise one tap on the magnifier defeats
+        // the whole round.
+        return [
+            document.getElementById('question-image'),
+            document.getElementById('image-zoom-img'),
+        ];
+    }
+
+    function setRevealBlur(remaining) {
+        if (!_revealActive) return;
+        var frac = (_revealDuration > 0)
+            ? Math.max(0, Math.min(1, remaining / _revealDuration)) : 0;
+        var px = (REVEAL_MAX_BLUR_PX * frac).toFixed(2) + 'px';
+        _revealTargets().forEach(function (el) {
+            if (el) el.style.setProperty('--reveal-blur', px);
+        });
+    }
+
+    function clearRevealBlur() {
+        _revealActive = false;
+        _revealTargets().forEach(function (el) {
+            if (!el) return;
+            el.classList.remove('progressive-reveal');
+            el.style.removeProperty('--reveal-blur');
+        });
+    }
+
     // Issue #183: render the question image banner + wire tap-to-zoom.
-    function renderQuestionImageBanner(imgUrl) {
+    function renderQuestionImageBanner(imgUrl, revealStyle, duration) {
         var media = document.getElementById('question-media');
         var img = document.getElementById('question-image');
         if (!media || !img) return;
@@ -249,6 +289,9 @@
             img.removeAttribute('src');
             media.hidden = true;
         };
+        // Reset first — the banner element is reused every round, so a blur
+        // left over from the last question must not bleed into this one.
+        clearRevealBlur();
         if (safeImg) {
             // #467: populate a localized generic alt so the image question
             // isn't announced as an unlabelled graphic.
@@ -256,6 +299,16 @@
             img.src = safeImg;
             img.alt = t('game.questionImageAlt');
             media.hidden = false;
+            if (revealStyle === 'progressive') {
+                _revealActive = true;
+                _revealDuration = duration || 0;
+                _revealTargets().forEach(function (el) {
+                    if (el) {
+                        el.classList.add('progressive-reveal');
+                        el.style.setProperty('--reveal-blur', REVEAL_MAX_BLUR_PX + 'px');
+                    }
+                });
+            }
         } else {
             img.removeAttribute('src');
             img.alt = '';
@@ -317,7 +370,7 @@
         // shown (server already sanitises; this is defence-in-depth).
         // Absent/invalid/load-error → the banner is hidden so the answer
         // pills stay reachable above the fold (graceful text-only fallback).
-        renderQuestionImageBanner(data.image_url);
+        renderQuestionImageBanner(data.image_url, data.reveal_style, data.timer_duration);
 
         // #275: branch on the question type. Estimate questions swap the 3-
         // answer grid for a slider (Variant B). Toggle the two sections and
@@ -1162,6 +1215,7 @@
         isFrozen: isFrozen,
         updateTimer: updateTimer,
         renderQuestion: renderQuestion,
+        clearRevealBlur: clearRevealBlur,
         handleAnswerClick: handleAnswerClick,
         lockSubmitted: lockSubmitted,
         resetSubmissionState: resetSubmissionState,

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -3427,6 +3427,9 @@
         // Soft tick in the last 5 seconds (one per whole second).
         if (window.QuizifyPlayerSound) window.QuizifyPlayerSound.tickFromRemaining(remaining);
 
+        // #434: same clock, same sharpening as the board.
+        setRevealBlur(remaining);
+
         if (remaining <= 5) {
             timerElement.classList.remove('timer--warning');
             timerElement.classList.add('timer--critical');
@@ -3455,8 +3458,45 @@
     // commit to a bet — which would defeat the Jeopardy-final tension.
     var _wagerGate = { active: false, submitted: false };
 
+    // #434: progressive reveal on the player's banner. The dashboard blurs
+    // the picture as the timer drains; the phone has to do the same, or a
+    // player simply reads the sharp copy in their hand and the mechanic on the
+    // TV is decoration.
+    var REVEAL_MAX_BLUR_PX = 14;   // smaller canvas than the TV, same feel
+    var _revealActive = false;
+    var _revealDuration = 0;
+
+    function _revealTargets() {
+        // The zoom overlay renders a SECOND <img> from the same src, so it has
+        // to carry the blur too — otherwise one tap on the magnifier defeats
+        // the whole round.
+        return [
+            document.getElementById('question-image'),
+            document.getElementById('image-zoom-img'),
+        ];
+    }
+
+    function setRevealBlur(remaining) {
+        if (!_revealActive) return;
+        var frac = (_revealDuration > 0)
+            ? Math.max(0, Math.min(1, remaining / _revealDuration)) : 0;
+        var px = (REVEAL_MAX_BLUR_PX * frac).toFixed(2) + 'px';
+        _revealTargets().forEach(function (el) {
+            if (el) el.style.setProperty('--reveal-blur', px);
+        });
+    }
+
+    function clearRevealBlur() {
+        _revealActive = false;
+        _revealTargets().forEach(function (el) {
+            if (!el) return;
+            el.classList.remove('progressive-reveal');
+            el.style.removeProperty('--reveal-blur');
+        });
+    }
+
     // Issue #183: render the question image banner + wire tap-to-zoom.
-    function renderQuestionImageBanner(imgUrl) {
+    function renderQuestionImageBanner(imgUrl, revealStyle, duration) {
         var media = document.getElementById('question-media');
         var img = document.getElementById('question-image');
         if (!media || !img) return;
@@ -3470,6 +3510,9 @@
             img.removeAttribute('src');
             media.hidden = true;
         };
+        // Reset first — the banner element is reused every round, so a blur
+        // left over from the last question must not bleed into this one.
+        clearRevealBlur();
         if (safeImg) {
             // #467: populate a localized generic alt so the image question
             // isn't announced as an unlabelled graphic.
@@ -3477,6 +3520,16 @@
             img.src = safeImg;
             img.alt = t('game.questionImageAlt');
             media.hidden = false;
+            if (revealStyle === 'progressive') {
+                _revealActive = true;
+                _revealDuration = duration || 0;
+                _revealTargets().forEach(function (el) {
+                    if (el) {
+                        el.classList.add('progressive-reveal');
+                        el.style.setProperty('--reveal-blur', REVEAL_MAX_BLUR_PX + 'px');
+                    }
+                });
+            }
         } else {
             img.removeAttribute('src');
             img.alt = '';
@@ -3538,7 +3591,7 @@
         // shown (server already sanitises; this is defence-in-depth).
         // Absent/invalid/load-error → the banner is hidden so the answer
         // pills stay reachable above the fold (graceful text-only fallback).
-        renderQuestionImageBanner(data.image_url);
+        renderQuestionImageBanner(data.image_url, data.reveal_style, data.timer_duration);
 
         // #275: branch on the question type. Estimate questions swap the 3-
         // answer grid for a slider (Variant B). Toggle the two sections and
@@ -4383,6 +4436,7 @@
         isFrozen: isFrozen,
         updateTimer: updateTimer,
         renderQuestion: renderQuestion,
+        clearRevealBlur: clearRevealBlur,
         handleAnswerClick: handleAnswerClick,
         lockSubmitted: lockSubmitted,
         resetSubmissionState: resetSubmissionState,
@@ -5125,6 +5179,10 @@
         // (and its timer) so it can never bleed onto the result screen.
         game.stopFrozenOverlay();
         _clearFinaleCountdown();
+        // #434: the round is over, so the picture stops hiding. The reveal
+        // view reuses the banner element, so leaving the blur on would show
+        // the correct answer next to an image nobody can read.
+        if (game.clearRevealBlur) game.clearRevealBlur();
         pu.showView('reveal-view');
 
         // Pass question context to reveal

--- a/tests/test_progressive_image_reveal_434.py
+++ b/tests/test_progressive_image_reveal_434.py
@@ -1,0 +1,221 @@
+"""Guard the progressive image reveal (#434).
+
+The mechanic: an image question may declare ``reveal_style: "progressive"``.
+The picture then starts heavily blurred and sharpens as the round timer drains,
+so an early guess is worth more than a late one. It rides the ``timer_tick``
+message the clients already receive — no new wire message.
+
+The tests below are grouped around the three ways this feature can fail
+*silently*, i.e. with a green suite and a broken round:
+
+1. **A blur that never comes off.** The reveal view reuses the question view's
+   ``<img>`` instead of re-rendering it, so the correct answer would be shown
+   next to a picture nobody can read. Both clients must clear it explicitly.
+2. **A blur the phone doesn't apply.** The dashboard is the shared screen, but
+   every player holds a second copy of the same image. If only the TV blurs,
+   the round is decoration — and the zoom overlay is a third copy again.
+3. **A style that survives without a picture.** This issue sat blocked for
+   months precisely because the image feature was empty; an "unblur" with
+   nothing to unblur is the same trap in a new shape.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from custom_components.quizify.game.questions import (
+    REVEAL_STYLE_NONE,
+    REVEAL_STYLE_PROGRESSIVE,
+    _parse_question,
+    _sanitize_reveal_style,
+)
+
+REPO = Path(__file__).resolve().parent.parent
+WWW = REPO / "custom_components" / "quizify" / "www"
+
+IMG = "/quizify/static/img/packs/example.jpg"
+
+
+def _mc_question(**extra) -> dict:
+    """A minimal valid multiple-choice question dict."""
+    data = {
+        "id": "q1",
+        "question": "Was ist das?",
+        "answers": [
+            {"text": "A", "correct": True},
+            {"text": "B"},
+            {"text": "C"},
+        ],
+    }
+    data.update(extra)
+    return data
+
+
+# ---------------------------------------------------------------- sanitizer
+
+
+def test_progressive_style_is_kept_when_there_is_an_image() -> None:
+    assert (
+        _sanitize_reveal_style("progressive", IMG, "q1") == REVEAL_STYLE_PROGRESSIVE
+    )
+
+
+def test_style_without_an_image_is_dropped() -> None:
+    """The exact trap #434 was blocked on: an effect with no subject.
+
+    Keeping the style here would blur an element that has no ``src``, i.e.
+    show a grey box where the question's layout expects nothing at all.
+    """
+    assert _sanitize_reveal_style("progressive", "", "q1") == REVEAL_STYLE_NONE
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["progresive", "blur", "PROGRESSIVE ", "true", 1, {"style": "progressive"}, None],
+)
+def test_unknown_styles_fall_back_to_showing_the_image(raw: object) -> None:
+    """A typo must not leave the picture permanently unreadable.
+
+    An unrecognised value keyed straight into a CSS class would do exactly
+    that — the class never matches a rule that removes the blur, so the round
+    plays out behind a grey rectangle. Falling back to "show it" degrades to
+    the pre-#434 behaviour instead.
+
+    ``"PROGRESSIVE "`` is the one case that is *accepted* after normalisation;
+    it is listed here to pin that trimming and case-folding happen.
+    """
+    result = _sanitize_reveal_style(raw, IMG, "q1")
+    if isinstance(raw, str) and raw.strip().lower() == REVEAL_STYLE_PROGRESSIVE:
+        assert result == REVEAL_STYLE_PROGRESSIVE
+    else:
+        assert result == REVEAL_STYLE_NONE
+
+
+def test_packs_without_the_field_are_unchanged() -> None:
+    q = _parse_question(_mc_question(image_url=IMG), "Test")
+    assert q is not None
+    assert q.reveal_style == REVEAL_STYLE_NONE
+
+
+def test_parse_question_carries_the_style_through() -> None:
+    q = _parse_question(
+        _mc_question(image_url=IMG, reveal_style="progressive"), "Test"
+    )
+    assert q is not None
+    assert q.reveal_style == REVEAL_STYLE_PROGRESSIVE
+
+
+def test_parse_question_drops_a_style_whose_image_was_rejected() -> None:
+    """A sanitised-away URL must take the style with it.
+
+    ``javascript:`` is dropped by ``_sanitize_image_url``, which leaves the
+    question image-less — so the style has to go too. This is why the style is
+    sanitised against the *cleaned* URL rather than the raw pack value.
+    """
+    q = _parse_question(
+        _mc_question(image_url="javascript:alert(1)", reveal_style="progressive"),
+        "Test",
+    )
+    assert q is not None
+    assert q.image_url == ""
+    assert q.reveal_style == REVEAL_STYLE_NONE
+
+
+# ------------------------------------------------------------------- wire
+
+
+def test_question_started_payload_carries_the_style() -> None:
+    from custom_components.quizify.server import serializers
+
+    q = _parse_question(
+        _mc_question(image_url=IMG, reveal_style="progressive"), "Test"
+    )
+    assert q is not None
+    payload = serializers.serialize_question_for_player(
+        question=q,
+        shuffled_answers=["A", "B", "C"],
+        round_num=1,
+        total_rounds=10,
+        timer_duration=30,
+    )
+    assert payload["reveal_style"] == REVEAL_STYLE_PROGRESSIVE
+
+
+# ---------------------------------------------------------------- clients
+
+DASHBOARD = WWW / "dashboard.html"
+PLAYER_GAME = WWW / "js" / "player-game.js"
+PLAYER_CORE = WWW / "js" / "player-core.js"
+BUNDLE = WWW / "js" / "player.bundle.js"
+CSS = WWW / "css" / "styles.css"
+
+
+def test_dashboard_drives_the_blur_off_the_timer() -> None:
+    src = DASHBOARD.read_text(encoding="utf-8")
+    assert "setRevealBlur" in src
+    # The tick handler is the only clock the board has; if the call is not
+    # there the picture stays at its opening blur for the whole round.
+    tick = src.split("function handleTimerTick")[1][:600]
+    assert "setRevealBlur" in tick
+
+
+def test_both_clients_clear_the_blur_at_reveal() -> None:
+    """Failure mode 1 — the answer shown beside an unreadable picture."""
+    dash = DASHBOARD.read_text(encoding="utf-8")
+    summary = dash.split("function handleRoundSummary")[1][:800]
+    assert "clearRevealBlur" in summary
+
+    core = PLAYER_CORE.read_text(encoding="utf-8")
+    player_summary = core.split("function handleRoundSummary")[1][:800]
+    assert "clearRevealBlur" in player_summary
+
+
+def test_player_blurs_its_own_copy_and_the_zoom_overlay() -> None:
+    """Failure mode 2 — the mechanic defeated by looking at your phone.
+
+    The zoom overlay is a *second* ``<img>`` built from the same ``src``, so
+    it needs the blur as well; otherwise one tap on the magnifier hands out
+    the sharp picture and the round is over.
+    """
+    src = PLAYER_GAME.read_text(encoding="utf-8")
+    assert "question-image" in src
+    assert "image-zoom-img" in src
+    targets = src.split("function _revealTargets")[1][:400]
+    assert "image-zoom-img" in targets
+
+
+def test_bundle_is_rebuilt_with_the_reveal() -> None:
+    """player.bundle.js is generated — a stale one ships the old behaviour."""
+    bundle = BUNDLE.read_text(encoding="utf-8")
+    assert "setRevealBlur" in bundle
+    assert "_revealTargets" in bundle
+
+
+def test_css_defines_the_blur_for_board_player_and_zoom() -> None:
+    css = CSS.read_text(encoding="utf-8")
+    assert ".question-image.progressive-reveal" in css
+    assert ".image-zoom-img.progressive-reveal" in css
+    assert "--reveal-blur" in css
+
+
+def test_reduced_motion_never_switches_the_blur_off() -> None:
+    """Accessibility must not turn into an advantage.
+
+    The global ``prefers-reduced-motion`` block collapses every transition
+    duration, which is all this feature needs — the tick-to-tick easing stops
+    and the blur still lands on each new value. The failure to guard against
+    is the *next* well-meant edit: a reduced-motion rule that also clears
+    ``filter`` would show the sharp picture to whoever asked for calmer
+    motion, i.e. hand them the answer.
+    """
+    css = CSS.read_text(encoding="utf-8")
+    for block in css.split("prefers-reduced-motion")[1:]:
+        body = block[:1500]
+        if "progressive-reveal" not in body:
+            continue
+        assert "filter" not in body, (
+            "a reduced-motion block touches the reveal's filter — that would "
+            "reveal the image early for those users"
+        )

--- a/tests/test_tv_grid_shuffle_521.py
+++ b/tests/test_tv_grid_shuffle_521.py
@@ -247,6 +247,7 @@ def test_malformed_shuffle_falls_back_to_json_order(bad_order) -> None:
         category = "geo"
         difficulty = "easy"
         image_url = None
+        reveal_style = ""  # #434
         type = "multiple_choice"
         is_estimate = False
         answers = [_A("a", True), _A("b", False), _A("c", False)]


### PR DESCRIPTION
Closes #434.

An image question may now declare `reveal_style: "progressive"`. The picture opens heavily blurred and sharpens as the round timer drains, so guessing early is worth more than guessing late — which lines up with the speed bonus the scoring already pays.

It rides `timer_tick`, the countdown both clients already receive, so the mechanic needs no message of its own.

## What was blocking this

Nothing, as of this morning. #536 taught the sanitiser to accept images shipped with the integration and #537 shipped the two picture packs, so this issue is what the earlier comment predicted it would become: a filter and a flag, not a hunt for pictures.

## The three silent failure modes

Each of these leaves the suite green and the round broken, so each has a test:

**The blur that never comes off.** The reveal view reuses the question view's `<img>` instead of re-rendering it. Without an explicit clear at `round_summary`, the correct answer is shown beside a picture nobody can read.

**The blur the phone doesn't apply.** The dashboard is the shared screen, but every player holds a second copy of the same image — and the zoom overlay builds a third `<img>` from the same `src`. If only the TV blurred, one tap on the magnifier would end the round. `_revealTargets()` covers both.

**The style that survives without a picture.** A `reveal_style` on an image-less question is dropped at parse time; an unblur with nothing to unblur is the exact trap this issue sat blocked on. An unknown value also falls back to showing the image, so a typo'd `"progresive"` cannot leave it permanently unreadable.

## Reduced motion

Deliberately without an override. The global `prefers-reduced-motion` block already collapses every transition duration, which stills the tick-to-tick easing; the blur itself is a paint and survives. Clearing `filter` there would hand the answer to whoever asked for calmer motion — a test pins that no future rule does.

## Scope

- Enabled on the two picture packs from #537 (17 questions each). A flag nobody sets is dead code, and the picture round is the round this mechanic is for. Every other pack is untouched.
- The lightning round is **not** covered: it runs on its own timer path. A `progressive` question landing there simply shows normally — degradation, not breakage.
- `_Q` in `test_tv_grid_shuffle_521` gained the field; it stands in for the `Question` dataclass and has to track it.

## Verification

- 1316 passed, 9 skipped.
- Pack → wire checked end to end: 34 questions carry the style, none without an image.
- `node --check` on every touched script, including the rebuilt `player.bundle.js`.

Note for whoever runs this next: the repo's `.venv` can no longer execute the suite — it pairs pytest 6.2.2 with Python 3.13, which fails in pytest's assertion rewriter before any test runs. That is pre-existing and untouched here; I ran the suite in a throwaway env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)