### PR TITLE
feat(#365): team model, lobby formation and the shared answer state (part 1)

### DIFF
--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -44,6 +44,7 @@ from .scoring import (
     calculate_podium,
 )
 from .scoring_engine import ScoringEngine
+from .team import TeamRegistry
 from .timer import QuestionTimer
 from .types import TIME_LIMITS, Difficulty
 
@@ -131,6 +132,9 @@ class QuizifyGameState:
 
         # Sub-managers
         self._player_registry = PlayerRegistry()
+        # Teams (#365). Empty unless somebody forms one in the lobby — the mode
+        # is opt-in per game and costs nothing while unused.
+        self._team_registry = TeamRegistry()
         self._question_bank = QuestionBank()
         self._powerup_manager = PowerUpManager()
         # Stateless scoring engine — owns the pure points/breakdown/wager/
@@ -339,6 +343,61 @@ class QuizifyGameState:
         return self._question_bank
 
     # ------------------------------------------------------------------
+    # Teams (#365)
+    # ------------------------------------------------------------------
+
+    @property
+    def team_registry(self) -> TeamRegistry:
+        """The game's teams. Empty unless somebody formed one in the lobby."""
+        return self._team_registry
+
+    @property
+    def team_mode(self) -> bool:
+        """True once at least one team exists.
+
+        Deliberately derived rather than stored: there is no separate switch to
+        forget to clear, and a game where everybody left their team falls back
+        to ordinary play on its own.
+        """
+        return self._team_registry.is_active
+
+    def create_team(self, name: str, founder: str) -> dict | None:
+        """Open a team in the lobby. Returns the team's wire shape.
+
+        Lobby only — teams are fixed from the start of the game
+        (Markus, 2026-08-12), so a request arriving mid-round is refused here
+        rather than handled halfway.
+        """
+        if self.phase != GamePhase.LOBBY:
+            return None
+        if self._player_registry.get_player(founder) is None:
+            return None
+        team = self._team_registry.create(name, founder)
+        return team.to_dict()
+
+    def join_team(self, team_id: str, player_name: str) -> dict | None:
+        """Move a player into an existing team (lobby only)."""
+        if self.phase != GamePhase.LOBBY:
+            return None
+        if self._player_registry.get_player(player_name) is None:
+            return None
+        team = self._team_registry.join(team_id, player_name)
+        return team.to_dict() if team else None
+
+    def leave_team(self, player_name: str) -> bool:
+        """Leave the current team (lobby only). Empty teams dissolve."""
+        if self.phase != GamePhase.LOBBY:
+            return False
+        if self._team_registry.get_by_member(player_name) is None:
+            return False
+        self._team_registry.leave(player_name)
+        return True
+
+    def get_team_of(self, player_name: str) -> dict | None:
+        team = self._team_registry.get_by_member(player_name)
+        return team.to_dict() if team else None
+
+    # ------------------------------------------------------------------
     # Player registry delegation
     # ------------------------------------------------------------------
 
@@ -405,6 +464,9 @@ class QuizifyGameState:
     def remove_player(self, name: str) -> None:
         """Remove a player from the game."""
         self._player_registry.remove_player(name)
+        # A player who leaves also leaves their team; a team whose last member
+        # goes is dissolved rather than left standing empty (#365).
+        self._team_registry.remove_player(name)
         self._phase_controller.drop_timer(name)
         self._notify_state_callbacks()
 
@@ -417,6 +479,7 @@ class QuizifyGameState:
         explicit "wipe everyone" action.
         """
         self._player_registry.reset()
+        self._team_registry.reset()
         self._phase_controller.clear_timers()
         self._notify_state_callbacks()
 

--- a/custom_components/quizify/game/team.py
+++ b/custom_components/quizify/game/team.py
@@ -1,0 +1,239 @@
+"""Teams (#365).
+
+A team is a *participant*, not a grouping: once the game starts it answers
+once, scores once and appears in the ranking exactly where a player would.
+That decision (Markus, 2026-08-12) is what keeps this module small — there is
+no per-capita arithmetic, no handicap and no balancing step to model.
+
+What a team owns:
+
+* its members, by player name (names are unique per game, see
+  ``PlayerRegistry``),
+* the answer currently standing for the round, and who set it — any member may
+  change it until the clock stops, and the last change is the one that counts,
+* a short lock after each change, so two members cannot flip the answer back
+  and forth in the final seconds.
+
+Scoring lives in the game state, not here: this module holds the state and the
+rules about *changing* an answer, and stays free of the scoring engine so the
+two can be tested apart.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+
+#: Seconds during which a freshly changed team answer cannot be changed again.
+#: Long enough to stop a tap war, short enough that the last second before the
+#: buzzer still belongs to whoever is quickest (Markus, 2026-08-12).
+ANSWER_CHANGE_LOCK_SECONDS = 2.0
+
+#: Team names offered in the lobby. Suggestions, never a required field — the
+#: whole point of the chosen lobby flow is that joining stays one tap.
+SUGGESTED_TEAM_NAMES = ["Sofa", "Küche", "Balkon", "Garten", "Terrasse", "Flur"]
+
+#: Colours a team can carry, in the Soft Parlor palette order used for player
+#: dots, so a team reads like any other participant on the dashboard.
+TEAM_COLORS = ["coral", "sage", "sky", "sun", "mauve", "brick"]
+
+
+@dataclass
+class Team:
+    """One team: its members and the answer currently standing for the round."""
+
+    name: str
+    team_id: str = field(default_factory=lambda: str(uuid.uuid4())[:8])
+    color: str = ""
+    members: list[str] = field(default_factory=list)
+
+    # ---- per-round answer state -------------------------------------
+    #: Canonical answer index for the current round, or None while unset.
+    current_answer: int | None = None
+    #: Member who set the answer that currently stands.
+    answer_by: str | None = None
+    #: Wall-clock of the last change, used for the lock and for the speed
+    #: bonus — the bonus keys on the *last* tap, so thinking is not free.
+    answered_at: float | None = None
+    #: How often the answer changed this round. Kept for diagnostics; the
+    #: reveal screen deliberately does not show it (Markus, 2026-08-12).
+    change_count: int = 0
+
+    # ---- scoring ----------------------------------------------------
+    score: int = 0
+    streak: int = 0
+    round_score: int = 0
+    round_history: list[str] = field(default_factory=list)
+    last_answer_correct: bool = False
+    last_elapsed: float = 0.0
+
+    # ------------------------------------------------------------------
+    # Membership
+    # ------------------------------------------------------------------
+
+    def add_member(self, player_name: str) -> None:
+        """Add a player; joining twice is a no-op rather than a duplicate."""
+        if player_name not in self.members:
+            self.members.append(player_name)
+
+    def remove_member(self, player_name: str) -> None:
+        """Remove a player. An empty team is dissolved by the registry."""
+        if player_name in self.members:
+            self.members.remove(player_name)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.members
+
+    @property
+    def size(self) -> int:
+        return len(self.members)
+
+    # ------------------------------------------------------------------
+    # Answering
+    # ------------------------------------------------------------------
+
+    def can_change_answer(self, now: float | None = None) -> bool:
+        """False while the post-change lock is still running."""
+        if self.answered_at is None:
+            return True
+        now = time.time() if now is None else now
+        return (now - self.answered_at) >= ANSWER_CHANGE_LOCK_SECONDS
+
+    def lock_remaining(self, now: float | None = None) -> float:
+        """Seconds left on the lock, 0 when the answer may be changed."""
+        if self.answered_at is None:
+            return 0.0
+        now = time.time() if now is None else now
+        return max(0.0, ANSWER_CHANGE_LOCK_SECONDS - (now - self.answered_at))
+
+    def set_answer(
+        self, answer_index: int, by_player: str, now: float | None = None
+    ) -> bool:
+        """Set the team's answer. Returns False while the lock is running.
+
+        Re-tapping the answer that already stands is accepted as a no-op: a
+        member confirming the current choice should never be told to wait.
+        """
+        now = time.time() if now is None else now
+        if self.current_answer == answer_index and self.answer_by is not None:
+            return True
+        if not self.can_change_answer(now):
+            return False
+        if self.current_answer is not None:
+            self.change_count += 1
+        self.current_answer = answer_index
+        self.answer_by = by_player
+        self.answered_at = now
+        return True
+
+    def reset_round(self) -> None:
+        """Clear the per-round answer state before the next question."""
+        self.current_answer = None
+        self.answer_by = None
+        self.answered_at = None
+        self.change_count = 0
+        self.round_score = 0
+        self.last_answer_correct = False
+        self.last_elapsed = 0.0
+
+    def to_dict(self) -> dict:
+        """Wire shape. Mirrors a player entry closely on purpose (#365)."""
+        return {
+            "team_id": self.team_id,
+            "name": self.name,
+            "color": self.color,
+            "members": list(self.members),
+            "size": self.size,
+            "score": self.score,
+            "streak": self.streak,
+        }
+
+
+class TeamRegistry:
+    """The teams of one game.
+
+    Formation happens in the lobby only — once the game starts the set is
+    frozen (Markus, 2026-08-12), which is why every mutating method here is
+    called from lobby-phase handlers.
+    """
+
+    def __init__(self) -> None:
+        self._teams: dict[str, Team] = {}
+        self._next_color = 0
+
+    # ---- lookup ------------------------------------------------------
+
+    @property
+    def teams(self) -> dict[str, Team]:
+        return self._teams
+
+    def get(self, team_id: str) -> Team | None:
+        return self._teams.get(team_id)
+
+    def get_by_member(self, player_name: str) -> Team | None:
+        for team in self._teams.values():
+            if player_name in team.members:
+                return team
+        return None
+
+    def all_teams(self) -> list[Team]:
+        return list(self._teams.values())
+
+    @property
+    def is_active(self) -> bool:
+        """True once at least one team exists — the mode is opt-in per game."""
+        return bool(self._teams)
+
+    # ---- formation ---------------------------------------------------
+
+    def create(self, name: str, founder: str) -> Team:
+        """Open a team and put its founder in it.
+
+        The name is taken as given (already trimmed by the caller); an empty
+        one falls back to a suggestion rather than rejecting the request,
+        because a nameless team is still a valid thing to want.
+        """
+        clean = (name or "").strip()[:24]
+        if not clean:
+            clean = SUGGESTED_TEAM_NAMES[len(self._teams) % len(SUGGESTED_TEAM_NAMES)]
+        color = TEAM_COLORS[self._next_color % len(TEAM_COLORS)]
+        self._next_color += 1
+        team = Team(name=clean, color=color)
+        team.add_member(founder)
+        self._teams[team.team_id] = team
+        return team
+
+    def join(self, team_id: str, player_name: str) -> Team | None:
+        """Move a player into a team, leaving their previous one first."""
+        team = self._teams.get(team_id)
+        if team is None:
+            return None
+        self.leave(player_name)
+        team.add_member(player_name)
+        return team
+
+    def leave(self, player_name: str) -> None:
+        """Remove a player from whatever team holds them; drop empty teams."""
+        team = self.get_by_member(player_name)
+        if team is None:
+            return
+        team.remove_member(player_name)
+        if team.is_empty:
+            self._teams.pop(team.team_id, None)
+
+    def remove_player(self, player_name: str) -> None:
+        """A player left the game entirely."""
+        self.leave(player_name)
+
+    def reset(self) -> None:
+        self._teams.clear()
+        self._next_color = 0
+
+    def reset_round(self) -> None:
+        for team in self._teams.values():
+            team.reset_round()
+
+    def to_list(self) -> list[dict]:
+        return [t.to_dict() for t in self._teams.values()]

--- a/tests/test_team_formation_365.py
+++ b/tests/test_team_formation_365.py
@@ -1,0 +1,229 @@
+"""Team formation and the shared answer state (#365, part 1).
+
+The decisions this pins down (Markus, 2026-08-12):
+
+* teams are formed **in the lobby**, by the players themselves, in any number,
+  and a player who joins none is simply not in a team;
+* the answer standing when the clock stops is the team's answer — any member
+  may change it until then, and the **last** change is the one that counts;
+* a short lock after each change stops two members flipping the answer back
+  and forth in the final seconds.
+
+Only the model and the lobby-phase API are covered here. Scoring a team as one
+participant, and the three screens, follow in part 2 — this file exists so that
+part lands on something already pinned.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.quizify.game.state import GamePhase, QuizifyGameState
+from custom_components.quizify.game.team import (
+    ANSWER_CHANGE_LOCK_SECONDS,
+    Team,
+    TeamRegistry,
+)
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+class _Runtime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+    def create_task(self, coro):  # noqa: ANN001
+        import asyncio
+
+        return asyncio.ensure_future(coro)
+
+
+@pytest.fixture
+def state(tmp_path: Path) -> QuizifyGameState:
+    st = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="test")
+    for name in ("Anna", "Jan", "Mira"):
+        st.add_player(name, _ws())
+    return st
+
+
+# ----------------------------------------------------------------------
+# The answer that stands
+# ----------------------------------------------------------------------
+
+
+def test_last_tap_wins() -> None:
+    """Any member may overwrite the answer — the last one counts."""
+    team = Team(name="Sofa", members=["Anna", "Jan"])
+
+    assert team.set_answer(1, "Anna", now=100.0) is True
+    assert team.set_answer(2, "Jan", now=100.0 + ANSWER_CHANGE_LOCK_SECONDS) is True
+
+    assert team.current_answer == 2
+    assert team.answer_by == "Jan"
+
+
+def test_lock_blocks_an_immediate_second_change() -> None:
+    """Two members flipping the answer in the last seconds is the failure mode."""
+    team = Team(name="Sofa", members=["Anna", "Jan"])
+    team.set_answer(1, "Anna", now=100.0)
+
+    assert team.set_answer(2, "Jan", now=100.5) is False
+    assert team.current_answer == 1, "the locked-out change must not apply"
+    assert team.lock_remaining(now=100.5) == pytest.approx(1.5)
+
+
+def test_confirming_the_standing_answer_is_never_refused() -> None:
+    """Re-tapping what already stands is agreement, not a change.
+
+    Without this, a member who taps the same answer during the lock gets told
+    to wait for something that would not have changed anything.
+    """
+    team = Team(name="Sofa", members=["Anna", "Jan"])
+    team.set_answer(1, "Anna", now=100.0)
+
+    assert team.set_answer(1, "Jan", now=100.2) is True
+    assert team.change_count == 0
+
+
+def test_speed_keys_on_the_last_change() -> None:
+    """``answered_at`` follows the final tap, not the first.
+
+    The speed bonus reads this: if it kept the first timestamp, tapping
+    anything instantly and thinking afterwards would be free.
+    """
+    team = Team(name="Sofa", members=["Anna", "Jan"])
+    team.set_answer(1, "Anna", now=100.0)
+    team.set_answer(2, "Jan", now=105.0)
+
+    assert team.answered_at == 105.0
+
+
+def test_reset_round_clears_the_answer_but_keeps_the_team() -> None:
+    team = Team(name="Sofa", members=["Anna", "Jan"], score=42, streak=3)
+    team.set_answer(1, "Anna", now=100.0)
+
+    team.reset_round()
+
+    assert team.current_answer is None
+    assert team.answer_by is None
+    assert team.score == 42, "round reset must not touch the running score"
+    assert team.members == ["Anna", "Jan"]
+
+
+# ----------------------------------------------------------------------
+# Registry
+# ----------------------------------------------------------------------
+
+
+def test_joining_moves_a_player_out_of_the_old_team() -> None:
+    reg = TeamRegistry()
+    sofa = reg.create("Sofa", "Anna")
+    kueche = reg.create("Küche", "Jan")
+
+    reg.join(kueche.team_id, "Anna")
+
+    assert reg.get_by_member("Anna").name == "Küche"
+    assert "Anna" not in sofa.members
+
+
+def test_the_last_member_leaving_dissolves_the_team() -> None:
+    reg = TeamRegistry()
+    team = reg.create("Sofa", "Anna")
+
+    reg.leave("Anna")
+
+    assert reg.get(team.team_id) is None
+    assert reg.is_active is False
+
+
+def test_an_unnamed_team_gets_a_suggestion_not_a_rejection() -> None:
+    """A nameless team is still a valid thing to want."""
+    reg = TeamRegistry()
+    team = reg.create("   ", "Anna")
+
+    assert team.name, "team must end up with some name"
+    assert team.members == ["Anna"]
+
+
+def test_teams_get_distinct_colors() -> None:
+    reg = TeamRegistry()
+    colors = {reg.create(f"T{i}", f"P{i}").color for i in range(4)}
+
+    assert len(colors) == 4, "four teams must be distinguishable on the TV"
+
+
+# ----------------------------------------------------------------------
+# Lobby-only formation, through the game state
+# ----------------------------------------------------------------------
+
+
+def test_forming_a_team_in_the_lobby(state: QuizifyGameState) -> None:
+    team = state.create_team("Sofa", "Anna")
+
+    assert team is not None
+    assert state.team_mode is True
+    assert state.get_team_of("Anna")["name"] == "Sofa"
+
+
+def test_a_player_without_a_team_is_not_an_error(state: QuizifyGameState) -> None:
+    """Mira joins nobody. That is a legitimate way to play."""
+    state.create_team("Sofa", "Anna")
+    state.join_team(state.get_team_of("Anna")["team_id"], "Jan")
+
+    assert state.get_team_of("Mira") is None
+    assert len(state.team_registry.all_teams()) == 1
+
+
+def test_teams_are_frozen_once_the_game_starts(state: QuizifyGameState) -> None:
+    """Formation is a lobby activity — mid-game requests are refused whole.
+
+    Half-applying one (moving the player but not their answer state) is the
+    bug this prevents.
+    """
+    state.create_team("Sofa", "Anna")
+    state.phase = GamePhase.QUESTION_ACTIVE
+
+    assert state.create_team("Küche", "Jan") is None
+    assert state.join_team(state.get_team_of("Anna")["team_id"], "Mira") is None
+    assert state.leave_team("Anna") is False
+    assert state.get_team_of("Anna")["name"] == "Sofa"
+
+
+def test_team_mode_is_off_until_somebody_forms_one(state: QuizifyGameState) -> None:
+    """No switch to forget: the mode is derived from there being a team."""
+    assert state.team_mode is False
+
+    state.create_team("Sofa", "Anna")
+    assert state.team_mode is True
+
+    state.leave_team("Anna")
+    assert state.team_mode is False
+
+
+def test_leaving_the_game_leaves_the_team(state: QuizifyGameState) -> None:
+    state.create_team("Sofa", "Anna")
+    team_id = state.get_team_of("Anna")["team_id"]
+    state.join_team(team_id, "Jan")
+
+    state.remove_player("Jan")
+
+    assert state.team_registry.get(team_id).members == ["Anna"]
+
+
+def test_wiping_the_lobby_wipes_the_teams(state: QuizifyGameState) -> None:
+    state.create_team("Sofa", "Anna")
+
+    state.clear_all_players()
+
+    assert state.team_mode is False
+    assert state.team_registry.all_teams() == []


### PR DESCRIPTION
Part 1 of #365. **Not the finished feature** — read the last section before merging.

## What this is

The team model and the lobby-phase API, wired into `QuizifyGameState` but not reachable from any screen yet. An existing game behaves exactly as before: `team_mode` is derived from there being at least one team, and nothing in this PR creates one.

Everything here comes from the decisions in the issue (2026-08-12):

* **A team is a participant, not a grouping.** `Team` carries `score`, `streak` and `round_history` in the same shape a player does — so part 2 can feed the existing leaderboard with teams instead of building a parallel rendering path. That was the point of "a team behaves in the ranking like a single player".
* **Formation is lobby-only.** `create_team` / `join_team` / `leave_team` refuse outside `LOBBY` and refuse *whole*. Half-applying one — moving the player but not their answer state — is the failure this avoids.
* **Any number of teams**, and a player who joins none is not an error state.
* **The answer standing when the clock stops is the team's.** Any member may overwrite it; `answered_at` follows the **last** tap, because the speed bonus reads it and thinking must not be free; a 2 s lock after each change stops a tap war in the final seconds; re-tapping the answer that already stands is treated as agreement and never refused.
* **Leaving takes you out of your team**, and an empty team dissolves rather than lingering in the lobby.

## Tests

`tests/test_team_formation_365.py`, 15 tests, split between the model and the lobby API. The ones worth reading: the lock blocking an immediate second change, the standing answer being confirmable during the lock, `answered_at` following the last tap, and formation being refused mid-game.

Suite: **1,331 passed, 9 skipped**. `ruff==0.15.17 check custom_components/` clean.

## What is NOT in this PR

Markus asked for the built feature, deployed and tested in the browser, and this is not that. Deliberately left for part 2:

* scoring a team once per round (the answer path still scores per player),
* feeding leaderboard, dashboard and finale with teams,
* per-team award aggregation in `highlights.py`, including the per-award team reading that still needs writing down,
* the three screens — lobby route C, member dots on the answer row, team podium,
* the shared per-team answer shuffle, so "B" means the same option for every member.

There is nothing to click yet, so nothing was browser-tested. Merging this changes no behaviour; it is a base for part 2, not a shippable feature.
