### PR TITLE
feat(#552): a team answers lightning together

### DIFF
--- a/custom_components/quizify/game/lightning.py
+++ b/custom_components/quizify/game/lightning.py
@@ -13,6 +13,10 @@ distinct live in one place:
   No speed bonus, no streak multiplier, no difficulty multiplier.
 * **Power-ups are disabled** — the WS layer never assigns or accepts them
   while a lightning round is active.
+* **A team answers together**, exactly as in a normal round (#552): one answer
+  and one score per team, any member may change it until the clock stops, and
+  the question therefore runs its full window instead of ending on the first
+  tap. Per-player shuffles stay per player — only the *answer* is shared.
 * **End screen** shows each player's total lightning score plus a compact
   recap of all questions: the *correct* answer per question (green), and —
   when the player got it wrong — their own wrong pick too, because there
@@ -35,6 +39,8 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from .questions import Question, QuestionBank
 
+from .team import ANSWER_CHANGE_LOCK_SECONDS
+
 _LOGGER = logging.getLogger(__name__)
 
 # Decided rules (issue #42, greenlit 2026-06-09).
@@ -45,13 +51,22 @@ LIGHTNING_POINTS_PER_CORRECT = 10
 
 @dataclass
 class LightningAnswer:
-    """One player's answer to one lightning question."""
+    """One entrant's answer to one lightning question.
 
-    #: True if the player answered correctly, False if wrong, None if they
+    An entrant is a player or, in team mode, a whole team (#552) — which is
+    why ``set_by`` exists: the team's answer belongs to the team, but the
+    other members still want to see who put it there.
+    """
+
+    #: True if the entrant answered correctly, False if wrong, None if they
     #: never answered before the question's time ran out.
     correct: bool | None = None
-    #: Original (unshuffled) answer index the player submitted, or None.
+    #: Original (unshuffled) answer index that was submitted, or None.
     answer_index: int | None = None
+    #: Member who set the answer that currently stands (team mode only).
+    set_by: str | None = None
+    #: Wall-clock of the last change, for the short re-decision lock.
+    answered_at: float | None = None
 
 
 @dataclass
@@ -95,6 +110,7 @@ class LightningRound:
         num_questions: int = LIGHTNING_NUM_QUESTIONS,
         seconds_per_question: float = LIGHTNING_SECONDS_PER_QUESTION,
         points_per_correct: int = LIGHTNING_POINTS_PER_CORRECT,
+        teams: list[dict[str, Any]] | None = None,
     ) -> None:
         self._bank = question_bank
         self._players = list(player_names)
@@ -112,8 +128,30 @@ class LightningRound:
         self.finished: bool = False
         self._question_start: float | None = None
 
-        # scores keyed by player name; recap rows in question order.
-        self.scores: dict[str, int] = dict.fromkeys(self._players, 0)
+        # Who is actually playing this round (#552). In an ordinary game the
+        # entrants ARE the players; in team mode a team is one entrant and its
+        # members map onto it. Teams are frozen in the lobby, so this mapping
+        # is built once and never changes mid-round.
+        #
+        # `teams` is a snapshot of `TeamRegistry.to_list()`; taking a snapshot
+        # rather than the registry keeps this module free of the game state.
+        self._entrant_of: dict[str, str] = {}
+        self._entrants: list[str] = []
+        for team in teams or []:
+            key = team.get("name") or team.get("team_id") or ""
+            if not key:
+                continue
+            self._entrants.append(key)
+            for member in team.get("members", []):
+                self._entrant_of[member] = key
+        self.team_mode = bool(self._entrants)
+        for name in self._players:
+            if name not in self._entrant_of:
+                self._entrants.append(name)
+
+        # scores keyed by ENTRANT (player name, or team name in team mode);
+        # recap rows in question order.
+        self.scores: dict[str, int] = dict.fromkeys(self._entrants, 0)
         self._recaps: list[LightningQuestionRecap] = []
 
         # Memoized end-screen payload (#455). Once the round is finished the
@@ -240,10 +278,36 @@ class LightningRound:
         )
         return True
 
+    def entrant_for(self, name: str) -> str:
+        """Who this player scores as: their team, or themselves."""
+        return self._entrant_of.get(name, name)
+
+    def score_for(self, name: str) -> int:
+        """This player's standing — their team's, in team mode."""
+        return self.scores.get(self.entrant_for(name), 0)
+
+    def standing_answer(self, name: str) -> LightningAnswer | None:
+        """The answer currently recorded for this player's entrant."""
+        return self._answers.get(self.index, {}).get(self.entrant_for(name))
+
+    def members_of(self, name: str) -> list[str]:
+        """Everyone who shares this player's entrant (just them, if solo)."""
+        entrant = self.entrant_for(name)
+        if entrant == name:
+            return [name]
+        return [p for p in self._players if self._entrant_of.get(p) == entrant]
+
     def add_player(self, name: str) -> None:
-        """Register a late-joining player so they can score from now on."""
+        """Register a late-joining player so they can score from now on.
+
+        They enter as their own entrant: teams are formed in the lobby and
+        frozen from the start of the game (#365), so somebody arriving during
+        a lightning round plays for themselves.
+        """
         if name not in self.scores:
             self.scores[name] = 0
+        if name not in self._entrants:
+            self._entrants.append(name)
         if name not in self._players:
             self._players.append(name)
         # Give them a shuffle for the in-flight question so they can answer
@@ -330,19 +394,39 @@ class LightningRound:
     # Answering
     # ------------------------------------------------------------------
 
-    def record_answer(self, name: str, shuffled_index: int) -> bool | None:
-        """Record a player's answer to the current question.
+    def record_answer(
+        self, name: str, shuffled_index: int, *, now: float | None = None
+    ) -> bool | None:
+        """Record an answer to the current question.
 
-        ``shuffled_index`` is the button index in the player's own shuffle.
+        ``shuffled_index`` is the button index in the *player's own* shuffle,
+        which is why the mapping happens here rather than at the call site.
+
+        In team mode the answer belongs to the team and any member may change
+        it until the clock stops (#552) — subject to the same short lock as a
+        normal round, so two members cannot flip it back and forth. A solo
+        player's answer stays final the moment they tap it.
+
         Returns True/False for correct/wrong, or None if the answer was
-        rejected (no active question, already answered, expired, bad index).
+        rejected (no active question, already answered, locked, expired, bad
+        index).
         """
         q = self.current_question
         if q is None or self.is_expired():
             return None
+        now = time.time() if now is None else now
+        entrant = self.entrant_for(name)
+        is_team = entrant != name
         bucket = self._answers.setdefault(self.index, {})
-        if name in bucket:
-            return None  # one answer per question
+        standing = bucket.get(entrant)
+        if standing is not None:
+            if not is_team:
+                return None  # one answer per question — the base rule
+            if (
+                standing.answered_at is not None
+                and (now - standing.answered_at) < ANSWER_CHANGE_LOCK_SECONDS
+            ):
+                return None  # the brake, same as a normal round
         order = self._shuffles.get(name) or list(range(len(q.answers)))
         if not 0 <= shuffled_index < len(order):
             return None
@@ -351,15 +435,27 @@ class LightningRound:
             0 <= original_index < len(q.answers)
             and q.answers[original_index].correct
         )
-        bucket[name] = LightningAnswer(correct=correct, answer_index=original_index)
+        bucket[entrant] = LightningAnswer(
+            correct=correct,
+            answer_index=original_index,
+            set_by=name,
+            answered_at=now,
+        )
         return correct
 
     def all_connected_answered(self, connected_names: list[str]) -> bool:
-        """True if every currently-connected player has answered this Q."""
-        if not connected_names:
+        """True if every currently-connected player has answered this Q.
+
+        Always False in team mode (#552). Ending the question as soon as
+        everyone has answered would close it on the *first* member's tap, and
+        the answer the team was supposed to agree on would be whatever one
+        person hit first — the same trap the normal round fell into. In team
+        mode the question runs its clock.
+        """
+        if not connected_names or self.team_mode:
             return False
         bucket = self._answers.get(self.index, {})
-        return all(name in bucket for name in connected_names)
+        return all(self.entrant_for(name) in bucket for name in connected_names)
 
     # ------------------------------------------------------------------
     # Advancing
@@ -400,7 +496,7 @@ class LightningRound:
             question_text=q.question,
             correct_answer=correct_answer,
         )
-        for name in self._players:
+        for name in self._entrants:
             ans = bucket.get(name)
             if ans is None or ans.correct is None:
                 recap.results[name] = "miss"

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -1772,6 +1772,10 @@ class QuizifyGameState:
                 else getattr(self, "categories", None)
             ),
             difficulty=difficulty,
+            # A team answers lightning together, like a normal round (#552).
+            # The roster is a snapshot: teams are frozen from the start of the
+            # game, so the detour cannot be joined or left mid-round.
+            teams=self._team_registry.to_list(),
         )
         # Reserve the questions the main game still owes the host (#544). Only
         # the auto path detours out of a running game; the lobby/finale entries

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -39,6 +39,9 @@ from custom_components.quizify.game.state import (
     QuizifyGameState,
     TeamAnswerAck,
 )
+from custom_components.quizify.game.team import (
+    ANSWER_CHANGE_LOCK_SECONDS as LIGHTNING_ANSWER_LOCK_SECONDS,
+)
 from custom_components.quizify.server.broadcast_dispatcher import BroadcastDispatcher
 from custom_components.quizify.server.connection import ConnectionManager
 from custom_components.quizify.server.rate_limit import SlidingWindowLimiter
@@ -2227,14 +2230,55 @@ class QuizifyWebSocketHandler:
 
         result = lr.record_answer(player.name, shuffled_index)
         if result is None:
-            return  # rejected (already answered / expired) — stay silent
+            return  # rejected (already answered / locked / expired) — stay silent
+
+        # Team mode (#552): the tap set the TEAM's answer and scored nothing
+        # yet, so it must not lock the tapper's buttons or claim right/wrong —
+        # a teammate may still change it. Every member is told what stands, in
+        # their own answer order.
+        if lr.team_mode and lr.entrant_for(player.name) != player.name:
+            await self._broadcast_lightning_team_answer(game_state, lr, player.name)
+            return
+
         # Lightweight ack: lock the player's buttons + show right/wrong.
         await self._conn.send(ws, {
             "type": "lightning_answer_result",
             "correct": bool(result),
             "index": lr.index,
-            "score": lr.scores.get(player.name, 0),
+            "score": lr.score_for(player.name),
         })
+
+    async def _broadcast_lightning_team_answer(
+        self, game_state: QuizifyGameState, lr: Any, setter: str
+    ) -> None:
+        """Show the team's standing lightning answer on every member's phone.
+
+        Mirrors the normal round's ``team_answer`` (#365): the index is
+        remapped per member, because each phone shuffles the answers for
+        itself — one number sent to the whole team would highlight the wrong
+        row for everybody but the person who tapped.
+        """
+        standing = lr.standing_answer(setter)
+        if standing is None or standing.answer_index is None:
+            return
+        members = lr.members_of(setter)
+        for name in members:
+            member = game_state.get_player(name)
+            if member is None or member.ws is None or not member.connected:
+                continue
+            order = lr.ensure_shuffle(name)
+            try:
+                shown_index = order.index(standing.answer_index)
+            except ValueError:
+                continue
+            await self._conn.send(member.ws, {
+                "type": "lightning_team_answer",
+                "index": lr.index,
+                "answer_index": shown_index,
+                "set_by": setter,
+                "members": list(members),
+                "lock_seconds": LIGHTNING_ANSWER_LOCK_SECONDS,
+            })
 
     def _start_lightning_loop(
         self,

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -391,6 +391,11 @@
             case 'lightning_answer_result':
                 if (lightning) lightning.handleLightningAnswerResult(msg);
                 break;
+            case 'lightning_team_answer':
+                // The team's standing lightning answer (#552) — same idea as
+                // `team_answer` in a normal round.
+                if (lightning) lightning.handleLightningTeamAnswer(msg);
+                break;
             case 'lightning_recap':
                 if (lightning) lightning.handleLightningRecap(msg);
                 break;

--- a/custom_components/quizify/www/js/player-lightning.js
+++ b/custom_components/quizify/www/js/player-lightning.js
@@ -105,6 +105,7 @@
 
         var answered = document.getElementById('lightning-answered');
         if (answered) answered.classList.add('hidden');
+        if (_lightningLockTimer) { clearTimeout(_lightningLockTimer); _lightningLockTimer = null; }
 
         var timer = document.getElementById('lightning-timer');
         if (timer) timer.textContent = Math.ceil(msg.seconds || 15);
@@ -121,7 +122,24 @@
         }
     }
 
+    function inTeam() {
+        var team = window.QuizifyPlayerTeam;
+        return !!(team && team.isTeamMode());
+    }
+
     function submitAnswer(shuffledIndex) {
+        // Team mode (#552): the tap sets the TEAM's answer, which any member
+        // may still change until the clock stops. So it neither locks this
+        // phone nor counts as this player's final say — the server answers
+        // with `lightning_team_answer`, which marks what stands and applies
+        // the shared lock.
+        if (inTeam()) {
+            _send('lightning_answer', {
+                answer_index: shuffledIndex, index: _questionIndex
+            });
+            return;
+        }
+
         // One answer per question; ignore re-taps.
         if (_answeredIndex !== -1) return;
         _answeredIndex = shuffledIndex;
@@ -141,6 +159,43 @@
         }
         var answered = document.getElementById('lightning-answered');
         if (answered) answered.classList.remove('hidden');
+    }
+
+    var _lightningLockTimer = null;
+
+    /**
+     * The team's standing lightning answer (#552).
+     *
+     * ``msg.answer_index`` is already expressed in THIS phone's answer order —
+     * the server remaps it per member, because every player sees the answers
+     * shuffled differently. The lock belongs to the team, so all buttons go
+     * quiet together for the same short moment.
+     */
+    function handleLightningTeamAnswer(msg) {
+        if (typeof msg.index === 'number' && msg.index !== _questionIndex) return;
+        var btns = document.querySelectorAll('[data-lightning-answer]');
+        for (var i = 0; i < btns.length; i++) {
+            var idx = parseInt(btns[i].getAttribute('data-lightning-answer'), 10);
+            var isStanding = idx === msg.answer_index;
+            btns[i].classList.toggle('selected', isStanding);
+            btns[i].disabled = true;
+            btns[i].classList.add('is-team-locked');
+        }
+        var answered = document.getElementById('lightning-answered');
+        if (answered) {
+            var who = msg.set_by || '';
+            answered.textContent = who ? t('teams.standingAnswer', { name: who }) : '';
+            answered.classList.remove('hidden');
+        }
+        if (_lightningLockTimer) clearTimeout(_lightningLockTimer);
+        _lightningLockTimer = setTimeout(function () {
+            var list = document.querySelectorAll('[data-lightning-answer]');
+            for (var j = 0; j < list.length; j++) {
+                list[j].disabled = false;
+                list[j].classList.remove('is-team-locked');
+            }
+            _lightningLockTimer = null;
+        }, (msg.lock_seconds || 2) * 1000);
     }
 
     function handleLightningAnswerResult(msg) {
@@ -257,6 +312,7 @@
         handleLightningSplash: handleLightningSplash,
         handleLightningQuestion: handleLightningQuestion,
         handleLightningTick: handleLightningTick,
+        handleLightningTeamAnswer: handleLightningTeamAnswer,
         handleLightningAnswerResult: handleLightningAnswerResult,
         handleLightningRecap: handleLightningRecap,
         renderRecap: renderRecap

--- a/custom_components/quizify/www/js/player-lightning.js
+++ b/custom_components/quizify/www/js/player-lightning.js
@@ -220,6 +220,19 @@
         if (playerMsg) playerMsg.classList.toggle('hidden', !!state.isAdmin);
     }
 
+    /**
+     * Whose row is "mine" in the recap (#552).
+     *
+     * In team mode the round scored the TEAM, so the recap is keyed by team
+     * name — looking myself up by player name finds nothing and every
+     * question silently renders as a miss, no matter how the team did.
+     */
+    function myEntrant() {
+        var team = window.QuizifyPlayerTeam;
+        var mine = team && team.myTeam();
+        return (mine && mine.name) || state.playerName;
+    }
+
     function renderRecap(recap) {
         var lb = recap.leaderboard || [];
         var lbEl = document.getElementById('lightning-recap-leaderboard');
@@ -231,7 +244,7 @@
                     rank: p.rank,
                     name: p.name,
                     score: p.score,
-                    isYou: p.name === state.playerName
+                    isYou: p.name === myEntrant()
                 };
             });
             pu.renderMedalStandings(lbEl, rows, { youLabel: youLabel });
@@ -242,7 +255,7 @@
         // when the player answered wrong, also shows their own wrong pick.
         var grid = document.getElementById('lightning-recap-grid');
         if (grid) {
-            var me = state.playerName;
+            var me = myEntrant();
             var questions = recap.questions || [];
             grid.innerHTML = questions.map(function (q, qi) {
                 var result = (q.results || {})[me] || 'miss';

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -3557,6 +3557,19 @@
         if (playerMsg) playerMsg.classList.toggle('hidden', !!state.isAdmin);
     }
 
+    /**
+     * Whose row is "mine" in the recap (#552).
+     *
+     * In team mode the round scored the TEAM, so the recap is keyed by team
+     * name — looking myself up by player name finds nothing and every
+     * question silently renders as a miss, no matter how the team did.
+     */
+    function myEntrant() {
+        var team = window.QuizifyPlayerTeam;
+        var mine = team && team.myTeam();
+        return (mine && mine.name) || state.playerName;
+    }
+
     function renderRecap(recap) {
         var lb = recap.leaderboard || [];
         var lbEl = document.getElementById('lightning-recap-leaderboard');
@@ -3568,7 +3581,7 @@
                     rank: p.rank,
                     name: p.name,
                     score: p.score,
-                    isYou: p.name === state.playerName
+                    isYou: p.name === myEntrant()
                 };
             });
             pu.renderMedalStandings(lbEl, rows, { youLabel: youLabel });
@@ -3579,7 +3592,7 @@
         // when the player answered wrong, also shows their own wrong pick.
         var grid = document.getElementById('lightning-recap-grid');
         if (grid) {
-            var me = state.playerName;
+            var me = myEntrant();
             var questions = recap.questions || [];
             grid.innerHTML = questions.map(function (q, qi) {
                 var result = (q.results || {})[me] || 'miss';

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -3442,6 +3442,7 @@
 
         var answered = document.getElementById('lightning-answered');
         if (answered) answered.classList.add('hidden');
+        if (_lightningLockTimer) { clearTimeout(_lightningLockTimer); _lightningLockTimer = null; }
 
         var timer = document.getElementById('lightning-timer');
         if (timer) timer.textContent = Math.ceil(msg.seconds || 15);
@@ -3458,7 +3459,24 @@
         }
     }
 
+    function inTeam() {
+        var team = window.QuizifyPlayerTeam;
+        return !!(team && team.isTeamMode());
+    }
+
     function submitAnswer(shuffledIndex) {
+        // Team mode (#552): the tap sets the TEAM's answer, which any member
+        // may still change until the clock stops. So it neither locks this
+        // phone nor counts as this player's final say — the server answers
+        // with `lightning_team_answer`, which marks what stands and applies
+        // the shared lock.
+        if (inTeam()) {
+            _send('lightning_answer', {
+                answer_index: shuffledIndex, index: _questionIndex
+            });
+            return;
+        }
+
         // One answer per question; ignore re-taps.
         if (_answeredIndex !== -1) return;
         _answeredIndex = shuffledIndex;
@@ -3478,6 +3496,43 @@
         }
         var answered = document.getElementById('lightning-answered');
         if (answered) answered.classList.remove('hidden');
+    }
+
+    var _lightningLockTimer = null;
+
+    /**
+     * The team's standing lightning answer (#552).
+     *
+     * ``msg.answer_index`` is already expressed in THIS phone's answer order —
+     * the server remaps it per member, because every player sees the answers
+     * shuffled differently. The lock belongs to the team, so all buttons go
+     * quiet together for the same short moment.
+     */
+    function handleLightningTeamAnswer(msg) {
+        if (typeof msg.index === 'number' && msg.index !== _questionIndex) return;
+        var btns = document.querySelectorAll('[data-lightning-answer]');
+        for (var i = 0; i < btns.length; i++) {
+            var idx = parseInt(btns[i].getAttribute('data-lightning-answer'), 10);
+            var isStanding = idx === msg.answer_index;
+            btns[i].classList.toggle('selected', isStanding);
+            btns[i].disabled = true;
+            btns[i].classList.add('is-team-locked');
+        }
+        var answered = document.getElementById('lightning-answered');
+        if (answered) {
+            var who = msg.set_by || '';
+            answered.textContent = who ? t('teams.standingAnswer', { name: who }) : '';
+            answered.classList.remove('hidden');
+        }
+        if (_lightningLockTimer) clearTimeout(_lightningLockTimer);
+        _lightningLockTimer = setTimeout(function () {
+            var list = document.querySelectorAll('[data-lightning-answer]');
+            for (var j = 0; j < list.length; j++) {
+                list[j].disabled = false;
+                list[j].classList.remove('is-team-locked');
+            }
+            _lightningLockTimer = null;
+        }, (msg.lock_seconds || 2) * 1000);
     }
 
     function handleLightningAnswerResult(msg) {
@@ -3594,6 +3649,7 @@
         handleLightningSplash: handleLightningSplash,
         handleLightningQuestion: handleLightningQuestion,
         handleLightningTick: handleLightningTick,
+        handleLightningTeamAnswer: handleLightningTeamAnswer,
         handleLightningAnswerResult: handleLightningAnswerResult,
         handleLightningRecap: handleLightningRecap,
         renderRecap: renderRecap
@@ -5251,6 +5307,11 @@
                 break;
             case 'lightning_answer_result':
                 if (lightning) lightning.handleLightningAnswerResult(msg);
+                break;
+            case 'lightning_team_answer':
+                // The team's standing lightning answer (#552) — same idea as
+                // `team_answer` in a normal round.
+                if (lightning) lightning.handleLightningTeamAnswer(msg);
                 break;
             case 'lightning_recap':
                 if (lightning) lightning.handleLightningRecap(msg);

--- a/tests/test_lightning_team_552.py
+++ b/tests/test_lightning_team_552.py
@@ -1,0 +1,187 @@
+"""A team answers lightning together (#552).
+
+Markus' decision (2026-08-12): in the Lightning Round a team answers exactly as
+it does in a normal round — one answer, one score, any member may change it
+until the clock stops. The alternative (everyone taps for themselves, the team
+collects) would have handed a team of four four bites at every question, which
+is precisely the arithmetic the normal rounds deliberately avoid.
+
+Two consequences follow from that decision rather than from taste, and both are
+pinned below:
+
+* the question runs its clock, because ending it as soon as everyone has
+  answered would close it on the first member's tap;
+* the recap and the standings name the team, since that is who scored.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from custom_components.quizify.game.lightning import LightningRound
+from custom_components.quizify.game.questions import QuestionBank
+from custom_components.quizify.game.team import ANSWER_CHANGE_LOCK_SECONDS
+
+_SOFA = [{"team_id": "t1", "name": "Sofa", "members": ["Anna", "Jan"]}]
+
+
+@pytest.fixture
+def bank() -> QuestionBank:
+    root = Path(__file__).resolve().parent.parent / "custom_components" / "quizify"
+    return QuestionBank(root / "questions")
+
+
+def _round(bank: QuestionBank, *, teams=None, players=("Anna", "Jan", "Mira")):
+    lr = LightningRound(
+        bank, list(players), language="en", category="picture-round-en",
+        teams=teams,
+    )
+    assert lr.start(), "the picture pack must yield lightning questions"
+    return lr
+
+
+def _correct_button(lr: LightningRound, name: str) -> int:
+    """The position of the correct answer on THIS player's phone."""
+    q = lr.current_question
+    correct = next(i for i, a in enumerate(q.answers) if a.correct)
+    return lr.ensure_shuffle(name).index(correct)
+
+
+def _wrong_button(lr: LightningRound, name: str) -> int:
+    q = lr.current_question
+    wrong = next(i for i, a in enumerate(q.answers) if not a.correct)
+    return lr.ensure_shuffle(name).index(wrong)
+
+
+# ----------------------------------------------------------------------
+# One answer, one score
+# ----------------------------------------------------------------------
+
+
+def test_a_team_scores_once_not_once_per_member(bank: QuestionBank) -> None:
+    lr = _round(bank, teams=_SOFA)
+
+    assert lr.record_answer("Anna", _correct_button(lr, "Anna"), now=100.0) is True
+    lr.advance()
+
+    assert lr.scores["Sofa"] == lr.points_per_correct
+    assert "Anna" not in lr.scores and "Jan" not in lr.scores, (
+        "members are represented by their team, not next to it"
+    )
+
+
+def test_both_members_read_the_teams_score(bank: QuestionBank) -> None:
+    """The ack the WS layer sends must not tell one member a different total."""
+    lr = _round(bank, teams=_SOFA)
+    lr.record_answer("Jan", _correct_button(lr, "Jan"), now=100.0)
+    lr.advance()
+
+    assert lr.score_for("Anna") == lr.score_for("Jan") == lr.points_per_correct
+    assert lr.score_for("Mira") == 0, "the solo player keeps her own total"
+
+
+def test_a_teammate_can_change_the_answer(bank: QuestionBank) -> None:
+    lr = _round(bank, teams=_SOFA)
+    lr.record_answer("Anna", _wrong_button(lr, "Anna"), now=100.0)
+
+    later = 100.0 + ANSWER_CHANGE_LOCK_SECONDS
+    assert lr.record_answer("Jan", _correct_button(lr, "Jan"), now=later) is True
+    lr.advance()
+
+    assert lr.scores["Sofa"] == lr.points_per_correct, "the last tap counts"
+
+
+def test_the_lock_refuses_an_instant_second_change(bank: QuestionBank) -> None:
+    lr = _round(bank, teams=_SOFA)
+    wrong = _wrong_button(lr, "Anna")
+    lr.record_answer("Anna", wrong, now=100.0)
+
+    assert lr.record_answer("Jan", _correct_button(lr, "Jan"), now=100.5) is None
+    lr.advance()
+
+    assert lr.scores["Sofa"] == 0, "the locked-out change must not apply"
+
+
+def test_a_solo_players_answer_is_still_final(bank: QuestionBank) -> None:
+    """The base game is untouched — only team mode gained re-decisions."""
+    lr = _round(bank, teams=_SOFA)
+    lr.record_answer("Mira", _wrong_button(lr, "Mira"), now=100.0)
+
+    assert lr.record_answer("Mira", _correct_button(lr, "Mira"), now=200.0) is None
+    lr.advance()
+
+    assert lr.scores["Mira"] == 0
+
+
+# ----------------------------------------------------------------------
+# The clock
+# ----------------------------------------------------------------------
+
+
+def test_the_question_runs_its_clock_in_team_mode(bank: QuestionBank) -> None:
+    """Otherwise the first member's tap ends the question, and "answering
+    together" is theatre — the same trap the normal round fell into."""
+    lr = _round(bank, teams=_SOFA)
+    lr.record_answer("Anna", 0, now=100.0)
+    lr.record_answer("Mira", 0, now=100.0)
+
+    assert lr.all_connected_answered(["Anna", "Jan", "Mira"]) is False
+
+
+def test_without_teams_the_question_still_ends_early(bank: QuestionBank) -> None:
+    """Lightning keeps its fast cadence in an ordinary game."""
+    lr = _round(bank, players=("Anna", "Mira"))
+    lr.record_answer("Anna", 0, now=100.0)
+    lr.record_answer("Mira", 0, now=100.0)
+
+    assert lr.all_connected_answered(["Anna", "Mira"]) is True
+
+
+# ----------------------------------------------------------------------
+# What the room sees
+# ----------------------------------------------------------------------
+
+
+def test_the_recap_and_standings_name_the_team(bank: QuestionBank) -> None:
+    lr = _round(bank, teams=_SOFA)
+    lr.record_answer("Anna", _correct_button(lr, "Anna"), now=100.0)
+    lr.record_answer("Mira", _wrong_button(lr, "Mira"), now=100.0)
+    while lr.advance():
+        pass
+
+    recap = lr.build_recap()
+    names = {row["name"] for row in recap["leaderboard"]}
+    assert names == {"Sofa", "Mira"}
+    first = recap["questions"][0]["results"]
+    assert first["Sofa"] == "correct"
+    assert first["Mira"] == "wrong"
+    assert "Anna" not in first and "Jan" not in first
+
+
+def test_the_standing_answer_is_readable_per_member(bank: QuestionBank) -> None:
+    """The broadcast needs both halves: what stands, and who is in the team."""
+    lr = _round(bank, teams=_SOFA)
+    lr.record_answer("Jan", _correct_button(lr, "Jan"), now=100.0)
+
+    standing = lr.standing_answer("Anna")
+    assert standing is not None
+    assert standing.set_by == "Jan"
+    assert sorted(lr.members_of("Anna")) == ["Anna", "Jan"]
+    assert lr.members_of("Mira") == ["Mira"], "a solo player is her own team"
+    # Anna's phone shuffles for itself, so the index she must highlight is
+    # resolved against her own order — not against Jan's tap.
+    assert lr.ensure_shuffle("Anna").index(standing.answer_index) >= 0
+
+
+def test_a_latecomer_plays_for_themselves(bank: QuestionBank) -> None:
+    """Teams are frozen in the lobby, so a mid-round arrival is their own."""
+    lr = _round(bank, teams=_SOFA)
+    lr.add_player("Late")
+
+    assert lr.entrant_for("Late") == "Late"
+    lr.record_answer("Late", _correct_button(lr, "Late"), now=100.0)
+    lr.advance()
+
+    assert lr.scores["Late"] == lr.points_per_correct

--- a/tests/test_team_screens_365.py
+++ b/tests/test_team_screens_365.py
@@ -31,6 +31,7 @@ JS_DIR = REPO / "custom_components" / "quizify" / "www" / "js"
 TEAM_JS = JS_DIR / "player-team.js"
 GAME_JS = JS_DIR / "player-game.js"
 BUNDLE_JS = JS_DIR / "player.bundle.js"
+LIGHTNING_JS = JS_DIR / "player-lightning.js"
 
 _HARNESS = r"""
 const fs = require('fs');
@@ -207,6 +208,79 @@ process.stdout.write(JSON.stringify(out));
 """
 
 
+_RECAP_HARNESS = r"""
+const fs = require('fs');
+
+function makeEl(id) {
+  const e = {
+    id, textContent: '', innerHTML: '', value: '', disabled: false,
+    dataset: {}, style: {}, children: [], _attrs: {}, _classes: new Set(),
+    _handlers: {},
+    classList: {
+      add(c) { e._classes.add(c); }, remove(c) { e._classes.delete(c); },
+      contains(c) { return e._classes.has(c); },
+      toggle(c, on) { on ? e._classes.add(c) : e._classes.delete(c); },
+    },
+    addEventListener() {}, appendChild() {}, remove() {},
+    setAttribute(k, v) { e._attrs[k] = v; },
+    getAttribute(k) { return e._attrs[k] === undefined ? null : e._attrs[k]; },
+    querySelector() { return null; }, querySelectorAll() { return []; },
+    focus() {}, closest() { return null; },
+  };
+  return e;
+}
+const nodes = {};
+function get(id) { if (!nodes[id]) nodes[id] = makeEl(id); return nodes[id]; }
+
+let medalRows = null;
+global.document = {
+  getElementById: get,
+  createElement: (t) => makeEl('created-' + t),
+  querySelector: () => null,
+  querySelectorAll: () => [],
+  addEventListener() {},
+  body: get('body'),
+};
+global.window = {
+  addEventListener() {},
+  QuizifyPlayerUtils: {
+    state: { playerName: 'Anna', isAdmin: false },
+    escapeHtml: (s) => String(s == null ? '' : s),
+    showView() {},
+    renderMedalStandings(el, rows) { medalRows = rows; },
+    setupCollapsibles() {},
+  },
+  QuizifyI18n: { t: (k) => k },
+};
+global.setTimeout = (f) => f && 0;
+global.clearTimeout = () => {};
+
+eval(fs.readFileSync(process.argv[2], 'utf8'));   // player-lightning.js
+eval(fs.readFileSync(process.argv[3], 'utf8'));   // player-team.js
+
+const team = global.window.QuizifyPlayerTeam;
+const lightning = global.window.QuizifyPlayerLightning;
+team.handleTeamJoined({ team: { team_id: 't1', name: 'Sofa', color: 'sage', members: ['Anna', 'Jan'] } });
+
+const out = { threw: null };
+try {
+  lightning.handleLightningRecap({ recap: {
+    leaderboard: [{ rank: 1, name: 'Sofa', score: 10 }, { rank: 2, name: 'Mira', score: 0 }],
+    questions: [{
+      question_id: 'q1', question_text: 'Why does a ball bounce?',
+      correct_answer: 'Compressed air', results: { Sofa: 'correct', Mira: 'wrong' }, chosen: {},
+    }],
+  }});
+  const html = get('lightning-recap-grid').innerHTML;
+  out.badge = /lr-recap-badge">(.)</.exec(html)[1];
+  out.isYouRow = (medalRows || []).filter((r) => r.isYou).map((r) => r.name)[0] || null;
+} catch (e) {
+  out.threw = String((e && e.stack) || e);
+}
+process.stdout.write(JSON.stringify(out));
+"""
+
+
 def _require_node() -> None:
     if shutil.which("node") is not None:
         return
@@ -339,3 +413,27 @@ def test_the_shipped_bundle_carries_the_team_module() -> None:
 
     assert "QuizifyPlayerTeam" in bundle
     assert "player-team.js" in bundle
+
+
+def test_the_lightning_recap_reads_the_teams_row(tmp_path: Path) -> None:
+    """The recap is keyed by whoever scored — the team, in team mode (#552).
+
+    Found by playing it: the round scored "Sofa", the client looked itself up
+    as "Anna", found nothing, and drew every question as a miss while the
+    standings above it showed the team's 10 points.
+    """
+    _require_node()
+    harness = tmp_path / "recap-harness.js"
+    harness.write_text(_RECAP_HARNESS, encoding="utf-8")
+    result = subprocess.run(
+        ["node", str(harness), str(LIGHTNING_JS), str(TEAM_JS)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"node harness failed:\n{result.stderr}"
+    out = json.loads(result.stdout)
+
+    assert out["threw"] is None, out["threw"]
+    assert out["badge"] == "✓", "the team answered this one correctly"
+    assert out["isYouRow"] == "Sofa", "the highlighted row is the team's"

--- a/tests/test_team_wire_365.py
+++ b/tests/test_team_wire_365.py
@@ -327,3 +327,61 @@ async def test_every_member_reads_the_same_reveal(
     assert (
         rows["Anna"]["correct_button_index"] != rows["Jan"]["correct_button_index"]
     ), "the correct-button hint is about each player's own button order"
+
+
+# ----------------------------------------------------------------------
+# The lightning round (#552)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_lightning_tap_reaches_the_team_not_the_scoreboard(
+    h: QuizifyWebSocketHandler, game: QuizifyGameState
+) -> None:
+    """Same contract as a normal round, one screen further in.
+
+    The tap sets the team's answer: no ``lightning_answer_result`` (which
+    would lock the tapper's phone and claim right/wrong), and both members
+    are told what stands — each in their own answer order.
+    """
+    anna_ws = _seat(h, game, "Anna")
+    jan_ws = _seat(h, game, "Jan")
+    await h._handle_create_team(anna_ws, {"name": "Sofa"}, game)
+    await h._handle_join_team(
+        jan_ws, {"team_id": game.get_team_of("Anna")["team_id"]}, game
+    )
+    game.start_lightning_round(category="picture-round-en", language="en")
+    game.begin_lightning_questions()
+    lr = game.lightning
+    lr._shuffles["Anna"] = [2, 0, 1]
+    lr._shuffles["Jan"] = [0, 1, 2]
+
+    await h._handle_lightning_answer(anna_ws, {"answer_index": 0}, game)
+
+    assert not _of_type(_to(h, anna_ws), "lightning_answer_result")
+    anna_msg = _of_type(_to(h, anna_ws), "lightning_team_answer")
+    jan_msg = _of_type(_to(h, jan_ws), "lightning_team_answer")
+    assert anna_msg and jan_msg, "both members see the standing answer"
+    # Canonical answer 2: Anna's position 0, Jan's position 2.
+    assert anna_msg[-1]["answer_index"] == 0
+    assert jan_msg[-1]["answer_index"] == 2
+    assert jan_msg[-1]["set_by"] == "Anna"
+    assert jan_msg[-1]["lock_seconds"] > 0
+
+
+@pytest.mark.asyncio
+async def test_a_solo_lightning_tap_is_unchanged(
+    h: QuizifyWebSocketHandler, game: QuizifyGameState
+) -> None:
+    """A player in no team still gets the ordinary ack that locks her phone."""
+    anna_ws = _seat(h, game, "Anna")
+    mira_ws = _seat(h, game, "Mira")
+    await h._handle_create_team(anna_ws, {"name": "Sofa"}, game)
+    game.start_lightning_round(category="picture-round-en", language="en")
+    game.begin_lightning_questions()
+    game.lightning._shuffles["Mira"] = [0, 1, 2]
+
+    await h._handle_lightning_answer(mira_ws, {"answer_index": 1}, game)
+
+    assert _of_type(_to(h, mira_ws), "lightning_answer_result")
+    assert not _of_type(_to(h, mira_ws), "lightning_team_answer")


### PR DESCRIPTION
Closes #552. Follows the decision recorded on the issue: **in the Lightning Round a team answers exactly as it does in a normal round** — one answer, one score, any member may change it until the clock stops. Everyone tapping for themselves would have given a team of four four bites at every question, which is the arithmetic the normal rounds deliberately avoid.

## The round knows entrants, not players

A team is one entrant and its members map onto it; an ordinary game's entrants are still the players. Scores, the recap grid and the lightning standings key on entrants, so the room reads "Sofa" where Sofa scored. Per-player shuffles stay per player — only the answer is shared, which is why the standing answer is re-addressed per member before it goes out.

## Two things that follow from the decision, not from taste

* **The question runs its clock in team mode.** Lightning normally ends a question as soon as everyone has answered; keeping that would close it on the *first* member's tap and the promised "answer together" would be theatre — the same trap the normal round fell into (fixed in #551).
* **A solo player is unaffected.** Her lightning answer is still final the moment she taps it, and in a game without teams the question still ends early.

## Found by playing it

The recap was keyed by player name. The round scored "Sofa", the client looked itself up as "Anna", found nothing, and drew every question as a miss — while the standings directly above showed the team's 10 points. The viewer's row is now their entrant.

## Verification

1386 tests and ruff green. Played through in Chrome at 390×844 with three phones: the lightning tap marked the standing answer on both members' screens in each phone's own order, the shared lock held and released, a teammate's change took, and the recap read "Sofa · Du · 20" next to the solo player's 10 with the team's per-question results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)