### PR TITLE
Five image questions for all six Spanish packs (#554)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ No apps to download. No accounts to create. Just scan a QR code and play.
 
 **Works on Any Screen** — Dashboard mode for the TV. Players use their phones. Admin runs the show. No extra hardware needed.
 
-**Eleven Themes, Three Languages** — 3,957 questions across 30 themed packs (Geography, Pop Culture, Animals & Nature, Sport, Music, Science, History, Food & Drink, Technology, World Cup, Estimation) in German, English and Spanish. Mix them, filter them, swap mid-session.
+**Eleven Themes, Three Languages** — 3,987 questions across 30 themed packs (Geography, Pop Culture, Animals & Nature, Sport, Music, Science, History, Food & Drink, Technology, World Cup, Estimation) in German, English and Spanish. Mix them, filter them, swap mid-session.
 
 ---
 
@@ -318,17 +318,17 @@ Then **"Start New Game"** (same settings, same players) or **Reset Game** (fresh
 
 ## Question Packs
 
-Quizify ships with **3,957 questions across 30 themed packs in 11 themes**, in German, English and Spanish.
+Quizify ships with **3,987 questions across 30 themed packs in 11 themes**, in German, English and Spanish.
 
 | Theme | 🇩🇪 Deutsch | 🇬🇧 English | 🇪🇸 Español |
 |-------|-------------|-------------|-------------|
-| 🌍 **Geographie / Geography / Geografía** | 154 | 155 | 150 |
-| 🦋 **Tiere & Natur / Animals & Nature / Naturaleza** | 154 | 155 | 150 |
-| 🎬 **Popkultur / Pop Culture / Cultura Pop** | 154 | 155 | 150 |
-| ⚽ **Sport / Deportes** | 153 | 155 | 150 |
+| 🌍 **Geographie / Geography / Geografía** | 154 | 155 | 155 |
+| 🦋 **Tiere & Natur / Animals & Nature / Naturaleza** | 154 | 155 | 155 |
+| 🎬 **Popkultur / Pop Culture / Cultura Pop** | 154 | 155 | 155 |
+| ⚽ **Sport / Deportes** | 153 | 155 | 155 |
 | 🎵 **Musik / Music** | 155 | 155 | — |
-| 🔬 **Wissenschaft / Science / Ciencia** | 155 | 155 | 150 |
-| 📜 **Geschichte / History / Historia** | 154 | 155 | 150 |
+| 🔬 **Wissenschaft / Science / Ciencia** | 155 | 155 | 155 |
+| 📜 **Geschichte / History / Historia** | 154 | 155 | 155 |
 | 🍔 **Essen & Trinken / Food & Drink** | 155 | 155 | — |
 | 💡 **Technik / Technology** | 155 | 155 | — |
 | 🏆 **Weltmeisterschaft / World Cup** | 104 | 105 | — |

--- a/custom_components/quizify/questions/ciencia-es.json
+++ b/custom_components/quizify/questions/ciencia-es.json
@@ -3153,6 +3153,76 @@
       "difficulty": "hard",
       "fun_fact": "La luz visible es una pequeña parte del espectro electromagnético.",
       "category": "Ciencia"
+    },
+    {
+      "id": "cie_es_161",
+      "question": "¿Qué técnica hizo posible esta imagen de una mano en 1895?",
+      "answers": [
+        {"text": "La ecografía", "correct": false},
+        {"text": "Los rayos X", "correct": true},
+        {"text": "La resonancia magnética", "correct": false}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Wilhelm Conrad Röntgen fotografió la mano de su esposa Anna Bertha; la mancha oscura es su anillo de boda. Se cuenta que ella dijo: «He visto mi muerte». Röntgen nunca patentó el procedimiento.",
+      "category": "Ciencia",
+      "image_url": "/quizify/static/img/packs/science/first-x-ray.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "cie_es_162",
+      "question": "¿Qué físico aparece aquí?",
+      "answers": [
+        {"text": "Niels Bohr", "correct": false},
+        {"text": "Max Planck", "correct": false},
+        {"text": "Albert Einstein", "correct": true}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El Nobel de 1921 no se lo dieron por la relatividad, sino por explicar el efecto fotoeléctrico: al comité la relatividad todavía le parecía demasiado incierta.",
+      "category": "Ciencia",
+      "image_url": "/quizify/static/img/packs/science/einstein-portrait.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "cie_es_163",
+      "question": "¿Qué científica aparece aquí?",
+      "answers": [
+        {"text": "Marie Curie", "correct": true},
+        {"text": "Lise Meitner", "correct": false},
+        {"text": "Rosalind Franklin", "correct": false}
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Marie Curie sigue siendo la única persona con premios Nobel en dos ciencias distintas: física en 1903 y química en 1911. Sus cuadernos de laboratorio siguen siendo tan radiactivos que se guardan en cajas de plomo.",
+      "category": "Ciencia",
+      "image_url": "/quizify/static/img/packs/science/marie-curie.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "cie_es_164",
+      "question": "¿Qué telescopio tomó esta imagen dentro de la nebulosa del Águila?",
+      "answers": [
+        {"text": "El telescopio James Webb", "correct": false},
+        {"text": "El telescopio Hubble", "correct": true},
+        {"text": "El Very Large Telescope", "correct": false}
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los Pilares de la Creación son torres de gas y polvo donde nacen estrellas. El más alto mide unos cuatro años luz, más o menos la distancia del Sol a la estrella más cercana.",
+      "category": "Ciencia",
+      "image_url": "/quizify/static/img/packs/science/pillars-of-creation.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "cie_es_165",
+      "question": "¿Qué instrumento hizo posible este dibujo de 1665?",
+      "answers": [
+        {"text": "El telescopio", "correct": false},
+        {"text": "La cámara oscura", "correct": false},
+        {"text": "El microscopio", "correct": true}
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La «Micrographia» de Robert Hooke mostró una pulga a un tamaño que nadie había visto antes. En ese mismo libro llamó «células» a las cavidades que encontró en el corcho, por las celdas de un monasterio.",
+      "category": "Ciencia",
+      "image_url": "/quizify/static/img/packs/science/hooke-flea.webp",
+      "reveal_style": "progressive"
     }
   ]
 }

--- a/custom_components/quizify/questions/cultura-pop-es.json
+++ b/custom_components/quizify/questions/cultura-pop-es.json
@@ -3153,6 +3153,76 @@
       "difficulty": "medium",
       "fun_fact": "Se emite desde 1989 y ha superado los setecientos episodios.",
       "category": "Cultura Pop"
+    },
+    {
+      "id": "pop_es_161",
+      "question": "¿De qué película de 1902 procede esta imagen?",
+      "answers": [
+        {"text": "Nosferatu", "correct": false},
+        {"text": "Viaje a la Luna", "correct": true},
+        {"text": "Metrópolis", "correct": false}
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Georges Méliès fue mago de escenario antes que cineasta. El cohete clavado en el ojo de la Luna es una de las imágenes más antiguas que casi todo el mundo reconoce sin haber visto la película.",
+      "category": "Cultura Pop",
+      "image_url": "/quizify/static/img/packs/popculture/voyage-dans-la-lune.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "pop_es_162",
+      "question": "¿Qué estrella del cine mudo aparece aquí?",
+      "answers": [
+        {"text": "Buster Keaton", "correct": false},
+        {"text": "Harold Lloyd", "correct": false},
+        {"text": "Charlie Chaplin", "correct": true}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Chaplin inventó a Charlot en una tarde en el almacén de vestuario: pantalón ancho, chaqueta estrecha, zapatos grandes y un bastón. El personaje acabó apareciendo en más de setenta películas.",
+      "category": "Cultura Pop",
+      "image_url": "/quizify/static/img/packs/popculture/charlie-chaplin.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "pop_es_163",
+      "question": "¿Qué personaje se dio a conocer en esta película de 1928?",
+      "answers": [
+        {"text": "Mickey Mouse", "correct": true},
+        {"text": "Bugs Bunny", "correct": false},
+        {"text": "El pato Donald", "correct": false}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "«Steamboat Willie» no fue el primer corto de Mickey Mouse, pero sí el primero con sonido sincronizado, y por eso es el que todo el mundo conoce. En Estados Unidos es de dominio público desde 2024.",
+      "category": "Cultura Pop",
+      "image_url": "/quizify/static/img/packs/popculture/steamboat-willie.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "pop_es_164",
+      "question": "¿Qué actriz aparece en esta foto promocional de 1953?",
+      "answers": [
+        {"text": "Grace Kelly", "correct": false},
+        {"text": "Marilyn Monroe", "correct": true},
+        {"text": "Rita Hayworth", "correct": false}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Solo en 1953 se estrenaron tres películas suyas. El estudio le pagaba menos que a sus compañeros de reparto masculinos, y la pelea por eso la llevó a fundar su propia productora.",
+      "category": "Cultura Pop",
+      "image_url": "/quizify/static/img/packs/popculture/marilyn-monroe.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "pop_es_165",
+      "question": "¿Con qué nombre se hizo célebre la mujer de este cartel?",
+      "answers": [
+        {"text": "Lady Liberty", "correct": false},
+        {"text": "Betty Boop", "correct": false},
+        {"text": "Rosie la Remachadora", "correct": true}
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El cartel estuvo colgado dos semanas de 1943 en unas pocas fábricas de Westinghouse y después desapareció durante cuarenta años. Se redescubrió en los años ochenta y se convirtió en símbolo: su fama actual no tiene nada que ver con su efecto original.",
+      "category": "Cultura Pop",
+      "image_url": "/quizify/static/img/packs/popculture/we-can-do-it.webp",
+      "reveal_style": "progressive"
     }
   ]
 }

--- a/custom_components/quizify/questions/deportes-es.json
+++ b/custom_components/quizify/questions/deportes-es.json
@@ -3153,6 +3153,76 @@
       "difficulty": "medium",
       "fun_fact": "Río de Janeiro fue la primera ciudad sudamericana en organizarlos.",
       "category": "Deportes"
+    },
+    {
+      "id": "dep_es_161",
+      "question": "¿Qué prueba muestra esta foto de los Juegos Olímpicos de 1936?",
+      "answers": [
+        {"text": "El salto de longitud", "correct": true},
+        {"text": "El salto con pértiga", "correct": false},
+        {"text": "Los 110 metros vallas", "correct": false}
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Jesse Owens ganó cuatro medallas de oro en Berlín. En la longitud fue su rival alemán Luz Long quien le dio un consejo antes del último intento; los dos salieron del estadio del brazo.",
+      "category": "Deportes",
+      "image_url": "/quizify/static/img/packs/sport/jesse-owens-1936.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "dep_es_162",
+      "question": "¿Qué boxeador aparece aquí?",
+      "answers": [
+        {"text": "Joe Frazier", "correct": false},
+        {"text": "Muhammad Ali", "correct": true},
+        {"text": "George Foreman", "correct": false}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Ali fue campeón olímpico en 1960 y tres veces campeón mundial de los pesados, y perdió por el camino tres años y medio de su mejor momento cuando le retiraron la licencia por negarse a ir a la guerra.",
+      "category": "Deportes",
+      "image_url": "/quizify/static/img/packs/sport/muhammad-ali.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "dep_es_163",
+      "question": "¿Qué deporte se juega en esta foto de 1916?",
+      "answers": [
+        {"text": "El críquet", "correct": false},
+        {"text": "El golf", "correct": false},
+        {"text": "El béisbol", "correct": true}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Babe Ruth empezó como lanzador y solo después se convirtió en el bateador más famoso del deporte. Su traspaso de Boston a Nueva York sigue considerándose el más determinante de la historia del béisbol.",
+      "category": "Deportes",
+      "image_url": "/quizify/static/img/packs/sport/babe-ruth.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "dep_es_164",
+      "question": "¿Qué carrera ganó este hombre en 1920?",
+      "answers": [
+        {"text": "El Tour de Francia", "correct": true},
+        {"text": "El maratón de Berlín", "correct": false},
+        {"text": "Las 24 Horas de Le Mans", "correct": false}
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Philippe Thys ganó el Tour tres veces. Entonces los corredores no tenían asistencia: una avería era cosa suya, y un cuadro roto significaba caminar hasta la fragua más cercana.",
+      "category": "Deportes",
+      "image_url": "/quizify/static/img/packs/sport/tour-de-france-1920.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "dep_es_165",
+      "question": "¿Qué deporte popularizó esta francesa en los años veinte?",
+      "answers": [
+        {"text": "El hockey", "correct": false},
+        {"text": "El bádminton", "correct": false},
+        {"text": "El tenis", "correct": true}
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Suzanne Lenglen perdió exactamente un partido entre 1919 y 1926. Jugaba con falda hasta la pantorrilla, sin corsé y con los antebrazos al aire: para el público de 1920, casi tan llamativo como sus golpes.",
+      "category": "Deportes",
+      "image_url": "/quizify/static/img/packs/sport/suzanne-lenglen.webp",
+      "reveal_style": "progressive"
     }
   ]
 }

--- a/custom_components/quizify/questions/geografia-es.json
+++ b/custom_components/quizify/questions/geografia-es.json
@@ -3153,6 +3153,76 @@
       "difficulty": "easy",
       "fun_fact": "África mide unos 30 millones de kilómetros cuadrados. Estados Unidos, China e India juntos cubren unos 25 millones y aún cabrían dentro de ella; la proyección de Mercator encoge mucho las regiones ecuatoriales e infla los polos.",
       "category": "Geografía"
+    },
+    {
+      "id": "geo_es_161",
+      "question": "¿En qué parque nacional se encuentra esta fuente termal?",
+      "answers": [
+        {"text": "Yosemite", "correct": false},
+        {"text": "Yellowstone", "correct": true},
+        {"text": "Banff", "correct": false}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Los anillos de color de la Gran Fuente Prismática son tapetes de bacterias. En el centro, a unos 70 °C, casi ningún organismo resiste, y por eso el agua se ve limpia y azul; hacia fuera se enfría y cada temperatura tiene sus microbios, que tiñen el borde de amarillo, naranja y rojo.",
+      "category": "Geografía",
+      "image_url": "/quizify/static/img/packs/geography/yellowstone-spring.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "geo_es_162",
+      "question": "¿En qué ciudad se encuentra esta estatua?",
+      "answers": [
+        {"text": "Nueva York", "correct": true},
+        {"text": "Boston", "correct": false},
+        {"text": "Filadelfia", "correct": false}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La Estatua de la Libertad cruzó el Atlántico en 1885 dentro de 214 cajas y se montó ya en la isla. Su piel de cobre tiene apenas dos milímetros de grosor: quien la sostiene es el armazón de hierro que lleva dentro.",
+      "category": "Geografía",
+      "image_url": "/quizify/static/img/packs/geography/statue-of-liberty.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "geo_es_163",
+      "question": "¿Qué estrecho separa aquí Europa de África?",
+      "answers": [
+        {"text": "El Bósforo", "correct": false},
+        {"text": "El Öresund", "correct": false},
+        {"text": "El estrecho de Gibraltar", "correct": true}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "En su punto más angosto hay unos 14 kilómetros entre España y Marruecos. El agua se intercambia en dos pisos: por arriba entra agua atlántica menos salada al Mediterráneo y por abajo sale la más salada.",
+      "category": "Geografía",
+      "image_url": "/quizify/static/img/packs/geography/strait-of-gibraltar.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "geo_es_164",
+      "question": "¿Qué río se dibuja aquí de noche visto desde el espacio?",
+      "answers": [
+        {"text": "El Ganges", "correct": false},
+        {"text": "El Nilo", "correct": true},
+        {"text": "El Danubio", "correct": false}
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Casi toda la población de Egipto vive en la franja estrecha junto al Nilo y en su delta, un porcentaje mínimo del territorio. Por eso la banda de luz se corta de golpe donde empieza el desierto.",
+      "category": "Geografía",
+      "image_url": "/quizify/static/img/packs/geography/nile-delta-night.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "geo_es_165",
+      "question": "¿En qué país se encuentra este edificio?",
+      "answers": [
+        {"text": "Irán", "correct": false},
+        {"text": "Uzbekistán", "correct": false},
+        {"text": "India", "correct": true}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El Taj Mahal de Agra se empezó en 1632 como mausoleo de Mumtaz Mahal, esposa del emperador Shah Jahan. La imagen es un fotocromo de hacia 1890: una foto en blanco y negro cuyos colores se aplicaron a mano sobre varias piedras de impresión.",
+      "category": "Geografía",
+      "image_url": "/quizify/static/img/packs/geography/taj-mahal.webp",
+      "reveal_style": "progressive"
     }
   ]
 }

--- a/custom_components/quizify/questions/historia-es.json
+++ b/custom_components/quizify/questions/historia-es.json
@@ -3153,6 +3153,76 @@
       "difficulty": "hard",
       "fun_fact": "El Canal de Suez acortó enormemente la ruta marítima entre Europa y Asia al evitar rodear todo el continente africano.",
       "category": "Historia"
+    },
+    {
+      "id": "his_es_161",
+      "question": "¿Quién logró en 1903 el primer vuelo a motor con esta máquina?",
+      "answers": [
+        {"text": "Otto Lilienthal", "correct": false},
+        {"text": "Los hermanos Wright", "correct": true},
+        {"text": "Louis Blériot", "correct": false}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El primer vuelo, el 17 de diciembre de 1903, duró 12 segundos y cubrió 36 metros: menos que la envergadura de un Boeing 747 actual. El cuarto intento de ese mismo día llegó ya a 260 metros.",
+      "category": "Historia",
+      "image_url": "/quizify/static/img/packs/history/wright-first-flight.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "his_es_162",
+      "question": "¿Qué crisis retrata esta famosa fotografía de 1936?",
+      "answers": [
+        {"text": "La Gran Depresión", "correct": true},
+        {"text": "La Primera Guerra Mundial", "correct": false},
+        {"text": "La crisis del petróleo", "correct": false}
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Dorothea Lange fotografió a Florence Owens Thompson en un campamento de recolectores de guisantes en California: seis tomas en diez minutos. El gobierno mandó alimentos al campamento poco después; la familia ya se había marchado.",
+      "category": "Historia",
+      "image_url": "/quizify/static/img/packs/history/migrant-mother.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "his_es_163",
+      "question": "¿Qué presidente de Estados Unidos aparece aquí?",
+      "answers": [
+        {"text": "Ulysses S. Grant", "correct": false},
+        {"text": "Andrew Jackson", "correct": false},
+        {"text": "Abraham Lincoln", "correct": true}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Alexander Gardner tomó el retrato en noviembre de 1863, pocos días antes del discurso de Gettysburg. Lincoln fue el primer presidente al que la fotografía siguió de cerca: se conservan más de 130 imágenes suyas.",
+      "category": "Historia",
+      "image_url": "/quizify/static/img/packs/history/lincoln-portrait.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "his_es_164",
+      "question": "¿Qué barco zarpa aquí de Southampton el 10 de abril de 1912?",
+      "answers": [
+        {"text": "El Lusitania", "correct": false},
+        {"text": "El Titanic", "correct": true},
+        {"text": "El Britannic", "correct": false}
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Cinco días después estaba en el fondo del mar. De sus cuatro chimeneas solo tres eran reales: la trasera servía para la ventilación y para el efecto que causaban cuatro.",
+      "category": "Historia",
+      "image_url": "/quizify/static/img/packs/history/titanic-southampton.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "his_es_165",
+      "question": "¿Qué acontecimiento de 1989 reunió a esta multitud ante la Puerta de Brandeburgo?",
+      "answers": [
+        {"text": "El levantamiento del 17 de junio de 1953", "correct": false},
+        {"text": "El bloqueo de Berlín", "correct": false},
+        {"text": "La caída del Muro de Berlín", "correct": true}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El Muro se abrió el 9 de noviembre de 1989, pero la Puerta de Brandeburgo no lo hizo hasta el 22 de diciembre: durante seis semanas el monumento más conocido de la ciudad siguió dentro de la zona prohibida mientras al lado ya se celebraba.",
+      "category": "Historia",
+      "image_url": "/quizify/static/img/packs/history/brandenburg-gate-1989.webp",
+      "reveal_style": "progressive"
     }
   ]
 }

--- a/custom_components/quizify/questions/naturaleza-es.json
+++ b/custom_components/quizify/questions/naturaleza-es.json
@@ -3153,6 +3153,76 @@
       "difficulty": "hard",
       "fun_fact": "Los canales semicirculares del sistema vestibular detectan el movimiento de la cabeza.",
       "category": "Naturaleza"
+    },
+    {
+      "id": "nat_es_161",
+      "question": "¿Qué ave marina es esta?",
+      "answers": [
+        {"text": "El frailecillo atlántico", "correct": true},
+        {"text": "El alca común", "correct": false},
+        {"text": "El fulmar boreal", "correct": false}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Un frailecillo puede llevar más de 60 peces pequeños atravesados en el pico: unas púas en el paladar sujetan los ya capturados mientras sigue pescando.",
+      "category": "Naturaleza",
+      "image_url": "/quizify/static/img/packs/nature/puffin.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "nat_es_162",
+      "question": "¿Qué ave rapaz está posada sobre la piedra?",
+      "answers": [
+        {"text": "El águila calva", "correct": true},
+        {"text": "El águila real", "correct": false},
+        {"text": "El águila pescadora", "correct": false}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La cabeza blanca no aparece hasta los cinco años. Las águilas calvas jóvenes son enteramente marrones, y por eso se las confunde a menudo con águilas reales.",
+      "category": "Naturaleza",
+      "image_url": "/quizify/static/img/packs/nature/bald-eagle.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "nat_es_163",
+      "question": "¿Qué muestran estas fotografías de 1902?",
+      "answers": [
+        {"text": "Cristales de nieve", "correct": true},
+        {"text": "Diatomeas", "correct": false},
+        {"text": "Cristales de sal", "correct": false}
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Wilson Bentley fotografió más de 5.000 cristales de nieve a través de un microscopio y nunca encontró dos iguales. Los recogía sobre una tabla de terciopelo negro antes de que se derritieran.",
+      "category": "Naturaleza",
+      "image_url": "/quizify/static/img/packs/nature/snowflake.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "nat_es_164",
+      "question": "¿Qué está mirando la estación espacial desde arriba?",
+      "answers": [
+        {"text": "El ojo de un huracán", "correct": true},
+        {"text": "El cráter de un volcán", "correct": false},
+        {"text": "Un remolino en el hielo marino", "correct": false}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Dentro del ojo casi no hay viento y a menudo está despejado. La destrucción ocurre en la pared que lo rodea, donde el aire asciende a mayor velocidad.",
+      "category": "Naturaleza",
+      "image_url": "/quizify/static/img/packs/nature/hurricane-iss.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "nat_es_165",
+      "question": "¿Qué brilla en verde sobre la curvatura de la Tierra?",
+      "answers": [
+        {"text": "Una aurora polar", "correct": true},
+        {"text": "Relámpagos de tormenta", "correct": false},
+        {"text": "Ceniza volcánica", "correct": false}
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El verde se forma entre los 100 y los 150 kilómetros de altura, cuando los átomos de oxígeno reciben el impacto de partículas del viento solar. Más arriba todavía, el brillo es rojo.",
+      "category": "Naturaleza",
+      "image_url": "/quizify/static/img/packs/nature/aurora-iss.webp",
+      "reveal_style": "progressive"
     }
   ]
 }

--- a/custom_components/quizify/www/img/packs/geography/credits.md
+++ b/custom_components/quizify/www/img/packs/geography/credits.md
@@ -44,3 +44,8 @@ provenance stays checkable later.
 1100 px on the long edge, WebP at quality 72–80, 51–137 KB each, 483 KB for the
 set. Each one was rendered at 340 px — the width the card actually gets on a
 390 px phone — and looked at before being kept.
+
+## Spanish
+
+The Spanish pack of this theme asks the same five pictures (#554). No new
+files, no new licence work — only question text.

--- a/custom_components/quizify/www/img/packs/history/credits.md
+++ b/custom_components/quizify/www/img/packs/history/credits.md
@@ -43,3 +43,8 @@ on a 390 px phone — and looked at before being kept, because a picture that is
 not recognisable at that size is not a picture question. All five carry their
 subject at that width: a portrait, a face, a ship in profile, a biplane against
 empty sand, and a gate behind a painted wall.
+
+## Spanish
+
+The Spanish pack of this theme asks the same five pictures (#554). No new
+files, no new licence work — only question text.

--- a/custom_components/quizify/www/img/packs/nature/credits.md
+++ b/custom_components/quizify/www/img/packs/nature/credits.md
@@ -33,3 +33,8 @@ provenance stays checkable later.
 also rendered at 340 px — the width the card actually gets on a 390 px phone —
 and looked at before being kept, because a picture that is not recognisable at
 that size is not a picture question.
+
+## Spanish
+
+The Spanish pack of this theme asks the same five pictures (#554). No new
+files, no new licence work — only question text.

--- a/custom_components/quizify/www/img/packs/popculture/credits.md
+++ b/custom_components/quizify/www/img/packs/popculture/credits.md
@@ -48,3 +48,8 @@ Up to 1100 px on the long edge; three keep their native size (993–1024 px).
 WebP at quality 80, 40–108 KB each, 371 KB for the folder. Each was rendered at
 340 px — the width the card gets on a 390 px phone — and looked at before being
 kept.
+
+## Spanish
+
+The Spanish pack of this theme asks the same five pictures (#554). No new
+files, no new licence work — only question text.

--- a/custom_components/quizify/www/img/packs/science/credits.md
+++ b/custom_components/quizify/www/img/packs/science/credits.md
@@ -31,3 +31,8 @@ folder. Each one was rendered at 340 px — the width the card gets on a 390 px
 phone — and looked at before being kept. The two portraits and the flea
 engraving hold up plainly; the X-ray needed the crop before the hand read as a
 hand at that size; the Pillars are large enough in frame to survive it.
+
+## Spanish
+
+The Spanish pack of this theme asks the same five pictures (#554). No new
+files, no new licence work — only question text.

--- a/custom_components/quizify/www/img/packs/sport/credits.md
+++ b/custom_components/quizify/www/img/packs/sport/credits.md
@@ -44,3 +44,8 @@ phone — and looked at before being kept. The two wide crowd scenes are the
 tightest call of the set: in both, the subject (a flower-covered bicycle, a
 player at full stretch on a tennis court) survives at that width, which is what
 the question rests on.
+
+## Spanish
+
+The Spanish pack of this theme asks the same five pictures (#554). No new
+files, no new licence work — only question text.

--- a/tests/test_pack_images_554.py
+++ b/tests/test_pack_images_554.py
@@ -38,10 +38,15 @@ EXPECTED_IMAGE_QUESTIONS = 5
 
 @dataclass(frozen=True)
 class ImageSet:
-    """One pack pair and the folder of pictures the two share."""
+    """One theme's packs and the folder of pictures they all share.
+
+    Started as a pair; the Spanish packs join their theme as a third member
+    rather than getting a folder of their own, which is the whole reason the
+    six of them cost question text and no licence work at all.
+    """
 
     folder: str
-    packs: tuple[str, str]
+    packs: tuple[str, ...]
     text_question_floor: int
 
     @property
@@ -54,16 +59,16 @@ class ImageSet:
 
 
 PACK_SETS = (
-    ImageSet("nature", ("tiere-natur.json", "animals-nature.json"), 149),
-    ImageSet("geography", ("geographie.json", "geography.json"), 149),
-    ImageSet("history", ("geschichte-de.json", "history-en.json"), 149),
-    ImageSet("science", ("wissenschaft-de.json", "science-en.json"), 150),
+    ImageSet("nature", ("tiere-natur.json", "animals-nature.json", "naturaleza-es.json"), 149),
+    ImageSet("geography", ("geographie.json", "geography.json", "geografia-es.json"), 149),
+    ImageSet("history", ("geschichte-de.json", "history-en.json", "historia-es.json"), 149),
+    ImageSet("science", ("wissenschaft-de.json", "science-en.json", "ciencia-es.json"), 150),
     ImageSet("tech", ("technik-de.json", "tech-en.json"), 150),
     ImageSet("food", ("essen-de.json", "food-en.json"), 150),
-    ImageSet("sport", ("sport-de.json", "sport-en.json"), 148),
+    ImageSet("sport", ("sport-de.json", "sport-en.json", "deportes-es.json"), 148),
     ImageSet("worldcup", ("weltmeisterschaft.json", "world-cup.json"), 99),
     ImageSet("music", ("musik-de.json", "music-en.json"), 150),
-    ImageSet("popculture", ("popkultur.json", "pop-culture.json"), 149),
+    ImageSet("popculture", ("popkultur.json", "pop-culture.json", "cultura-pop-es.json"), 149),
 )
 
 # (set, pack) for the guards that look at one pack at a time.
@@ -106,11 +111,12 @@ def test_a_reveal_style_never_stands_without_an_image(iset: ImageSet, name: str)
 
 
 @pytest.mark.parametrize("iset", PACK_SETS, ids=SET_IDS)
-def test_both_languages_use_the_same_pictures(iset: ImageSet) -> None:
+def test_every_language_uses_the_same_pictures(iset: ImageSet) -> None:
     """A picture asked in German but not in English is a silent gap — and the
-    whole reason the pair is cheaper than two packs is the shared images."""
+    whole reason a theme is cheaper than its packs counted separately is that
+    they share the images. Spanish is held to the same rule."""
     sets = [{q["image_url"] for q in _image_questions(iset, name)} for name in iset.packs]
-    assert sets[0] == sets[1]
+    assert all(s == sets[0] for s in sets), f"{iset.folder}: languages disagree on pictures"
 
 
 @pytest.mark.parametrize("iset", PACK_SETS, ids=SET_IDS)


### PR DESCRIPTION
The last six units of #554, in one change because they cost **no licence work at all**: each Spanish pack asks the same five pictures its German and English theme already ships. Thirty questions, zero new files.

| Spanish pack | Reuses the folder of |
|---|---|
| `geografia-es.json` | geography |
| `naturaleza-es.json` | nature |
| `historia-es.json` | history |
| `ciencia-es.json` | science |
| `deportes-es.json` | sport |
| `cultura-pop-es.json` | pop culture |

## The registry stops being a pair and becomes a theme

`ImageSet.packs` is now a variable-length tuple, and Spanish joins its theme as a third member. The six packs inherit every guard the pairs already had — five per pack, files that exist, no `reveal_style` without an image, no orphaned files, and the same pictures in every language. That last check changed from comparing two sets to comparing all of them.

The four themes with no Spanish pack (technology, food, music, world cup) stay pairs. That is the same gap 1.6.1 documented: Spanish has no music, food or technology pack for pictures to go into.

## Checks

- README: six Spanish columns move 150 → 155, total 3,957 → 3,987, matching the packs on disk.
- Each theme's `credits.md` notes that its Spanish pack reuses the same files.
- Answer positions mixed so the correct tile is not always first (#521).
- Suite **1,614 green**.

**Ledger for #554: 16 of 16 units done.** Every pack that has a matching theme now carries five image questions. What remains open is the question the issue raised at the start and never settled: the four small packs (the two estimation packs at 15 questions and the two picture rounds at 17), where five images would be a third of the pack — and the picture rounds are already nothing but pictures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)