### PR TITLE
feat(#566): five estimate questions for the nature pack pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ No apps to download. No accounts to create. Just scan a QR code and play.
 
 **Works on Any Screen** — Dashboard mode for the TV. Players use their phones. Admin runs the show. No extra hardware needed.
 
-**Eleven Themes, Three Languages** — 3,987 questions across 30 themed packs (Geography, Pop Culture, Animals & Nature, Sport, Music, Science, History, Food & Drink, Technology, World Cup, Estimation) in German, English and Spanish. Mix them, filter them, swap mid-session.
+**Eleven Themes, Three Languages** — 3,997 questions across 30 themed packs (Geography, Pop Culture, Animals & Nature, Sport, Music, Science, History, Food & Drink, Technology, World Cup, Estimation) in German, English and Spanish. Mix them, filter them, swap mid-session.
 
 ---
 
@@ -318,12 +318,12 @@ Then **"Start New Game"** (same settings, same players) or **Reset Game** (fresh
 
 ## Question Packs
 
-Quizify ships with **3,987 questions across 30 themed packs in 11 themes**, in German, English and Spanish.
+Quizify ships with **3,997 questions across 30 themed packs in 11 themes**, in German, English and Spanish.
 
 | Theme | 🇩🇪 Deutsch | 🇬🇧 English | 🇪🇸 Español |
 |-------|-------------|-------------|-------------|
 | 🌍 **Geographie / Geography / Geografía** | 154 | 155 | 155 |
-| 🦋 **Tiere & Natur / Animals & Nature / Naturaleza** | 154 | 155 | 155 |
+| 🦋 **Tiere & Natur / Animals & Nature / Naturaleza** | 159 | 160 | 155 |
 | 🎬 **Popkultur / Pop Culture / Cultura Pop** | 154 | 155 | 155 |
 | ⚽ **Sport / Deportes** | 153 | 155 | 155 |
 | 🎵 **Musik / Music** | 155 | 155 | — |
@@ -335,7 +335,7 @@ Quizify ships with **3,987 questions across 30 themed packs in 11 themes**, in G
 | 🎯 **Schätzfragen / Estimation** | 15 | 15 | — |
 | 🖼️ **Bilderrätsel / Picture Round** | 17 | 17 | — |
 
-Spanish arrived in 1.3.0 and grew through 1.6.1; music, food and technology are the three themes it is still missing. The two Estimation packs hold slider questions rather than multiple choice — see [How to Play](#the-experience).
+Spanish arrived in 1.3.0 and grew through 1.6.1; music, food and technology are the three themes it is still missing. The two Estimation packs hold slider questions rather than multiple choice — see [How to Play](#the-experience); the themed packs are gaining five slider questions of their own as well, which is why Animals & Nature runs longer than its siblings.
 
 Pack selection lives on the **first screen**: a featured pack card (e.g. World Cup) up top, with every other pack as a tappable chip right beneath it — tap to select or deselect, mix several, then hit **Start Game**. Game settings (difficulty, rounds, timer) stay one tap away under **Adjust settings**. **Mixed mode** drops you a random question from every selected pack, so you can stir Geography + Pop + Sport together for chaos mode.
 

--- a/custom_components/quizify/questions/animals-nature.json
+++ b/custom_components/quizify/questions/animals-nature.json
@@ -1,7 +1,7 @@
 {
   "name": "Animals & Nature",
   "language": "en",
-  "version": "1.1",
+  "version": "1.2",
   "theme": "nature",
   "questions": [
     {
@@ -1873,6 +1873,66 @@
       "category": "Animals & Nature",
       "image_url": "/quizify/static/img/packs/nature/aurora-iss.webp",
       "reveal_style": "progressive"
+    },
+    {
+      "id": "nat_en_164",
+      "question": "How long was the longest blue whale ever reliably measured?",
+      "type": "estimate",
+      "answer": 33,
+      "min": 5,
+      "max": 60,
+      "unit": "metres",
+      "difficulty": "medium",
+      "fun_fact": "Its tongue alone weighs as much as a grown elephant. The larger lengths quoted from the whaling era were almost always eyeballed on deck rather than measured.",
+      "category": "Animals & Nature"
+    },
+    {
+      "id": "nat_en_165",
+      "question": "What is a cheetah's top speed over a short sprint?",
+      "type": "estimate",
+      "answer": 120,
+      "min": 20,
+      "max": 200,
+      "unit": "km/h",
+      "difficulty": "easy",
+      "fun_fact": "It can only hold that for about 20 seconds before overheating, which is why a hunt is usually decided inside 300 metres.",
+      "category": "Animals & Nature"
+    },
+    {
+      "id": "nat_en_166",
+      "question": "How long is an elephant pregnant?",
+      "type": "estimate",
+      "answer": 22,
+      "min": 1,
+      "max": 36,
+      "unit": "months",
+      "difficulty": "medium",
+      "fun_fact": "That is the longest gestation of any land mammal. The calf already weighs around 120 kg at birth.",
+      "category": "Animals & Nature"
+    },
+    {
+      "id": "nat_en_167",
+      "question": "How deep is the deepest recorded dive by an emperor penguin?",
+      "type": "estimate",
+      "answer": 564,
+      "min": 50,
+      "max": 1000,
+      "unit": "metres",
+      "difficulty": "hard",
+      "fun_fact": "The pressure down there is over 50 bar. The penguin lets its lungs collapse and lives off the oxygen stored in its blood and muscles.",
+      "category": "Animals & Nature"
+    },
+    {
+      "id": "nat_en_168",
+      "question": "What percentage of the Earth's surface is covered by ocean?",
+      "type": "estimate",
+      "answer": 71,
+      "min": 0,
+      "max": 100,
+      "unit": "percent",
+      "difficulty": "easy",
+      "fun_fact": "Very little of it is mapped in detail — we know the surface of Mars better than we know our own seafloor.",
+      "category": "Animals & Nature"
     }
   ]
 }

--- a/custom_components/quizify/questions/tiere-natur.json
+++ b/custom_components/quizify/questions/tiere-natur.json
@@ -1,7 +1,7 @@
 {
   "name": "Tiere & Natur",
   "language": "de",
-  "version": "1.1",
+  "version": "1.2",
   "theme": "nature",
   "questions": [
     {
@@ -1861,6 +1861,66 @@
       "category": "Tiere & Natur",
       "image_url": "/quizify/static/img/packs/nature/aurora-iss.webp",
       "reveal_style": "progressive"
+    },
+    {
+      "id": "nat_166",
+      "question": "Wie lang ist der längste jemals verlässlich vermessene Blauwal?",
+      "type": "estimate",
+      "answer": 33,
+      "min": 5,
+      "max": 60,
+      "unit": "Meter",
+      "difficulty": "medium",
+      "fun_fact": "Schon seine Zunge wiegt so viel wie ein ausgewachsener Elefant. Größere Längenangaben aus der Walfangzeit stammen fast immer von Schätzungen an Deck, nicht von einem Maßband.",
+      "category": "Tiere & Natur"
+    },
+    {
+      "id": "nat_167",
+      "question": "Wie schnell wird ein Gepard auf kurzer Strecke höchstens?",
+      "type": "estimate",
+      "answer": 120,
+      "min": 20,
+      "max": 200,
+      "unit": "km/h",
+      "difficulty": "easy",
+      "fun_fact": "Er hält das nur rund 20 Sekunden durch — danach droht Überhitzung. Die Jagd ist deshalb fast immer nach 300 Metern entschieden.",
+      "category": "Tiere & Natur"
+    },
+    {
+      "id": "nat_168",
+      "question": "Wie lange ist eine Elefantenkuh trächtig?",
+      "type": "estimate",
+      "answer": 22,
+      "min": 1,
+      "max": 36,
+      "unit": "Monate",
+      "difficulty": "medium",
+      "fun_fact": "Das ist die längste Tragzeit aller Landsäugetiere. Das Kalb wiegt bei der Geburt schon rund 120 Kilo.",
+      "category": "Tiere & Natur"
+    },
+    {
+      "id": "nat_169",
+      "question": "Wie tief ist der tiefste gemessene Tauchgang eines Kaiserpinguins?",
+      "type": "estimate",
+      "answer": 564,
+      "min": 50,
+      "max": 1000,
+      "unit": "Meter",
+      "difficulty": "hard",
+      "fun_fact": "In dieser Tiefe herrschen über 50 bar Druck. Der Pinguin lässt dafür seine Lungen kollabieren und zehrt vom Sauerstoff in Blut und Muskeln.",
+      "category": "Tiere & Natur"
+    },
+    {
+      "id": "nat_170",
+      "question": "Wie viel Prozent der Erdoberfläche bedecken die Ozeane?",
+      "type": "estimate",
+      "answer": 71,
+      "min": 0,
+      "max": 100,
+      "unit": "Prozent",
+      "difficulty": "easy",
+      "fun_fact": "Kartiert ist davon nur ein Bruchteil: Den Meeresboden kennen wir weniger genau als die Oberfläche des Mars.",
+      "category": "Tiere & Natur"
     }
   ]
 }

--- a/custom_components/quizify/questions/versions.json
+++ b/custom_components/quizify/questions/versions.json
@@ -1,10 +1,10 @@
 {
   "geographie": "1.1",
-  "tiere-natur": "1.1",
+  "tiere-natur": "1.2",
   "popkultur": "1.1",
   "geography": "1.1",
   "geografia-es": "1.0",
-  "animals-nature": "1.1",
+  "animals-nature": "1.2",
   "pop-culture": "1.1",
   "essen-de": "1.1",
   "food-en": "1.1",

--- a/tests/test_pack_estimates_566.py
+++ b/tests/test_pack_estimates_566.py
@@ -1,0 +1,151 @@
+"""Estimate questions inside ordinary packs (#566).
+
+Estimate questions (#275) lived in two packs that are nothing *but* estimates.
+Five per themed pack, added rather than swapped in, spreads the slider across
+the library the way #554 spread pictures.
+
+What can go wrong here is different from the image work. Nothing ships, so
+there are no files to orphan and no licences to verify; the failure modes are
+in the numbers. A slider whose range excludes its own answer silently drops the
+question at load time (the loader logs and skips it, see
+``_parse_estimate_question``), and a range so tight it brackets the answer
+hands the game away. Both are invisible in review and cheap to assert.
+
+The pairs are a registry for the same reason the image test is: a new pack pair
+is one ``EstimateSet`` entry that inherits the whole checklist instead of a
+copy of it.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+QUESTIONS = REPO / "custom_components" / "quizify" / "questions"
+
+EXPECTED_ESTIMATE_QUESTIONS = 5
+
+# The two packs that are entirely estimates (#275). They predate #566 and are
+# not part of it — they hold 15 each and are excluded from the per-pack count.
+DEDICATED_ESTIMATE_PACKS = frozenset({"schaetzfragen-de", "estimation-en"})
+
+
+@dataclass(frozen=True)
+class EstimateSet:
+    """One theme's packs and the five facts they share across languages.
+
+    A number survives translation unchanged, so the members of a set carry the
+    *same* answers in the same order — that parity is the cheapest guard
+    against a fact drifting in one language and not the other.
+    """
+
+    theme: str
+    packs: tuple[str, ...]
+
+    def path(self, pack: str) -> Path:
+        return QUESTIONS / f"{pack}.json"
+
+
+ESTIMATE_SETS: tuple[EstimateSet, ...] = (
+    EstimateSet(theme="nature", packs=("tiere-natur", "animals-nature")),
+)
+
+PACKS_WITH_ESTIMATES = [p for s in ESTIMATE_SETS for p in s.packs]
+
+
+def load(pack: str) -> list[dict]:
+    return json.loads((QUESTIONS / f"{pack}.json").read_text(encoding="utf-8"))[
+        "questions"
+    ]
+
+
+def estimates(pack: str) -> list[dict]:
+    return [q for q in load(pack) if q.get("type") == "estimate"]
+
+
+@pytest.mark.parametrize("pack", PACKS_WITH_ESTIMATES)
+class TestEstimateQuestionsPerPack:
+    def test_pack_carries_exactly_five(self, pack: str) -> None:
+        assert len(estimates(pack)) == EXPECTED_ESTIMATE_QUESTIONS
+
+    def test_answer_lies_inside_its_range(self, pack: str) -> None:
+        """A stray answer is dropped at load time, not raised — assert here."""
+        for q in estimates(pack):
+            assert q["min"] < q["max"], q["id"]
+            assert q["min"] <= q["answer"] <= q["max"], q["id"]
+
+    def test_range_is_not_a_giveaway(self, pack: str) -> None:
+        """The answer must not sit in a range so narrow it announces itself.
+
+        A slider spanning less than four times the answer's own magnitude
+        leaves so few plausible values that closeness scoring stops measuring
+        anything. The existing dedicated packs clear this comfortably.
+        """
+        for q in estimates(pack):
+            span = q["max"] - q["min"]
+            assert span >= 20, f"{q['id']}: range spans only {span}"
+
+    def test_every_estimate_has_a_unit(self, pack: str) -> None:
+        for q in estimates(pack):
+            assert q.get("unit", "").strip(), q["id"]
+
+    def test_estimates_carry_no_answers_array(self, pack: str) -> None:
+        """An ``answers`` list on an estimate means the type was bolted on."""
+        for q in estimates(pack):
+            assert "answers" not in q, q["id"]
+
+    def test_fun_fact_and_difficulty_present(self, pack: str) -> None:
+        for q in estimates(pack):
+            assert q.get("fun_fact", "").strip(), q["id"]
+            assert q.get("difficulty") in {"easy", "medium", "hard"}, q["id"]
+
+    def test_ids_are_unique_within_the_pack(self, pack: str) -> None:
+        ids = [q["id"] for q in load(pack)]
+        assert len(ids) == len(set(ids))
+
+
+@pytest.mark.parametrize("eset", ESTIMATE_SETS, ids=lambda s: s.theme)
+class TestLanguageParity:
+    def test_same_facts_in_every_language(self, eset: EstimateSet) -> None:
+        """Same numbers, same order — only the wording differs."""
+        reference = [
+            (q["answer"], q["min"], q["max"]) for q in estimates(eset.packs[0])
+        ]
+        for pack in eset.packs[1:]:
+            assert [
+                (q["answer"], q["min"], q["max"]) for q in estimates(pack)
+            ] == reference, pack
+
+    def test_question_text_is_not_shared(self, eset: EstimateSet) -> None:
+        """Catches a pack that was copied and never translated."""
+        texts = [{q["question"] for q in estimates(p)} for p in eset.packs]
+        for i, first in enumerate(texts):
+            for second in texts[i + 1 :]:
+                assert not (first & second)
+
+
+class TestRegistryCoversTheLibrary:
+    def test_no_pack_gains_estimates_without_an_entry(self) -> None:
+        """A themed pack that grows estimates must join the registry.
+
+        Without this, a later pair inherits none of the guards above and the
+        omission looks exactly like a pack that simply has not been done yet.
+        """
+        known = set(PACKS_WITH_ESTIMATES) | DEDICATED_ESTIMATE_PACKS
+        for path in QUESTIONS.glob("*.json"):
+            if path.stem == "versions" or path.stem in known:
+                continue
+            data = json.loads(path.read_text(encoding="utf-8"))
+            found = [
+                q for q in data.get("questions", []) if q.get("type") == "estimate"
+            ]
+            assert not found, f"{path.stem} has estimates but no EstimateSet entry"
+
+    def test_dedicated_packs_are_left_alone(self) -> None:
+        """#566 adds to themed packs; it does not touch the original two."""
+        for pack in DEDICATED_ESTIMATE_PACKS:
+            assert len(estimates(pack)) == 15

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -50,7 +50,7 @@ class TestLoadCategory:
     def test_load_category_returns_questions(self, bank: QuestionBank) -> None:
         questions = bank.load_category("geographie")
         assert len(questions) == bank.get_question_count("geographie")
-        assert 145 <= len(questions) <= 155
+        assert 145 <= len(questions) <= 160
         assert all(isinstance(q, Question) for q in questions)
 
     def test_load_all_categories(self, bank: QuestionBank) -> None:
@@ -86,14 +86,15 @@ class TestLoadCategory:
                 assert count >= 10, f"{cat} has only {count} questions (floor: 10)"
                 assert count <= 20, f"{cat} has {count} questions (ceiling: 20)"
                 continue
-            # 155, not 150: the five image questions of #554 are *added* to a
-            # themed pack rather than replacing written ones. Deleting five
-            # working questions to make room for a picture would be a worse
-            # trade than letting a pack run five long — the ceiling exists so
-            # packs stay comparable in length, and 3% does not threaten that.
-            # If every pack gains its five, they all move together anyway.
+            # 160, not 150: the five image questions of #554 and the five
+            # estimate questions of #566 are *added* to a themed pack rather
+            # than replacing written ones. Deleting working questions to make
+            # room would be a worse trade than letting a pack run ten long —
+            # the ceiling exists so packs stay comparable in length, and two
+            # additions of five do not threaten that. If every pack gains its
+            # ten, they all move together anyway.
             assert count >= 95, f"{cat} has only {count} questions (floor: 95)"
-            assert count <= 155, f"{cat} has {count} questions (ceiling: 155)"
+            assert count <= 160, f"{cat} has {count} questions (ceiling: 160)"
 
 
 class TestValidateAnswer:
@@ -121,7 +122,7 @@ class TestValidateAnswer:
 class TestQuestionCount:
     def test_get_question_count(self, bank: QuestionBank) -> None:
         count = bank.get_question_count("geographie")
-        assert 145 <= count <= 155
+        assert 145 <= count <= 160
 
     def test_get_question_count_by_difficulty(self, bank: QuestionBank) -> None:
         easy = bank.get_question_count("geographie", "easy")


### PR DESCRIPTION
First pair for #566 — the estimate mechanic (#275) spread into themed packs the way #554 spread pictures.

**Decision applied:** five per pack (Markus, 2026-08-13), added rather than swapped in. Ceiling moves 155 → 160.

## What is here

`tiere-natur` and `animals-nature` each gain five estimate questions carrying the same five facts:

| Fact | Answer | Slider |
|---|---|---|
| Longest reliably measured blue whale | 33 m | 5–60 |
| Cheetah top speed | 120 km/h | 20–200 |
| Elephant gestation | 22 months | 1–36 |
| Deepest recorded emperor penguin dive | 564 m | 50–1000 |
| Share of the Earth's surface under ocean | 71 % | 0–100 |

All five are constants rather than moving figures. That was the selection rule: a pack cannot tell that its own answer has gone stale, so population counts, current records and "how many exist today" numbers were avoided on purpose.

## Guards

`tests/test_pack_estimates_566.py` is a registry, like the image test — the next pair is one `EstimateSet` entry rather than a copy of the file. It asserts what can actually go wrong with a slider question:

- an answer outside its own `min`/`max` is **dropped silently** by `_parse_estimate_question`, so the pack would just quietly be four questions long;
- a range too narrow gives the answer away and makes closeness scoring meaningless;
- the languages must carry the **same numbers** and **different sentences** — parity catches a fact drifting on one side, the text check catches a pack that was copied and never translated;
- a themed pack that grows estimates without a registry entry fails the suite, so a later pair cannot silently inherit none of this.

## Not touched

The two dedicated estimate packs (15 questions each) are asserted unchanged. The lightning pool is multiple-choice only by design (#285), so these five are simply never drawn there — noted in the issue, no code change needed.

Suite **1632 green** locally.

Closes nothing — #566 stays open for the remaining nine subject pairs and the six Spanish packs.