### PR TITLE
feat(#566): five estimate questions for the geography pack pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ No apps to download. No accounts to create. Just scan a QR code and play.
 
 **Works on Any Screen** — Dashboard mode for the TV. Players use their phones. Admin runs the show. No extra hardware needed.
 
-**Eleven Themes, Three Languages** — 3,997 questions across 30 themed packs (Geography, Pop Culture, Animals & Nature, Sport, Music, Science, History, Food & Drink, Technology, World Cup, Estimation) in German, English and Spanish. Mix them, filter them, swap mid-session.
+**Eleven Themes, Three Languages** — 4,007 questions across 30 themed packs (Geography, Pop Culture, Animals & Nature, Sport, Music, Science, History, Food & Drink, Technology, World Cup, Estimation) in German, English and Spanish. Mix them, filter them, swap mid-session.
 
 ---
 
@@ -318,11 +318,11 @@ Then **"Start New Game"** (same settings, same players) or **Reset Game** (fresh
 
 ## Question Packs
 
-Quizify ships with **3,997 questions across 30 themed packs in 11 themes**, in German, English and Spanish.
+Quizify ships with **4,007 questions across 30 themed packs in 11 themes**, in German, English and Spanish.
 
 | Theme | 🇩🇪 Deutsch | 🇬🇧 English | 🇪🇸 Español |
 |-------|-------------|-------------|-------------|
-| 🌍 **Geographie / Geography / Geografía** | 154 | 155 | 155 |
+| 🌍 **Geographie / Geography / Geografía** | 159 | 160 | 155 |
 | 🦋 **Tiere & Natur / Animals & Nature / Naturaleza** | 159 | 160 | 155 |
 | 🎬 **Popkultur / Pop Culture / Cultura Pop** | 154 | 155 | 155 |
 | ⚽ **Sport / Deportes** | 153 | 155 | 155 |
@@ -335,7 +335,7 @@ Quizify ships with **3,997 questions across 30 themed packs in 11 themes**, in G
 | 🎯 **Schätzfragen / Estimation** | 15 | 15 | — |
 | 🖼️ **Bilderrätsel / Picture Round** | 17 | 17 | — |
 
-Spanish arrived in 1.3.0 and grew through 1.6.1; music, food and technology are the three themes it is still missing. The two Estimation packs hold slider questions rather than multiple choice — see [How to Play](#the-experience); the themed packs are gaining five slider questions of their own as well, which is why Animals & Nature runs longer than its siblings.
+Spanish arrived in 1.3.0 and grew through 1.6.1; music, food and technology are the three themes it is still missing. The two Estimation packs hold slider questions rather than multiple choice — see [How to Play](#the-experience); the themed packs are gaining five slider questions of their own as well, which is why some rows already run longer than their Spanish column.
 
 Pack selection lives on the **first screen**: a featured pack card (e.g. World Cup) up top, with every other pack as a tappable chip right beneath it — tap to select or deselect, mix several, then hit **Start Game**. Game settings (difficulty, rounds, timer) stay one tap away under **Adjust settings**. **Mixed mode** drops you a random question from every selected pack, so you can stir Geography + Pop + Sport together for chaos mode.
 

--- a/custom_components/quizify/questions/geographie.json
+++ b/custom_components/quizify/questions/geographie.json
@@ -1,7 +1,7 @@
 {
   "name": "Geographie",
   "language": "de",
-  "version": "1.1",
+  "version": "1.2",
   "theme": "geography",
   "questions": [
     {
@@ -1861,6 +1861,66 @@
       "category": "Geographie",
       "image_url": "/quizify/static/img/packs/geography/taj-mahal.webp",
       "reveal_style": "progressive"
+    },
+    {
+      "id": "geo_166",
+      "question": "Wie hoch ist der Mount Everest?",
+      "type": "estimate",
+      "answer": 8849,
+      "min": 5000,
+      "max": 12000,
+      "unit": "Meter",
+      "difficulty": "easy",
+      "fun_fact": "Die 8.849 m sind erst seit 2020 amtlich: China und Nepal hatten sich jahrzehntelang um 4 m gestritten, weil der eine die Schneekappe mitmaß und der andere nicht.",
+      "category": "Geographie"
+    },
+    {
+      "id": "geo_167",
+      "question": "Wie lang ist der Äquator?",
+      "type": "estimate",
+      "answer": 40075,
+      "min": 10000,
+      "max": 100000,
+      "unit": "Kilometer",
+      "difficulty": "easy",
+      "fun_fact": "Genau daher kommt das Meter: Es wurde ursprünglich als der zehnmillionste Teil der Strecke vom Nordpol zum Äquator festgelegt.",
+      "category": "Geographie"
+    },
+    {
+      "id": "geo_168",
+      "question": "Wie lang ist der Nil?",
+      "type": "estimate",
+      "answer": 6650,
+      "min": 1000,
+      "max": 10000,
+      "unit": "Kilometer",
+      "difficulty": "medium",
+      "fun_fact": "Ob er oder der Amazonas der längste Fluss ist, hängt davon ab, wo man die Quelle ansetzt — im Amazonasdelta streitet die Messung sich um mehrere hundert Kilometer.",
+      "category": "Geographie"
+    },
+    {
+      "id": "geo_169",
+      "question": "Über wie viele Zeitzonen erstreckt sich Russland?",
+      "type": "estimate",
+      "answer": 11,
+      "min": 1,
+      "max": 24,
+      "unit": "Zeitzonen",
+      "difficulty": "medium",
+      "fun_fact": "Wenn in Kaliningrad der Morgen beginnt, ist auf Kamtschatka schon Abend. 2010 wurden zwei Zonen gestrichen und 2014 wieder eingeführt.",
+      "category": "Geographie"
+    },
+    {
+      "id": "geo_170",
+      "question": "Wie tief ist die tiefste Stelle des Marianengrabens?",
+      "type": "estimate",
+      "answer": 10935,
+      "min": 1000,
+      "max": 15000,
+      "unit": "Meter",
+      "difficulty": "hard",
+      "fun_fact": "Der Mount Everest hätte darin Platz und läge immer noch gut zwei Kilometer unter der Wasseroberfläche.",
+      "category": "Geographie"
     }
   ]
 }

--- a/custom_components/quizify/questions/geography.json
+++ b/custom_components/quizify/questions/geography.json
@@ -1,7 +1,7 @@
 {
   "name": "Geography",
   "language": "en",
-  "version": "1.1",
+  "version": "1.2",
   "theme": "geography",
   "questions": [
     {
@@ -3223,6 +3223,66 @@
       "category": "Geography",
       "image_url": "/quizify/static/img/packs/geography/taj-mahal.webp",
       "reveal_style": "progressive"
+    },
+    {
+      "id": "geo_en_166",
+      "question": "How high is Mount Everest?",
+      "type": "estimate",
+      "answer": 8849,
+      "min": 5000,
+      "max": 12000,
+      "unit": "metres",
+      "difficulty": "easy",
+      "fun_fact": "The 8,849 m figure has only been official since 2020: China and Nepal had argued for decades over 4 m, because one side measured the snow cap and the other did not.",
+      "category": "Geography"
+    },
+    {
+      "id": "geo_en_167",
+      "question": "How long is the equator?",
+      "type": "estimate",
+      "answer": 40075,
+      "min": 10000,
+      "max": 100000,
+      "unit": "kilometres",
+      "difficulty": "easy",
+      "fun_fact": "This is where the metre comes from: it was originally defined as one ten-millionth of the distance from the North Pole to the equator.",
+      "category": "Geography"
+    },
+    {
+      "id": "geo_en_168",
+      "question": "How long is the Nile?",
+      "type": "estimate",
+      "answer": 6650,
+      "min": 1000,
+      "max": 10000,
+      "unit": "kilometres",
+      "difficulty": "medium",
+      "fun_fact": "Whether it or the Amazon is the longest river depends on where you put the source — in the Amazon delta the measurement argues over several hundred kilometres.",
+      "category": "Geography"
+    },
+    {
+      "id": "geo_en_169",
+      "question": "How many time zones does Russia span?",
+      "type": "estimate",
+      "answer": 11,
+      "min": 1,
+      "max": 24,
+      "unit": "time zones",
+      "difficulty": "medium",
+      "fun_fact": "When morning breaks in Kaliningrad it is already evening in Kamchatka. Two zones were scrapped in 2010 and brought back in 2014.",
+      "category": "Geography"
+    },
+    {
+      "id": "geo_en_170",
+      "question": "How deep is the deepest point of the Mariana Trench?",
+      "type": "estimate",
+      "answer": 10935,
+      "min": 1000,
+      "max": 15000,
+      "unit": "metres",
+      "difficulty": "hard",
+      "fun_fact": "Mount Everest would fit inside it and still sit a good two kilometres below the surface.",
+      "category": "Geography"
     }
   ]
 }

--- a/custom_components/quizify/questions/versions.json
+++ b/custom_components/quizify/questions/versions.json
@@ -1,8 +1,8 @@
 {
-  "geographie": "1.1",
+  "geographie": "1.2",
   "tiere-natur": "1.2",
   "popkultur": "1.1",
-  "geography": "1.1",
+  "geography": "1.2",
   "geografia-es": "1.0",
   "animals-nature": "1.2",
   "pop-culture": "1.1",

--- a/tests/test_pack_estimates_566.py
+++ b/tests/test_pack_estimates_566.py
@@ -52,6 +52,7 @@ class EstimateSet:
 
 ESTIMATE_SETS: tuple[EstimateSet, ...] = (
     EstimateSet(theme="nature", packs=("tiere-natur", "animals-nature")),
+    EstimateSet(theme="geography", packs=("geographie", "geography")),
 )
 
 PACKS_WITH_ESTIMATES = [p for s in ESTIMATE_SETS for p in s.packs]


### PR DESCRIPTION
Second pair for #566, following the nature pilot in #567.

| Fact | Answer | Slider |
|---|---|---|
| Height of Mount Everest | 8,849 m | 5,000–12,000 |
| Length of the equator | 40,075 km | 10,000–100,000 |
| Length of the Nile | 6,650 km | 1,000–10,000 |
| Time zones spanned by Russia | 11 | 1–24 |
| Depth of the Mariana Trench | 10,935 m | 1,000–15,000 |

Geography turns out to be the cheapest subject for this mechanic, in mirror image of #554 where it was already expensive: what an estimate question wants is a fixed dimension, and geography is mostly fixed dimensions.

**One drop worth recording.** The Dead Sea surface level is the obvious geography estimate and it is exactly the kind of number the selection rule exists to exclude — it falls roughly a metre a year, so a pack shipping "430 m below sea level" would be quietly wrong within a few releases and could not tell anyone.

Registry gains its second `EstimateSet` entry, so both pairs run the full checklist. README counts updated (4,007). Suite **1648 green** locally.