### PR TITLE
feat(#566): five estimate questions for the pop culture pack pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ No apps to download. No accounts to create. Just scan a QR code and play.
 
 **Works on Any Screen** — Dashboard mode for the TV. Players use their phones. Admin runs the show. No extra hardware needed.
 
-**Eleven Themes, Three Languages** — 4,077 questions across 30 themed packs (Geography, Pop Culture, Animals & Nature, Sport, Music, Science, History, Food & Drink, Technology, World Cup, Estimation) in German, English and Spanish. Mix them, filter them, swap mid-session.
+**Eleven Themes, Three Languages** — 4,087 questions across 30 themed packs (Geography, Pop Culture, Animals & Nature, Sport, Music, Science, History, Food & Drink, Technology, World Cup, Estimation) in German, English and Spanish. Mix them, filter them, swap mid-session.
 
 ---
 
@@ -318,13 +318,13 @@ Then **"Start New Game"** (same settings, same players) or **Reset Game** (fresh
 
 ## Question Packs
 
-Quizify ships with **4,077 questions across 30 themed packs in 11 themes**, in German, English and Spanish.
+Quizify ships with **4,087 questions across 30 themed packs in 11 themes**, in German, English and Spanish.
 
 | Theme | 🇩🇪 Deutsch | 🇬🇧 English | 🇪🇸 Español |
 |-------|-------------|-------------|-------------|
 | 🌍 **Geographie / Geography / Geografía** | 159 | 160 | 155 |
 | 🦋 **Tiere & Natur / Animals & Nature / Naturaleza** | 159 | 160 | 155 |
-| 🎬 **Popkultur / Pop Culture / Cultura Pop** | 154 | 155 | 155 |
+| 🎬 **Popkultur / Pop Culture / Cultura Pop** | 159 | 160 | 155 |
 | ⚽ **Sport / Deportes** | 158 | 160 | 155 |
 | 🎵 **Musik / Music** | 160 | 160 | — |
 | 🔬 **Wissenschaft / Science / Ciencia** | 160 | 160 | 155 |

--- a/custom_components/quizify/questions/pop-culture.json
+++ b/custom_components/quizify/questions/pop-culture.json
@@ -1,7 +1,7 @@
 {
   "name": "Pop Culture",
   "language": "en",
-  "version": "1.1",
+  "version": "1.2",
   "theme": "popculture",
   "questions": [
     {
@@ -1873,6 +1873,66 @@
       "category": "Pop Culture",
       "image_url": "/quizify/static/img/packs/popculture/we-can-do-it.webp",
       "reveal_style": "progressive"
+    },
+    {
+      "id": "pop_en_166",
+      "question": "How many Oscars did Titanic win in 1998?",
+      "type": "estimate",
+      "answer": 11,
+      "min": 1,
+      "max": 30,
+      "unit": "Oscars",
+      "difficulty": "easy",
+      "fun_fact": "Eleven — level with Ben Hur and The Lord of the Rings: The Return of the King. Not one of them was for acting.",
+      "category": "Pop Culture"
+    },
+    {
+      "id": "pop_en_167",
+      "question": "How many episodes does the series Friends have in total?",
+      "type": "estimate",
+      "answer": 236,
+      "min": 10,
+      "max": 1000,
+      "unit": "episodes",
+      "difficulty": "medium",
+      "fun_fact": "236 episodes across ten seasons. In the final season each of the six leads earned a million dollars per episode, negotiated as a block and never individually.",
+      "category": "Pop Culture"
+    },
+    {
+      "id": "pop_en_168",
+      "question": "How many minutes long is the first Star Wars film from 1977?",
+      "type": "estimate",
+      "answer": 121,
+      "min": 30,
+      "max": 300,
+      "unit": "minutes",
+      "difficulty": "medium",
+      "fun_fact": "121 minutes. The studio thought the film unsalvageable until Marcia Lucas and two colleagues recut it — the edit won an Oscar.",
+      "category": "Pop Culture"
+    },
+    {
+      "id": "pop_en_169",
+      "question": "How old was Macaulay Culkin when Home Alone was filmed?",
+      "type": "estimate",
+      "answer": 10,
+      "min": 1,
+      "max": 40,
+      "unit": "years",
+      "difficulty": "medium",
+      "fun_fact": "Ten. The film took nearly half a billion dollars worldwide and still holds the record for the highest-grossing live-action comedy.",
+      "category": "Pop Culture"
+    },
+    {
+      "id": "pop_en_170",
+      "question": "How many minutes long is Gone with the Wind?",
+      "type": "estimate",
+      "answer": 238,
+      "min": 30,
+      "max": 500,
+      "unit": "minutes",
+      "difficulty": "hard",
+      "fun_fact": "238 minutes including overture and intermission. Adjusted for inflation it remains the highest-grossing film ever made.",
+      "category": "Pop Culture"
     }
   ]
 }

--- a/custom_components/quizify/questions/popkultur.json
+++ b/custom_components/quizify/questions/popkultur.json
@@ -1,7 +1,7 @@
 {
   "name": "Popkultur",
   "language": "de",
-  "version": "1.1",
+  "version": "1.2",
   "theme": "popculture",
   "questions": [
     {
@@ -1861,6 +1861,66 @@
       "category": "Popkultur",
       "image_url": "/quizify/static/img/packs/popculture/we-can-do-it.webp",
       "reveal_style": "progressive"
+    },
+    {
+      "id": "pop_166",
+      "question": "Wie viele Oscars gewann „Titanic“ 1998?",
+      "type": "estimate",
+      "answer": 11,
+      "min": 1,
+      "max": 30,
+      "unit": "Oscars",
+      "difficulty": "easy",
+      "fun_fact": "Elf — gleichauf mit „Ben Hur“ und „Der Herr der Ringe: Die Rückkehr des Königs“. Für keine einzige schauspielerische Leistung gab es einen.",
+      "category": "Popkultur"
+    },
+    {
+      "id": "pop_167",
+      "question": "Wie viele Folgen hat die Serie „Friends“ insgesamt?",
+      "type": "estimate",
+      "answer": 236,
+      "min": 10,
+      "max": 1000,
+      "unit": "Folgen",
+      "difficulty": "medium",
+      "fun_fact": "236 Folgen in zehn Staffeln. In der letzten Staffel bekam jeder der sechs Hauptdarsteller eine Million Dollar pro Folge — ausgehandelt als Block, nie einzeln.",
+      "category": "Popkultur"
+    },
+    {
+      "id": "pop_168",
+      "question": "Wie viele Minuten dauert der erste Star-Wars-Film von 1977?",
+      "type": "estimate",
+      "answer": 121,
+      "min": 30,
+      "max": 300,
+      "unit": "Minuten",
+      "difficulty": "medium",
+      "fun_fact": "121 Minuten. Die Studioleitung hielt den Film für unrettbar, bis Marcia Lucas und zwei Kollegen ihn neu schnitten — der Schnitt bekam einen Oscar.",
+      "category": "Popkultur"
+    },
+    {
+      "id": "pop_169",
+      "question": "Wie alt war Macaulay Culkin bei den Dreharbeiten zu „Kevin — Allein zu Haus“?",
+      "type": "estimate",
+      "answer": 10,
+      "min": 1,
+      "max": 40,
+      "unit": "Jahre",
+      "difficulty": "medium",
+      "fun_fact": "Zehn. Der Film spielte weltweit fast eine halbe Milliarde Dollar ein und steht bis heute als erfolgreichste Live-Action-Komödie in den Büchern.",
+      "category": "Popkultur"
+    },
+    {
+      "id": "pop_170",
+      "question": "Wie viele Minuten dauert „Vom Winde verweht“?",
+      "type": "estimate",
+      "answer": 238,
+      "min": 30,
+      "max": 500,
+      "unit": "Minuten",
+      "difficulty": "hard",
+      "fun_fact": "238 Minuten, inklusive Ouvertüre und Pause. Inflationsbereinigt ist er bis heute der erfolgreichste Film aller Zeiten.",
+      "category": "Popkultur"
     }
   ]
 }

--- a/custom_components/quizify/questions/versions.json
+++ b/custom_components/quizify/questions/versions.json
@@ -1,11 +1,11 @@
 {
   "geographie": "1.2",
   "tiere-natur": "1.2",
-  "popkultur": "1.1",
+  "popkultur": "1.2",
   "geography": "1.2",
   "geografia-es": "1.0",
   "animals-nature": "1.2",
-  "pop-culture": "1.1",
+  "pop-culture": "1.2",
   "essen-de": "1.2",
   "food-en": "1.2",
   "geschichte-de": "1.2",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,28 +55,27 @@ def _mixed_draw_serves_multiple_choice():
     *names* a category returns exactly what that pack holds, and the estimate
     tests inject their question into ``_current_question`` directly, so
     nothing that actually exercises the mechanic is hidden by this.
+
+    The filter sits in ``_build_queue`` rather than in the draw itself,
+    because skipping at serve time means an extra draw, and an extra draw
+    advances ``_queue_index`` — which #350 asserts to the number.
     """
     from custom_components.quizify.game.questions import QuestionBank
 
-    original = QuestionBank.get_next_question
+    original = QuestionBank._build_queue
 
-    def _mixed_draw_skips_estimates(
-        self, category=None, difficulty=None
+    def _build_mixed_queue_without_estimates(
+        self, category=None, difficulty=None, language=None, categories=None
     ):  # noqa: ANN001, ANN202
-        question = original(self, category=category, difficulty=difficulty)
-        if category is not None:
-            return question
-        for _ in range(50):
-            if question is None or question.answers:
-                return question
-            question = original(self, category=category, difficulty=difficulty)
-        return question
+        original(self, category, difficulty, language, categories)
+        if category is None and not categories:
+            self._queue = [q for q in self._queue if q.answers]
 
-    QuestionBank.get_next_question = _mixed_draw_skips_estimates
+    QuestionBank._build_queue = _build_mixed_queue_without_estimates
     try:
         yield
     finally:
-        QuestionBank.get_next_question = original
+        QuestionBank._build_queue = original
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_pack_estimates_566.py
+++ b/tests/test_pack_estimates_566.py
@@ -60,6 +60,7 @@ ESTIMATE_SETS: tuple[EstimateSet, ...] = (
     EstimateSet(theme="sport", packs=("sport-de", "sport-en")),
     EstimateSet(theme="world-cup", packs=("weltmeisterschaft", "world-cup")),
     EstimateSet(theme="music", packs=("musik-de", "music-en")),
+    EstimateSet(theme="pop-culture", packs=("popkultur", "pop-culture")),
 )
 
 PACKS_WITH_ESTIMATES = [p for s in ESTIMATE_SETS for p in s.packs]


### PR DESCRIPTION
Tenth and final DE/EN pair for #566.

| Fact | Answer | Slider |
|---|---|---|
| Oscars won by Titanic in 1998 | 11 | 1–30 |
| Total episodes of Friends | 236 | 10–1,000 |
| Runtime of the first Star Wars film | 121 minutes | 30–300 |
| Macaulay Culkin's age during Home Alone | 10 years | 1–40 |
| Runtime of Gone with the Wind | 238 minutes | 30–500 |

Pop culture has the same shape as sport: the numbers a quiz reaches for first — box office, the episode count of a running show, streaming records — all move, and a shipped pack cannot correct them. These five are **closed works**. A finished film has a runtime and a finished series has an episode count, and neither will ever change again.

## Conftest fix, refined

The fixture from #575 skipped estimates at *serve* time, which consumes a queue slot — and #350 asserts `_queue_index` to the number, so it failed on this pair. The filter now sits in `_build_queue`: a mixed queue is built without estimates in the first place, so the index stays honest and nothing is consumed invisibly.

Worth noting that this is the third form the same fix has taken (three files → one fixture → one fixture in the right place). Each version was correct about the problem and wrong about the blast radius, which is the usual shape of a test-infrastructure fix.

**Ten of ten pairs done.** Six Spanish packs remain, and they cost question text only — the numbers are already chosen and translated once.

Suite **1776 green** locally.