### PR TITLE
feat(#579): ask for a pack instead of pasting one

### DIFF
--- a/cf-workers/contract-check.mjs
+++ b/cf-workers/contract-check.mjs
@@ -112,7 +112,64 @@ for (const spec of malformations) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// 3. Pack requests (#579) — same idea, second validator.
+//
+// The request path has no fixture pack to mutate: a request is three short
+// fields, so the shared catalog carries whole request objects (valid ones and
+// malformed ones) and both sides just run their validator over them.
+// tests/test_pack_request_579.py replays the identical file against
+// server/pack_submission.py::validate_request.
+// ---------------------------------------------------------------------------
+
+const requestCases = JSON.parse(
+  readFileSync(join(repoRoot, 'tests', 'fixtures', 'pack_request_cases.json'), 'utf8'),
+);
+
+const MAX_THEME_CHARS = extractConst('MAX_THEME_CHARS');
+const MAX_NOTES_CHARS = extractConst('MAX_NOTES_CHARS');
+const MAX_LANGUAGE_CHARS = extractConst('MAX_LANGUAGE_CHARS');
+
+const reqFnMatch = workerSrc.match(/function validateRequest\(req\)\s*\{[\s\S]*?\n\}/);
+if (!reqFnMatch) fail('could not extract validateRequest from quizify-api.js');
+
+// eslint-disable-next-line no-new-func
+const makeRequestValidator = new Function(
+  'MAX_THEME_CHARS',
+  'MAX_NOTES_CHARS',
+  'MAX_LANGUAGE_CHARS',
+  `${reqFnMatch[0]}\nreturn validateRequest;`,
+);
+const validateRequest = makeRequestValidator(
+  MAX_THEME_CHARS,
+  MAX_NOTES_CHARS,
+  MAX_LANGUAGE_CHARS,
+);
+
+if (!Array.isArray(requestCases.valid) || requestCases.valid.length < 3) {
+  fail('shared request catalog has too few valid cases');
+}
+if (!Array.isArray(requestCases.malformations) || requestCases.malformations.length < 5) {
+  fail('shared request catalog has too few malformations');
+}
+for (const c of requestCases.valid) {
+  const err = validateRequest(c.request);
+  if (err !== null) {
+    fail(`worker REJECTED a valid request ('${c.id}': ${c.reason}) — ${err}`);
+  }
+}
+for (const c of requestCases.malformations) {
+  const err = validateRequest(c.request);
+  if (err === null) {
+    fail(
+      `worker ACCEPTED a malformed request ('${c.id}': ${c.reason}) — schema too loose`,
+    );
+  }
+}
+
 console.log(
-  `contract-check OK: worker validatePack accepts the fixture and rejects all ${malformations.length} catalogued malformations`,
+  `contract-check OK: validatePack accepts the fixture and rejects all ${malformations.length} ` +
+    `catalogued malformations; validateRequest accepts all ${requestCases.valid.length} valid ` +
+    `requests and rejects all ${requestCases.malformations.length} malformed ones`,
 );
 process.exit(0);

--- a/cf-workers/quizify-api.js
+++ b/cf-workers/quizify-api.js
@@ -7,12 +7,23 @@
  * GITHUB_PAT, turns the pack into a GitHub issue, and returns the issue number
  * + URL.
  *
- * Contract (matches server/pack_submission.py::submit_pack_view + validate_pack):
- *   Request:  POST  Content-Type: application/json   { "pack": { ... } }
- *   pack    = { name, language, questions: [ { id, question,
- *                 answers: [ {text, correct:bool} x3, exactly 1 correct ] } ] }
+ * Two payload shapes on the SAME endpoint, discriminated by the body's key:
+ *
+ *   a) submission (#180) — matches server/pack_submission.py::validate_pack
+ *      POST { "pack": { name, language, questions: [ { id, question,
+ *              answers: [ {text, correct:bool} x3, exactly 1 correct ] } ] } }
+ *      → issue labelled `community-pack`
+ *
+ *   b) request (#579) — matches server/pack_submission.py::validate_request
+ *      POST { "request": { theme, language, notes? } }
+ *      → issue labelled `pack-request`
+ *
  *   Success:  200   { "issue_number": <int>, "issue_url": "<html_url>" }
  *   Error:    4xx/5xx { "code": "INVALID_FORMAT" | "GITHUB_ERROR", "message": "<text>" }
+ *
+ * The discriminator is the body key, not a new route: the secret gate, the
+ * method guard and the PAT handling are identical for both, and a second URL
+ * would have meant a second wrangler route to keep in sync for no gain.
  *
  * Security gate (FAIL CLOSED — #292): the secret SHARED_SECRET MUST be set and
  * the integration MUST send a matching `X-Quizify-Secret` header. If
@@ -34,6 +45,11 @@ const MAX_QUESTIONS = 500;
 const MIN_QUESTIONS = 1;
 const ANSWERS_PER_QUESTION = 3;
 const MAX_BYTES = 1_048_576; // 1 MiB
+
+// Pack-request caps (#579) — mirror REQUEST_MAX_* in const.py.
+const MAX_THEME_CHARS = 80;
+const MAX_NOTES_CHARS = 500;
+const MAX_LANGUAGE_CHARS = 10;
 
 // CORS (#292): the Quizify HA integration calls this worker server-side (from
 // the HA Python backend via aiohttp — server/pack_submission.py), NOT from a
@@ -96,6 +112,23 @@ function validatePack(pack) {
   return null;
 }
 
+/** Validate a pack request (#579) — must match
+ *  server/pack_submission.py::validate_request. There is no content to check,
+ *  only three short fields, so the caps ARE the validation: theme and notes go
+ *  verbatim into an issue body. Returns an error string or null. */
+function validateRequest(req) {
+  if (!req || typeof req !== 'object' || Array.isArray(req)) return 'Top-level JSON must be an object.';
+  if (typeof req.theme !== 'string' || !req.theme.trim()) return "Field 'theme' is required.";
+  if (req.theme.length > MAX_THEME_CHARS) return `Field 'theme' exceeds ${MAX_THEME_CHARS} characters.`;
+  const lang = req.language === undefined ? 'de' : req.language;
+  if (typeof lang !== 'string' || !lang.trim()) return "Field 'language' must be a non-empty string.";
+  if (lang.length > MAX_LANGUAGE_CHARS) return `Field 'language' exceeds ${MAX_LANGUAGE_CHARS} characters.`;
+  const notes = req.notes === undefined || req.notes === null ? '' : req.notes;
+  if (typeof notes !== 'string') return "Field 'notes' must be a string when present.";
+  if (notes.length > MAX_NOTES_CHARS) return `Field 'notes' exceeds ${MAX_NOTES_CHARS} characters.`;
+  return null;
+}
+
 /** Neutralise Markdown / mention injection in user-supplied strings going into
  *  the issue: break @mentions and #issue-refs (notification spam / fake
  *  cross-links), escape table/code controls, escape Markdown link/image control
@@ -136,6 +169,39 @@ function buildIssue(pack) {
   return { title: title.slice(0, 250), body: lines.join('\n'), labels: ['community-pack'] };
 }
 
+/** Build the issue for a pack REQUEST (#579).
+ *
+ *  Note `esc()` collapses newlines, so a multi-line note arrives as one line.
+ *  That is deliberate: the notes field is a hint, not a document, and a body
+ *  that can inject Markdown structure into an auto-filed issue is worse than a
+ *  body that reads as one paragraph. */
+function buildRequestIssue(req) {
+  const theme = esc(req.theme);
+  const lang = esc(req.language || 'de');
+  const notes = esc(req.notes || '');
+  const lines = [
+    '## Pack request', '',
+    'A host asked for a pack that does not exist yet. Nothing was authored — this is a wish.', '',
+    '| Field | Value |', '|-------|-------|',
+    `| **Theme** | ${theme} |`,
+    `| **Language** | ${lang} |`,
+    `| **Notes** | ${notes || '—'} |`,
+    '',
+    '### What happens next', '',
+    '- A generated pack lands as a **pull request** for review — never a direct merge.',
+    '- Generator rules that apply (see #579): durable facts over current ones, never let the',
+    '  question title carry its own answer, and keep an estimate answer inside its min/max.',
+    '- Requests are public: the resulting pack ships to everyone or not at all.',
+    '',
+    '---', '*Auto-filed by the Quizify in-app pack request (#579).*',
+  ];
+  return {
+    title: `pack request: ${theme} (${lang})`.slice(0, 250),
+    body: lines.join('\n'),
+    labels: ['pack-request'],
+  };
+}
+
 async function handleSubmit(request, env) {
   if (!env.GITHUB_PAT) {
     return jsonError('GITHUB_ERROR', 'Worker is missing its GITHUB_PAT secret.', 500);
@@ -161,11 +227,22 @@ async function handleSubmit(request, env) {
   } catch {
     return jsonError('INVALID_FORMAT', 'Body is not valid JSON.', 400);
   }
-  const pack = body && typeof body === 'object' ? body.pack : null;
-  const err = validatePack(pack);
-  if (err) return jsonError('INVALID_FORMAT', err, 400);
 
-  const issue = buildIssue(pack);
+  // Discriminate on the body key. A body carrying `request` is a pack request
+  // (#579); anything else is treated as a submission, which keeps the old
+  // contract byte-for-byte — including the error text for a body with neither
+  // key, which still fails through validatePack as it always did.
+  let issue;
+  if (body && typeof body === 'object' && body.request !== undefined) {
+    const reqErr = validateRequest(body.request);
+    if (reqErr) return jsonError('INVALID_FORMAT', reqErr, 400);
+    issue = buildRequestIssue(body.request);
+  } else {
+    const pack = body && typeof body === 'object' ? body.pack : null;
+    const err = validatePack(pack);
+    if (err) return jsonError('INVALID_FORMAT', err, 400);
+    issue = buildIssue(pack);
+  }
   const ghRes = await fetch(GITHUB_ISSUES_API, {
     method: 'POST',
     headers: {

--- a/custom_components/quizify/const.py
+++ b/custom_components/quizify/const.py
@@ -137,7 +137,23 @@ SUBMIT_POLL_INTERVAL_SECONDS = 3600  # ~hourly, like Beatify's PlaylistRequestsV
 SUBMIT_POLL_TIMEOUT_SECONDS = 12
 SUBMIT_RECORDS_FILE = "pack_submissions.json"
 
+# ---------------------------------------------------------------------------
+# Pack *requests* (#579) — the inverse of a submission: the host describes a
+# pack they want instead of authoring one. Caps are deliberately tiny; a
+# request is three short fields, and the generated issue must stay readable.
+REQUEST_MAX_THEME_CHARS = 80
+REQUEST_MAX_NOTES_CHARS = 500
+REQUEST_MAX_LANGUAGE_CHARS = 10
+
+# Record kinds inside pack_submissions.json. Older records predate #579 and
+# carry no ``kind`` at all — readers must treat a missing kind as a submission,
+# never as an unknown. One store, one reconcile, two kinds of record.
+RECORD_KIND_SUBMISSION = "submission"
+RECORD_KIND_REQUEST = "request"
+
 # Submission status values (issue-state derived; see pack_submission.py).
+# Requests share them: a request issue closes exactly like a submission issue,
+# which is why both kinds can live in one store with one reconcile pass.
 SUBMIT_STATUS_PENDING = "pending"
 SUBMIT_STATUS_ACCEPTED = "accepted"  # issue closed as completed
 SUBMIT_STATUS_DECLINED = "declined"  # issue closed as not_planned

--- a/custom_components/quizify/server/pack_submission.py
+++ b/custom_components/quizify/server/pack_submission.py
@@ -1,4 +1,4 @@
-"""In-app community-pack submission (#180).
+"""In-app community-pack submission (#180) and pack requests (#579).
 
 A user composes/pastes a community question pack in the admin UI. The browser
 validates it against the same schema the on-disk loader enforces (#179), then
@@ -13,6 +13,13 @@ state** (closed-as-completed = accepted, closed-as-not_planned = declined),
 throttled to ~hourly so a busy admin tab can't hammer GitHub's
 unauthenticated, per-IP rate limit. This mirrors Beatify's
 ``PlaylistRequestsView`` (the #970 lesson: trust the issue *state*, not labels).
+
+Since #579 the same pipe carries the inverse direction: a **pack request**, in
+which the host describes a pack they want instead of authoring one. It reuses
+this module end to end — one worker, one store, one reconcile — and differs only
+in the payload (``{"request": {...}}``) and the record's ``kind``. That is the
+point: a request issue closes exactly like a submission issue, so a second
+status mechanism would have been a second thing to keep correct.
 
 The whole feature stays inert until ``community_submit_url`` is set: the config
 endpoint reports ``enabled: false`` (so the UI hides the section) and POSTs are
@@ -42,6 +49,11 @@ from ..const import (
     ERR_SUBMIT_GITHUB_ERROR,
     ERR_SUBMIT_INVALID_FORMAT,
     ERR_SUBMIT_RATE_LIMITED,
+    RECORD_KIND_REQUEST,
+    RECORD_KIND_SUBMISSION,
+    REQUEST_MAX_LANGUAGE_CHARS,
+    REQUEST_MAX_NOTES_CHARS,
+    REQUEST_MAX_THEME_CHARS,
     SUBMIT_ANSWERS_PER_QUESTION,
     SUBMIT_MAX_PACK_BYTES,
     SUBMIT_MAX_QUESTIONS,
@@ -172,6 +184,50 @@ def validate_pack(pack: object) -> tuple[bool, list[str]]:
                 f"{prefix}: exactly 1 answer must be marked correct "
                 f"(got {correct_count})."
             )
+
+    return (not errors), errors[:10]
+
+
+# ---------------------------------------------------------------------------
+# Validation — pack *request* (#579)
+# ---------------------------------------------------------------------------
+#
+# A request carries no content, so there is nothing to validate against the
+# question schema — only three short fields. The caps matter anyway: theme and
+# notes go verbatim into a GitHub issue, and an unbounded field turns the issue
+# into a wall (the worker escapes and truncates as a second line of defence).
+# Mirrored by validateRequest in cf-workers/quizify-api.js; the shared cases in
+# tests/fixtures/pack_request_cases.json keep both sides in lockstep.
+
+
+def validate_request(req: object) -> tuple[bool, list[str]]:
+    """Validate a pack request. Returns (ok, errors)."""
+    errors: list[str] = []
+
+    if not isinstance(req, dict):
+        return False, ["Top-level JSON must be an object."]
+
+    theme = req.get("theme")
+    if not isinstance(theme, str) or not theme.strip():
+        errors.append("Field 'theme' is required and must be a non-empty string.")
+    elif len(theme) > REQUEST_MAX_THEME_CHARS:
+        errors.append(f"Field 'theme' exceeds {REQUEST_MAX_THEME_CHARS} characters.")
+
+    language = req.get("language", "de")
+    if not isinstance(language, str) or not language.strip():
+        errors.append("Field 'language' must be a non-empty string.")
+    elif len(language) > REQUEST_MAX_LANGUAGE_CHARS:
+        errors.append(
+            f"Field 'language' exceeds {REQUEST_MAX_LANGUAGE_CHARS} characters."
+        )
+
+    notes = req.get("notes", "")
+    # Absent notes are fine — the field is optional. A wrong *type* is not:
+    # silently coercing it would put "None" or "[1, 2]" into the issue body.
+    if notes is not None and not isinstance(notes, str):
+        errors.append("Field 'notes' must be a string when present.")
+    elif isinstance(notes, str) and len(notes) > REQUEST_MAX_NOTES_CHARS:
+        errors.append(f"Field 'notes' exceeds {REQUEST_MAX_NOTES_CHARS} characters.")
 
     return (not errors), errors[:10]
 
@@ -377,47 +433,15 @@ def _get_ctx(request: web.Request) -> AppContext:
     return request.app[APP_CTX_KEY]
 
 
-async def submit_config_view(request: web.Request) -> web.Response:
-    """Report whether the submit feature is enabled (drives the UI's visibility).
+def _check_gates(request: web.Request, ctx: AppContext) -> web.Response | None:
+    """Shared pre-flight for both POST paths: feature enabled + rate limit.
 
-    Never leaks the worker URL to the browser — the browser POSTs to *our*
-    endpoint, which proxies to the worker server-side. Returns the validation
-    caps so the client validator stays in sync without hardcoding them.
+    Returns the error response to send, or None when the request may proceed.
+    Submissions and requests deliberately share **one** rate-limit bucket: they
+    hit the same worker, the same PAT and the same repo, so splitting the budget
+    would just hand a caller twice the issue-filing rate.
     """
-    ctx = _get_ctx(request)
-    enabled = bool((ctx.community_submit_url or "").strip())
-    return web.json_response(
-        {
-            "enabled": enabled,
-            "limits": {
-                "max_questions": SUBMIT_MAX_QUESTIONS,
-                "min_questions": SUBMIT_MIN_QUESTIONS,
-                "answers_per_question": SUBMIT_ANSWERS_PER_QUESTION,
-                "max_bytes": SUBMIT_MAX_PACK_BYTES,
-            },
-        }
-    )
-
-
-async def submissions_list_view(request: web.Request) -> web.Response:
-    """Return persisted submissions, reconciling status against GitHub if due."""
-    ctx = _get_ctx(request)
-    store = PackSubmissionStore(ctx)
-    data = await store.get_with_reconcile()
-    return web.json_response({"submissions": data.get("submissions", [])})
-
-
-async def submit_pack_view(request: web.Request) -> web.Response:
-    """Validate a composed pack and proxy it to the configured worker.
-
-    Body: ``{"pack": {...}}``. On success records the submission (so its status
-    can later be reconciled) and returns ``{ok, issue_number, issue_url}``.
-    Error responses carry a localizable ``code`` (INVALID_FORMAT / RATE_LIMITED
-    / GITHUB_ERROR / SUBMIT_DISABLED) plus a raw ``message`` fallback.
-    """
-    ctx = _get_ctx(request)
-    submit_url = (ctx.community_submit_url or "").strip()
-    if not submit_url:
+    if not (ctx.community_submit_url or "").strip():
         return web.json_response(
             {
                 "code": ERR_SUBMIT_DISABLED,
@@ -449,6 +473,126 @@ async def submit_pack_view(request: web.Request) -> web.Response:
             },
             status=429,
         )
+    return None
+
+
+async def _post_to_worker(
+    ctx: AppContext, payload: dict[str, Any]
+) -> tuple[dict[str, Any] | None, web.Response | None]:
+    """Proxy a payload to the worker. Returns (worker_payload, error_response).
+
+    Exactly one of the two is not None. The worker holds the GitHub token and
+    creates the issue; when a shared secret is configured it travels as the
+    ``X-Quizify-Secret`` header so the worker can reject unauthenticated
+    requests, closing the open-proxy hole (#256). No secret → no header, and a
+    worker without SHARED_SECRET behaves exactly as before.
+    """
+    submit_url = (ctx.community_submit_url or "").strip()
+    submit_secret = (ctx.community_submit_secret or "").strip()
+    submit_headers: dict[str, str] | None = (
+        {"X-Quizify-Secret": submit_secret} if submit_secret else None
+    )
+    # Reuse the runtime's shared client session (#456); pass the timeout on the
+    # request rather than baking it into a per-call session.
+    timeout = aiohttp.ClientTimeout(total=SUBMIT_POLL_TIMEOUT_SECONDS)
+    session = ctx.runtime.get_client_session()
+    worker_payload: dict[str, Any]
+    try:
+        async with session.post(
+            submit_url, json=payload, headers=submit_headers, timeout=timeout
+        ) as resp:
+            try:
+                worker_payload = await resp.json(content_type=None)
+            except (ValueError, aiohttp.ClientError):
+                worker_payload = {}
+            if resp.status >= 400:
+                code = (
+                    worker_payload.get("code")
+                    if isinstance(worker_payload, dict)
+                    else None
+                )
+                message = (
+                    worker_payload.get("message")
+                    if isinstance(worker_payload, dict)
+                    else None
+                )
+                return None, web.json_response(
+                    {
+                        "code": code or ERR_SUBMIT_GITHUB_ERROR,
+                        "message": message or f"Worker returned HTTP {resp.status}.",
+                    },
+                    status=resp.status if resp.status in (400, 429) else 502,
+                )
+    except aiohttp.ClientError as err:
+        _LOGGER.warning("Pack submission proxy failed: %s", err)
+        return None, web.json_response(
+            {
+                "code": ERR_SUBMIT_GITHUB_ERROR,
+                "message": f"Could not reach the worker: {err}",
+            },
+            status=502,
+        )
+
+    if not isinstance(worker_payload, dict):
+        worker_payload = {}
+    return worker_payload, None
+
+
+def _issue_refs(worker_payload: dict[str, Any]) -> tuple[int | None, str | None]:
+    """Pull (issue_number, issue_url) out of a worker response."""
+    issue_url = worker_payload.get("issue_url") or worker_payload.get("html_url")
+    issue_number = worker_payload.get("issue_number")
+    if issue_number is None:
+        issue_number = PackSubmissionStore.issue_number_from_url(issue_url)
+    return issue_number, issue_url
+
+
+async def submit_config_view(request: web.Request) -> web.Response:
+    """Report whether the submit feature is enabled (drives the UI's visibility).
+
+    Never leaks the worker URL to the browser — the browser POSTs to *our*
+    endpoint, which proxies to the worker server-side. Returns the validation
+    caps so the client validator stays in sync without hardcoding them.
+    """
+    ctx = _get_ctx(request)
+    enabled = bool((ctx.community_submit_url or "").strip())
+    return web.json_response(
+        {
+            "enabled": enabled,
+            "limits": {
+                "max_questions": SUBMIT_MAX_QUESTIONS,
+                "min_questions": SUBMIT_MIN_QUESTIONS,
+                "answers_per_question": SUBMIT_ANSWERS_PER_QUESTION,
+                "max_bytes": SUBMIT_MAX_PACK_BYTES,
+                # Request caps (#579) — same endpoint, same on/off switch, so
+                # the client learns both sets of limits in one call.
+                "max_theme_chars": REQUEST_MAX_THEME_CHARS,
+                "max_notes_chars": REQUEST_MAX_NOTES_CHARS,
+            },
+        }
+    )
+
+
+async def submissions_list_view(request: web.Request) -> web.Response:
+    """Return persisted submissions, reconciling status against GitHub if due."""
+    ctx = _get_ctx(request)
+    store = PackSubmissionStore(ctx)
+    data = await store.get_with_reconcile()
+    return web.json_response({"submissions": data.get("submissions", [])})
+
+
+async def submit_pack_view(request: web.Request) -> web.Response:
+    """Validate a composed pack and proxy it to the configured worker.
+
+    Body: ``{"pack": {...}}``. On success records the submission (so its status
+    can later be reconciled) and returns ``{ok, issue_number, issue_url}``.
+    Error responses carry a localizable ``code`` (INVALID_FORMAT / RATE_LIMITED
+    / GITHUB_ERROR / SUBMIT_DISABLED) plus a raw ``message`` fallback.
+    """
+    ctx = _get_ctx(request)
+    gate = _check_gates(request, ctx)
+    if gate is not None:
+        return gate
 
     try:
         body = await request.json()
@@ -490,70 +634,105 @@ async def submit_pack_view(request: web.Request) -> web.Response:
             status=400,
         )
 
-    # Proxy to the worker, which holds the GitHub token and creates the issue.
-    # When a shared secret is configured, send it as the X-Quizify-Secret header
-    # so the worker can reject unauthenticated requests, closing the open-proxy
-    # hole (#256). No secret → no header, and the worker (which only enforces
-    # when its SHARED_SECRET is set) behaves exactly as before — back-compatible.
-    submit_secret = (ctx.community_submit_secret or "").strip()
-    submit_headers: dict[str, str] | None = (
-        {"X-Quizify-Secret": submit_secret} if submit_secret else None
-    )
-    # Reuse the runtime's shared client session (#456); pass the timeout on the
-    # request rather than baking it into a per-call session.
-    timeout = aiohttp.ClientTimeout(total=SUBMIT_POLL_TIMEOUT_SECONDS)
-    session = ctx.runtime.get_client_session()
-    worker_payload: dict[str, Any]
-    try:
-        async with session.post(
-            submit_url, json={"pack": pack}, headers=submit_headers, timeout=timeout
-        ) as resp:
-            try:
-                worker_payload = await resp.json(content_type=None)
-            except (ValueError, aiohttp.ClientError):
-                worker_payload = {}
-            if resp.status >= 400:
-                code = (
-                    worker_payload.get("code")
-                    if isinstance(worker_payload, dict)
-                    else None
-                )
-                message = (
-                    worker_payload.get("message")
-                    if isinstance(worker_payload, dict)
-                    else None
-                )
-                return web.json_response(
-                    {
-                        "code": code or ERR_SUBMIT_GITHUB_ERROR,
-                        "message": message or f"Worker returned HTTP {resp.status}.",
-                    },
-                    status=resp.status if resp.status in (400, 429) else 502,
-                )
-    except aiohttp.ClientError as err:
-        _LOGGER.warning("Pack submission proxy failed: %s", err)
-        return web.json_response(
+    worker_payload, error = await _post_to_worker(ctx, {"pack": pack})
+    if error is not None or worker_payload is None:
+        return error or web.json_response(
             {
                 "code": ERR_SUBMIT_GITHUB_ERROR,
-                "message": f"Could not reach the worker: {err}",
+                "message": "Worker returned no payload.",
             },
             status=502,
         )
-
-    if not isinstance(worker_payload, dict):
-        worker_payload = {}
-    issue_url = worker_payload.get("issue_url") or worker_payload.get("html_url")
-    issue_number = worker_payload.get("issue_number")
-    if issue_number is None:
-        issue_number = PackSubmissionStore.issue_number_from_url(issue_url)
+    issue_number, issue_url = _issue_refs(worker_payload)
 
     record = {
         "id": f"{int(time.time() * 1000)}",
+        "kind": RECORD_KIND_SUBMISSION,
         "name": str(pack.get("name", "")) if isinstance(pack, dict) else "",
         "language": str(pack.get("language", "")) if isinstance(pack, dict) else "",
         "question_count": (
             len(pack.get("questions", [])) if isinstance(pack, dict) else 0
         ),
+        "issue_number": issue_number,
+        "issue_url": issue_url,
+        "status": SUBMIT_STATUS_PENDING,
+        "created": datetime.now(UTC).isoformat(),
+        "last_checked": None,
+    }
+    await PackSubmissionStore(ctx).add(record)
+
+    return web.json_response(
+        {"ok": True, "issue_number": issue_number, "issue_url": issue_url}
+    )
+
+
+async def request_pack_view(request: web.Request) -> web.Response:
+    """File a pack *request* — a wish, not content (#579).
+
+    Body: ``{"request": {"theme": str, "language": str, "notes": str?}}``. The
+    worker turns it into an issue labelled ``pack-request``; the record lands in
+    the same store as a submission with ``kind: "request"``, so the existing
+    reconcile and the existing timeline cover it without a second mechanism.
+
+    Requests are public by design (Markus, 2026-08-13): the resulting pack ships
+    to everyone or not at all. Nothing here writes a pack to the host's disk.
+    """
+    ctx = _get_ctx(request)
+    gate = _check_gates(request, ctx)
+    if gate is not None:
+        return gate
+
+    try:
+        body = await request.json()
+    except (ValueError, TypeError):
+        return web.json_response(
+            {"code": ERR_SUBMIT_INVALID_FORMAT, "message": "Body is not valid JSON."},
+            status=400,
+        )
+
+    req = (body or {}).get("request") if isinstance(body, dict) else None
+    ok, errors = validate_request(req)
+    if not ok:
+        return web.json_response(
+            {
+                "code": ERR_SUBMIT_INVALID_FORMAT,
+                "message": "; ".join(errors) or "Request failed validation.",
+                "errors": errors,
+            },
+            status=400,
+        )
+    # validate_request only returns ok for a dict; the cast keeps mypy happy
+    # without an assert in a request handler.
+    fields: dict[str, Any] = req if isinstance(req, dict) else {}
+
+    # Send the normalized fields, not the caller's dict: an extra key in the
+    # body must not travel to the worker and end up in the issue.
+    payload = {
+        "theme": str(fields.get("theme", "")).strip(),
+        "language": str(fields.get("language", "de")).strip() or "de",
+        "notes": str(fields.get("notes") or "").strip(),
+    }
+    worker_payload, error = await _post_to_worker(ctx, {"request": payload})
+    if error is not None or worker_payload is None:
+        return error or web.json_response(
+            {
+                "code": ERR_SUBMIT_GITHUB_ERROR,
+                "message": "Worker returned no payload.",
+            },
+            status=502,
+        )
+    issue_number, issue_url = _issue_refs(worker_payload)
+
+    record = {
+        "id": f"{int(time.time() * 1000)}",
+        "kind": RECORD_KIND_REQUEST,
+        # ``name`` carries the theme so the existing timeline renders a request
+        # with no changes; ``theme`` keeps the field addressable by its own name.
+        "name": payload["theme"],
+        "theme": payload["theme"],
+        "language": payload["language"],
+        "notes": payload["notes"],
+        "question_count": 0,
         "issue_number": issue_number,
         "issue_url": issue_url,
         "status": SUBMIT_STATUS_PENDING,

--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -25,6 +25,7 @@ from ..const import SUBMIT_POLL_INTERVAL_SECONDS
 from ..game.seasons import is_in_season, parse_season, pick_active_season
 from .context import APP_CTX_KEY
 from .pack_submission import (
+    request_pack_view,
     submissions_list_view,
     submit_config_view,
     submit_pack_view,
@@ -1331,6 +1332,9 @@ ROUTES: list[tuple[str, str, _RouteHandler]] = [
     ("GET", "/api/quizify/pack-submit/config", submit_config_view),
     ("GET", "/api/quizify/pack-submit/submissions", _gated_submissions_list_view),
     ("POST", "/api/quizify/pack-submit", submit_pack_view),
+    # Pack requests (#579) — the same feature switch and the same worker as the
+    # submission above, only the other direction: a wish instead of content.
+    ("POST", "/api/quizify/pack-submit/request", request_pack_view),
 ]
 
 

--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -560,6 +560,25 @@
                         <p class="pack-submit-intro" data-i18n="packSubmit.intro">
                             Three quick steps. Your pack lands as a review issue on GitHub.</p>
 
+                        <!-- Mode switch (#579): the same card serves two
+                             directions — send a finished pack, or ask for one
+                             that doesn't exist yet. Deliberately not a second
+                             screen: both end as an issue and both show up in
+                             the one timeline below. -->
+                        <div class="pack-mode" role="tablist"
+                             aria-label="Pack submission mode">
+                            <button type="button" id="pack-mode-submit-btn"
+                                    class="pack-mode-btn active" role="tab"
+                                    aria-selected="true" aria-controls="pack-submit-pane"
+                                    data-i18n="packSubmit.mode.submit">Send a pack</button>
+                            <button type="button" id="pack-mode-request-btn"
+                                    class="pack-mode-btn" role="tab"
+                                    aria-selected="false" aria-controls="pack-request-pane"
+                                    data-i18n="packSubmit.mode.request">Ask for a pack</button>
+                        </div>
+
+                        <div id="pack-submit-pane" role="tabpanel">
+
                         <!-- step rail: Compose / Check / Submit -->
                         <div class="pack-steps" role="list">
                             <div class="pack-step" data-step="1" role="listitem">
@@ -614,11 +633,48 @@
                                     data-i18n="packSubmit.backBtn">Back to edit</button>
                             <div id="pack-submit-status" class="pack-submit-status" role="status" aria-live="polite"></div>
                         </div>
+                        </div><!-- /#pack-submit-pane -->
+
+                        <!-- Request mode (#579): three short fields, no JSON.
+                             Requests are public — the resulting pack ships to
+                             everyone or not at all. -->
+                        <div id="pack-request-pane" class="hidden" role="tabpanel">
+                            <p class="pack-submit-intro" data-i18n="packSubmit.request.intro">
+                                Describe the pack you are missing. It lands as a request issue;
+                                the finished pack comes back as a pull request for review.</p>
+
+                            <label class="pack-submit-input-label" for="pack-request-theme"
+                                   data-i18n="packSubmit.request.themeLabel">Theme</label>
+                            <input type="text" id="pack-request-theme" class="pack-submit-input pack-request-line"
+                                   maxlength="80" autocomplete="off"
+                                   data-i18n-placeholder="packSubmit.request.themePlaceholder"
+                                   placeholder="80s German TV shows">
+
+                            <label class="pack-submit-input-label" for="pack-request-language"
+                                   data-i18n="packSubmit.request.languageLabel">Language</label>
+                            <select id="pack-request-language" class="pack-submit-input pack-request-line">
+                                <option value="de">Deutsch</option>
+                                <option value="en">English</option>
+                                <option value="es">Español</option>
+                            </select>
+
+                            <label class="pack-submit-input-label" for="pack-request-notes"
+                                   data-i18n="packSubmit.request.notesLabel">Anything to keep in mind? (optional)</label>
+                            <textarea id="pack-request-notes" class="pack-submit-input" rows="3"
+                                      maxlength="500"
+                                      data-i18n-placeholder="packSubmit.request.notesPlaceholder"
+                                      placeholder="Skew towards things a 50-year-old would remember."></textarea>
+
+                            <button type="button" id="pack-request-btn"
+                                    class="btn btn-primary btn-block" disabled
+                                    data-i18n="packSubmit.request.submit">Send request</button>
+                            <div id="pack-request-status" class="pack-submit-status" role="status" aria-live="polite"></div>
+                        </div>
                     </div>
 
                     <!-- My submissions timeline -->
                     <div id="pack-submit-list-card" class="pack-submit-card pack-submit-list-card hidden">
-                        <div class="pack-submit-list-title" data-i18n="packSubmit.recent">My submissions</div>
+                        <div class="pack-submit-list-title" data-i18n="packSubmit.recent">My packs &amp; requests</div>
                         <div id="pack-submit-list" class="pack-submit-timeline"></div>
                     </div>
                 </section>

--- a/custom_components/quizify/www/css/src/08-responsive.css
+++ b/custom_components/quizify/www/css/src/08-responsive.css
@@ -1027,6 +1027,69 @@ body:not(.is-admin) .pl-result { padding-bottom: 16px; }
     margin: 0 0 var(--space-lg, 24px);
 }
 
+/* ---- mode switch (#579): send a pack vs ask for one ----
+   A segmented pair, not two cards: the two directions share the timeline below,
+   so they belong in one surface. Both buttons stay at least 44px tall — this is
+   the first thing a thumb hits in this card. */
+.pack-mode {
+    display: flex;
+    gap: 4px;
+    padding: 4px;
+    margin-bottom: var(--space-lg, 24px);
+    background: var(--color-bg-card-alt);
+    border: 1px solid var(--color-border-light);
+    border-radius: var(--radius-md, 10px);
+}
+.pack-mode-btn {
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: 44px;
+    padding: 10px 8px;
+    border: 0;
+    border-radius: var(--radius-sm, 8px);
+    background: transparent;
+    color: var(--color-text-secondary);
+    font-family: inherit;
+    font-size: 0.8rem;
+    font-weight: 600;
+    line-height: 1.2;
+    cursor: pointer;
+    /* Long German labels ("Pack wünschen") must wrap instead of pushing the
+       segment wider than the card at 390px. */
+    white-space: normal;
+    overflow-wrap: break-word;
+}
+.pack-mode-btn.active {
+    background: var(--color-bg-surface);
+    color: var(--color-text-heading);
+    box-shadow: var(--shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.08));
+}
+
+/* Single-line request fields reuse .pack-submit-input for border/background but
+   must not inherit the monospace JSON look or the textarea resize handle. */
+.pack-request-line {
+    font-family: inherit;
+    font-size: 0.85rem;
+    resize: none;
+    margin-bottom: var(--space-md, 16px);
+}
+
+/* Request rows in the timeline: same node colours (status is the same three
+   states), one lighter chip so the two kinds stay distinguishable at a glance. */
+.pack-tli-kind {
+    display: inline-block;
+    margin-right: 6px;
+    padding: 1px 6px;
+    border-radius: 999px;
+    background: var(--color-bg-card-alt);
+    border: 1px solid var(--color-border-light);
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    color: var(--color-text-muted);
+    vertical-align: 1px;
+}
+
 /* ---- step rail ---- */
 .pack-steps {
     display: flex;

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -8439,6 +8439,69 @@ body:not(.is-admin) .pl-result { padding-bottom: 16px; }
     margin: 0 0 var(--space-lg, 24px);
 }
 
+/* ---- mode switch (#579): send a pack vs ask for one ----
+   A segmented pair, not two cards: the two directions share the timeline below,
+   so they belong in one surface. Both buttons stay at least 44px tall — this is
+   the first thing a thumb hits in this card. */
+.pack-mode {
+    display: flex;
+    gap: 4px;
+    padding: 4px;
+    margin-bottom: var(--space-lg, 24px);
+    background: var(--color-bg-card-alt);
+    border: 1px solid var(--color-border-light);
+    border-radius: var(--radius-md, 10px);
+}
+.pack-mode-btn {
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: 44px;
+    padding: 10px 8px;
+    border: 0;
+    border-radius: var(--radius-sm, 8px);
+    background: transparent;
+    color: var(--color-text-secondary);
+    font-family: inherit;
+    font-size: 0.8rem;
+    font-weight: 600;
+    line-height: 1.2;
+    cursor: pointer;
+    /* Long German labels ("Pack wünschen") must wrap instead of pushing the
+       segment wider than the card at 390px. */
+    white-space: normal;
+    overflow-wrap: break-word;
+}
+.pack-mode-btn.active {
+    background: var(--color-bg-surface);
+    color: var(--color-text-heading);
+    box-shadow: var(--shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.08));
+}
+
+/* Single-line request fields reuse .pack-submit-input for border/background but
+   must not inherit the monospace JSON look or the textarea resize handle. */
+.pack-request-line {
+    font-family: inherit;
+    font-size: 0.85rem;
+    resize: none;
+    margin-bottom: var(--space-md, 16px);
+}
+
+/* Request rows in the timeline: same node colours (status is the same three
+   states), one lighter chip so the two kinds stay distinguishable at a glance. */
+.pack-tli-kind {
+    display: inline-block;
+    margin-right: 6px;
+    padding: 1px 6px;
+    border-radius: 999px;
+    background: var(--color-bg-card-alt);
+    border: 1px solid var(--color-border-light);
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    color: var(--color-text-muted);
+    vertical-align: 1px;
+}
+
 /* ---- step rail ---- */
 .pack-steps {
     display: flex;

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -641,7 +641,7 @@
     "submitting": "Wird eingereicht…",
     "success": "Eingereicht — danke! Es wird in Kürze geprüft.",
     "failed": "Einreichung fehlgeschlagen.",
-    "recent": "Meine Einsendungen",
+    "recent": "Meine Packs & Wünsche",
     "step": {
       "compose": "Erstellen",
       "check": "Prüfen",
@@ -669,6 +669,26 @@
       "pending": "In Prüfung",
       "accepted": "Angenommen — zur Community hinzugefügt",
       "declined": "Abgelehnt"
+    },
+    "mode": {
+      "submit": "Pack senden",
+      "request": "Pack wünschen"
+    },
+    "kind": {
+      "request": "Wunsch"
+    },
+    "request": {
+      "intro": "Beschreibe das Pack, das dir fehlt. Es landet als Wunsch-Issue; das fertige Pack kommt als Pull Request zurück.",
+      "themeLabel": "Thema",
+      "themePlaceholder": "Deutsche TV-Serien der 80er",
+      "languageLabel": "Sprache",
+      "notesLabel": "Noch was zu beachten? (optional)",
+      "notesPlaceholder": "Eher Sachen, die ein 50-Jähriger noch kennt.",
+      "submit": "Wunsch senden",
+      "sending": "Wird gesendet…",
+      "success": "Wunsch ist raus — danke! Du siehst ihn unten in der Liste.",
+      "failed": "Wunsch konnte nicht gesendet werden.",
+      "tooLong": "Zu lang — bitte kürzer fassen."
     }
   },
   "lightning": {

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -641,7 +641,7 @@
     "submitting": "Submitting…",
     "success": "Submitted — thanks! It will be reviewed shortly.",
     "failed": "Submission failed.",
-    "recent": "My submissions",
+    "recent": "My packs & requests",
     "step": {
       "compose": "Compose",
       "check": "Check",
@@ -669,6 +669,26 @@
       "pending": "In review",
       "accepted": "Accepted — added to community",
       "declined": "Declined"
+    },
+    "mode": {
+      "submit": "Send a pack",
+      "request": "Ask for a pack"
+    },
+    "kind": {
+      "request": "Request"
+    },
+    "request": {
+      "intro": "Describe the pack you are missing. It lands as a request issue; the finished pack comes back as a pull request.",
+      "themeLabel": "Theme",
+      "themePlaceholder": "80s German TV shows",
+      "languageLabel": "Language",
+      "notesLabel": "Anything to keep in mind? (optional)",
+      "notesPlaceholder": "Skew towards things a 50-year-old would remember.",
+      "submit": "Send request",
+      "sending": "Sending…",
+      "success": "Request sent — thanks! It shows up in the list below.",
+      "failed": "Could not send the request.",
+      "tooLong": "Too long — please shorten it."
     }
   },
   "lightning": {

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -641,7 +641,7 @@
     "submitting": "Enviando…",
     "success": "Enviado — ¡gracias! Se revisará en breve.",
     "failed": "El envío ha fallado.",
-    "recent": "Mis envíos",
+    "recent": "Mis packs y peticiones",
     "step": {
       "compose": "Redactar",
       "check": "Comprobar",
@@ -669,6 +669,26 @@
       "pending": "En revisión",
       "accepted": "Aceptado — añadido a la comunidad",
       "declined": "Rechazado"
+    },
+    "mode": {
+      "submit": "Enviar un pack",
+      "request": "Pedir un pack"
+    },
+    "kind": {
+      "request": "Petición"
+    },
+    "request": {
+      "intro": "Describe el pack que te falta. Se registra como una petición; el pack terminado vuelve como pull request.",
+      "themeLabel": "Tema",
+      "themePlaceholder": "Series de televisión de los 80",
+      "languageLabel": "Idioma",
+      "notesLabel": "¿Algo a tener en cuenta? (opcional)",
+      "notesPlaceholder": "Mejor cosas que recuerde alguien de 50 años.",
+      "submit": "Enviar petición",
+      "sending": "Enviando…",
+      "success": "Petición enviada — ¡gracias! Aparece en la lista de abajo.",
+      "failed": "No se pudo enviar la petición.",
+      "tooLong": "Demasiado largo — acórtalo, por favor."
     }
   },
   "lightning": {

--- a/custom_components/quizify/www/js/pack-submit.js
+++ b/custom_components/quizify/www/js/pack-submit.js
@@ -19,6 +19,7 @@ window.QuizifyPackSubmit = (function () {
 
     var CONFIG_URL = '/api/quizify/pack-submit/config';
     var SUBMIT_URL = '/api/quizify/pack-submit';
+    var REQUEST_URL = '/api/quizify/pack-submit/request';
     var SUBMISSIONS_URL = '/api/quizify/pack-submit/submissions';
 
     // Defaults; overwritten by the server's reported limits.
@@ -26,7 +27,9 @@ window.QuizifyPackSubmit = (function () {
         max_questions: 500,
         min_questions: 1,
         answers_per_question: 3,
-        max_bytes: 1048576
+        max_bytes: 1048576,
+        max_theme_chars: 80,
+        max_notes_chars: 500
     };
 
     // The pack that last passed validation — carried from Check to Submit.
@@ -291,6 +294,92 @@ window.QuizifyPackSubmit = (function () {
         }
     }
 
+    /* ---------------- request mode (#579) ---------------- */
+
+    /** Switch the card between "send a pack" and "ask for a pack". */
+    function setMode(mode) {
+        var submitPane = el('pack-submit-pane');
+        var requestPane = el('pack-request-pane');
+        var submitBtn = el('pack-mode-submit-btn');
+        var requestBtn = el('pack-mode-request-btn');
+        var isRequest = mode === 'request';
+        if (submitPane) { submitPane.classList.toggle('hidden', isRequest); }
+        if (requestPane) { requestPane.classList.toggle('hidden', !isRequest); }
+        [[submitBtn, !isRequest], [requestBtn, isRequest]].forEach(function (pair) {
+            if (!pair[0]) { return; }
+            pair[0].classList.toggle('active', pair[1]);
+            pair[0].setAttribute('aria-selected', pair[1] ? 'true' : 'false');
+        });
+    }
+
+    function setRequestStatus(msg, kind) {
+        var statusEl = el('pack-request-status');
+        if (!statusEl) { return; }
+        statusEl.textContent = msg || '';
+        statusEl.className = 'pack-submit-status' + (kind ? ' pack-submit-status--' + kind : '');
+    }
+
+    /** The send button stays disabled until there is a theme to send. */
+    function syncRequestButton() {
+        var theme = el('pack-request-theme');
+        var btn = el('pack-request-btn');
+        if (!btn) { return; }
+        btn.disabled = !(theme && theme.value.trim());
+    }
+
+    async function doRequest() {
+        var themeEl = el('pack-request-theme');
+        var langEl = el('pack-request-language');
+        var notesEl = el('pack-request-notes');
+        var btn = el('pack-request-btn');
+        var theme = themeEl ? themeEl.value.trim() : '';
+        if (!theme) { syncRequestButton(); return; }
+
+        // Client-side cap check mirrors the server so an over-long field fails
+        // here with a readable message instead of coming back as a 400.
+        if (theme.length > limits.max_theme_chars) {
+            setRequestStatus(t('packSubmit.request.tooLong'), 'bad');
+            return;
+        }
+        var notes = notesEl ? notesEl.value.trim() : '';
+        if (notes.length > limits.max_notes_chars) {
+            setRequestStatus(t('packSubmit.request.tooLong'), 'bad');
+            return;
+        }
+
+        if (btn) { btn.disabled = true; }
+        setRequestStatus(t('packSubmit.request.sending'), 'pending');
+        try {
+            var resp = await fetch(REQUEST_URL, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    request: {
+                        theme: theme,
+                        language: (langEl && langEl.value) || 'de',
+                        notes: notes
+                    }
+                })
+            });
+            var data = {};
+            try { data = await resp.json(); } catch (_e) { /* ignore */ }
+            if (!resp.ok || !data.ok) {
+                setRequestStatus(errorText(data, t('packSubmit.request.failed')), 'bad');
+                if (btn) { btn.disabled = false; }
+                return;
+            }
+            var link = data.issue_url ? ' (#' + (data.issue_number || '?') + ')' : '';
+            setRequestStatus(t('packSubmit.request.success') + link, 'ok');
+            if (themeEl) { themeEl.value = ''; }
+            if (notesEl) { notesEl.value = ''; }
+            syncRequestButton();
+            loadSubmissions();
+        } catch (err) {
+            setRequestStatus(errorText({ code: 'GITHUB_ERROR' }, String(err)), 'bad');
+            if (btn) { btn.disabled = false; }
+        }
+    }
+
     function statusLabel(status) {
         var key = 'packSubmit.status.' + (status || 'pending');
         var translated = t(key);
@@ -330,11 +419,16 @@ window.QuizifyPackSubmit = (function () {
                 var title = s.issue_url
                     ? '<a href="' + escapeHtml(s.issue_url) + '" target="_blank" rel="noopener">' + name + '</a>'
                     : name;
+                // Records written before #579 carry no `kind` at all — a missing
+                // kind is a submission, never an unknown.
+                var kindChip = s.kind === 'request'
+                    ? '<span class="pack-tli-kind">' + escapeHtml(t('packSubmit.kind.request')) + '</span>'
+                    : '';
                 var sub = '';
                 if (s.issue_number) { sub += '#' + escapeHtml(s.issue_number); }
                 html += '<div class="pack-tli ' + meta.cls + '">' +
                     '<div class="pack-tli-node"></div>' +
-                    '<div class="pack-tli-t">' + title + '</div>' +
+                    '<div class="pack-tli-t">' + kindChip + title + '</div>' +
                     (sub ? '<div class="pack-tli-m">' + sub + '</div>' : '') +
                     '<div class="pack-tli-stat">' + meta.mark + ' ' + escapeHtml(statusLabel(s.status)) + '</div>' +
                     '</div>';
@@ -386,12 +480,44 @@ window.QuizifyPackSubmit = (function () {
         var back2Btn = el('pack-submit-back2-btn');
         if (back2Btn) { back2Btn.addEventListener('click', function () { setStatus(''); goToStep(1); }); }
 
+        // ---- request mode (#579)
+        var modeSubmitBtn = el('pack-mode-submit-btn');
+        var modeRequestBtn = el('pack-mode-request-btn');
+        if (modeSubmitBtn) {
+            modeSubmitBtn.addEventListener('click', function () { setMode('submit'); });
+        }
+        if (modeRequestBtn) {
+            modeRequestBtn.addEventListener('click', function () { setMode('request'); });
+        }
+        setMode('submit');
+
+        var themeEl = el('pack-request-theme');
+        if (themeEl) {
+            themeEl.addEventListener('input', function () {
+                setRequestStatus('');
+                syncRequestButton();
+            });
+        }
+        var langEl = el('pack-request-language');
+        // Preselect the language the admin UI is already running in — a German
+        // host asking for a pack almost never wants an English one.
+        if (langEl && window.QuizifyI18n && typeof window.QuizifyI18n.getLanguage === 'function') {
+            var cur = window.QuizifyI18n.getLanguage();
+            if (cur && langEl.querySelector('option[value="' + cur + '"]')) {
+                langEl.value = cur;
+            }
+        }
+        var requestBtn = el('pack-request-btn');
+        if (requestBtn) { requestBtn.addEventListener('click', doRequest); }
+        syncRequestButton();
+
         loadSubmissions();
     }
 
     return {
         init: init,
-        validatePack: validatePack  // exported for tests
+        validatePack: validatePack,  // exported for tests
+        setMode: setMode             // exported for tests
     };
 })();
 

--- a/tests/fixtures/pack_request_cases.json
+++ b/tests/fixtures/pack_request_cases.json
@@ -1,0 +1,142 @@
+{
+  "_comment": "Shared cases for the pack-request validator (#579). Read by BOTH tests/test_pack_request_579.py (server/pack_submission.py::validate_request) and cf-workers/contract-check.mjs (quizify-api.js::validateRequest) so the two implementations cannot drift. Caps mirror REQUEST_MAX_* in const.py: theme 80, notes 500, language 10.",
+  "valid": [
+    {
+      "id": "full",
+      "request": {
+        "theme": "80s German TV shows",
+        "language": "de",
+        "notes": "Skew towards things a 50-year-old would remember."
+      },
+      "reason": "all three fields present"
+    },
+    {
+      "id": "no-notes",
+      "request": {
+        "theme": "Belgian beer",
+        "language": "en"
+      },
+      "reason": "notes is optional"
+    },
+    {
+      "id": "notes-null",
+      "request": {
+        "theme": "Belgian beer",
+        "language": "en",
+        "notes": null
+      },
+      "reason": "an explicit null means no notes"
+    },
+    {
+      "id": "no-language",
+      "request": {
+        "theme": "Formel 1"
+      },
+      "reason": "language defaults to de"
+    },
+    {
+      "id": "theme-at-cap",
+      "request": {
+        "theme": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "language": "de"
+      },
+      "reason": "exactly at the 80-char cap is still valid"
+    },
+    {
+      "id": "notes-at-cap",
+      "request": {
+        "theme": "Cheese",
+        "language": "de",
+        "notes": "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
+      },
+      "reason": "exactly at the 500-char cap is still valid"
+    }
+  ],
+  "malformations": [
+    {
+      "id": "not-an-object",
+      "request": [
+        "theme"
+      ],
+      "reason": "array instead of object"
+    },
+    {
+      "id": "string-body",
+      "request": "Harry Potter",
+      "reason": "bare string instead of object"
+    },
+    {
+      "id": "missing-theme",
+      "request": {
+        "language": "de"
+      },
+      "reason": "theme is required"
+    },
+    {
+      "id": "empty-theme",
+      "request": {
+        "theme": "",
+        "language": "de"
+      },
+      "reason": "empty theme"
+    },
+    {
+      "id": "whitespace-theme",
+      "request": {
+        "theme": "   ",
+        "language": "de"
+      },
+      "reason": "whitespace-only theme"
+    },
+    {
+      "id": "theme-too-long",
+      "request": {
+        "theme": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "language": "de"
+      },
+      "reason": "one over the 80-char cap"
+    },
+    {
+      "id": "theme-wrong-type",
+      "request": {
+        "theme": 42,
+        "language": "de"
+      },
+      "reason": "theme must be a string"
+    },
+    {
+      "id": "empty-language",
+      "request": {
+        "theme": "Cheese",
+        "language": ""
+      },
+      "reason": "language present but empty"
+    },
+    {
+      "id": "language-too-long",
+      "request": {
+        "theme": "Cheese",
+        "language": "ddddddddddd"
+      },
+      "reason": "one over the 10-char cap"
+    },
+    {
+      "id": "notes-wrong-type",
+      "request": {
+        "theme": "Cheese",
+        "language": "de",
+        "notes": 5
+      },
+      "reason": "notes must be a string when present"
+    },
+    {
+      "id": "notes-too-long",
+      "request": {
+        "theme": "Cheese",
+        "language": "de",
+        "notes": "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
+      },
+      "reason": "one over the 500-char cap"
+    }
+  ]
+}

--- a/tests/test_pack_request_579.py
+++ b/tests/test_pack_request_579.py
@@ -1,0 +1,427 @@
+"""Tests for pack requests (#579) — asking for a pack instead of authoring one.
+
+Covers:
+  1. ``validate_request`` against the SHARED case catalog
+     (tests/fixtures/pack_request_cases.json), which the worker's
+     ``validateRequest`` reads too — that file is the anti-drift contract.
+  2. The view: feature gate, validation errors, and the persisted record shape
+     (``kind: "request"``, theme in ``name`` so the existing timeline renders it).
+  3. What actually travels to the worker: exactly three normalized fields, so an
+     extra key in the request body cannot reach the issue.
+  4. The rate limit is SHARED with submissions — same worker, same PAT, one budget.
+  5. Reconcile handles a request record with no special casing, which is the
+     whole reason requests live in the submission store.
+
+No HA, no network: the worker POST is intercepted with a fake session.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.const import (  # noqa: E402
+    RECORD_KIND_REQUEST,
+    RECORD_KIND_SUBMISSION,
+    REQUEST_MAX_NOTES_CHARS,
+    REQUEST_MAX_THEME_CHARS,
+    SUBMIT_STATUS_ACCEPTED,
+    SUBMIT_STATUS_PENDING,
+)
+from custom_components.quizify.server import pack_submission as ps  # noqa: E402
+from custom_components.quizify.server.pack_submission import (  # noqa: E402
+    PackSubmissionStore,
+    request_pack_view,
+    submit_pack_view,
+    validate_request,
+)
+
+_CASES = json.loads(
+    (_REPO_ROOT / "tests" / "fixtures" / "pack_request_cases.json").read_text(
+        encoding="utf-8"
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, status: int = 200) -> None:
+        self.status = status
+
+    async def json(self, content_type: Any = None) -> dict:
+        return {
+            "issue_number": 579,
+            "issue_url": "https://github.com/mholzi/quizify/issues/579",
+        }
+
+    async def __aenter__(self) -> "_FakeResponse":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        return None
+
+
+class _CapturingSession:
+    """Captures the JSON body and headers handed to .post()."""
+
+    captured_json: Any = "<unset>"
+    captured_headers: Any = "<unset>"
+
+    async def __aenter__(self) -> "_CapturingSession":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        return None
+
+    def post(self, url, json=None, headers=None, timeout=None):  # noqa: A002
+        type(self).captured_json = json
+        type(self).captured_headers = headers
+        return _FakeResponse()
+
+
+class _FakeRuntime:
+    def __init__(self, data_dir: Path) -> None:
+        self.data_dir = data_dir
+
+    async def run_in_executor(self, func, *args) -> Any:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func, *args)
+
+    def get_client_session(self) -> _CapturingSession:
+        return _CapturingSession()
+
+
+class _FakeCtx:
+    def __init__(
+        self,
+        data_dir: Path,
+        submit_url: str | None = "https://worker.example/submit",
+        submit_secret: str | None = None,
+    ) -> None:
+        self.runtime = _FakeRuntime(data_dir)
+        self.community_submit_url = submit_url
+        self.community_submit_secret = submit_secret
+
+
+class _FakeRequest:
+    """Just enough of aiohttp.web.Request for the two POST views."""
+
+    def __init__(self, ctx: _FakeCtx, body: Any, remote: str = "1.2.3.4") -> None:
+        self.app = {ps.APP_CTX_KEY: ctx}
+        self.remote = remote
+        self._body = body
+
+    async def json(self) -> Any:
+        if isinstance(self._body, Exception):
+            raise self._body
+        return self._body
+
+
+def _reset_limiter() -> None:
+    ps._rate_limiter._buckets.clear()
+
+
+def _good_pack() -> dict:
+    return {
+        "name": "Filler Pack",
+        "language": "en",
+        "questions": [
+            {
+                "id": "q1",
+                "question": "Which planet is the Red Planet?",
+                "answers": [
+                    {"text": "Mars", "correct": True},
+                    {"text": "Venus", "correct": False},
+                    {"text": "Jupiter", "correct": False},
+                ],
+            }
+        ],
+    }
+
+
+def _post_request(ctx: _FakeCtx, body: Any, remote: str = "1.2.3.4") -> Any:
+    """Drive request_pack_view once and return the response."""
+    request = _FakeRequest(ctx, body, remote)
+
+    async def _go() -> Any:
+        return await request_pack_view(request)  # type: ignore[arg-type]
+
+    return asyncio.run(_go())
+
+
+def _payload_of(resp: Any) -> dict:
+    return json.loads(resp.body.decode())
+
+
+# ---------------------------------------------------------------------------
+# 1. Validator — lockstep with the worker via the shared catalog
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("case", _CASES["valid"], ids=lambda c: c["id"])
+def test_shared_valid_cases_pass(case: dict) -> None:
+    ok, errors = validate_request(case["request"])
+    assert ok, f"{case['id']} should validate ({case['reason']}): {errors}"
+    assert errors == []
+
+
+@pytest.mark.parametrize("case", _CASES["malformations"], ids=lambda c: c["id"])
+def test_shared_malformations_rejected(case: dict) -> None:
+    ok, errors = validate_request(case["request"])
+    assert not ok, f"{case['id']} should be rejected ({case['reason']})"
+    assert errors, "a rejection must carry at least one message"
+
+
+def test_cap_boundaries_are_off_by_one_safe() -> None:
+    """The caps are inclusive: exactly at the limit passes, one over fails.
+
+    Pinned separately from the fixture so a cap change in const.py has to be a
+    decision, not a silent widening of what lands in a GitHub issue.
+    """
+    ok, _ = validate_request({"theme": "x" * REQUEST_MAX_THEME_CHARS})
+    assert ok
+    ok, _ = validate_request({"theme": "x" * (REQUEST_MAX_THEME_CHARS + 1)})
+    assert not ok
+    ok, _ = validate_request({"theme": "ok", "notes": "y" * REQUEST_MAX_NOTES_CHARS})
+    assert ok
+    ok, _ = validate_request(
+        {"theme": "ok", "notes": "y" * (REQUEST_MAX_NOTES_CHARS + 1)}
+    )
+    assert not ok
+
+
+def test_error_names_the_offending_field() -> None:
+    ok, errors = validate_request({"language": "de"})
+    assert not ok
+    assert any("theme" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# 2. View — gate, validation, record shape
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_when_no_worker_url(tmp_path: Path) -> None:
+    _reset_limiter()
+    ctx = _FakeCtx(tmp_path, submit_url=None)
+    resp = _post_request(ctx, {"request": {"theme": "Cheese"}})
+    assert resp.status == 403
+    assert _payload_of(resp)["code"] == "SUBMIT_DISABLED"
+
+
+def test_invalid_request_is_400_with_errors(tmp_path: Path) -> None:
+    _reset_limiter()
+    ctx = _FakeCtx(tmp_path)
+    resp = _post_request(ctx, {"request": {"theme": ""}})
+    assert resp.status == 400
+    body = _payload_of(resp)
+    assert body["code"] == "INVALID_FORMAT"
+    assert body["errors"]
+
+
+def test_non_json_body_is_400(tmp_path: Path) -> None:
+    _reset_limiter()
+    ctx = _FakeCtx(tmp_path)
+    resp = _post_request(ctx, ValueError("not json"))
+    assert resp.status == 400
+    assert _payload_of(resp)["code"] == "INVALID_FORMAT"
+
+
+def test_missing_request_key_is_400(tmp_path: Path) -> None:
+    """A body without a `request` key must not be read as an empty request."""
+    _reset_limiter()
+    ctx = _FakeCtx(tmp_path)
+    resp = _post_request(ctx, {"pack": _good_pack()})
+    assert resp.status == 400
+
+
+def test_success_persists_request_record(tmp_path: Path) -> None:
+    _reset_limiter()
+    ctx = _FakeCtx(tmp_path)
+    resp = _post_request(
+        ctx,
+        {
+            "request": {
+                "theme": "  80s German TV shows  ",
+                "language": "de",
+                "notes": "  skew nostalgic  ",
+            }
+        },
+    )
+    assert resp.status == 200
+    assert _payload_of(resp) == {
+        "ok": True,
+        "issue_number": 579,
+        "issue_url": "https://github.com/mholzi/quizify/issues/579",
+    }
+
+    records = json.loads((tmp_path / "pack_submissions.json").read_text())
+    assert len(records["submissions"]) == 1
+    rec = records["submissions"][0]
+    assert rec["kind"] == RECORD_KIND_REQUEST
+    assert rec["theme"] == "80s German TV shows"  # stripped
+    assert rec["name"] == rec["theme"]  # timeline renders `name` unchanged
+    assert rec["notes"] == "skew nostalgic"
+    assert rec["question_count"] == 0
+    assert rec["status"] == SUBMIT_STATUS_PENDING
+    assert rec["issue_number"] == 579
+
+
+def test_submission_record_is_tagged_too(tmp_path: Path) -> None:
+    """The submission path now stamps its kind as well, so a reader never has to
+    guess which of two shapes a record is."""
+    _reset_limiter()
+    ctx = _FakeCtx(tmp_path)
+    request = _FakeRequest(ctx, {"pack": _good_pack()})
+
+    async def _go() -> Any:
+        return await submit_pack_view(request)  # type: ignore[arg-type]
+
+    resp = asyncio.run(_go())
+    assert resp.status == 200
+    records = json.loads((tmp_path / "pack_submissions.json").read_text())
+    assert records["submissions"][0]["kind"] == RECORD_KIND_SUBMISSION
+
+
+# ---------------------------------------------------------------------------
+# 3. What travels to the worker
+# ---------------------------------------------------------------------------
+
+
+def test_worker_gets_exactly_three_normalized_fields(tmp_path: Path) -> None:
+    """An extra key in the body must not reach the worker — and therefore not
+    the issue. The view sends its own dict, not the caller's."""
+    _reset_limiter()
+    _CapturingSession.captured_json = "<unset>"
+    ctx = _FakeCtx(tmp_path)
+    _post_request(
+        ctx,
+        {
+            "request": {
+                "theme": "Belgian beer",
+                "language": "en",
+                "notes": "",
+                "labels": ["urgent"],
+                "assignee": "mholzi",
+            }
+        },
+    )
+    sent = _CapturingSession.captured_json
+    assert set(sent) == {"request"}
+    assert sent["request"] == {
+        "theme": "Belgian beer",
+        "language": "en",
+        "notes": "",
+    }
+
+
+def test_language_defaults_to_de(tmp_path: Path) -> None:
+    _reset_limiter()
+    _CapturingSession.captured_json = "<unset>"
+    ctx = _FakeCtx(tmp_path)
+    _post_request(ctx, {"request": {"theme": "Formel 1"}})
+    assert _CapturingSession.captured_json["request"]["language"] == "de"
+
+
+def test_secret_header_travels_on_the_request_path(tmp_path: Path) -> None:
+    """The request path must not be an unauthenticated back door into the worker
+    while the submission path is gated."""
+    _reset_limiter()
+    _CapturingSession.captured_headers = "<unset>"
+    ctx = _FakeCtx(tmp_path, submit_secret="s3cr3t-token")
+    _post_request(ctx, {"request": {"theme": "Cheese"}})
+    assert _CapturingSession.captured_headers == {"X-Quizify-Secret": "s3cr3t-token"}
+
+
+# ---------------------------------------------------------------------------
+# 4. One rate-limit budget for both paths
+# ---------------------------------------------------------------------------
+
+
+def test_rate_limit_is_shared_with_submissions(tmp_path: Path) -> None:
+    """Both paths file issues with the same PAT in the same repo, so they share
+    one bucket. Splitting the budget would hand a caller twice the rate."""
+    _reset_limiter()
+    ctx = _FakeCtx(tmp_path)
+
+    async def _go() -> Any:
+        # Exhaust the window with submissions from one IP...
+        for _ in range(ps._RATE_LIMIT_REQUESTS):
+            resp = await submit_pack_view(
+                _FakeRequest(ctx, {"pack": _good_pack()})  # type: ignore[arg-type]
+            )
+            assert resp.status == 200
+        # ...then a request from the same IP must be refused.
+        return await request_pack_view(
+            _FakeRequest(ctx, {"request": {"theme": "Cheese"}})  # type: ignore[arg-type]
+        )
+
+    resp = asyncio.run(_go())
+    assert resp.status == 429
+    assert _payload_of(resp)["code"] == "RATE_LIMITED"
+
+
+def test_other_ip_still_allowed(tmp_path: Path) -> None:
+    """The bucket is per IP, not global — one busy tablet must not lock out the
+    host's phone."""
+    _reset_limiter()
+    ctx = _FakeCtx(tmp_path)
+
+    async def _go() -> Any:
+        for _ in range(ps._RATE_LIMIT_REQUESTS):
+            await request_pack_view(
+                _FakeRequest(ctx, {"request": {"theme": "A"}}, remote="10.0.0.1")  # type: ignore[arg-type]
+            )
+        return await request_pack_view(
+            _FakeRequest(ctx, {"request": {"theme": "B"}}, remote="10.0.0.2")  # type: ignore[arg-type]
+        )
+
+    assert asyncio.run(_go()).status == 200
+
+
+# ---------------------------------------------------------------------------
+# 5. Reconcile needs no special case for requests
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_resolves_a_request_record(tmp_path: Path) -> None:
+    """A request issue closes exactly like a submission issue. This is the claim
+    that justifies one store and one reconcile for both kinds — if it ever stops
+    holding, this test is where it shows."""
+
+    async def _run() -> dict:
+        ctx = _FakeCtx(tmp_path)
+        store = PackSubmissionStore(ctx)
+
+        async def _fake_fetch(_session, issue_number, *_a):
+            assert issue_number == 579
+            return "closed", "completed"
+
+        store._fetch_issue = _fake_fetch  # type: ignore[assignment]
+        data = {
+            "submissions": [
+                {
+                    "id": "1",
+                    "kind": RECORD_KIND_REQUEST,
+                    "issue_number": 579,
+                    "status": SUBMIT_STATUS_PENDING,
+                }
+            ],
+            "last_poll": None,
+        }
+        return await store.reconcile(data)
+
+    result = asyncio.run(_run())
+    assert result["submissions"][0]["status"] == SUBMIT_STATUS_ACCEPTED


### PR DESCRIPTION
Implements the request direction from #579. The host describes a pack they want; it lands as an issue labelled `pack-request`, and a generated pack comes back as a PR for review.

## What changed

| Layer | Change |
|---|---|
| `cf-workers/quizify-api.js` | Second payload shape on the **same** endpoint, discriminated by the body key (`{"request": {…}}`). New `validateRequest` + `buildRequestIssue`, label `pack-request`. Same secret gate, same method guard. |
| `server/pack_submission.py` | `validate_request` + `request_pack_view`. The gate (feature switch + rate limit) and the worker proxy are now shared helpers used by both POST paths. Records carry `kind`. |
| `server/views.py` | `POST /api/quizify/pack-submit/request` |
| `www/admin.html`, `pack-submit.js`, CSS, i18n de/en/es | A mode switch inside the existing pack-submit card — three short fields instead of JSON. The one timeline lists both kinds with a chip. |

## Decisions worth reviewing

- **One endpoint, not two.** The discriminator is the body key. A second URL would have meant a second wrangler route to keep in sync for no gain, and the auth/method handling is identical.
- **One rate-limit bucket for both paths.** Both file issues with the same PAT in the same repo; splitting the budget would hand a caller twice the achievable issue rate. Pinned by `test_rate_limit_is_shared_with_submissions`.
- **Status handling untouched.** A request issue closes exactly like a submission issue, so one store and one reconcile cover both. `test_reconcile_resolves_a_request_record` is where that claim breaks if it ever stops holding.
- **A record without `kind` is a submission**, never an unknown — that is the pre-#579 data on disk.
- **The view sends its own normalized dict** (`theme`/`language`/`notes` only), so an extra key in the request body cannot travel into the issue body.
- **Requests are public** (decided in #579): the resulting pack ships to everyone or not at all, and nothing here writes a pack to the host's disk — the local-pack question that closed #370 stays closed.

## Verification

- `tests/test_pack_request_579.py` — 27 tests: validator, gate, record shape, worker payload, shared rate limit, reconcile.
- `tests/fixtures/pack_request_cases.json` — one case catalog replayed by **both** validators: the Python one in the test file, the worker one in `cf-workers/contract-check.mjs`. Drift on either side fails CI.
- Full suite 1766 passed / 9 skipped, `ruff check custom_components/` clean, generated `styles.css` rebuilt.

## Not in this PR

- The generator side (a bot job that turns a `pack-request` issue into a pack PR) — separate, lives in the bot, not the integration.
- **No mobile verification yet.** This touches the admin UI, so per the project's own rule it needs a 390×844 pass on real hardware before merge.

Closes #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)