### PR TITLE
fix(#586): end the round when connected players have no timers

### DIFF
--- a/custom_components/quizify/game/phase_controller.py
+++ b/custom_components/quizify/game/phase_controller.py
@@ -233,6 +233,17 @@ class PhaseController:
         ]
         return bool(timers) and all(timer.is_expired() for timer in timers)
 
+    def has_live_timers(self, player_names: list[str]) -> bool:
+        """Whether any of *player_names* currently holds a per-player timer.
+
+        The countdown loop pairs this with ``round_wall_clock_expired`` to
+        decide whether the wall-clock fallback applies. ``all_timers_expired``
+        can only break the loop once at least one supplied player has a timer,
+        so the loop needs a way to recognise the opposite state — connected
+        players, no timers — and fall back to the shared round clock (#586).
+        """
+        return any(self.timers.get(name) is not None for name in player_names)
+
     def round_wall_clock_expired(self) -> bool:
         """Whether the round's wall-clock has run out, regardless of timers.
 

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -2118,6 +2118,15 @@ class QuizifyGameState:
         """
         return self._phase_controller.all_timers_expired(player_names)
 
+    def has_live_timers(self, player_names: list[str]) -> bool:
+        """Whether any supplied player still holds a per-player timer (#586).
+
+        Pairs with ``round_wall_clock_expired`` in the countdown loop: the
+        wall-clock fallback applies exactly when no supplied player has a
+        timer. Delegated to the PhaseController.
+        """
+        return self._phase_controller.has_live_timers(player_names)
+
     def round_wall_clock_expired(self) -> bool:
         """Whether the round wall-clock has elapsed (#255).
 

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -2685,13 +2685,18 @@ class QuizifyWebSocketHandler:
                     connected = [p.name for p in players if p.connected]
                     if connected and game_state.all_timers_expired(connected):
                         break
-                    # Fallback: when every player has disconnected mid-question
-                    # there are no live timers left for all_timers_expired to
-                    # break on, so the loop would spin forever and the admin
-                    # couldn't advance. Break once the round wall-clock has run
-                    # out, so the round still auto-evaluates with zero connected
-                    # players. (#255.)
-                    if not connected and game_state.round_wall_clock_expired():
+                    # Fallback: all_timers_expired needs at least one live
+                    # timer to break on, so the loop hangs in every state where
+                    # the connected players have none. That covers the original
+                    # case — everyone disconnected mid-question (#255) — and
+                    # the one it missed: connected players who never got a
+                    # timer, where NEITHER condition could fire and the loop
+                    # spun forever with the countdown frozen at 0 (#586).
+                    # Keying the fallback on "no live timers" instead of "no
+                    # connected players" covers both with one condition.
+                    if not game_state.has_live_timers(
+                        connected
+                    ) and game_state.round_wall_clock_expired():
                         break
 
                 # Timer expired globally

--- a/tests/test_tick_loop_stall_586.py
+++ b/tests/test_tick_loop_stall_586.py
@@ -1,0 +1,137 @@
+"""Regression tests for the frozen countdown reported in #586.
+
+The countdown loop had two break conditions and a gap between them:
+
+- ``all_timers_expired(connected)`` needs at least one live timer, so it
+  returns False when the connected players have none.
+- the wall-clock fallback only applied when *nobody* was connected (#255).
+
+A round with connected players who hold no timer therefore matched neither
+condition: the loop spun forever, the client counted its local clock down to
+zero and sat there, and the admin's Skip/Pause/End were the only way out.
+
+The fallback now keys on "no live timers" instead of "no connected players",
+which covers the #255 case and this one with a single condition.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.phase_controller import (  # noqa: E402
+    PhaseController,
+)
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+
+
+def _fake_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+class _Runtime:
+    """Minimal runtime: runs scheduled coroutines on the live loop."""
+
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+    def create_task(self, coro):  # noqa: ANN001
+        return asyncio.ensure_future(coro)
+
+
+def _break_conditions(gs: QuizifyGameState, connected: list[str]) -> bool:
+    """Mirror the tick loop's two break conditions (server/websocket.py).
+
+    Kept as a tiny helper so the test asserts the *decision* the loop makes
+    rather than driving the whole websocket handler.
+    """
+    if connected and gs.all_timers_expired(connected):
+        return True
+    return not gs.has_live_timers(connected) and gs.round_wall_clock_expired()
+
+
+class TestHasLiveTimers:
+    def test_false_when_connected_players_hold_no_timer(self) -> None:
+        pc = PhaseController(players_fn=lambda: [])
+        pc.begin_round(round_duration=10.0)
+        # begin_round created timers for the (empty) player list, so a
+        # connected player who never got one is unknown to the controller.
+        assert pc.has_live_timers(["Alice"]) is False
+        # And this is precisely why all_timers_expired can't end the round.
+        assert pc.all_timers_expired(["Alice"]) is False
+
+    def test_true_once_the_player_has_a_timer(self) -> None:
+        pc = PhaseController(players_fn=lambda: ["Alice"])
+        pc.begin_round(round_duration=10.0)
+        assert pc.has_live_timers(["Alice"]) is True
+
+    def test_empty_list_has_no_live_timers(self) -> None:
+        pc = PhaseController(players_fn=lambda: ["Alice"])
+        pc.begin_round(round_duration=10.0)
+        assert pc.has_live_timers([]) is False
+
+
+class TestTickLoopBreaksOnStall:
+    def test_connected_without_timer_used_to_hang_forever(
+        self, tmp_path: Path
+    ) -> None:
+        """The #586 state: a connected player, no timer, wall-clock elapsed."""
+        gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+        gs.add_player("Alice", _fake_ws())
+        gs.start_game(language="de", num_rounds=3)
+        gs.start_next_question()
+
+        # Drop every per-player timer while the player stays connected — the
+        # state neither break condition could resolve before.
+        gs._phase_controller.clear_timers()
+        connected = ["Alice"]
+        assert gs.all_timers_expired(connected) is False
+        assert gs.has_live_timers(connected) is False
+
+        # Before the wall-clock runs out the loop must keep going: a round
+        # that is merely mid-flight is not allowed to end early.
+        assert _break_conditions(gs, connected) is False
+
+        gs._phase_controller.round_start_time = time.monotonic() - 9999.0
+        assert gs.round_wall_clock_expired() is True
+        assert _break_conditions(gs, connected) is True
+
+    def test_all_disconnected_still_breaks(self, tmp_path: Path) -> None:
+        """The original #255 case keeps working through the same condition."""
+        gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+        gs.add_player("Alice", _fake_ws())
+        gs.start_game(language="de", num_rounds=3)
+        gs.start_next_question()
+
+        gs._phase_controller.round_start_time = time.monotonic() - 9999.0
+        assert _break_conditions(gs, []) is True
+
+    def test_live_timers_do_not_end_the_round_early(self, tmp_path: Path) -> None:
+        """A running timer must outrank an elapsed wall-clock.
+
+        The wall-clock can read expired while a player still has time left —
+        a late joiner's timer outlives the shared clock. The fallback must not
+        cut that round short, which is why it requires *no* live timers.
+        """
+        gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+        gs.add_player("Alice", _fake_ws())
+        gs.start_game(language="de", num_rounds=3)
+        gs.start_next_question()
+
+        gs._phase_controller.round_start_time = time.monotonic() - 9999.0
+        assert gs.round_wall_clock_expired() is True
+        assert gs.has_live_timers(["Alice"]) is True
+        # Alice's own timer has not expired, so the round runs on.
+        assert gs.all_timers_expired(["Alice"]) is False
+        assert _break_conditions(gs, ["Alice"]) is False


### PR DESCRIPTION
## Proposed change

The countdown loop in `server/websocket.py` had two break conditions and a gap between them:

- `all_timers_expired(connected)` returns `False` when none of the connected players holds a timer — it needs at least one live timer to have something to expire (`game/phase_controller.py`).
- the wall-clock fallback only applied when **nobody** was connected (#255).

A round with connected players who hold no timer matched neither condition. The loop spun forever, the client counted its own clock down to zero and sat there, and the round never evaluated. That is the hang reported in #586, and it does not need team mode — the reporter reproduced it playing alone.

This keys the fallback on *no live timers* rather than *no connected players*, which covers the original all-disconnected case and this one with a single condition:

```python
if not game_state.has_live_timers(connected) and game_state.round_wall_clock_expired():
    break
```

A live timer still outranks an elapsed wall-clock, so a late joiner — whose timer deliberately outlives the shared round clock — does not get their round cut short.

### Not fixed here

#586 also reports dead Skip/Pause/Stop buttons and a Cast picker that never asks which TV. Those come from `_grant_admin()` being fail-soft: a missing or invalid token leaves the socket open but withholds the admin role, so admin commands answer `Admin only` and admin-scoped data comes back empty. That is a separate defect and needs the reporter's log to confirm; this PR does not touch it.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes issue #586 (partially — see "Not fixed here")

## Checklist

- [x] The code change is tested and works locally (`pytest tests/` — 1901 passed).
- [x] There is no commented out code in this PR.