### PR TITLE
fix(#588): persist question stats outside end_game()

### DIFF
--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -108,6 +108,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     question_stats = QuestionStatsService(runtime)
     await question_stats.load()
 
+    # Persist accumulated rounds when HA shuts down (#588). Without this the
+    # only write path was end_game(), so a restart during a game — or after a
+    # game the host simply walked away from — silently dropped every round it
+    # had collected. async_flush() cancels the pending debounce and writes.
+    from homeassistant.const import (  # noqa: PLC0415
+        EVENT_HOMEASSISTANT_STOP,
+    )
+
+    async def _flush_question_stats(_event: object) -> None:
+        await question_stats.async_flush()
+
+    entry.async_on_unload(
+        hass.bus.async_listen_once(
+            EVENT_HOMEASSISTANT_STOP, _flush_question_stats
+        )
+    )
+
     game_state = QuizifyGameState(runtime=runtime, entry_id=entry.entry_id)
     game_state.set_stats_services(analytics, question_stats)
     # Read persisted question history off the event loop (issue #222).
@@ -591,6 +608,17 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     domain_data = hass.data.get(DOMAIN)
     if domain_data:
+        # Write out the per-question stats before anything is torn down
+        # (#588). A reload or an integration update goes through here, and
+        # whatever rounds are still only in memory would otherwise be lost.
+        ctx = domain_data.get("ctx")
+        question_stats = getattr(ctx, "question_stats", None)
+        if question_stats is not None:
+            try:
+                await question_stats.async_flush()
+            except Exception:  # noqa: BLE001
+                _LOGGER.exception("Failed to flush question stats on unload")
+
         ws_handler = domain_data.get("ws_handler")
         if ws_handler:
             await ws_handler.cleanup_game_tasks()

--- a/custom_components/quizify/analytics.py
+++ b/custom_components/quizify/analytics.py
@@ -184,7 +184,18 @@ class QuizifyAnalytics:
         task.add_done_callback(self._handle_save_error)
 
     def _handle_save_error(self, task: asyncio.Task) -> None:
-        """Log exceptions from fire-and-forget save tasks."""
+        """Log exceptions from fire-and-forget save tasks.
+
+        A cancelled task is not an error and must be checked first: calling
+        ``task.exception()`` on one re-raises the ``CancelledError`` right
+        inside this callback, where nobody is waiting for it. That happens on
+        every HA shutdown that catches a save in flight — rare enough to have
+        gone unnoticed until the question-stats flush (#588) started awaiting
+        during ``EVENT_HOMEASSISTANT_STOP`` and gave the loop the chance to
+        cancel this task while the shutdown was still running.
+        """
+        if task.cancelled():
+            return
         if (exc := task.exception()) is not None:
             _LOGGER.error("Unhandled error in analytics save task: %s", exc)
 

--- a/custom_components/quizify/question_stats.py
+++ b/custom_components/quizify/question_stats.py
@@ -46,12 +46,18 @@ class QuestionStatsData(TypedDict):
 class QuestionStatsService:
     """Async JSON store for per-question aggregate stats."""
 
+    #: Seconds between the last recorded round and the debounced write. Long
+    #: enough that a normal round cadence coalesces into one write, short
+    #: enough that walking away mid-game costs at most this much (#588).
+    SAVE_DEBOUNCE_SECONDS = 5.0
+
     def __init__(self, runtime: Runtime) -> None:
         self._runtime = runtime
         self._path = runtime.data_dir / "question_stats.json"
         self._data: QuestionStatsData = {"version": 1, "questions": {}}
         self._save_lock = asyncio.Lock()
         self._dirty = False
+        self._save_timer: asyncio.Future[None] | None = None
 
     async def load(self) -> None:
         try:
@@ -108,6 +114,7 @@ class QuestionStatsService:
                 q["correct_count"] += 1
                 q["total_time_correct"] += float(elapsed)
         self._dirty = True
+        self._schedule_save()
 
     def aggregate_for_questions(self, ids: Iterable[str]) -> tuple[int, int]:
         """Sum (shown_count, correct_count) over the given question *ids*.
@@ -182,3 +189,51 @@ class QuestionStatsService:
                 self._dirty = False
             except OSError as err:
                 _LOGGER.error("Failed to save question stats: %s", err)
+
+    def _schedule_save(self) -> None:
+        """(Re-)arm the debounced write after a recorded round (#588).
+
+        ``end_game()`` used to be the only caller of :meth:`save_if_dirty`, so
+        a game that was abandoned — tab closed, HA restarted, integration
+        reloaded — threw away every round it had accumulated. Rearming a short
+        timer here means an interrupted evening still leaves its rounds on
+        disk, while a game played to the end still writes exactly once at the
+        end (the timer coalesces the rounds in between).
+
+        No-op without a running event loop: ``record_round`` is a plain
+        synchronous call and is exercised that way in tests, where scheduling a
+        task would raise. Those callers keep the previous behaviour and persist
+        through :meth:`save_if_dirty` / :meth:`async_flush`.
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        timer = self._save_timer
+        if timer is not None and not timer.done():
+            timer.cancel()
+        self._save_timer = self._runtime.create_task(self._debounced_save())
+
+    async def _debounced_save(self) -> None:
+        """Wait out the quiet period, then persist."""
+        try:
+            await asyncio.sleep(self.SAVE_DEBOUNCE_SECONDS)
+        except asyncio.CancelledError:
+            # Superseded by a later round, or cancelled by async_flush() —
+            # which persists itself. Nothing to do.
+            return
+        await self.save_if_dirty()
+
+    async def async_flush(self) -> None:
+        """Persist right now, cancelling any armed debounce (#588).
+
+        Called on config-entry unload and on ``EVENT_HOMEASSISTANT_STOP`` so a
+        restart, a reload or an integration update cannot drop the rounds that
+        are still only in memory. Safe to call when nothing is pending:
+        :meth:`save_if_dirty` is a no-op then.
+        """
+        timer = self._save_timer
+        self._save_timer = None
+        if timer is not None and not timer.done():
+            timer.cancel()
+        await self.save_if_dirty()

--- a/tests/test_question_stats_flush_588.py
+++ b/tests/test_question_stats_flush_588.py
@@ -1,0 +1,291 @@
+"""Per-question stats survive an unfinished game (issue #588).
+
+Before this, ``save_if_dirty()`` had exactly one caller — ``end_game()`` in
+``game/state.py`` — so ``record_round()`` only ever mutated an in-memory dict.
+Every game that did not reach the end (host closed the tab, HA restarted, the
+integration was reloaded or updated mid-game) threw its rounds away without a
+trace. On the live instance that showed up as a stats file whose newest entry
+was nine days old while games were being played.
+
+Two paths close the hole and both are pinned here:
+
+* a **debounced write** armed by ``record_round()``, so an abandoned game still
+  leaves its rounds on disk;
+* an explicit **flush** on config-entry unload and on ``EVENT_HOMEASSISTANT_
+  STOP``, so a restart or reload cannot drop what is still only in memory.
+
+The service-level tests run anywhere. The lifecycle tests need the real
+``homeassistant`` package plus the ``pytest-homeassistant-custom-component``
+harness and skip (not error) without them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.question_stats import (  # noqa: E402
+    QuestionStatsService,
+)
+from custom_components.quizify.runtime import StandaloneRuntime  # noqa: E402
+
+
+def _service(tmp_path: Path, debounce: float = 0.02) -> QuestionStatsService:
+    """A stats service on a tmp data dir with a test-length debounce."""
+    svc = QuestionStatsService(StandaloneRuntime(tmp_path))
+    # Instance attribute shadows the class constant — the production value
+    # (5 s) would make these tests sleep for no benefit.
+    svc.SAVE_DEBOUNCE_SECONDS = debounce
+    return svc
+
+
+def _stored(tmp_path: Path) -> dict:
+    return json.loads((tmp_path / "question_stats.json").read_text())
+
+
+async def test_abandoned_game_still_persists_its_rounds(tmp_path: Path) -> None:
+    """The regression itself: rounds reach disk without any end_game()."""
+    svc = _service(tmp_path)
+
+    svc.record_round("geo_en_001", [(True, 4.0), (False, 9.0)])
+
+    # Nothing is written synchronously — the point is that it lands *later*
+    # without anyone ending the game.
+    assert not (tmp_path / "question_stats.json").exists()
+
+    await asyncio.sleep(0.1)
+
+    q = _stored(tmp_path)["questions"]["geo_en_001"]
+    assert q["shown_count"] == 2
+    assert q["correct_count"] == 1
+
+
+async def test_rounds_in_quick_succession_write_once(tmp_path: Path) -> None:
+    """The debounce coalesces a normal round cadence into a single write.
+
+    A save per round would rewrite the whole file (which grows with the pack
+    catalogue) several times a minute during a game.
+    """
+    svc = _service(tmp_path, debounce=0.08)
+    writes = 0
+    original = svc.save_if_dirty
+
+    async def counting_save() -> None:
+        nonlocal writes
+        writes += 1
+        await original()
+
+    svc.save_if_dirty = counting_save  # type: ignore[method-assign]
+
+    for i in range(4):
+        svc.record_round(f"geo_en_{i:03d}", [(True, 3.0)])
+        await asyncio.sleep(0.01)
+    await asyncio.sleep(0.2)
+
+    assert writes == 1, f"expected the rounds to coalesce, saw {writes} writes"
+    assert len(_stored(tmp_path)["questions"]) == 4
+
+
+async def test_flush_writes_immediately_and_disarms_the_timer(
+    tmp_path: Path,
+) -> None:
+    """async_flush() persists now, and the pending debounce does not fire
+    a second, redundant write afterwards."""
+    svc = _service(tmp_path, debounce=5.0)
+    writes = 0
+    original = svc.save_if_dirty
+
+    async def counting_save() -> None:
+        nonlocal writes
+        writes += 1
+        await original()
+
+    svc.save_if_dirty = counting_save  # type: ignore[method-assign]
+
+    svc.record_round("nat_en_007", [(True, 2.5)])
+    await svc.async_flush()
+
+    assert _stored(tmp_path)["questions"]["nat_en_007"]["shown_count"] == 1
+    assert writes == 1
+
+    # Give the (cancelled) debounce more than its due; it must stay quiet.
+    await asyncio.sleep(0.05)
+    assert writes == 1
+
+
+async def test_flush_without_pending_changes_is_a_noop(tmp_path: Path) -> None:
+    """Called on every unload, so it has to be cheap and safe when idle."""
+    svc = _service(tmp_path)
+    await svc.async_flush()
+    assert not (tmp_path / "question_stats.json").exists()
+
+
+def test_record_round_outside_an_event_loop_does_not_raise(
+    tmp_path: Path,
+) -> None:
+    """``record_round`` is a plain synchronous call and is used that way in
+    tests and in the standalone server's sync paths. Arming a task there would
+    raise ``RuntimeError: no running event loop``; the scheduler skips instead
+    and the data still persists through an explicit save."""
+    svc = _service(tmp_path)
+
+    svc.record_round("pop_010", [(True, 1.0)])
+
+    assert svc._save_timer is None
+    asyncio.run(svc.save_if_dirty())
+    assert _stored(tmp_path)["questions"]["pop_010"]["shown_count"] == 1
+
+
+async def test_cancelled_analytics_save_is_not_reported_as_an_error(
+    tmp_path: Path,
+) -> None:
+    """Fallout from the flush, fixed alongside it.
+
+    ``QuizifyAnalytics.schedule_save`` attaches a done-callback that reads
+    ``task.exception()``. On a cancelled task that call re-raises the
+    ``CancelledError`` inside the callback, where nobody handles it. The flush
+    added here awaits during ``EVENT_HOMEASSISTANT_STOP``, which is exactly the
+    window in which HA cancels a save in flight — so a latent crash became a
+    reproducible one, and the callback now checks for cancellation first.
+    """
+    from custom_components.quizify.analytics import QuizifyAnalytics
+
+    analytics = QuizifyAnalytics(StandaloneRuntime(tmp_path))
+
+    async def _never() -> None:
+        await asyncio.sleep(3600)
+
+    task = asyncio.ensure_future(_never())
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # Must not raise — this runs as a done-callback with no waiter.
+    analytics._handle_save_error(task)
+
+
+# --------------------------------------------------------------------------
+# Entry lifecycle — needs the real HA harness.
+# --------------------------------------------------------------------------
+
+pytest.importorskip("homeassistant")
+pytest.importorskip("pytest_homeassistant_custom_component")
+
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP  # noqa: E402
+from homeassistant.core import HomeAssistant  # noqa: E402
+from homeassistant.setup import async_setup_component  # noqa: E402
+from pytest_homeassistant_custom_component.common import (  # noqa: E402
+    MockConfigEntry,
+)
+
+from custom_components.quizify.const import DOMAIN  # noqa: E402
+
+pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+
+@pytest.fixture(autouse=True)
+def _stub_frontend_panel():
+    """Same stubs as ``test_init_313`` — the prebuilt ``hass_frontend`` wheel
+    isn't installed under the harness, so the two panel helpers the
+    integration imports inside setup/unload are replaced."""
+    from unittest.mock import patch
+
+    with (
+        patch(
+            "homeassistant.components.frontend.async_register_built_in_panel"
+        ),
+        patch("homeassistant.components.frontend.async_remove_panel"),
+    ):
+        yield
+
+
+@pytest.fixture
+async def http_hass(hass: HomeAssistant) -> HomeAssistant:
+    """A hass with the HTTP component set up (setup mounts routes on it)."""
+    assert await async_setup_component(hass, "http", {"http": {}})
+    await hass.async_block_till_done()
+    return hass
+
+
+async def _setup(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id) is True
+    await hass.async_block_till_done()
+    return entry
+
+
+def _stats_file(hass: HomeAssistant) -> Path:
+    return Path(hass.config.path("quizify")) / "question_stats.json"
+
+
+def _stored_questions(hass: HomeAssistant) -> dict:
+    """Questions currently on disk, ``{}`` when the file isn't there yet."""
+    path = _stats_file(hass)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text()).get("questions", {})
+
+
+@pytest.fixture
+def clean_stats_file(hass: HomeAssistant):
+    """Remove the stats file around the test.
+
+    The harness config dir lives inside site-packages and survives between
+    runs, so a file left by an earlier test would be loaded at setup and
+    written back out — which would make an "is it on disk yet" assertion
+    meaningless.
+    """
+    path = _stats_file(hass)
+    path.unlink(missing_ok=True)
+    yield
+    path.unlink(missing_ok=True)
+
+
+async def test_unload_flushes_recorded_rounds(
+    http_hass: HomeAssistant, clean_stats_file: None
+) -> None:
+    """A reload or an integration update goes through unload — the rounds
+    collected so far must be on disk when it returns."""
+    hass = http_hass
+    entry = await _setup(hass)
+
+    stats = hass.data[DOMAIN]["ctx"].question_stats
+    stats.SAVE_DEBOUNCE_SECONDS = 3600.0  # only the flush can save here
+    stats.record_round("hist_en_042", [(True, 5.0), (True, 6.5)])
+    assert "hist_en_042" not in _stored_questions(hass)
+
+    assert await hass.config_entries.async_unload(entry.entry_id) is True
+    await hass.async_block_till_done()
+
+    q = _stored_questions(hass)["hist_en_042"]
+    assert q["shown_count"] == 2
+    assert q["correct_count"] == 2
+
+
+async def test_ha_stop_flushes_recorded_rounds(
+    http_hass: HomeAssistant, clean_stats_file: None
+) -> None:
+    """Shutting HA down mid-game keeps the rounds."""
+    hass = http_hass
+    await _setup(hass)
+
+    stats = hass.data[DOMAIN]["ctx"].question_stats
+    stats.SAVE_DEBOUNCE_SECONDS = 3600.0
+    stats.record_round("sci_en_013", [(False, 12.0)])
+    assert "sci_en_013" not in _stored_questions(hass)
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    await hass.async_block_till_done()
+
+    q = _stored_questions(hass)["sci_en_013"]
+    assert q["shown_count"] == 1
+    assert q["correct_count"] == 0


### PR DESCRIPTION
Closes #588.

## What was wrong

`record_round()` only mutated an in-memory dict and set a dirty flag.
`save_if_dirty()` had exactly one caller — `end_game()` in `game/state.py`.
So any game that did not reach the end lost every round it had collected:
the host closing the tab, an HA restart, a config-entry reload, an
integration update mid-game.

Measured on the live instance: the newest `last_shown` across all 163
tracked questions was nine days old while games were being played. It is
also why the `sport-de` correct-rate watch could never fire — it was waiting
on a counter that only grows for games played to the end.

## What changed

**A debounced save, armed by `record_round()`** (`SAVE_DEBOUNCE_SECONDS = 5`).
An abandoned game still leaves its rounds on disk. A game played to the end
still writes exactly once, because the timer coalesces the rounds in between
— a save per round would rewrite the whole file (which grows with the pack
catalogue) several times a minute.

It is a deliberate no-op when there is no running event loop: `record_round()`
is a plain synchronous call, used that way in tests and in the standalone
server's sync paths, where arming a task would raise. Those callers keep the
old behaviour and persist through an explicit save.

**`async_flush()` on config-entry unload and on `EVENT_HOMEASSISTANT_STOP`.**
Cancels the pending debounce and writes, so a restart, a reload or an update
cannot drop what is still only in memory.

**One fix the flush made reproducible.** `QuizifyAnalytics.schedule_save()`
attaches a done-callback that reads `task.exception()`. On a *cancelled* task
that call re-raises the `CancelledError` inside the callback, where nothing is
waiting for it. Awaiting during `EVENT_HOMEASSISTANT_STOP` is exactly the
window in which HA cancels a save in flight, so a latent crash turned into a
reproducible teardown error in `test_game_control_services_367`. The callback
now checks `task.cancelled()` first. Verified it is pre-existing: the test is
clean on `main` and fails with the flush in place, which is what surfaced it.

## Tests

8 new tests in `tests/test_question_stats_flush_588.py`:

- the regression itself — rounds reach disk with no `end_game()` anywhere
- rounds in quick succession coalesce into a single write
- `async_flush()` writes immediately and disarms the pending timer (no second
  redundant write)
- flushing with nothing pending is a no-op
- `record_round()` outside an event loop does not raise
- the cancelled-analytics-task callback stays quiet
- unload flushes, against the real HA harness
- `EVENT_HOMEASSISTANT_STOP` flushes, against the real HA harness

Full suite: **1,908 passed**.

## Not in this PR

The stats on the live instance stay as they are — this changes what gets
recorded from now on, it cannot reconstruct the nine days that were dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
