### PR TITLE
feat(packs): add the Spanish picture round `imagenes-es`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ No apps to download. No accounts to create. Just scan a QR code and play.
 
 **Works on Any Screen** — Dashboard mode for the TV. Players use their phones. Admin runs the show. No extra hardware needed.
 
-**Eleven Themes, Three Languages** — 4,597 questions across 33 themed packs (Geography, Pop Culture, Animals & Nature, Sport, Music, Science, History, Food & Drink, Technology, World Cup, Estimation) in German, English and Spanish. Mix them, filter them, swap mid-session.
+**Twelve Themes, Three Languages** — 4,614 questions across 34 themed packs (Geography, Pop Culture, Animals & Nature, Sport, Music, Science, History, Food & Drink, Technology, World Cup, Estimation, Picture Round) in German, English and Spanish. Mix them, filter them, swap mid-session.
 
 ---
 
@@ -318,7 +318,7 @@ Then **"Start New Game"** (same settings, same players) or **Reset Game** (fresh
 
 ## Question Packs
 
-Quizify ships with **4,597 questions across 33 themed packs in 11 themes**, in German, English and Spanish.
+Quizify ships with **4,614 questions across 34 themed packs in 12 themes**, in German, English and Spanish.
 
 | Theme | 🇩🇪 Deutsch | 🇬🇧 English | 🇪🇸 Español |
 |-------|-------------|-------------|-------------|
@@ -326,16 +326,16 @@ Quizify ships with **4,597 questions across 33 themed packs in 11 themes**, in G
 | 🦋 **Tiere & Natur / Animals & Nature / Naturaleza** | 159 | 160 | 160 |
 | 🎬 **Popkultur / Pop Culture / Cultura Pop** | 159 | 160 | 160 |
 | ⚽ **Sport / Deportes** | 158 | 160 | 160 |
-| 🎵 **Musik / Music** | 160 | 160 | — |
+| 🎵 **Musik / Music / Música** | 160 | 160 | 160 |
 | 🔬 **Wissenschaft / Science / Ciencia** | 160 | 160 | 160 |
 | 📜 **Geschichte / History / Historia** | 159 | 160 | 160 |
-| 🍔 **Essen & Trinken / Food & Drink** | 160 | 160 | — |
-| 💡 **Technik / Technology** | 160 | 160 | — |
+| 🍔 **Essen & Trinken / Food & Drink / Comida** | 160 | 160 | 160 |
+| 💡 **Technik / Technology / Tecnología** | 160 | 160 | 160 |
 | 🏆 **Weltmeisterschaft / World Cup** | 109 | 110 | — |
 | 🎯 **Schätzfragen / Estimation** | 15 | 15 | — |
-| 🖼️ **Bilderrätsel / Picture Round** | 17 | 17 | — |
+| 🖼️ **Bilderrätsel / Picture Round / Ronda de Imágenes** | 17 | 17 | 17 |
 
-Spanish arrived in 1.3.0 and grew through 1.6.1; music, food and technology are the three themes it is still missing. The two Estimation packs hold slider questions rather than multiple choice — see [How to Play](#the-experience); every themed pack now carries five slider questions of its own (#566) on top of its written ones.
+Spanish arrived in 1.3.0 and reached every written theme in 1.9.0; the World Cup and Estimation packs are the two it is still missing. The two Estimation packs hold slider questions rather than multiple choice — see [How to Play](#the-experience); every themed pack now carries five slider questions of its own (#566) on top of its written ones.
 
 Pack selection lives on the **first screen**: a featured pack card (e.g. World Cup) up top, with every other pack as a tappable chip right beneath it — tap to select or deselect, mix several, then hit **Start Game**. Game settings (difficulty, rounds, timer) stay one tap away under **Adjust settings**. **Mixed mode** drops you a random question from every selected pack, so you can stir Geography + Pop + Sport together for chaos mode.
 

--- a/custom_components/quizify/questions/imagenes-es.json
+++ b/custom_components/quizify/questions/imagenes-es.json
@@ -1,0 +1,382 @@
+{
+  "name": "Ronda de Imágenes",
+  "language": "es",
+  "version": "1.0",
+  "theme": "trivia",
+  "questions": [
+    {
+      "id": "pic-es-001",
+      "question": "¿Quién pintó Los jugadores de cartas?",
+      "answers": [
+        {
+          "text": "Paul Cézanne",
+          "correct": true
+        },
+        {
+          "text": "Édouard Manet",
+          "correct": false
+        },
+        {
+          "text": "Henri de Toulouse-Lautrec",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Cézanne repitió el motivo cinco veces; una de esas versiones figura entre los cuadros más caros que se han vendido nunca.",
+      "image_url": "/quizify/static/img/packs/picture-round/card-players.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "pic-es-002",
+      "question": "¿De qué país procede esta pareja de espadas?",
+      "answers": [
+        {
+          "text": "Japón",
+          "correct": true
+        },
+        {
+          "text": "China",
+          "correct": false
+        },
+        {
+          "text": "Corea",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Un daishō es la pareja de sable largo y corto: llevar los dos a la vez era un privilegio reservado a los samuráis.",
+      "image_url": "/quizify/static/img/packs/picture-round/daisho-swords.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "pic-es-003",
+      "question": "¿Desde dónde se tomó esta fotografía?",
+      "answers": [
+        {
+          "text": "Desde una órbita alrededor de la Luna",
+          "correct": true
+        },
+        {
+          "text": "Desde la superficie de Marte",
+          "correct": false
+        },
+        {
+          "text": "Desde la Estación Espacial Internacional",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La «salida de la Tierra» del Apolo 8 se cuenta entre las fotografías que más empujaron al movimiento ecologista.",
+      "image_url": "/quizify/static/img/packs/picture-round/earthrise.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "pic-es-004",
+      "question": "¿De dónde procede este objeto?",
+      "answers": [
+        {
+          "text": "Del Antiguo Egipto",
+          "correct": true
+        },
+        {
+          "text": "De la Antigua Roma",
+          "correct": false
+        },
+        {
+          "text": "De la época maya",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Los ojos pintados en el costado servían para que el difunto pudiera mirar hacia fuera del sarcófago.",
+      "image_url": "/quizify/static/img/packs/picture-round/egyptian-coffin.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "pic-es-005",
+      "question": "¿En qué isla se pintó este cuadro?",
+      "answers": [
+        {
+          "text": "Tahití",
+          "correct": true
+        },
+        {
+          "text": "Cuba",
+          "correct": false
+        },
+        {
+          "text": "Sicilia",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Gauguin trasladó la Anunciación cristiana a la Polinesia: el título y las figuras mezclan los dos mundos.",
+      "image_url": "/quizify/static/img/packs/picture-round/gauguin-ia-orana-maria.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "pic-es-006",
+      "question": "¿Qué imagen mundialmente conocida es esta?",
+      "answers": [
+        {
+          "text": "La gran ola de Kanagawa",
+          "correct": true
+        },
+        {
+          "text": "El monte Fuji en la tormenta",
+          "correct": false
+        },
+        {
+          "text": "Olas en Ise",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "No es una pintura, sino una estampa xilográfica: en tiempos de Hokusai se tiraron varios miles de ejemplares.",
+      "image_url": "/quizify/static/img/packs/picture-round/great-wave.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "pic-es-007",
+      "question": "¿Qué recipiente es este?",
+      "answers": [
+        {
+          "text": "Un ánfora griega",
+          "correct": true
+        },
+        {
+          "text": "Una urna romana",
+          "correct": false
+        },
+        {
+          "text": "Un vaso canopo egipcio",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Las ánforas transportaban vino y aceite; las decoradas como esta se entregaban además como premio en los juegos.",
+      "image_url": "/quizify/static/img/packs/picture-round/greek-amphora.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "pic-es-008",
+      "question": "¿De qué siglo es esta pintura?",
+      "answers": [
+        {
+          "text": "Siglo XVI",
+          "correct": true
+        },
+        {
+          "text": "Siglo XVIII",
+          "correct": false
+        },
+        {
+          "text": "Siglo XIX",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los segadores, que Bruegel pintó en 1565, forma parte de una serie de seis cuadros sobre las estaciones del año.",
+      "image_url": "/quizify/static/img/packs/picture-round/harvesters.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "pic-es-009",
+      "question": "¿Qué es esto?",
+      "answers": [
+        {
+          "text": "Una armadura de placas europea",
+          "correct": true
+        },
+        {
+          "text": "Una armadura de samurái japonesa",
+          "correct": false
+        },
+        {
+          "text": "El equipo de un legionario romano",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Una armadura completa pesaba unos 25 kilos, repartidos por todo el cuerpo en lugar de colgar de los hombros.",
+      "image_url": "/quizify/static/img/packs/picture-round/knight-armor.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "pic-es-010",
+      "question": "Este retrato provocó un escándalo en 1884. ¿Quién lo pintó?",
+      "answers": [
+        {
+          "text": "John Singer Sargent",
+          "correct": true
+        },
+        {
+          "text": "James McNeill Whistler",
+          "correct": false
+        },
+        {
+          "text": "Gustav Klimt",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Todo el escándalo giró en torno a un tirante caído; Sargent acabó repintándolo en su sitio.",
+      "image_url": "/quizify/static/img/packs/picture-round/madame-x.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "pic-es-011",
+      "question": "¿Dónde está esta huella?",
+      "answers": [
+        {
+          "text": "En la Luna",
+          "correct": true
+        },
+        {
+          "text": "En el desierto de Gobi",
+          "correct": false
+        },
+        {
+          "text": "En Marte",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Sin viento ni agua que la borren, es probable que siga ahí dentro de millones de años.",
+      "image_url": "/quizify/static/img/packs/picture-round/moon-footprint.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "pic-es-012",
+      "question": "¿Qué es esta página?",
+      "answers": [
+        {
+          "text": "Una miniatura de un manuscrito persa",
+          "correct": true
+        },
+        {
+          "text": "Una vidriera medieval",
+          "correct": false
+        },
+        {
+          "text": "Un rollo chino colgante",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La hoja procede del Lenguaje de los pájaros, un poema persa en el que las aves se reúnen en asamblea.",
+      "image_url": "/quizify/static/img/packs/picture-round/persian-birds-folio.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "pic-es-013",
+      "question": "¿Quién pintó este retrato?",
+      "answers": [
+        {
+          "text": "Rembrandt",
+          "correct": true
+        },
+        {
+          "text": "Peter Paul Rubens",
+          "correct": false
+        },
+        {
+          "text": "Anthony van Dyck",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Rembrandt retrató más de una vez a su mujer, Saskia, en el papel de Flora, la diosa de las flores.",
+      "image_url": "/quizify/static/img/packs/picture-round/rembrandt-flora.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "pic-es-014",
+      "question": "¿Quién aparece en este retrato?",
+      "answers": [
+        {
+          "text": "Vincent van Gogh",
+          "correct": true
+        },
+        {
+          "text": "Paul Gauguin",
+          "correct": false
+        },
+        {
+          "text": "Edgar Degas",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Van Gogh se pintó a sí mismo más de 35 veces, sobre todo porque no le llegaba el dinero para pagar a un modelo.",
+      "image_url": "/quizify/static/img/packs/picture-round/self-portrait-straw-hat.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "pic-es-015",
+      "question": "¿Qué acontecimiento representa esta escena?",
+      "answers": [
+        {
+          "text": "Washington cruzando el Delaware",
+          "correct": true
+        },
+        {
+          "text": "Napoleón cruzando el Berézina",
+          "correct": false
+        },
+        {
+          "text": "César cruzando el Rubicón",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Se pintó en Düsseldorf en 1851, así que el río del fondo es en realidad el Rin.",
+      "image_url": "/quizify/static/img/packs/picture-round/washington-crossing.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "pic-es-016",
+      "question": "¿Quién pintó este cuadro?",
+      "answers": [
+        {
+          "text": "Vincent van Gogh",
+          "correct": true
+        },
+        {
+          "text": "Claude Monet",
+          "correct": false
+        },
+        {
+          "text": "Paul Cézanne",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Van Gogh pintó los cipreses en el verano de 1889, mientras vivía internado en Saint-Rémy.",
+      "image_url": "/quizify/static/img/packs/picture-round/wheat-field-cypresses.webp",
+      "reveal_style": "progressive"
+    },
+    {
+      "id": "pic-es-017",
+      "question": "¿De qué pintor es esta escena?",
+      "answers": [
+        {
+          "text": "Johannes Vermeer",
+          "correct": true
+        },
+        {
+          "text": "Rembrandt",
+          "correct": false
+        },
+        {
+          "text": "Frans Hals",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "De Vermeer solo se conocen unas 35 obras; esta fue la primera que llegó a una colección estadounidense.",
+      "image_url": "/quizify/static/img/packs/picture-round/young-woman-water-pitcher.webp",
+      "reveal_style": "progressive"
+    }
+  ]
+}

--- a/custom_components/quizify/questions/versions.json
+++ b/custom_components/quizify/questions/versions.json
@@ -31,5 +31,6 @@
   "picture-round-en": "1.0",
   "musica-es": "1.0",
   "comida-es": "1.0",
-  "tecnologia-es": "1.0"
+  "tecnologia-es": "1.0",
+  "imagenes-es": "1.0"
 }

--- a/tests/test_picture_round_537.py
+++ b/tests/test_picture_round_537.py
@@ -19,7 +19,7 @@ QUESTIONS = COMPONENT / "questions"
 IMAGES = COMPONENT / "www" / "img" / "packs" / "picture-round"
 PREFIX = "/quizify/static/img/packs/picture-round/"
 
-PACKS = ("bilderraetsel-de.json", "picture-round-en.json")
+PACKS = ("bilderraetsel-de.json", "picture-round-en.json", "imagenes-es.json")
 
 
 def _pack(name: str) -> dict:
@@ -51,10 +51,20 @@ def test_pack_shape_matches_every_other_pack(name: str) -> None:
         assert question["fun_fact"].strip(), f"{question['id']}: fun_fact is empty"
 
 
-def test_both_languages_cover_the_same_images() -> None:
-    """A picture available in one language only would be a silent gap."""
-    urls = [{q["image_url"] for q in _pack(name)["questions"]} for name in PACKS]
-    assert urls[0] == urls[1]
+def test_every_language_covers_the_same_images() -> None:
+    """A picture available in one language only would be a silent gap.
+
+    Written over all shipped picture packs rather than a pair: the third one
+    (``imagenes-es``) would otherwise have been free to drift, because a
+    comparison of the first two still passed.
+    """
+    urls = {name: {q["image_url"] for q in _pack(name)["questions"]} for name in PACKS}
+    reference = urls[PACKS[0]]
+    for name, seen in urls.items():
+        assert seen == reference, (
+            f"{name} does not cover the same images as {PACKS[0]}: "
+            f"missing {sorted(reference - seen)}, extra {sorted(seen - reference)}"
+        )
 
 
 def test_no_image_is_shipped_without_a_question() -> None:

--- a/tests/test_question_image_url_540.py
+++ b/tests/test_question_image_url_540.py
@@ -178,7 +178,7 @@ def test_picture_packs_ship_urls_the_client_accepts() -> None:
     _require_node()
     questions_dir = REPO / "custom_components" / "quizify" / "questions"
     urls: list[str] = []
-    for pack in ("bilderraetsel-de.json", "picture-round-en.json"):
+    for pack in ("bilderraetsel-de.json", "picture-round-en.json", "imagenes-es.json"):
         data = json.loads((questions_dir / pack).read_text(encoding="utf-8"))
         questions = data["questions"] if isinstance(data, dict) else data
         urls.extend(q["image_url"] for q in questions if q.get("image_url"))

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -77,6 +77,7 @@ class TestLoadCategory:
         small_packs = {
             "schaetzfragen-de", "estimation-en",       # estimate (#275)
             "bilderraetsel-de", "picture-round-en",    # picture round (#537)
+            "imagenes-es",                             # picture round (es)
         }
         for cat in bank.get_categories():
             if cat.startswith("community-"):


### PR DESCRIPTION
## What

A Spanish picture-round pack, `imagenes-es` — 17 questions on the 17 images the integration already ships.

## Why

Counted at `86c357d`: German ships **12 packs / 1,575 questions**, English **12 / 1,582**, Spanish only **9 / 1,440**. The difference is exactly the three standalone packs that never got a Spanish sibling — picture round (17), estimation (15) and World Cup (109). This closes the first of the three.

The picture round is the cheapest of them by a wide margin: `bilderraetsel-de` and `picture-round-en` already point at the **same 17 files** under `www/img/packs/picture-round/`, so this pack reuses them unchanged. No new assets, no growth in the download every install pulls, and no licence review — the expensive half of #554 does not recur here.

Worth being precise about what this is *not*: Spanish players were never missing the picture *question type*. Each of the nine Spanish themed packs already carries five image questions and five estimate questions. What was missing is the dedicated pack.

## How

Same facts and answer options as the German and English siblings, written in Spanish rather than translated line by line — the approach the Spanish themed packs used.

## Tests

- `test_questions.py` — `imagenes-es` joins the 10–20 small-pack window, the exemption the other picture and estimation packs already hold.
- `test_picture_round_537.py` — the pack list gains the third file. The image-parity check now compares **every** shipped picture pack against the first, instead of asserting `urls[0] == urls[1]`: with three packs the old pairwise form would have passed while the new pack drifted.
- `test_question_image_url_540.py` — the client-side URL guard covers the new pack too.

`1,911 passed` locally (`main` collects 1,909).

## Docs

README now quotes **34 packs / 4,614 questions**. While in that table: the Spanish column still showed dashes for music, food and technology, which shipped in 1.9.0.

## Not in this PR

No merge, no tag, no release — Markus' ship gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqxJDAoSf3tmGciz8ZtfTL