### PR TITLE
fix(#586): tell the host when an admin command is refused

### DIFF
--- a/custom_components/quizify/const.py
+++ b/custom_components/quizify/const.py
@@ -48,6 +48,12 @@ ERR_ALREADY_SUBMITTED = "ALREADY_SUBMITTED"
 ERR_FROZEN = "FROZEN"  # frozen player tried to submit during the freeze lockout (#300)
 ERR_NOT_IN_GAME = "NOT_IN_GAME"
 ERR_INVALID_ACTION = "INVALID_ACTION"
+#: A command was understood but refused because the connection does not hold
+#: the admin role (#586). Distinct from ERR_INVALID_ACTION on purpose: the
+#: admin UI suppresses the "Admin only" INVALID_ACTION that the pre-auth
+#: ``admin_connect`` handshake produces, and that filter used to swallow every
+#: refused Skip/Pause/Stop with it — the buttons looked dead.
+ERR_ADMIN_REQUIRED = "ADMIN_REQUIRED"
 ERR_GAME_FULL = "GAME_FULL"
 ERR_NO_QUESTIONS_REMAINING = "NO_QUESTIONS_REMAINING"
 

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -12,12 +12,12 @@ from typing import TYPE_CHECKING, Any
 from aiohttp import WSMsgType, web
 
 from custom_components.quizify.const import (
+    ERR_ADMIN_REQUIRED,
     ERR_ALREADY_SUBMITTED,
     ERR_FROZEN,
     ERR_GAME_ALREADY_STARTED,
     ERR_GAME_FULL,
     ERR_GAME_NOT_STARTED,
-    ERR_ADMIN_REQUIRED,
     ERR_INVALID_ACTION,
     ERR_NAME_INVALID,
     ERR_NAME_TAKEN,

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -17,6 +17,7 @@ from custom_components.quizify.const import (
     ERR_GAME_ALREADY_STARTED,
     ERR_GAME_FULL,
     ERR_GAME_NOT_STARTED,
+    ERR_ADMIN_REQUIRED,
     ERR_INVALID_ACTION,
     ERR_NAME_INVALID,
     ERR_NAME_TAKEN,
@@ -539,7 +540,9 @@ class QuizifyWebSocketHandler:
             # and idempotent — it can only return the game to its initial
             # state, never escalate privilege — so this cannot be abused.
             if not self._is_reset_authorized(ws, is_admin, game_state):
-                await self._conn.send_error(ws, ERR_INVALID_ACTION, "Admin only")
+                await self._conn.send_error(
+                    ws, ERR_ADMIN_REQUIRED, "This connection is not the host"
+                )
                 return
             await self._handle_reset_game(ws, game_state)
             return
@@ -560,7 +563,14 @@ class QuizifyWebSocketHandler:
             # admin (admin tab via ?role=admin) OR a player whose session has
             # is_admin=True (admin-as-player flow). Without that relaxation the
             # admin-as-player flow could never advance LOBBY → QUESTION_ACTIVE.
-            await self._conn.send_error(ws, ERR_INVALID_ACTION, "Admin only")
+            _LOGGER.warning(
+                "Refused admin command %s from a connection without the admin "
+                "role — the client is told, not just ignored (#586)",
+                msg_type,
+            )
+            await self._conn.send_error(
+                ws, ERR_ADMIN_REQUIRED, "This connection is not the host"
+            )
             return
 
         # Every handler in ``_DISPATCH`` is normalized to the uniform

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -604,7 +604,8 @@
     "INVALID_FORMAT": "Das Pack-Format ist ungültig. Prüfe die markierten Felder.",
     "RATE_LIMITED": "Zu viele Einsendungen. Bitte kurz warten und erneut versuchen.",
     "GITHUB_ERROR": "Der Einsende-Dienst ist gerade nicht erreichbar. Später erneut versuchen.",
-    "SUBMIT_DISABLED": "Pack-Einsendung ist nicht konfiguriert."
+    "SUBMIT_DISABLED": "Pack-Einsendung ist nicht konfiguriert.",
+    "ADMIN_REQUIRED": "Dieses Fenster ist nicht der Host — der Befehl wurde abgelehnt. Öffne das Admin-Fenster erneut über Home Assistant."
   },
   "page": {
     "titleAdmin": "Quizify — Admin",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -604,7 +604,8 @@
     "INVALID_FORMAT": "The pack format is invalid. Check the highlighted fields.",
     "RATE_LIMITED": "Too many submissions. Please wait a moment and try again.",
     "GITHUB_ERROR": "Submission service is unavailable right now. Try again later.",
-    "SUBMIT_DISABLED": "Pack submission is not configured."
+    "SUBMIT_DISABLED": "Pack submission is not configured.",
+    "ADMIN_REQUIRED": "This window is not the host — the command was refused. Reopen the admin window from Home Assistant."
   },
   "page": {
     "titleAdmin": "Quizify — Admin",

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -604,7 +604,8 @@
     "INVALID_FORMAT": "El formato del paquete no es válido. Revisa los campos resaltados.",
     "RATE_LIMITED": "Demasiados envíos. Espera un momento e inténtalo de nuevo.",
     "GITHUB_ERROR": "El servicio de envío no está disponible ahora mismo. Inténtalo más tarde.",
-    "SUBMIT_DISABLED": "El envío de paquetes no está configurado."
+    "SUBMIT_DISABLED": "El envío de paquetes no está configurado.",
+    "ADMIN_REQUIRED": "Esta ventana no es la del anfitrión: el comando fue rechazado. Vuelve a abrir la ventana de administración desde Home Assistant."
   },
   "page": {
     "titleAdmin": "Quizify — Administración",

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -1337,7 +1337,10 @@
             case 'error':
                 // The initial admin_connect attempt before authentication
                 // returns "Admin only" — that's expected handshake noise,
-                // not an error worth showing in the console.
+                // not an error worth showing in the console. A REFUSED
+                // command arrives as ADMIN_REQUIRED instead and is always
+                // shown: swallowing it is what made Skip/Pause/Stop look
+                // dead in #586.
                 if (!(msg.code === 'INVALID_ACTION' && msg.message === 'Admin only')) {
                     console.warn('[Quizify Admin] Error:', msg.code, msg.message);
                 }

--- a/tests/test_admin_refusal_visible_586.py
+++ b/tests/test_admin_refusal_visible_586.py
@@ -1,0 +1,169 @@
+"""A refused admin command must not be invisible (#586).
+
+The reporter of #586 saw Skip, Pause and Stop do nothing at all: no movement,
+no message, nothing in the interface. The server was answering — it sent
+``INVALID_ACTION`` with the message ``"Admin only"`` — but the admin page
+suppresses exactly that code-and-message pair on purpose, because the
+pre-authentication ``admin_connect`` handshake produces it on every load. A
+filter written for handshake noise was swallowing every refused command with
+it.
+
+So the fix is not "show more errors". It is to stop the two cases from
+looking identical on the wire: a refused command now answers
+``ADMIN_REQUIRED``, which nothing suppresses, while the handshake keeps its
+``INVALID_ACTION`` / "Admin only" pair and stays quiet.
+
+These tests pin both halves. Without the first, a future refactor could route
+the refusal back through the suppressed pair and the buttons would go silent
+again — with every existing test still green, because they only ever asserted
+that *an* error was sent.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.const import (  # noqa: E402
+    ERR_ADMIN_REQUIRED,
+    ERR_INVALID_ACTION,
+)
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server import websocket as ws_mod  # noqa: E402
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+ADMIN_JS = _REPO_ROOT / "custom_components" / "quizify" / "www" / "js" / "admin.js"
+I18N_DIR = _REPO_ROOT / "custom_components" / "quizify" / "www" / "i18n"
+
+#: The commands the reporter pressed.
+DEAD_BUTTONS = (
+    ws_mod.MSG_ADMIN_SKIP,
+    ws_mod.MSG_PAUSE_GAME,
+    ws_mod.MSG_END_GAME,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    ws.close = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+def _handler(game: QuizifyGameState, tmp_path: Path):
+    runtime = _FakeRuntime(tmp_path)
+    handler = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    handler._conn = ConnectionManager(runtime, lambda: game)
+    handler._get_game_state = lambda: game  # type: ignore[assignment]
+    sent: list[dict] = []
+
+    async def _send_error(ws, code, message) -> None:
+        sent.append({"code": code, "message": message})
+
+    handler._conn.send_error = _send_error  # type: ignore[assignment]
+    handler._conn.broadcast = AsyncMock()  # type: ignore[assignment]
+    return handler, sent
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("msg_type", DEAD_BUTTONS)
+async def test_refused_command_does_not_use_the_suppressed_pair(
+    game: QuizifyGameState, tmp_path: Path, msg_type: str
+) -> None:
+    """The refusal must be distinguishable from handshake noise."""
+    handler, sent = _handler(game, tmp_path)
+
+    admin_ws = _ws()
+    handler._conn.add_connection(admin_ws, is_admin=True, is_dashboard=False)
+    game.add_player("Host", admin_ws)
+    game.get_player("Host").is_admin = True
+
+    guest_ws = _ws()
+    handler._conn.add_connection(guest_ws, is_admin=False, is_dashboard=False)
+    game.add_player("Guest", guest_ws)
+
+    await handler._handle_message(guest_ws, {"type": msg_type}, is_admin=False)
+
+    assert sent, f"{msg_type} was refused without telling the client anything"
+    refusal = sent[-1]
+    assert refusal["code"] == ERR_ADMIN_REQUIRED
+    assert not (
+        refusal["code"] == ERR_INVALID_ACTION and refusal["message"] == "Admin only"
+    ), "the refusal is back on the pair the admin page suppresses — #586 again"
+
+
+@pytest.mark.asyncio
+async def test_admin_connect_handshake_keeps_the_quiet_pair(
+    game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """The other half: the pre-auth handshake must stay silent.
+
+    If this one flipped to ADMIN_REQUIRED, every admin page would greet its
+    host with a red toast on load, which is how a well-meant fix turns into a
+    worse bug than the one it cured.
+    """
+    handler, sent = _handler(game, tmp_path)
+    guest_ws = _ws()
+    handler._conn.add_connection(guest_ws, is_admin=False, is_dashboard=False)
+
+    await handler._handle_message(
+        guest_ws, {"type": ws_mod.MSG_ADMIN_CONNECT}, is_admin=False
+    )
+
+    assert sent and sent[-1]["code"] == ERR_INVALID_ACTION
+    assert sent[-1]["message"] == "Admin only"
+
+
+def test_admin_page_suppresses_only_the_handshake_pair() -> None:
+    """Asserted on the source: the filter must name both code and message.
+
+    A filter on the code alone would swallow the refusal again the moment its
+    message changed.
+    """
+    source = ADMIN_JS.read_text(encoding="utf-8")
+    for match in re.finditer(r"msg\.code === 'INVALID_ACTION'", source):
+        window = source[match.start() : match.start() + 120]
+        assert "msg.message === 'Admin only'" in window, (
+            "admin.js suppresses INVALID_ACTION without checking the message — "
+            "a refused command would be swallowed with the handshake again"
+        )
+    # Comments are stripped first: the branch *explains* ADMIN_REQUIRED in
+    # prose, and an assertion that cannot tell prose from code fails on its
+    # own documentation.
+    branch = source.split("case 'error':")[1][:900]
+    code_only = "\n".join(
+        line for line in branch.splitlines() if not line.strip().startswith("//")
+    )
+    assert "ADMIN_REQUIRED" not in code_only, (
+        "the refusal code is being matched in the suppression branch"
+    )
+
+
+@pytest.mark.parametrize("lang", ("de", "en", "es"))
+def test_every_language_can_explain_the_refusal(lang: str) -> None:
+    """An untranslated code would show the raw English wire message."""
+    data = json.loads((I18N_DIR / f"{lang}.json").read_text(encoding="utf-8"))
+    text = data["errors"].get(ERR_ADMIN_REQUIRED, "")
+    assert text.strip(), f"{lang}.json has no wording for {ERR_ADMIN_REQUIRED}"

--- a/tests/test_dispatch_guard_270.py
+++ b/tests/test_dispatch_guard_270.py
@@ -12,9 +12,9 @@ fails loudly:
 
   1. Every admin-required type, when sent by a non-admin connection while
      a legitimate admin holds the crown, is rejected with the EXACT
-     "Admin only" error and never reaches its handler.
+     refusal (code ``ADMIN_REQUIRED``) and never reaches its handler.
   2. A representative non-admin type (``submit_answer``) is NOT gated —
-     a non-admin connection reaches its handler with no "Admin only"
+     a non-admin connection reaches its handler with no refusal
      rejection.
   3. The admin-required set in the live dispatch table matches the pinned
      expectation exactly (catches accidental add/remove/flip).
@@ -152,7 +152,7 @@ async def test_admin_required_type_rejected_for_non_admin(
 ) -> None:
     """Each admin-required type, sent by a non-admin connection while a
     legitimate admin holds the crown, MUST be rejected with the exact
-    "Admin only" error and must not mutate game state behind the guard."""
+    refusal and must not mutate game state behind the guard."""
     h = _handler(game, tmp_path)
     rogue_ws = _seed_with_admin(h, game)
     assert game.phase == GamePhase.LOBBY
@@ -165,7 +165,7 @@ async def test_admin_required_type_rejected_for_non_admin(
 
     errs = h._errors.get(id(rogue_ws), [])  # type: ignore[attr-defined]
     assert errs, f"{msg_type} from non-admin produced no error"
-    assert errs[-1]["message"] == "Admin only", (
+    assert errs[-1]["code"] == "ADMIN_REQUIRED", (
         f"{msg_type} rejected with wrong message: {errs[-1]}"
     )
     # The guard fired before the game advanced out of LOBBY.
@@ -177,7 +177,7 @@ async def test_non_admin_type_not_gated(
     game: QuizifyGameState, tmp_path: Path
 ) -> None:
     """A representative non-admin type (``submit_answer``) must NOT be
-    gated: a non-admin connection reaches the handler with no "Admin only"
+    gated: a non-admin connection reaches the handler with no refusal
     rejection (the centralized guard must not over-reach)."""
     h = _handler(game, tmp_path)
     rogue_ws = _seed_with_admin(h, game)
@@ -189,7 +189,7 @@ async def test_non_admin_type_not_gated(
     )
 
     errs = h._errors.get(id(rogue_ws), [])  # type: ignore[attr-defined]
-    assert all(e["message"] != "Admin only" for e in errs), (
+    assert all(e["code"] != "ADMIN_REQUIRED" for e in errs), (
         f"submit_answer was wrongly admin-gated: {errs}"
     )
 

--- a/tests/test_dispatch_table_363.py
+++ b/tests/test_dispatch_table_363.py
@@ -13,7 +13,7 @@ This must be strictly behaviour-preserving. These tests pin:
   3. ``admin_connect`` / ``reset_game`` are NOT in the table (special paths).
   4. An unknown type is rejected with "Unknown message type" and reaches no
      handler.
-  5. Admin-required types are rejected with "Admin only" for a non-admin
+  5. Admin-required types are rejected with ``ADMIN_REQUIRED`` for a non-admin
      connection and never reach their handler.
 """
 
@@ -209,5 +209,5 @@ async def test_admin_required_rejected_without_admin(
     await h._handle_message(rogue_ws, {"type": msg_type}, is_admin=False)
 
     errs = h._errors.get(id(rogue_ws), [])  # type: ignore[attr-defined]
-    assert errs and errs[-1]["message"] == "Admin only"
+    assert errs and errs[-1]["code"] == "ADMIN_REQUIRED"
     assert all(spy.await_count == 0 for spy in spies.values())

--- a/tests/test_house_config_ws_494.py
+++ b/tests/test_house_config_ws_494.py
@@ -323,7 +323,7 @@ def test_unwired_consumers_are_a_noop(handler) -> None:
 @pytest.mark.asyncio
 async def test_configure_house_is_admin_gated(handler, game) -> None:
     """A non-admin socket must never reconfigure the host's lights: the frame is
-    rejected with "Admin only" and no consumer is touched."""
+    rejected with ``ADMIN_REQUIRED`` and no consumer is touched."""
     admin_ws = _ws()
     handler._conn.add_connection(admin_ws, is_admin=True, is_dashboard=False)
     game.add_player("Host", admin_ws)
@@ -340,7 +340,7 @@ async def test_configure_house_is_admin_gated(handler, game) -> None:
     )
 
     handler._conn.send_error.assert_awaited()
-    assert handler._conn.send_error.await_args.args[2] == "Admin only"
+    assert handler._conn.send_error.await_args.args[1] == "ADMIN_REQUIRED"
     handler._party_lights.configure.assert_not_called()
     handler._sound_effects.configure.assert_not_called()
     handler._event_emitter.configure.assert_not_called()

--- a/tests/test_reset_game_207.py
+++ b/tests/test_reset_game_207.py
@@ -184,7 +184,7 @@ async def test_reset_during_active_game_delivers_to_all_players(
 # auth guard in ``_handle_message`` — which is exactly where the reopened
 # bug lived. Pressing reset routed through ``reset_game`` → the guard
 # rejected the legitimate host → the client silently swallowed the
-# "Admin only" error → nothing happened server-side ("no reset processing
+# refusal → nothing happened server-side ("no reset processing
 # at all"). Root cause: the #209 single-admin invariant compared admin
 # slots by NAME only, so when the host's /admin → /player redirect
 # re-joined under a disambiguated name ("Host 2") while the stale "Host"
@@ -238,7 +238,7 @@ async def test_legit_admin_reset_authorized_and_clears(
 
     assert game.phase == GamePhase.LOBBY
     assert game.get_players() == []
-    # No "Admin only" rejection was sent to the host.
+    # No refusal was sent to the host.
     sent = h._sent  # type: ignore[attr-defined]
     errs = [m for m in sent.get(id(admin_ws), []) if m.get("type") == "error"]
     assert errs == []
@@ -288,7 +288,7 @@ async def test_non_admin_reset_rejected_while_live_admin_present(
 
     sent = h._sent  # type: ignore[attr-defined]
     errs = [m for m in sent.get(id(rogue_ws), []) if m.get("type") == "error"]
-    assert errs and errs[0]["message"] == "Admin only"
+    assert errs and errs[0]["code"] == "ADMIN_REQUIRED"
     # Game untouched: both players still present, crown still on the host.
     assert len(game.get_players()) == 2
     assert game.get_admin() is not None and game.get_admin().name == "Host"


### PR DESCRIPTION
Part of #586 — the half that can be fixed without the reporter's logs.

## What was actually happening

The buttons were not dead and the socket was not broken. The server answered every press with `INVALID_ACTION` / `"Admin only"`. The admin page suppresses **exactly that code-and-message pair**, deliberately, because the pre-authentication `admin_connect` handshake emits it on every page load:

```js
// admin.js, before this PR
if (msg.code === 'INVALID_ACTION' && msg.message === 'Admin only') {
    break;   // expected handshake noise
}
showErrorToast(userMsg);
```

A refused Skip, Pause or Stop produced the same pair, so it went out the same trapdoor. That is the "nothing happens" in the report.

## The change

A refused command now answers a distinct code, `ADMIN_REQUIRED`, which nothing suppresses. The handshake keeps `INVALID_ACTION` / `"Admin only"` and stays quiet. The refusal is also logged server-side, so an install that hits this leaves a trace in the HA log rather than only a puzzled host.

Wording in all three shipped languages — an untranslated code would surface the raw English wire message.

## What this does not do

It does not fix whatever costs that connection its admin role. That cause is still open in #586, waiting on the reporter's version and log lines; guessing at it is what I said I would not do. This makes the symptom legible: *"this window is not the host"* instead of a button that appears broken.

## Tests

A new file pins both halves:

- a refused command must **not** use the suppressed pair — parametrised over the three buttons the reporter actually pressed;
- the handshake must **keep** it. If that flipped, every admin page would greet its host with a red toast on load, which is how a well-meant fix becomes worse than the bug.

Plus a source assertion that the suppression still matches on code *and* message (a code-only filter would swallow the refusal again the moment its message changed), and one that each of `de`/`en`/`es` has wording for the new code.

The existing guard tests asserted on the old message string; they now assert on the code, which is the part that is actually a contract.

`1,968 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqxJDAoSf3tmGciz8ZtfTL