### PR TITLE
fix(#600,#601,#602): settle team rounds on one clock, once, including estimates

### DIFF
--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -45,7 +45,7 @@ from .scoring import (
     calculate_podium,
 )
 from .scoring_engine import ScoringEngine
-from .team import ANSWER_CHANGE_LOCK_SECONDS, TeamRegistry
+from .team import ANSWER_CHANGE_LOCK_SECONDS, Team, TeamRegistry
 from .timer import QuestionTimer
 from .types import TIME_LIMITS, Difficulty
 
@@ -959,7 +959,16 @@ class QuizifyGameState:
         # Route through the guarded `evaluate_round()` (not directly to
         # `_do_evaluate_round`) so the `_round_summary is not None` check
         # closes the race with the timer-expiry path. (#143 in code review.)
-        if self._player_registry.all_submitted():
+        #
+        # NOT during team settlement (#601). `_settle_team_answers` calls this
+        # method once per team while the round is already being evaluated, and
+        # `_round_summary` is not set until that evaluation finishes — so the
+        # guard inside `evaluate_round()` is still open and the round would
+        # re-enter `_do_evaluate_round` from the middle of its own settlement
+        # loop. Measured consequence: a team scored twice for one round and
+        # its history grew three entries. The settlement caller evaluates the
+        # round itself; it never needs this path.
+        if not _settling_team and self._player_registry.all_submitted():
             self.evaluate_round()
 
         return result
@@ -1005,13 +1014,32 @@ class QuizifyGameState:
         q_max = question.estimate_max if question.estimate_max is not None else guess
         clamped = max(q_min, min(q_max, float(guess)))
 
+        # Team mode (#602): the guess belongs to the *team*, exactly as a tap
+        # does on a multiple-choice round. Nobody is marked submitted here —
+        # every member may keep re-guessing until the clock stops, and the
+        # number standing then is the one that scores, once, in
+        # `_settle_team_guesses`. Before this, estimate rounds ignored teams
+        # completely: the points landed on the member's individual score,
+        # which is invisible in team mode, and the team finished on zero.
+        team = self._team_registry.get_by_member(player.name)
+        if team is not None:
+            if not team.set_guess(clamped, player.name):
+                return ERR_TEAM_LOCKED
+            self._notify_state_callbacks()
+            return None
+
         elapsed = timer.get_elapsed() if timer else 0.0
         player.current_guess = clamped
         player.submitted = True
         player.submission_time = time.time()
         player.last_elapsed = elapsed
 
-        if self._player_registry.all_submitted():
+        # `state.all_submitted()`, not the registry directly (#602): the public
+        # accessor is the one that knows a team round always runs to the clock.
+        # Reaching past it ended estimate rounds on the first guess from each
+        # member, so the "the answer standing at the buzzer counts" rule did
+        # not apply to estimates either.
+        if self.all_submitted():
             self.evaluate_round()
 
         return None
@@ -1024,6 +1052,37 @@ class QuizifyGameState:
         if self._round_summary is not None:
             return self._round_summary
         return self._do_evaluate_round()
+
+    def _pick_team_carrier(
+        self, team: Team, setter: str | None
+    ) -> PlayerSession | None:
+        """The member who carries a team's response into the scoring path.
+
+        Normally the member who set it. If they left between the tap and the
+        buzzer the response still stands for the team, so it is handed to
+        another member rather than dropping a round the team did answer.
+
+        Connected members are preferred over disconnected ones (#601). The
+        earlier version took the first member who had not submitted, which
+        could be someone whose phone had simply locked — and during the
+        re-entrant evaluation that bug allowed, handing the answer to that
+        member scored the same round a second time.
+        """
+        player = self._player_registry.get_player(setter) if setter else None
+        if player is not None and not player.submitted:
+            return player
+        candidates = [
+            p
+            for name in team.members
+            if (p := self._player_registry.get_player(name)) is not None
+            and not p.submitted
+        ]
+        if not candidates:
+            return None
+        # Fall back to a disconnected member only when nobody is left online:
+        # the team did answer, and losing the round because every phone went
+        # dark would punish the wrong thing.
+        return next((p for p in candidates if p.connected), candidates[0])
 
     def _settle_team_answers(self) -> None:
         """Score each team's standing answer once, through the player path.
@@ -1045,20 +1104,7 @@ class QuizifyGameState:
                 team.round_scores.append(0)
                 team.rounds_played += 1
                 continue
-            player = self._player_registry.get_player(team.answer_by)
-            if player is None or player.submitted:
-                # The setter left the game between the tap and the buzzer. The
-                # answer still stands for the team, so hand it to any remaining
-                # member rather than dropping a round the team did answer.
-                player = next(
-                    (
-                        p
-                        for name in team.members
-                        if (p := self._player_registry.get_player(name)) is not None
-                        and not p.submitted
-                    ),
-                    None,
-                )
+            player = self._pick_team_carrier(team, team.answer_by)
             if player is None:
                 team.streak = 0
                 team.round_history.append("timeout")
@@ -1097,6 +1143,88 @@ class QuizifyGameState:
                         team.hard_score += result.points_earned
                 if team.streak > team.max_streak:
                     team.max_streak = team.streak
+
+    def _settle_team_guesses(self) -> dict[str, str]:
+        """Hand each team's standing guess to the member who set it (#602).
+
+        The estimate path ranks *participants* by closeness to the true value.
+        In team mode the participant is the team — so rather than teach
+        ``calculate_estimate_scores`` about teams, the team's guess is carried
+        into the ranking by one of its members, the same shape
+        ``_settle_team_answers`` uses for multiple choice. The ranking then
+        contains one entry per team plus any solo players, and the scoring
+        function needs no change at all.
+
+        Returns ``{team_id: carrier_name}`` so the results can be copied back
+        onto the teams once the per-player pass has run.
+        """
+        round_started = self._round_start_time or 0.0
+        carriers: dict[str, str] = {}
+        for team in self._team_registry.all_teams():
+            if team.current_guess is None or team.guess_by is None:
+                continue
+            player = self._pick_team_carrier(team, team.guess_by)
+            if player is None:
+                continue
+            player.current_guess = team.current_guess
+            player.submitted = True
+            player.submission_time = time.time()
+            player.last_elapsed = max(
+                0.0, (team.guessed_at or round_started) - round_started
+            )
+            carriers[team.team_id] = player.name
+        return carriers
+
+    def _apply_estimate_results_to_teams(
+        self, carriers: dict[str, str], scores: dict[str, dict]
+    ) -> None:
+        """Copy each carrier's estimate result onto their team (#602).
+
+        The mirror of the bookkeeping block in ``_settle_team_answers``: the
+        team takes the points, the streak, the history entry and the award
+        tallies, in the same shape a player keeps them, so the awards can be
+        computed by the same code. A team that never guessed records a
+        timeout, which is what a missed round looks like everywhere else.
+        """
+        for team in self._team_registry.all_teams():
+            carrier_name = carriers.get(team.team_id)
+            player = (
+                self._player_registry.get_player(carrier_name)
+                if carrier_name
+                else None
+            )
+            entry = scores.get(carrier_name) if carrier_name else None
+            if player is None or entry is None:
+                team.streak = 0
+                team.round_history.append("timeout")
+                team.round_scores.append(0)
+                team.rounds_played += 1
+                continue
+
+            points = player.round_score
+            exact = bool(entry["exact"])
+            team.score += points
+            if team.score < 0:
+                team.score = 0
+            # Streak only advances on an exact hit, matching the per-player
+            # rule (#408) — a near miss is recorded as "wrong", and growing a
+            # streak on it would step past a milestone that was never paid.
+            team.streak = team.streak + 1 if exact else 0
+            if team.streak > team.max_streak:
+                team.max_streak = team.streak
+            team.last_answer_correct = exact
+            team.last_elapsed = player.last_elapsed
+            team.round_score = points
+            team.round_score_breakdown = dict(player.round_score_breakdown)
+            team.round_history.append("correct" if exact else "wrong")
+            team.round_scores.append(points)
+            team.rounds_played += 1
+            if exact:
+                team.answer_times.append(player.last_elapsed)
+                if (question := self._current_question) is not None and (
+                    question.difficulty == Difficulty.HARD.value
+                ):
+                    team.hard_score += points
 
     def _collect_team_powerup_stats(self) -> None:
         """Roll each team's members' power-up usage up to the team (#365).
@@ -1286,6 +1414,11 @@ class QuizifyGameState:
         except ValueError:
             diff_enum = Difficulty.MEDIUM
 
+        # Team mode (#602): settle each team's standing guess onto a member
+        # before the ranking is built, so the ranking sees one entry per team
+        # (plus any solo players) instead of every individual member.
+        carriers = self._settle_team_guesses() if self.team_mode else {}
+
         guesses: dict[str, float] = {
             p.name: p.current_guess
             for p in self._player_registry.players.values()
@@ -1342,6 +1475,9 @@ class QuizifyGameState:
                 )
                 player.round_scores.append(points)
             player.rounds_played += 1
+
+        if self.team_mode:
+            self._apply_estimate_results_to_teams(carriers, scores)
 
         # Build per-player results (connected only).
         results: list[AnswerResult] = []

--- a/custom_components/quizify/game/team.py
+++ b/custom_components/quizify/game/team.py
@@ -53,9 +53,18 @@ class Team:
     current_answer: int | None = None
     #: Member who set the answer that currently stands.
     answer_by: str | None = None
-    #: Wall-clock of the last change, used for the lock and for the speed
-    #: bonus — the bonus keys on the *last* tap, so thinking is not free.
+    #: ``time.monotonic()`` of the last change, used for the lock and for the
+    #: speed bonus — the bonus keys on the *last* tap, so thinking is not free.
+    #: MUST stay on the same clock as ``PhaseController.round_start_time``
+    #: (#600): the speed bonus is ``answered_at - round_start_time``, and a
+    #: wall clock here made that difference the seconds since 1970.
     answered_at: float | None = None
+    #: The team's standing guess for an estimate round, and who set it (#602).
+    #: Same rules as ``current_answer``: any member may change it until the
+    #: clock stops, the last change counts, and the change lock applies.
+    current_guess: float | None = None
+    guess_by: str | None = None
+    guessed_at: float | None = None
     #: How often the answer changed this round. Kept for diagnostics; the
     #: reveal screen deliberately does not show it (Markus, 2026-08-12).
     change_count: int = 0
@@ -124,14 +133,14 @@ class Team:
         """False while the post-change lock is still running."""
         if self.answered_at is None:
             return True
-        now = time.time() if now is None else now
+        now = time.monotonic() if now is None else now
         return (now - self.answered_at) >= ANSWER_CHANGE_LOCK_SECONDS
 
     def lock_remaining(self, now: float | None = None) -> float:
         """Seconds left on the lock, 0 when the answer may be changed."""
         if self.answered_at is None:
             return 0.0
-        now = time.time() if now is None else now
+        now = time.monotonic() if now is None else now
         return max(0.0, ANSWER_CHANGE_LOCK_SECONDS - (now - self.answered_at))
 
     def set_answer(
@@ -142,7 +151,7 @@ class Team:
         Re-tapping the answer that already stands is accepted as a no-op: a
         member confirming the current choice should never be told to wait.
         """
-        now = time.time() if now is None else now
+        now = time.monotonic() if now is None else now
         if self.current_answer == answer_index and self.answer_by is not None:
             return True
         if not self.can_change_answer(now):
@@ -154,11 +163,41 @@ class Team:
         self.answered_at = now
         return True
 
+    def set_guess(
+        self, guess: float, by_player: str, now: float | None = None
+    ) -> bool:
+        """Set the team's guess for an estimate round (#602).
+
+        The mirror of ``set_answer``: any member may re-guess until the clock
+        stops, the last guess is the one that scores, and the same lock stops
+        two members from flipping the number back and forth. Returns False
+        while the lock is running.
+
+        The lock reads ``answered_at``, which both setters share — a team has
+        one standing response per round whatever its shape, so a guess and an
+        answer must not be able to dodge each other's brake.
+        """
+        now = time.monotonic() if now is None else now
+        if self.current_guess == guess and self.guess_by is not None:
+            return True
+        if not self.can_change_answer(now):
+            return False
+        if self.current_guess is not None:
+            self.change_count += 1
+        self.current_guess = guess
+        self.guess_by = by_player
+        self.guessed_at = now
+        self.answered_at = now
+        return True
+
     def reset_round(self) -> None:
         """Clear the per-round answer state before the next question."""
         self.current_answer = None
         self.answer_by = None
         self.answered_at = None
+        self.current_guess = None
+        self.guess_by = None
+        self.guessed_at = None
         self.change_count = 0
         self.round_score = 0
         self.last_answer_correct = False

--- a/tests/test_team_scoring_365.py
+++ b/tests/test_team_scoring_365.py
@@ -81,7 +81,7 @@ def test_a_tap_sets_the_team_answer_and_scores_nobody_yet(
 
 def test_a_teammate_can_overwrite_the_answer(game: QuizifyGameState) -> None:
     game.submit_answer("Anna", 0)
-    _team(game).answered_at = time.time() - 5  # let the lock run out
+    _team(game).answered_at = time.monotonic() - 5  # let the lock run out
 
     assert isinstance(game.submit_answer("Jan", 2), TeamAnswerAck)
     assert _team(game).current_answer == 2
@@ -144,13 +144,13 @@ def test_the_speed_bonus_follows_the_last_tap(game: QuizifyGameState) -> None:
     correct = _correct_index(game)
     game.submit_answer("Anna", correct)
     team = _team(game)
-    team.answered_at = (game._round_start_time or time.time()) + 0.1
+    team.answered_at = (game._round_start_time or time.monotonic()) + 0.1
     game.evaluate_round()
     fast_points = team.score
 
     game.start_next_question()
     game.submit_answer("Anna", _correct_index(game))
-    team.answered_at = (game._round_start_time or time.time()) + 15.0
+    team.answered_at = (game._round_start_time or time.monotonic()) + 15.0
     before = team.score
     game.evaluate_round()
     slow_points = team.score - before

--- a/tests/test_team_settlement_regressions_600_602.py
+++ b/tests/test_team_settlement_regressions_600_602.py
@@ -1,0 +1,213 @@
+"""The three team-settlement defects found on 2026-08-22 (#600, #601, #602).
+
+All three sat in the same place — the moment a round closes and a team's
+standing response is turned into a score — and all three survived a 1968-test
+suite because the existing tests set the clock and the connection state by
+hand. These tests deliberately do not: they tap through the real entry points
+and let the production defaults stand.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from custom_components.quizify.game.state import QuizifyGameState
+
+
+def _ws(closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    return ws
+
+
+class _Runtime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+    def create_task(self, coro):  # noqa: ANN001
+        import asyncio
+
+        return asyncio.ensure_future(coro)
+
+
+def _game(tmp_path: Path, category: str, members: tuple[str, ...] = ("Anna", "Jan"),
+          solo: tuple[str, ...] = ("Mira",)) -> QuizifyGameState:
+    st = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="test")
+    for name in (*members, *solo):
+        st.add_player(name, _ws())
+    st.create_team("Sofa", members[0])
+    for name in members[1:]:
+        st.join_team(st.get_team_of(members[0])["team_id"], name)
+    st.start_game(category=category, difficulty="easy", num_rounds=3, language="en")
+    st.start_next_question()
+    return st
+
+
+def _team(game: QuizifyGameState):  # noqa: ANN202
+    return game.team_registry.all_teams()[0]
+
+
+def _correct_index(game: QuizifyGameState) -> int:
+    q = game.get_current_question()
+    return next(i for i, a in enumerate(q.answers) if a.correct)
+
+
+# --------------------------------------------------------------------------
+# #600 — the two clocks
+# --------------------------------------------------------------------------
+
+
+def test_a_real_tap_produces_an_elapsed_a_human_could_have_taken(
+    tmp_path: Path,
+) -> None:
+    """The regression itself: no hand-set timestamp, just a tap.
+
+    `Team.set_answer` used a wall clock while the round start was monotonic,
+    so this subtraction returned the seconds since 1970 — about 1.79e9. Any
+    assertion loose enough to pass then would have been useless, so this pins
+    the only thing that matters: the elapsed time of a tap must be a number of
+    seconds from *this round*.
+    """
+    game = _game(tmp_path, "picture-round-en")
+    game.submit_answer("Anna", _correct_index(game))
+    game.evaluate_round()
+
+    assert 0.0 <= _team(game).last_elapsed < 60.0
+
+
+def test_the_team_speed_bonus_is_actually_paid(tmp_path: Path) -> None:
+    """With both clocks agreeing, a fast team answer earns a speed bonus.
+
+    Before the fix every team answer was scored as maximally slow, so the
+    documented "the last tap costs you speed" rule was inert in production
+    even though a test pinned it — that test supplied its own timestamp.
+    """
+    game = _game(tmp_path, "picture-round-en")
+    game.submit_answer("Anna", _correct_index(game))
+    game.evaluate_round()
+
+    assert _team(game).round_score_breakdown["speed_bonus"] > 0
+
+
+# --------------------------------------------------------------------------
+# #601 — re-entrant evaluation
+# --------------------------------------------------------------------------
+
+
+def test_a_locked_phone_does_not_score_the_round_twice(tmp_path: Path) -> None:
+    """One round, one score — even when a teammate's socket is closed.
+
+    The settlement path called `submit_answer`, which then found every active
+    player submitted and re-entered `evaluate_round()` from inside the
+    settlement loop. Measured before the fix: three evaluations, 22 points for
+    an 11-point round, and a three-entry history.
+    """
+    game = _game(tmp_path, "picture-round-en", solo=())
+    # Jan's phone locked: his socket is closed, so he is not "active" — which
+    # is what let the all-submitted check pass mid-settlement.
+    game.get_player("Jan").ws = _ws(closed=True)
+    game.get_player("Jan").connected = False
+
+    game.submit_answer("Anna", _correct_index(game))
+    game.evaluate_round()
+
+    team = _team(game)
+    # Measured on the unfixed code, for exactly this setup:
+    # rounds_played=3, history=['timeout', 'correct', 'correct'], score=22
+    # for an 11-point round.
+    assert team.rounds_played == 1
+    assert len(team.round_history) == 1
+    assert team.round_scores == [team.round_score]
+    assert team.score == team.round_score
+
+
+def test_the_solo_players_do_not_double_their_history(tmp_path: Path) -> None:
+    """The other shape of the same defect: a one-member team plus solo players.
+
+    Everyone else had already answered, so settling the team tripped the
+    all-submitted check and the whole round was evaluated a second time —
+    doubling `round_history` and `rounds_played` for every player in the game.
+    """
+    game = _game(tmp_path, "picture-round-en", members=("Anna",), solo=("Mira",))
+    correct = _correct_index(game)
+    game.submit_answer("Mira", correct)
+    game.submit_answer("Anna", correct)
+    game.evaluate_round()
+
+    assert len(game.get_player("Mira").round_history) == 1
+    assert game.get_player("Mira").rounds_played == 1
+    assert _team(game).rounds_played == 1
+
+
+# --------------------------------------------------------------------------
+# #602 — estimate rounds in team mode
+# --------------------------------------------------------------------------
+
+
+def test_a_team_scores_its_estimate_guess(tmp_path: Path) -> None:
+    """The team, not the invisible individual score, takes the points.
+
+    Before the fix `_evaluate_estimate_round` had no team branch at all: the
+    points landed on the member's own score, the team finished the round on
+    zero, and the solo player won a round the team had won.
+    """
+    game = _game(tmp_path, "estimation-en")
+    answer = game.get_current_question().estimate_answer
+
+    game.submit_guess("Anna", answer)        # exact
+    game.submit_guess("Mira", answer * 0.5)  # far off
+    game.evaluate_round()
+
+    team = _team(game)
+    assert team.score > 0
+    assert team.rounds_played == 1
+    assert team.round_history == ["correct"]
+    assert team.score > game.get_player("Mira").score
+
+
+def test_an_estimate_round_in_team_mode_runs_to_the_clock(tmp_path: Path) -> None:
+    """Guessing does not end the round early for a team.
+
+    `submit_guess` reached past `state.all_submitted()` into the registry,
+    which does not know the team rule, so the round closed the moment each
+    member had guessed once — leaving nothing to re-decide.
+    """
+    game = _game(tmp_path, "estimation-en")
+    answer = game.get_current_question().estimate_answer
+
+    game.submit_guess("Anna", answer)
+    game.submit_guess("Jan", answer)
+    game.submit_guess("Mira", answer)
+
+    assert game.get_round_summary() is None, "the round must still be open"
+
+
+def test_the_last_guess_is_the_one_that_counts(tmp_path: Path) -> None:
+    """A team's guess behaves like its answer: any member may change it."""
+    game = _game(tmp_path, "estimation-en")
+    answer = game.get_current_question().estimate_answer
+
+    game.submit_guess("Anna", answer * 0.5)
+    _team(game).answered_at = time.monotonic() - 5  # let the change lock run out
+    game.submit_guess("Jan", answer)
+
+    team = _team(game)
+    assert team.current_guess == answer
+    assert team.guess_by == "Jan"
+
+
+def test_a_team_that_never_guessed_records_a_timeout(tmp_path: Path) -> None:
+    """A missed estimate round looks like every other missed round."""
+    game = _game(tmp_path, "estimation-en")
+    game.submit_guess("Mira", game.get_current_question().estimate_answer)
+    game.evaluate_round()
+
+    team = _team(game)
+    assert team.round_history == ["timeout"]
+    assert team.rounds_played == 1
+    assert team.score == 0


### PR DESCRIPTION
Fixes #600, #601, #602 — three defects in the same place: the moment a round closes and a team's standing response becomes a score.

They shared a cause. That path was never exercised with production clocks, with a team whose other member had gone quiet, or with an estimate question — and the existing tests hand-set exactly the values that would have exposed it.

## #600 — two clocks

`Team.set_answer` stamped `time.time()`; `PhaseController.begin_round` stamps `time.monotonic()`. `_settle_team_answers` subtracted one from the other:

```
elapsed = 1,785,951,498.8 s
```

Consequences, all silent:

- **The team speed bonus has never been paid.** Every team answer scored as maximally slow.
- **`question_stats.json` has been accumulating garbage** since team mode shipped — the value flows through `carrier.last_elapsed` into `record_round`, so `total_time_correct` holds ~57-year averages. Those numbers are not recoverable; the file may be worth resetting.
- "Fastest Finger" in team mode read the same value.

The three `Team` methods that touch the clock now use `time.monotonic()`. They only ever compare `answered_at` against itself (the change lock) or against the round start, so moving the whole set keeps the lock working and puts the subtraction on one clock. The field comment now states the constraint rather than leaving it to be rediscovered.

**One edge case worth stating rather than hiding:** `round_start_time` is pushed forward on resume to discount a pause. A team answer set *before* a pause therefore lands before the adjusted start and clamps to `elapsed = 0`, i.e. a full speed bonus. That is the pre-existing `max(0.0, …)` behaviour and it is generous in the player's favour; fixing it properly means giving the team its own timer, which is a larger change than these three bugs.

## #601 — re-entrant evaluation

`submit_answer` ran its all-submitted auto-evaluate even when `_settle_team_answers` called it, and `_round_summary` is not set until that evaluation returns — so the guard inside `evaluate_round()` was still open and the round re-entered its own settlement loop.

Reproduced on a two-member team whose other member had a closed socket (a locked phone is enough):

```
_do_evaluate_round × 3
team.score = 22          # for an 11-point round
team.round_history = ['timeout', 'correct', 'correct']
team.rounds_played = 3
```

Beyond the score: doubled `question_stats` shown-counts, the calibrator fed twice, and `round_evaluated` broadcast twice.

The auto-evaluate is now skipped during settlement. The carrier lookup was also extracted and now prefers connected members — taking the first member who had merely not *submitted* is what let the re-entrant pass hand the answer to the disconnected member and score it again. A disconnected member is still used when nobody is left online, because the team did answer and losing the round to a dark room punishes the wrong thing.

## #602 — estimate rounds ignored team mode entirely

`_evaluate_estimate_round` had no team branch. The points landed on the member's individual score, which is invisible in team mode, and the team finished the round on zero — so the solo player won rounds the team had won:

```
team "Sofa"  score=0  round_history=[]  rounds_played=0
final ranking: [('Sofa', 0), ('Mira', 24)]
```

Since #566 almost every shipped pack carries five estimate questions, and `estimation-en` / `schaetzfragen-de` are entirely estimate, so a mixed team game hit this within a few rounds.

The fix mirrors the multiple-choice design rather than inventing a second one: a team now holds a standing guess with the same "any member may change it, the last one counts, the same lock applies" rule, and `_settle_team_guesses` carries it into the ranking on behalf of one member. `calculate_estimate_scores` is untouched — it simply sees one entry per team plus any solo players.

`submit_guess` also reached past `state.all_submitted()` into the registry, which does not know the team rule, so estimate rounds ended the moment each member had guessed once instead of running to the clock. Fixed in the same place.

**Deliberately not in this PR:** the other members' screens do not yet show the team's standing guess the way they show its standing answer. The scoring is correct; the shared-visibility UI for estimates is a separate piece of work and I did not want to bury it in a bug fix.

## Tests

Eight new regressions in `tests/test_team_settlement_regressions_600_602.py`. Each was run against the unfixed code first — **8 failed, 8 pass after** — so they pin the defects rather than the implementation.

Three existing tests in `test_team_scoring_365.py` had to change, and that is the part worth reading. They set `answered_at` by hand:

```python
team.answered_at = (game._round_start_time or time.time()) + 0.1
```

That fixture supplied a monotonic-based timestamp production never produced. `test_the_speed_bonus_follows_the_last_tap` therefore passed for a year while the rule it pins did not work in a single real game. The new tests tap through the real entry points and leave the production defaults standing.

**Related but not touched:** `lightning.py` has the same `answered_at` + wall-clock pattern. It is currently harmless because it never subtracts that value from its monotonic `_question_start` — but it is one line away from the same bug.

Ruff clean, suite **1976** (1968 + 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018uGUzVsEseQjvLR8sgpofU
