### PR TITLE
fix(#607): declare the HA minimum the code actually needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Turn any gathering into a trivia battle. Players scan, questions fly, everyone competes. No app needed.
 
-[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2024.1+-41BDF5?style=for-the-badge&logo=homeassistant&logoColor=white)](https://www.home-assistant.io/)
+[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2024.12+-41BDF5?style=for-the-badge&logo=homeassistant&logoColor=white)](https://www.home-assistant.io/)
 [![Version](https://img.shields.io/github/v/release/mholzi/quizify?style=for-the-badge&color=ff00ff&label=Version)](https://github.com/mholzi/quizify/releases)
 [![License](https://img.shields.io/badge/License-MIT-green?style=for-the-badge)](LICENSE)
 
@@ -443,7 +443,7 @@ That's it. No mDNS, no broadcast, no additional ports.
 ## Technical Details
 
 ### Requirements
-- **Home Assistant** 2024.1+
+- **Home Assistant** 2024.12+
 - **HACS** (recommended) or manual installation
 - A device with a browser for the admin / TV view; phones for players
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,1 +1,1 @@
-{"name": "Quizify", "render_readme": true, "homeassistant": "2024.1.0"}
+{"name": "Quizify", "render_readme": true, "homeassistant": "2024.12.0"}

--- a/tests/test_declared_ha_floor_607.py
+++ b/tests/test_declared_ha_floor_607.py
@@ -1,0 +1,61 @@
+"""The declared HA minimum must not drift below what the code actually needs (#607).
+
+`hacs.json` is metadata: nothing in the suite executes it, and CI runs against a
+current core, so a floor that is too low stays green forever while breaking every
+install below it. This test is the only thing standing between that field and an
+`ImportError` on a stranger's machine.
+
+The three features that set the floor, each verified against the source when this
+test was written:
+
+* ``ConfigFlowResult`` imported from ``homeassistant.config_entries``  (HA 2024.4)
+* ``StaticPathConfig`` / ``async_register_static_paths``               (HA 2024.6)
+* the automatic ``OptionsFlow.config_entry`` property, which
+  ``QuizifyOptionsFlow`` relies on instead of stashing the entry itself (HA 2024.11/12)
+
+The declared floor is deliberately rounded up to 2024.12.0 rather than shaved to
+the last version that happens to work. If you lower it, one of the three above has
+to be gone from the code first.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DECLARED_FLOOR = (2024, 12, 0)
+
+
+def _version_tuple(value: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in value.split("."))
+
+
+def test_hacs_json_declares_the_real_minimum() -> None:
+    """HACS shows this number to users before they install."""
+    hacs = json.loads((REPO_ROOT / "hacs.json").read_text())
+    assert _version_tuple(hacs["homeassistant"]) >= DECLARED_FLOOR
+
+
+def test_readme_agrees_with_hacs_json() -> None:
+    """Two places state the requirement; a reader who hits the stale one is misled."""
+    hacs = json.loads((REPO_ROOT / "hacs.json").read_text())
+    major, minor, _ = _version_tuple(hacs["homeassistant"])
+    readme = (REPO_ROOT / "README.md").read_text()
+    assert f"**Home Assistant** {major}.{minor}+" in readme
+    assert f"Home%20Assistant-{major}.{minor}+-" in readme
+
+
+def test_the_options_flow_still_leans_on_the_automatic_property() -> None:
+    """Pins the reason for the floor, not just the number.
+
+    ``QuizifyOptionsFlow`` never assigns ``self.config_entry``; it reads the
+    property HA provides. That is the newest requirement of the three, so if this
+    ever changes the floor is worth re-deriving.
+    """
+    source = (
+        REPO_ROOT / "custom_components" / "quizify" / "config_flow.py"
+    ).read_text()
+    class_body = source.split("class QuizifyOptionsFlow")[1]
+    assert "self.config_entry =" not in class_body
+    assert "self.config_entry" in class_body


### PR DESCRIPTION
Closes #607.

## The problem

`hacs.json` advertised `2024.1.0`. Since the HACS default listing on 2026-08-01, anyone on an older core can install Quizify because the metadata told them it would work, and then hit an import error with no explanation.

## What sets the real floor

| Code | Needs |
|---|---|
| `config_flow.py` imports `ConfigFlowResult` | HA 2024.4 |
| `__init__.py` uses `StaticPathConfig` / `async_register_static_paths` | HA 2024.6 |
| `QuizifyOptionsFlow` reads the automatic `OptionsFlow.config_entry` property instead of stashing the entry | HA 2024.11/12 |

All three verified against the source. The declared floor is **2024.12.0**, rounded up deliberately rather than shaved to the last version that happens to work: the third requirement is the one I could not date precisely offline, and being one release conservative costs nothing to anybody running a core from this decade.

## Why CI never caught it

The suite runs against a current core, so every import and attribute exists. 1979 green tests say nothing about a number no test reads.

## Changes

- `hacs.json`: `2024.1.0` → `2024.12.0`
- `README.md`: badge and requirement line said `2024.1+`, now agree with `hacs.json`
- `tests/test_declared_ha_floor_607.py`: pins the floor, pins README-vs-`hacs.json` agreement, and pins the *reason* (that the options flow still leans on the automatic property, the newest of the three requirements)

Both metadata tests were run against the unfixed `hacs.json` first: 2 failed, then green.

Suite 1979, `ruff check` clean.