### PR TITLE
fix(#606): register the Quizify routes once, resolve the WS handler per call

### DIFF
--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -22,6 +22,38 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[str] = ["sensor", "binary_sensor"]
 
+# Marks that this HA process has already put Quizify's routes on the aiohttp
+# router. Deliberately NOT stored under hass.data[DOMAIN]: that key is popped on
+# unload, while the routes stay on the router forever (see #606 and the comment
+# in async_setup_entry).
+ROUTES_REGISTERED_KEY = f"{DOMAIN}_routes_registered"
+
+
+def _ws_dispatch(hass: HomeAssistant):
+    """Return a WebSocket route handler that resolves the live handler per call.
+
+    The route object is created once and outlives every reload, so it must not
+    close over a handler instance — that is precisely the bug in #606. It looks
+    the current handler up in ``hass.data`` at call time instead, the same shape
+    the ``game_state_provider`` lambda already uses for the game.
+
+    While the integration is unloaded, ``hass.data[DOMAIN]`` is gone and the
+    route answers 503 rather than raising: the path stays registered whether or
+    not Quizify is set up, so "not set up right now" is a normal state and needs
+    an honest status code.
+    """
+
+    async def dispatch(request):
+        from aiohttp import web  # noqa: PLC0415
+
+        handler = (hass.data.get(DOMAIN) or {}).get("ws_handler")
+        if handler is None:
+            _LOGGER.debug("WebSocket request while Quizify is not set up")
+            return web.Response(status=503, text="Quizify is not set up")
+        return await handler.handle(request)
+
+    return dispatch
+
 
 def _wire_house_consumers(
     ws_handler: object, party_lights: object, sound_effects: object
@@ -202,18 +234,34 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # request handlers in server.views can read it via request.app.
     hass.http.app[APP_CTX_KEY] = ctx
 
-    # Register routes directly on HA's aiohttp router (no HomeAssistantView
-    # needed — the handlers don't require HA auth).
-    register_routes(hass.http.app.router)
-
-    # Register WebSocket endpoint.
-    hass.http.app.router.add_get(WS_PATH, ws_handler.handle)
-
-    # Register static file paths via HA's helper so it does the right thing
-    # for the frontend resource version stamp.
-    await hass.http.async_register_static_paths(
-        [StaticPathConfig(STATIC_URL_PREFIX, str(WWW_DIR), cache_headers=True)]
-    )
+    # Routes are registered ONCE per HA process, not once per setup (#606).
+    #
+    # aiohttp normally freezes its router at startup and a second add_get()
+    # would raise — but HA deliberately un-freezes it
+    # (homeassistant/components/http/__init__.py: `self.app._router.freeze =
+    # lambda: None`), so a duplicate registration silently succeeds instead.
+    # UrlDispatcher.resolve() then matches in *registration order*, which means
+    # the handler bound during the FIRST setup keeps serving forever. After a
+    # reload — the Integrations "Reload" button, and every HACS update — new
+    # sockets reached the previous QuizifyWebSocketHandler while the game
+    # broadcast callback pointed at the new one, whose connection manager holds
+    # zero sockets. Every state broadcast went nowhere and the game looked hung.
+    #
+    # The plain HTTP views survived that because they read APP_CTX_KEY per
+    # request (refreshed just above), which is exactly what made the failure
+    # look like a game bug rather than a routing bug.
+    if not hass.data.get(ROUTES_REGISTERED_KEY):
+        register_routes(hass.http.app.router)
+        hass.http.app.router.add_get(WS_PATH, _ws_dispatch(hass))
+        await hass.http.async_register_static_paths(
+            [StaticPathConfig(STATIC_URL_PREFIX, str(WWW_DIR), cache_headers=True)]
+        )
+        hass.data[ROUTES_REGISTERED_KEY] = True
+        _LOGGER.debug("Quizify routes registered (once per HA process)")
+    else:
+        _LOGGER.debug(
+            "Quizify routes already registered; reusing them with the new handler"
+        )
 
     # Keep the live manifest version (the asset cache-buster source) fresh OFF
     # the event loop (#343). The launcher/HTML serve path reads a pure

--- a/tests/test_ws_route_survives_reload_606.py
+++ b/tests/test_ws_route_survives_reload_606.py
@@ -1,0 +1,186 @@
+"""A reload must leave the *current* WebSocket handler in charge (issue #606).
+
+``async_setup_entry`` used to call ``router.add_get(WS_PATH, ws_handler.handle)``
+on every setup with no guard. aiohttp normally freezes its router at startup so
+a second registration would raise, but HA un-freezes it on purpose
+(``homeassistant/components/http/__init__.py``: ``self.app._router.freeze =
+lambda: None``), so the duplicate quietly succeeded. ``UrlDispatcher.resolve()``
+matches in registration order, so the handler bound during the *first* setup
+kept serving every socket forever, while ``game_state.set_broadcast_callback``
+pointed at the new one — whose connection manager holds zero sockets. Every
+broadcast went nowhere and the game looked hung, which is the same shape users
+report in #586.
+
+The trigger is any unload followed by a setup: the Integrations "Reload" button,
+and every HACS update.
+
+These tests drive the real config-entries state machine and inspect the real
+aiohttp router, because the bug lived in the interaction between the two. They
+were run against the unfixed code first, where both fail.
+
+Not the same thing as the documented "an rsync of changed Python needs a full HA
+restart" rule: that one is about ``sys.modules`` holding old modules. This one
+bites with completely unchanged code.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("homeassistant")
+pytest.importorskip("pytest_homeassistant_custom_component")
+
+from homeassistant.core import HomeAssistant  # noqa: E402
+from homeassistant.setup import async_setup_component  # noqa: E402
+from pytest_homeassistant_custom_component.common import (  # noqa: E402
+    MockConfigEntry,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.const import DOMAIN  # noqa: E402
+from custom_components.quizify.server import WS_PATH  # noqa: E402
+
+pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+
+@pytest.fixture(autouse=True)
+def _stub_frontend_panel():
+    """Patch the frontend panel helpers (same harness as #313 / #328)."""
+    panels: dict = {}
+
+    def _register_panel(_hass, *, frontend_url_path, **_kw):
+        panels[frontend_url_path] = True
+
+    def _remove_panel(_hass, path):
+        if path not in panels:
+            raise KeyError(path)
+        del panels[path]
+
+    with (
+        patch(
+            "homeassistant.components.frontend.async_register_built_in_panel",
+            side_effect=_register_panel,
+        ),
+        patch(
+            "homeassistant.components.frontend.async_remove_panel",
+            side_effect=_remove_panel,
+        ),
+    ):
+        yield panels
+
+
+@pytest.fixture
+async def http_hass(hass: HomeAssistant) -> HomeAssistant:
+    """A hass with the HTTP component set up (setup mounts routes on it)."""
+    assert await async_setup_component(hass, "http", {"http": {}})
+    await hass.async_block_till_done()
+    return hass
+
+
+async def _setup(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id) is True
+    await hass.async_block_till_done()
+    return entry
+
+
+async def _reload(hass: HomeAssistant, entry: MockConfigEntry) -> None:
+    """Unload and set up again — exactly what the Reload button does."""
+    assert await hass.config_entries.async_unload(entry.entry_id) is True
+    await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(entry.entry_id) is True
+    await hass.async_block_till_done()
+
+
+def _ws_routes(hass: HomeAssistant) -> list:
+    """Every GET route registered on the WebSocket path.
+
+    Filtered to GET on purpose: ``add_get`` also creates an implicit HEAD route
+    on the same resource pointing at the same handler, so counting raw routes
+    reports 2 for a single registration and the count assertion below would pass
+    for the wrong reason.
+    """
+    return [
+        route
+        for route in hass.http.app.router.routes()
+        if getattr(route.resource, "canonical", None) == WS_PATH
+        and route.method == "GET"
+    ]
+
+
+async def test_reload_does_not_stack_a_second_ws_route(
+    http_hass: HomeAssistant,
+) -> None:
+    """The route is registered once per process, not once per setup.
+
+    Before the fix this found two routes after one reload (and would grow by one
+    on every further reload), with the *first* one winning resolution.
+    """
+    hass = http_hass
+    entry = await _setup(hass)
+    assert len(_ws_routes(hass)) == 1
+
+    await _reload(hass, entry)
+    assert len(_ws_routes(hass)) == 1
+
+    await _reload(hass, entry)
+    assert len(_ws_routes(hass)) == 1
+
+
+async def test_the_route_reaches_the_handler_from_the_latest_setup(
+    http_hass: HomeAssistant,
+) -> None:
+    """Resolution must land on the live handler, not the one it started with.
+
+    This is the actual defect: with two stacked routes the socket went to the
+    previous handler while broadcasts went to the current one. Asserting the
+    route count alone would not have caught a fix that kept one route but still
+    closed over a stale instance, so this test follows the route object to the
+    handler it actually calls.
+    """
+    hass = http_hass
+    entry = await _setup(hass)
+    first_handler = hass.data[DOMAIN]["ws_handler"]
+
+    await _reload(hass, entry)
+    live_handler = hass.data[DOMAIN]["ws_handler"]
+    assert live_handler is not first_handler, "reload should build a fresh handler"
+
+    called_on: list = []
+
+    async def _spy(request):  # noqa: ARG001
+        called_on.append(live_handler)
+        return "ok"
+
+    with patch.object(live_handler, "handle", side_effect=_spy):
+        route_handler = _ws_routes(hass)[0].handler
+        assert await route_handler(object()) == "ok"
+
+    assert called_on == [live_handler]
+
+
+async def test_the_route_answers_503_while_unloaded(
+    http_hass: HomeAssistant,
+) -> None:
+    """The path outlives the integration, so "not set up" needs an honest answer.
+
+    ``async_unload_entry`` pops ``hass.data[DOMAIN]`` while the route stays on
+    the router forever. Without this branch the dispatcher would raise on a
+    socket that arrives between unload and setup.
+    """
+    hass = http_hass
+    entry = await _setup(hass)
+    assert await hass.config_entries.async_unload(entry.entry_id) is True
+    await hass.async_block_till_done()
+
+    route_handler = _ws_routes(hass)[0].handler
+    response = await route_handler(object())
+    assert response.status == 503


### PR DESCRIPTION
Closes #606.

## The defect

`async_setup_entry` re-registered the HTTP routes, the WebSocket route and the static paths on every setup, with no guard, and `async_unload_entry` never touched the router.

aiohttp normally freezes its router at startup, so a second `add_get` would raise. HA un-freezes it deliberately (`homeassistant/components/http/__init__.py`: `self.app._router.freeze = lambda: None`), so the duplicate registration succeeded silently instead.

`UrlDispatcher.resolve()` matches in **registration order**, so the handler bound during the *first* setup kept serving every socket forever. Meanwhile `game_state.set_broadcast_callback` pointed at the newest handler, whose connection manager holds zero sockets. Every state broadcast went nowhere and the game looked hung — the same shape as the reports in #586.

Trigger: any unload followed by a setup. That is the Integrations "Reload" button, and **every HACS update**.

The plain HTTP views survived a reload because they read `APP_CTX_KEY` per request. That is what made the failure look like a game bug rather than a routing bug.

## The fix

- Routes are registered **once per HA process**. The guard key lives outside `hass.data[DOMAIN]`, because that key is popped on unload while the routes stay on the router forever.
- The WS route points at a small dispatcher that resolves `hass.data[DOMAIN]["ws_handler"]` **at call time** — the same shape the existing `game_state_provider` lambda uses. No route object can outlive the handler it serves.
- Between unload and setup the path answers `503` instead of raising: the route outlives the integration, so "not set up right now" is a normal state that deserves an honest status code.

`APP_CTX_KEY` is still refreshed on every setup, so the plain views keep picking up the new context.

## Not the restart rule

The project documents that an rsync of changed Python needs a full HA restart rather than a reload, because `sys.modules` holds the old modules. That is a separate defect with the same visible shape, and it does not heal this one: this bites with completely unchanged code.

## Tests

`tests/test_ws_route_survives_reload_606.py` drives the real config-entries state machine against the real aiohttp router:

1. repeated reloads leave exactly one GET route on the path,
2. the route reaches the handler from the **latest** setup,
3. the path answers 503 while the integration is unloaded.

All three were run against the unfixed code first: **3 failed**, then green.

Test 2 exists because the count assertion alone would pass for a fix that keeps one route but still closes over a stale handler. One detail worth recording: `add_get` also creates an implicit HEAD route on the same resource, so counting raw routes reports 2 for a single registration — the helper filters to GET, otherwise the count test would have passed for the wrong reason.

Suite 1982, `ruff` clean, `mypy` clean.