### PR TITLE
fix(#604): stop sending the answer to the tokenless dashboard role

### DIFF
--- a/custom_components/quizify/server/connection.py
+++ b/custom_components/quizify/server/connection.py
@@ -374,9 +374,10 @@ class ConnectionManager:
         if tasks:
             await asyncio.gather(*tasks)
 
-    async def broadcast_to_admins_and_dashboards(self, message: dict) -> None:
-        """Broadcast admin-only messages (with correct answer) to pure admin
-        connections and the TV-dashboard spectator connections (role=dashboard).
+    async def broadcast_to_admins_and_dashboards(
+        self, message: dict, *, dashboard_message: dict | None = None
+    ) -> None:
+        """Broadcast to pure admin connections and the TV-dashboard spectators.
 
         Dashboards need the same canonical-order question payload the admin
         sees — they render an unshuffled view of the same content. Without
@@ -384,6 +385,13 @@ class ConnectionManager:
         the v1.1.47 #151 answer-distribution chart has nothing to attach to.
         Admin-as-player connections are still excluded so a player who is
         also admin doesn't see the correct answer before submitting.
+
+        ``dashboard_message`` sends the two groups *different* payloads (#604).
+        ``role=dashboard`` requires no token, so anything sent to dashboards is
+        readable by anyone who can reach the integration: the question fan-out
+        passes an answer-stripped copy here while admins keep the full one.
+        Callers whose payload holds no answer at all (timer ticks, the lightning
+        question, which sends option texts only) can keep passing one message.
         """
         if not self._admin_connections and not self._dashboard_connections:
             return
@@ -393,15 +401,27 @@ class ConnectionManager:
             for p in gs.get_players():
                 if p.is_admin and p.ws is not None:
                     admin_as_player_ws.add(p.ws)
-        targets: set[web.WebSocketResponse] = set()
-        targets.update(self._admin_connections)
-        targets.update(self._dashboard_connections)
         payload = json.dumps(message)  # serialize once, send_str per client (#258)
-        tasks = [
-            self._safe_send_str(ws, payload)
-            for ws in targets
-            if not ws.closed and ws not in admin_as_player_ws
-        ]
+        # Dashboards only get their own payload when the caller supplied one;
+        # otherwise both groups keep sharing the single message as before.
+        dash_payload = (
+            json.dumps(dashboard_message) if dashboard_message is not None else payload
+        )
+        tasks = []
+        seen: set[web.WebSocketResponse] = set()
+        # Admins first, so a socket that is registered as both admin and
+        # dashboard is served the full payload exactly once: it authenticated,
+        # so it is entitled to the answer, and it must not also receive the
+        # stripped copy and overwrite the grid it just rendered.
+        for group, group_payload in (
+            (self._admin_connections, payload),
+            (self._dashboard_connections, dash_payload),
+        ):
+            for ws in group:
+                if ws.closed or ws in admin_as_player_ws or ws in seen:
+                    continue
+                seen.add(ws)
+                tasks.append(self._safe_send_str(ws, group_payload))
         if tasks:
             await asyncio.gather(*tasks)
 

--- a/custom_components/quizify/server/serializers.py
+++ b/custom_components/quizify/server/serializers.py
@@ -229,6 +229,42 @@ def serialize_question_for_admin(
     return payload
 
 
+def strip_answer_for_dashboard(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return the admin question payload with every trace of the answer removed.
+
+    The TV connects as ``role=dashboard``, which takes no token at all (#604),
+    so whatever this payload carries is readable by anyone who can reach the
+    integration while the question is still running. The per-player answer
+    shuffle exists to make copying hard; shipping the answer to an
+    unauthenticated role walks around it with one query parameter.
+
+    The answer hides in three places, and missing any one of them leaves the
+    hole open:
+
+    * ``correct_answer`` — the plain text,
+    * ``correct`` on every option — a boolean that names the right tile,
+    * ``estimate.answer`` — the true value on estimate rounds (#275).
+
+    Everything the TV actually renders survives: the canonical shuffled order
+    from #521, the option texts, and the shape ``{"text": …}`` that
+    ``dashboard.html`` reads. It never looks at ``correct`` before the reveal —
+    the reveal runs off ``round_summary``'s ``correct_answer_index`` — so this
+    costs the big screen nothing.
+    """
+    stripped = dict(payload)
+    stripped.pop("correct_answer", None)
+    stripped["answers"] = [
+        {"text": a["text"]} if isinstance(a, dict) else {"text": a}
+        for a in payload.get("answers", [])
+    ]
+    estimate = payload.get("estimate")
+    if isinstance(estimate, dict):
+        stripped["estimate"] = {
+            k: v for k, v in estimate.items() if k != "answer"
+        }
+    return stripped
+
+
 def serialize_leaderboard(players: list[PlayerSession]) -> list[dict[str, Any]]:
     """Build sorted leaderboard from player list.
 

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -53,6 +53,7 @@ from custom_components.quizify.server.serializers import (
     serialize_player_list,
     snapshot_house_entities,
     snapshot_tts_entities,
+    strip_answer_for_dashboard,
 )
 
 if TYPE_CHECKING:
@@ -2565,7 +2566,11 @@ class QuizifyWebSocketHandler:
         # populates with the same canonical-order payload. Without this the
         # dashboard's answer-grid stays empty and the v1.1.47 #151 answer-
         # distribution bars never attach. Admin-as-player still excluded.
-        await self._conn.broadcast_to_admins_and_dashboards(admin_msg)
+        # The TV connects without a token (#604), so it gets the same payload
+        # with the answer taken out — see strip_answer_for_dashboard.
+        await self._conn.broadcast_to_admins_and_dashboards(
+            admin_msg, dashboard_message=strip_answer_for_dashboard(admin_msg)
+        )
 
         # Narrate the question text (+ options) at round start (#281). The
         # canonical shuffled order matches the TV grid so spoken letters line

--- a/tests/test_dashboard_answer_leak_604.py
+++ b/tests/test_dashboard_answer_leak_604.py
@@ -1,0 +1,201 @@
+"""The unauthenticated TV role must not learn the answer mid-question (#604).
+
+``/api/quizify/ws?role=dashboard`` takes **no token of any kind** — the
+handshake reads the role straight off the query string. Until this fix the
+question fan-out sent that role the *admin* payload, which carries the answer
+three separate ways: ``correct_answer``, a ``correct`` flag on every option, and
+the true value inside ``estimate`` on estimate rounds.
+
+That mattered because the per-player answer shuffle exists precisely to make
+copying hard. One query parameter walked around all of it: a guest on the LAN,
+or anyone holding the Nabu Casa URL, could open a second tab and win every
+round.
+
+Distinct from the ``is_admin: true`` join trust documented in DESIGN.md, which
+deliberately grants *control* on a trusted LAN. This one leaked *answers* to an
+unauthenticated role, undocumented, and strictly more than the big screen ever
+renders before the reveal.
+
+The tests below cover each of the three carriers plus the split itself, because
+plugging two of three still leaves the round readable.
+
+A note on how these were verified, since the usual "run them against the unfixed
+code" step does not work here: the fix adds a new function, so on the old code
+the module fails to *import* rather than failing an assertion, and an ImportError
+proves nothing about the leak. The last test therefore reproduces the old call
+site directly — one payload for both groups, which is exactly what
+``_emit_question`` used to do — and asserts that the dashboard receives the
+answer. That test passes on both sides of the fix by design: it documents the
+vulnerability and pins why the call site had to change, rather than pretending
+to be a regression guard.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.server.connection import (  # noqa: E402
+    ConnectionManager,
+)
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    strip_answer_for_dashboard,
+)
+
+ADMIN_QUESTION = {
+    "type": "question_started",
+    "question_text": "Which planet is closest to the sun?",
+    "correct_answer": "Mercury",
+    "answers": [
+        {"text": "Venus", "correct": False},
+        {"text": "Mercury", "correct": True},
+        {"text": "Mars", "correct": False},
+    ],
+    "round_num": 1,
+    "total_rounds": 5,
+}
+
+ESTIMATE_QUESTION = {
+    "type": "question_started",
+    "question_text": "How tall is the Eiffel Tower in metres?",
+    "correct_answer": "",
+    "answers": [],
+    "estimate": {"min": 100, "max": 500, "unit": "m", "step": 1, "answer": 330},
+}
+
+
+def _fake_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_str = AsyncMock()
+    return ws
+
+
+def _sent_payloads(ws: MagicMock) -> list[dict]:
+    return [json.loads(call.args[0]) for call in ws.send_str.call_args_list]
+
+
+def test_the_stripper_removes_all_three_carriers() -> None:
+    """Text, per-option flag and estimate value all have to go.
+
+    Asserted separately rather than by comparing whole dicts: a future payload
+    key would silently pass a dict comparison written today, while these three
+    assertions keep naming the thing that must not be there.
+    """
+    stripped = strip_answer_for_dashboard(ADMIN_QUESTION)
+
+    assert "correct_answer" not in stripped
+    assert all("correct" not in a for a in stripped["answers"])
+    assert strip_answer_for_dashboard(ESTIMATE_QUESTION)["estimate"] == {
+        "min": 100,
+        "max": 500,
+        "unit": "m",
+        "step": 1,
+    }
+
+
+def test_the_stripper_keeps_what_the_tv_renders() -> None:
+    """Option texts and their canonical order survive untouched.
+
+    The order is the #521 shuffle. If stripping reordered the tiles, the big
+    screen would stop lining up with ``correct_answer_index`` at the reveal and
+    with the letters the TTS narrator speaks.
+    """
+    stripped = strip_answer_for_dashboard(ADMIN_QUESTION)
+
+    assert [a["text"] for a in stripped["answers"]] == ["Venus", "Mercury", "Mars"]
+    assert stripped["question_text"] == ADMIN_QUESTION["question_text"]
+    assert stripped["round_num"] == 1
+    # The source payload must not be mutated — admins still need the full one.
+    assert ADMIN_QUESTION["correct_answer"] == "Mercury"
+
+
+async def test_dashboards_and_admins_receive_different_payloads() -> None:
+    """The split itself: same broadcast, two different messages on the wire."""
+    conn = ConnectionManager(runtime=MagicMock(), game_state_provider=lambda: None)
+    admin_ws, dash_ws = _fake_ws(), _fake_ws()
+    conn.add_connection(admin_ws, is_admin=True, is_dashboard=False)
+    conn.add_connection(dash_ws, is_admin=False, is_dashboard=True)
+
+    await conn.broadcast_to_admins_and_dashboards(
+        ADMIN_QUESTION, dashboard_message=strip_answer_for_dashboard(ADMIN_QUESTION)
+    )
+
+    (admin_msg,) = _sent_payloads(admin_ws)
+    (dash_msg,) = _sent_payloads(dash_ws)
+
+    assert admin_msg["correct_answer"] == "Mercury"
+    assert "correct_answer" not in dash_msg
+    assert all("correct" not in a for a in dash_msg["answers"])
+    # "Mercury" still appears as an option on the TV — it must, it is one of the
+    # tiles. What must not appear is anything marking it as the right one.
+    assert "Mercury" in [a["text"] for a in dash_msg["answers"]]
+
+
+async def test_a_socket_registered_as_both_gets_the_full_payload_once() -> None:
+    """An admin-authenticated socket that also registered as a dashboard.
+
+    It holds a token, so it is entitled to the answer; and it must receive
+    exactly one message, or the stripped copy would land second and blank the
+    grid it just rendered.
+    """
+    conn = ConnectionManager(runtime=MagicMock(), game_state_provider=lambda: None)
+    both_ws = _fake_ws()
+    conn.add_connection(both_ws, is_admin=True, is_dashboard=True)
+
+    await conn.broadcast_to_admins_and_dashboards(
+        ADMIN_QUESTION, dashboard_message=strip_answer_for_dashboard(ADMIN_QUESTION)
+    )
+
+    sent = _sent_payloads(both_ws)
+    assert len(sent) == 1
+    assert sent[0]["correct_answer"] == "Mercury"
+
+
+async def test_callers_without_a_dashboard_message_still_send_one_payload() -> None:
+    """Timer ticks and the lightning question carry no answer and keep sharing.
+
+    Guards the back-compatible default: those call sites were left untouched,
+    so the single-message path has to keep behaving exactly as before.
+    """
+    conn = ConnectionManager(runtime=MagicMock(), game_state_provider=lambda: None)
+    admin_ws, dash_ws = _fake_ws(), _fake_ws()
+    conn.add_connection(admin_ws, is_admin=True, is_dashboard=False)
+    conn.add_connection(dash_ws, is_admin=False, is_dashboard=True)
+
+    tick = {"type": "timer_tick", "remaining": 12.0}
+    await conn.broadcast_to_admins_and_dashboards(tick)
+
+    assert _sent_payloads(admin_ws) == [tick]
+    assert _sent_payloads(dash_ws) == [tick]
+
+
+async def test_the_old_single_payload_path_is_what_leaked() -> None:
+    """Reproduces the pre-fix behaviour, deliberately.
+
+    ``_emit_question`` used to call this with the admin payload only. Feeding it
+    that way still does what it always did: both groups get the same message, so
+    the tokenless dashboard receives ``correct_answer`` and the ``correct`` flag
+    while the question is live.
+
+    Keeping the leak reproducible is the point. If someone later "simplifies"
+    the question fan-out back to a single argument, the fix is undone silently —
+    the three tests above would still pass, because they exercise the helper and
+    the split rather than the call site. This one names what that call site must
+    never go back to.
+    """
+    conn = ConnectionManager(runtime=MagicMock(), game_state_provider=lambda: None)
+    dash_ws = _fake_ws()
+    conn.add_connection(dash_ws, is_admin=False, is_dashboard=True)
+
+    await conn.broadcast_to_admins_and_dashboards(ADMIN_QUESTION)
+
+    (leaked,) = _sent_payloads(dash_ws)
+    assert leaked["correct_answer"] == "Mercury"
+    assert [a["correct"] for a in leaked["answers"]] == [False, True, False]


### PR DESCRIPTION
Closes #604.

## The hole

`/api/quizify/ws?role=dashboard` takes **no credential of any kind** — `websocket.py` reads the role straight off the query string. Until now the question fan-out handed that role the *admin* payload, which carries the answer three separate ways:

| Carrier | Where |
|---|---|
| `correct_answer` | top level |
| `correct: true` | on every option |
| `estimate.answer` | estimate rounds (#275) |

The per-player answer shuffle exists precisely to make copying hard. One query parameter walked around all of it: a guest on the LAN, or anyone holding the Nabu Casa URL, could sit on the sofa with a second tab open and win every round.

This is not the `is_admin: true` join trust documented in DESIGN.md. That one deliberately grants *control* on a trusted LAN. This leaked *answers*, to an unauthenticated role, undocumented, and strictly more than the big screen ever renders mid-question.

## The fix

`broadcast_to_admins_and_dashboards` takes an optional `dashboard_message`, so one broadcast can put different payloads on the wire for the two groups. The question fan-out passes `strip_answer_for_dashboard(admin_msg)`; admins keep the full payload.

A socket registered as **both** admin and dashboard receives the full payload exactly once. It authenticated, so it is entitled to the answer — and a second, stripped message would arrive right after and blank the grid it just rendered.

The other two callers of this method (timer ticks, the lightning question, which sends option texts only) carry no answer and keep the single-message path unchanged.

## Verified before writing it

The obvious question was whether the TV needs the answer early for some render path. It does not: `dashboard.html` writes only `answer.text` into the tiles at question start and never reads `correct`; the reveal runs off `round_summary`'s `correct_answer_index`. The canonical #521 shuffle and the #151 distribution bars are untouched, so nothing on the big screen changes.

## Tests

`tests/test_dashboard_answer_leak_604.py` — all three carriers stripped, what the TV renders preserved (including the shuffle order and the un-mutated source payload), the admin/dashboard split on the wire, the both-roles socket, and the untouched single-message path.

**Two honest notes on the test suite:**

1. The usual "run the new tests against the unfixed code" step does not produce a meaningful red here. The fix adds a new function, so the old code fails to *import* the test module, and an `ImportError` says nothing about the leak. The last test therefore reproduces the old call site directly — one payload for both groups — and asserts the dashboard receives the answer. It passes on both sides of the fix by design: it documents the vulnerability and pins what the call site must never go back to.

2. The call site in `_emit_question` itself is not covered by a behaviour test — driving it needs the full handler. If someone "simplifies" that call back to a single argument, the fix is undone and the first five tests still pass. Test six is the closest guard available without a heavyweight harness, and it names the failure mode in prose. Worth a proper end-to-end test if this area is touched again.

Suite 1988, `ruff` clean on `custom_components/` and the new file, `mypy` clean.