### PR TITLE
fix(#603): decide the canonical player name once, at join

### DIFF
--- a/custom_components/quizify/game/player_registry.py
+++ b/custom_components/quizify/game/player_registry.py
@@ -26,7 +26,7 @@ from .player import PLAYER_COLORS, PlayerSession
 _LOGGER = logging.getLogger(__name__)
 
 
-def _sanitize_name(raw: str) -> str:
+def sanitize_player_name(raw: str) -> str:
     """Normalize and strip unsafe characters from a player name.
 
     Defends against impersonation via:
@@ -37,6 +37,11 @@ def _sanitize_name(raw: str) -> str:
     - Trailing/leading whitespace
 
     (#15 in logical review.)
+
+    Public because the join handler has to canonicalize the name *before* it
+    builds anything keyed on it (#603). Running this in two places is fine —
+    it is idempotent — but deciding the canonical name in two places is not,
+    which is exactly the bug #603 describes.
     """
     # NFKC normalizes compatibility-equivalent characters.
     n = unicodedata.normalize("NFKC", raw or "").strip()
@@ -77,7 +82,12 @@ class PlayerRegistry:
             (success, error_code) - error_code is None on success
         """
         # Validate + sanitize name (Unicode NFKC, strip control/format chars).
-        name = _sanitize_name(name)
+        # Idempotent safety net. Since #603 the join handler canonicalizes the
+        # name before it gets here, so this normally changes nothing — but
+        # add_player is also reachable from other paths, and a registry that
+        # trusts its caller to have sanitized is a registry that stores an
+        # unsanitized name the first time someone forgets.
+        name = sanitize_player_name(name)
         if not name or len(name) < MIN_NAME_LENGTH:
             return False, ERR_NAME_INVALID
         if len(name) > MAX_NAME_LENGTH:

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -29,6 +29,7 @@ from custom_components.quizify.const import (
 )
 from custom_components.quizify.game.highlights import compute_superlatives
 from custom_components.quizify.game.phase_controller import TICK_INTERVAL
+from custom_components.quizify.game.player_registry import sanitize_player_name
 from custom_components.quizify.game.powerups import (
     FREEZE_DURATION,
     PowerUpEffect,
@@ -645,7 +646,14 @@ class QuizifyWebSocketHandler:
         self, ws: web.WebSocketResponse, data: dict, game_state: QuizifyGameState
     ) -> None:
         """Handle player join."""
-        name = data.get("name", "").strip()
+        # Canonicalize ONCE, here, before anything is keyed on the name (#603).
+        # The registry sanitizes on store; using the raw name afterwards meant
+        # the session token was issued under a name the registry did not have
+        # and every later `get_player(name)` missed. That silently cost the
+        # host the crown and, after a wifi blip, made the player's score
+        # unreachable — for any name holding a zero-width joiner, i.e. most
+        # multi-codepoint emoji, and for a stray double space.
+        name = sanitize_player_name(data.get("name", ""))
 
         if not name:
             await self._conn.send_error(ws, ERR_NAME_INVALID, "Name is required")
@@ -693,9 +701,23 @@ class QuizifyWebSocketHandler:
         # unreachable, spawning a duplicate ghost with score 0. Falling through
         # on a stale slot lets add_player reclaim the original name; genuinely
         # live duplicates (ws still open) still get the "Name 2" suffix.
+        #
+        # ``existing.ws is not ws`` (#603): once the name is canonicalized, an
+        # idempotent rejoin from the SAME connection — a lobby refresh, the
+        # admin's redirect from /quizify/admin to /quizify/player — matches an
+        # active slot that IS this connection. Renaming it to "Name 2" would
+        # spawn a score-0 duplicate of the player who is already sitting there.
+        # Before canonicalization this never surfaced, because the raw name
+        # differed from the stored one and the duplicate-self-join guard above
+        # rejected the rejoin outright instead. Both behaviours were wrong; a
+        # rejoin under the same name from the same socket is a no-op reclaim.
         original_name = name
         counter = 2
-        while (existing := game_state.get_player(name)) and existing.is_active:
+        while (
+            (existing := game_state.get_player(name))
+            and existing.is_active
+            and existing.ws is not ws
+        ):
             name = f"{original_name} {counter}"
             counter += 1
 

--- a/tests/test_join_canonical_name_603.py
+++ b/tests/test_join_canonical_name_603.py
@@ -1,0 +1,176 @@
+"""One canonical player name per join (issue #603).
+
+``PlayerRegistry.add_player`` sanitizes the name before storing it, but
+``_handle_join`` used to keep working with the **raw** name afterwards: the
+session token was issued under the raw name and ``get_player(name)`` looked the
+raw name up, so for any name sanitization changes, both missed.
+
+This was never an exotic input. ``sanitize_player_name`` strips Unicode category
+``Cf``, which includes the zero-width joiner holding multi-codepoint emoji
+together — family emoji, flag emoji, most of what a phone keyboard offers under
+"people" — and it collapses repeated whitespace, so a stray double space does it
+too. The names in ``CHANGED_BY_SANITIZE`` below were produced by running the
+real function, not guessed.
+
+Three consequences, and the third is the expensive one:
+
+1. the ``joined`` frame goes out without colour and without the admin flag,
+2. the host silently loses the crown, because the admin-as-player block is
+   skipped when the lookup returns ``None``,
+3. after a wifi blip the reconnect lookup misses too, the token is revoked, and
+   because mid-game name-rejoin is deliberately closed, the score is unreachable
+   until grace removal. To the player it looks like the game forgot them.
+
+The fix canonicalizes once, in ``_handle_join``, before anything is keyed on the
+name. All tests here were run against the unfixed code first.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.player_registry import (  # noqa: E402
+    sanitize_player_name,
+)
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server.connection import (  # noqa: E402
+    ConnectionManager,
+)
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+# Real-world names the sanitizer rewrites. Kept as data so every test below
+# runs against all of them: a fix that handles the emoji but not the double
+# space is not a fix.
+CHANGED_BY_SANITIZE = [
+    "Anna 👩‍👦",   # family emoji — zero-width joiner
+    "Lea 🏳️‍🌈",   # flag emoji — same
+    "x²",                # NFKC folds the superscript
+    "Ben  Klaus",        # collapsed double space
+]
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    def create_task(self, coro):
+        return asyncio.ensure_future(coro)
+
+    async def run_in_executor(self, func, *args):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func, *args)
+
+
+def _ws(closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    ws.send_json = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+@pytest.fixture
+def handler(game: QuizifyGameState) -> QuizifyWebSocketHandler:
+    runtime = _FakeRuntime(game._runtime.data_dir)  # type: ignore[attr-defined]
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    h._conn = ConnectionManager(runtime, lambda: game)
+    h._conn.broadcast = AsyncMock()
+    h._conn.send = AsyncMock()
+    h._conn.send_error = AsyncMock()
+    h._REACTION_FLUSH_WINDOW = 0.02
+    return h
+
+
+def test_the_sample_names_really_are_rewritten() -> None:
+    """Guards the premise of every test below.
+
+    If a future sanitizer stopped touching these names, the tests would still
+    pass while testing nothing at all. This one fails instead.
+    """
+    for raw in CHANGED_BY_SANITIZE:
+        assert sanitize_player_name(raw) != raw, raw
+
+
+@pytest.mark.parametrize("raw", CHANGED_BY_SANITIZE)
+@pytest.mark.asyncio
+async def test_the_player_is_findable_under_the_name_that_was_stored(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState, raw: str
+) -> None:
+    """The lookup the join itself performs has to hit."""
+    await handler._handle_join(_ws(), {"name": raw}, game)
+
+    canonical = sanitize_player_name(raw)
+    assert game.get_player(canonical) is not None
+    assert [p.name for p in game.get_players()] == [canonical]
+
+
+@pytest.mark.parametrize("raw", CHANGED_BY_SANITIZE)
+@pytest.mark.asyncio
+async def test_the_session_token_resolves_to_the_stored_player(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState, raw: str
+) -> None:
+    """The token is what a reconnect after a wifi blip trades in.
+
+    Issued under the raw name, it resolved to a player that does not exist, the
+    token got revoked and the score became unreachable mid-game.
+    """
+    await handler._handle_join(_ws(), {"name": raw}, game)
+
+    canonical = sanitize_player_name(raw)
+    token = next(
+        (t for t, (n, _) in handler._conn._session_tokens.items() if n == canonical),
+        None,
+    )
+    assert token is not None, "no token was issued under the stored name"
+    assert game.get_player(handler._conn.get_player_for_token(token)) is not None
+
+
+@pytest.mark.parametrize("raw", CHANGED_BY_SANITIZE)
+@pytest.mark.asyncio
+async def test_the_host_keeps_the_crown(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState, raw: str
+) -> None:
+    """The admin-as-player grant runs off the same lookup.
+
+    A host joining with a family emoji in their name silently ended up without
+    the crown and could not advance rounds from the player tab.
+    """
+    await handler._handle_join(_ws(), {"name": raw, "is_admin": True}, game)
+
+    player = game.get_player(sanitize_player_name(raw))
+    assert player is not None
+    assert player.is_admin is True
+
+
+@pytest.mark.asyncio
+async def test_an_idempotent_rejoin_is_not_treated_as_a_second_player(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState
+) -> None:
+    """Rejoining under the same raw name must reclaim, not spawn "Name 2".
+
+    The duplicate-self-join guard and the auto-rename loop both compare against
+    the stored name. Feeding them the raw one made an ordinary lobby refresh
+    look like a different player to one check and like a taken name to the
+    other.
+    """
+    raw = "Anna 👩‍👦"
+    ws = _ws()
+    await handler._handle_join(ws, {"name": raw}, game)
+    await handler._handle_join(ws, {"name": raw}, game)
+
+    names = [p.name for p in game.get_players()]
+    assert names == [sanitize_player_name(raw)]


### PR DESCRIPTION
Closes #603.

## The defect

`PlayerRegistry.add_player` sanitizes the name before storing it. `_handle_join` kept using the **raw** name afterwards: the session token was issued under the raw name, and `get_player(name)` looked the raw name up. For any name sanitization changes, both missed. The case-insensitive fallback does not help — the strings differ in stripped characters, not in case.

## Not an exotic input

`sanitize_player_name` strips Unicode category `Cf`, which includes the zero-width joiner that holds multi-codepoint emoji together, and collapses repeated whitespace. Verified by running the real function:

```
'Anna 👩‍👦'  -> 'Anna 👩👦'
'Lea 🏳️‍🌈'   -> 'Lea 🏳️🌈'
'x²'         -> 'x2'
'Ben  Klaus' -> 'Ben Klaus'
```

That is most of what a phone keyboard offers under "people", plus a stray double space.

## What it cost

1. The `joined` frame went out with no colour and `is_admin: false`.
2. **The host silently lost the crown** — the admin-as-player block is skipped when the lookup returns `None`, so a host who joined with a family emoji could not advance rounds from the player tab.
3. **A wifi blip orphaned the player.** The reconnect lookup missed too, the token was revoked, and mid-game name-rejoin is deliberately closed (`ERR_NAME_TAKEN` for disconnected slots outside LOBBY), so the score stayed unreachable until grace removal. To the player it looks like the game forgot them.

## The fix

`_handle_join` canonicalizes once, before anything is keyed on the name. `_sanitize_name` becomes public `sanitize_player_name`; `add_player` keeps calling it as an idempotent safety net, because it is reachable from other paths and a registry that trusts its caller to have sanitized will eventually store an unsanitized name.

The issue's alternative — have `add_player` return the canonical name — would change its return type and every caller for the same effect.

## A regression the tests caught, not review

Canonicalizing alone broke the idempotent rejoin. With the canonical name, a rejoin from the **same** connection (a lobby refresh, the admin's `/quizify/admin` → `/quizify/player` redirect) matches an active slot that *is* this connection, and the auto-rename loop renamed it to "Name 2" — a score-0 duplicate of the player already sitting there. Before canonicalization the raw/stored mismatch meant the duplicate-self-join guard rejected that rejoin outright with an error instead. Both behaviours were wrong; the loop now also requires `existing.ws is not ws`.

Worth stating plainly: without that second change this PR would have replaced a visible wrong rejection with a silent duplicate.

## Tests

`tests/test_join_canonical_name_603.py`, parametrized over all four names — a fix that handles the emoji but not the double space is not a fix. Covers the lookup, the token resolving to a real player, the crown, and the idempotent rejoin.

The first test asserts the sample names really are rewritten by the sanitizer. If that ever stops being true, the rest would pass while testing nothing; this one fails instead.

Run against an unfixed `_handle_join` (keeping the public rename so the module still imports, which isolates the behavioural change): **8 of 14 failed**.

Suite 2002, `ruff` clean, `mypy` clean.