### PR TITLE
fix(#618): give the non-playing host controls at the reveal

### DIFF
--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -1591,18 +1591,35 @@
         if (els.endGameBtn) els.endGameBtn.classList.add('hidden');
     }
 
-    // handleRoundSummary / showReveal / renderAnswerDistribution lived
-    // here in v1.1.15 and earlier to populate the admin-only reveal
-    // view. The host always redirects to /quizify/player on game start,
-    // so they were never actually run for HACS users. Removed with
-    // the #admin-reveal-view markup in v1.1.16.
-    function handleRoundSummary(/* msg */) {
+    // The full admin reveal view (showReveal / renderAnswerDistribution) was
+    // removed in v1.1.16 because "the host always redirects to
+    // /quizify/player on game start" — true then, but the lobby has since
+    // grown a "start without joining" path (doStartGameNoJoin), and that host
+    // stays here. For them this used to render nothing at all: both controls
+    // are hidden at question start and nothing un-hid them, so the reveal was
+    // a dead screen and the guests' only way on was the 60-second "host gone"
+    // reset, which wipes the game (#618).
+    //
+    // This deliberately does NOT rebuild the old reveal view. The player tab
+    // still owns the rich reveal; the admin tab needs the answer and a way
+    // forward, and nothing more.
+    function handleRoundSummary(msg) {
         if (_redirecting) return;
         currentPhase = 'ANSWER_REVEAL';
         adminTimer.stop();
-        // The player tab owns the reveal UI; nothing for the admin tab
-        // to render. Keeping this stub so the WS message router still
-        // has a target (avoids "undefined" route errors).
+
+        if (els.adminCorrect && msg && msg.correct_answer) {
+            els.adminCorrect.textContent = _t('admin.correctLabel', {
+                answer: msg.correct_answer,
+            });
+            els.adminCorrect.style.display = '';
+        }
+        // Only "End Game" on the last round: "Next Question" there would
+        // promise a round that does not exist.
+        if (els.nextQuestionBtn && !(msg && msg.last_round)) {
+            els.nextQuestionBtn.classList.remove('hidden');
+        }
+        if (els.endGameBtn) els.endGameBtn.classList.remove('hidden');
     }
 
     function handleFinale(msg) {

--- a/tests/test_admin_reveal_controls_618.py
+++ b/tests/test_admin_reveal_controls_618.py
@@ -1,0 +1,105 @@
+"""The non-playing host gets controls at the reveal (issue #618).
+
+The lobby offers starting a game without joining as a player
+(``doStartGameNoJoin``); that host stays on ``/quizify/admin``. But
+``handleQuestionStarted`` hides ``#next-question-btn`` and ``#end-game-btn`` at
+question start, and before this fix **nothing anywhere un-hid them** — the old
+admin reveal view was removed in v1.1.16 on the premise that "the host always
+redirects to /quizify/player on game start", which stopped being true when
+start-without-joining arrived.
+
+So that host sat in front of a stale question with no controls at every reveal.
+With nobody holding the crown, the guests' only way forward was the 60-second
+"host gone" reset hatch — which wipes the running game. A quiz night ended in a
+reset instead of a winner.
+
+These follow the project's existing frontend-test pattern (read the shipped
+source, assert on structure) because the suite has no JS runtime. They are
+therefore structural, not behavioural: they pin that the un-hiding happens in
+the reveal handler and that the string it renders exists in every language
+bundle. A browser check of the actual screen is still worth doing before the
+release — noted in the PR rather than implied away.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WWW = _REPO_ROOT / "custom_components" / "quizify" / "www"
+_ADMIN_JS = _WWW / "js" / "admin.js"
+
+
+def _function_body(source: str, signature: str) -> str:
+    """The text of one top-level function, brace-matched.
+
+    Slicing to the next ``\\n    }`` would stop at the first nested block, so
+    this counts braces — the assertions below are only meaningful if they see
+    the whole function and nothing of its neighbours.
+    """
+    start = source.index(signature)
+    depth = 0
+    for i in range(start, len(source)):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : i + 1]
+    raise AssertionError(f"unbalanced braces after {signature!r}")
+
+
+def test_question_start_still_hides_the_controls() -> None:
+    """Guards the premise. Without this the rest proves nothing."""
+    body = _function_body(
+        _ADMIN_JS.read_text("utf-8"), "function handleQuestionStarted("
+    )
+
+    assert "nextQuestionBtn.classList.add('hidden')" in body
+    assert "endGameBtn.classList.add('hidden')" in body
+
+
+def test_the_reveal_brings_both_controls_back() -> None:
+    """The defect itself: hidden at question start, never shown again."""
+    body = _function_body(_ADMIN_JS.read_text("utf-8"), "function handleRoundSummary(")
+
+    assert "nextQuestionBtn.classList.remove('hidden')" in body
+    assert "endGameBtn.classList.remove('hidden')" in body
+
+
+def test_the_last_round_offers_only_end_game() -> None:
+    """"Next Question" on the final round would promise a round that does not
+    exist. End Game stays unconditional — it is the way out of every reveal."""
+    body = _function_body(_ADMIN_JS.read_text("utf-8"), "function handleRoundSummary(")
+
+    next_line = next(
+        line
+        for line in body.splitlines()
+        if "nextQuestionBtn" in line and "remove" not in line
+    )
+    assert "last_round" in next_line, (
+        "Next Question must be gated on last_round"
+    )
+    end_lines = [line for line in body.splitlines() if "endGameBtn" in line]
+    assert not any("last_round" in line for line in end_lines), (
+        "End Game must stay available on the last round"
+    )
+
+
+def test_the_reveal_shows_the_correct_answer() -> None:
+    """The host is the one person who may see it — that is the whole point of
+    the admin tab at the reveal."""
+    body = _function_body(_ADMIN_JS.read_text("utf-8"), "function handleRoundSummary(")
+
+    assert "admin.correctLabel" in body
+    assert "msg.correct_answer" in body
+
+
+def test_every_language_bundle_carries_the_label() -> None:
+    """A missing key renders the raw key on screen, in a place only the host
+    ever sees — exactly where nobody would notice it for months."""
+    for code in ("de", "en", "es"):
+        bundle = json.loads((_WWW / "i18n" / f"{code}.json").read_text("utf-8"))
+        label = bundle["admin"]["correctLabel"]
+        assert "{answer}" in label, f"{code}: correctLabel must interpolate the answer"


### PR DESCRIPTION
Closes #618.

## The dead screen

The lobby explicitly supports starting a game without joining as a player (`doStartGameNoJoin`); that host stays on `/quizify/admin` as a pure TV control. But `handleQuestionStarted` hides `#next-question-btn` and `#end-game-btn` at question start, and **nothing anywhere un-hid them** — grep finds the two `classList.add('hidden')` calls, the element lookups and the click handlers, and nothing else.

The premise sat in a comment above the empty `handleRoundSummary`:

> the host always redirects to /quizify/player on game start, so they were never actually run for HACS users

That was true when it was written. It stopped being true when start-without-joining arrived: the redirect only fires when an admin name is set, so it does not rescue this host.

**Consequence.** With nobody holding the crown, the guests' only way forward is the 60-second "host gone" reset hatch — which wipes the running game. The evening ends in a reset instead of a winner.

## The change

`handleRoundSummary` writes the correct answer into the `#admin-correct` element that already exists (and is hidden at question start), then un-hides both buttons.

**Next Question** is gated on `last_round`: offering it on the final round would promise a round that does not exist. **End Game** stays unconditional — it is the way out of every reveal, including the last one.

Deliberately *not* a rebuild of the v1.1.15 admin reveal view. The player tab still owns the rich reveal; this host needs the answer and a way forward, nothing more.

No server change. The socket is already authenticated as admin, so `next_question` was always accepted — the wiring was missing, not the permission.

## Tests

`tests/test_admin_reveal_controls_618.py`, following the project's existing frontend-test pattern (read the shipped source, assert on structure) since the suite has no JS runtime:

1. question start still hides both controls — the premise, without which the rest proves nothing,
2. the reveal brings both back,
3. the last round offers only End Game,
4. the reveal renders the correct answer,
5. `admin.correctLabel` exists with `{answer}` in all three language bundles — a missing key would render the raw key on a screen only the host ever sees, which is exactly where it would go unnoticed for months.

The helper brace-matches the function body rather than slicing to the next `\n    }`, which would stop at the first nested block and make the assertions meaningless.

Run against the unfixed `admin.js`: **3 of 5 failed**.

**Honest limit:** these are structural, not behavioural. They pin that the un-hiding happens in the reveal handler; they cannot prove the buttons are visible and clickable on a real screen. A browser pass on the admin tab is worth doing before the next release.

Suite 2010, `ruff` clean.