### PR TITLE
fix(#625): route the last hardcoded UI strings through i18n

### DIFF
--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -86,6 +86,8 @@
     "category": "Kategorie",
     "categoryMixed": "Gemischt",
     "mixedAllPacks": "Alle Packs",
+    "packsAndQuestions": "{packs} Packs · {questions} Fragen",
+    "questionsOnly": "{questions} Fragen",
     "spotlightFeatured": "⭐ Empfohlen",
     "spotlightPlay": "▶︎ Sofort spielen",
     "themes": "Themen",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -86,6 +86,8 @@
     "category": "Category",
     "categoryMixed": "Mixed",
     "mixedAllPacks": "All packs",
+    "packsAndQuestions": "{packs} packs · {questions} questions",
+    "questionsOnly": "{questions} questions",
     "spotlightFeatured": "⭐ Featured",
     "spotlightPlay": "▶︎ Play now",
     "themes": "Themes",

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -86,6 +86,8 @@
     "category": "Categoría",
     "categoryMixed": "Mixto",
     "mixedAllPacks": "Todos los paquetes",
+    "packsAndQuestions": "{packs} paquetes · {questions} preguntas",
+    "questionsOnly": "{questions} preguntas",
     "spotlightFeatured": "⭐ Destacado",
     "spotlightPlay": "▶︎ Jugar ahora",
     "themes": "Temas",

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -651,7 +651,10 @@
                     var chip = els.categoryChips.querySelector('.chip[data-value="' + val + '"]');
                     if (chip) total += parseInt(chip.dataset.count || '0', 10);
                 });
-                countEl.textContent = selectedCategories.length + ' Packs · ' + total + ' Fragen';
+                countEl.textContent = _t('admin.packsAndQuestions', {
+                    packs: selectedCategories.length,
+                    questions: total,
+                });
                 countEl.classList.remove('hidden');
             }
         } else {
@@ -660,7 +663,9 @@
             if (countEl) {
                 var count = activeChip ? parseInt(activeChip.dataset.count || '0', 10) : 0;
                 if (count > 0) {
-                    countEl.textContent = count + ' Fragen';
+                    countEl.textContent = _t('admin.questionsOnly', {
+                        questions: count,
+                    });
                     countEl.classList.remove('hidden');
                 } else {
                     countEl.classList.add('hidden');
@@ -694,7 +699,12 @@
         var diffLabel = (els.difficultyChips && els.difficultyChips.querySelector('.chip.active'))
             ? els.difficultyChips.querySelector('.chip.active').textContent.trim()
             : _t('difficulties.medium');
-        var langFlag = selectedLanguage === 'en' ? '🇬🇧' : '🇩🇪';
+        // Map, not a ternary (#625): "English or else German" flew a German
+        // flag over every Spanish game. An unknown code falls back to the
+        // globe rather than to some language's flag — wrong-but-plausible is
+        // worse here than visibly neutral.
+        var LANG_FLAGS = { en: '🇬🇧', de: '🇩🇪', es: '🇪🇸' };
+        var langFlag = LANG_FLAGS[selectedLanguage] || '🌐';
         var parts = [];
         if (preset) parts.push(preset.label);
         parts.push(selectedRounds + ' ' + _t('admin.summaryRoundsUnit'));

--- a/custom_components/quizify/www/js/player-game.js
+++ b/custom_components/quizify/www/js/player-game.js
@@ -946,7 +946,15 @@
         var rankClass = rank <= 3 ? ' rank-' + rank : '';
         var currentClass = entry.is_current ? ' is-current' : '';
         var disconnectedClass = entry.connected === false ? ' is-disconnected' : '';
-        var youBadge = entry.is_current ? '<span class="you-badge">(you)</span>' : '';
+        // #625: `lobby.you` ships in all three bundles; this spot rendered a
+        // literal English "(you)" on every phone for the whole game. Same
+        // local-`t` shape the rest of this file uses — there is no module-wide
+        // helper here, so a bare `_t` would be a ReferenceError that takes the
+        // whole leaderboard render down with it.
+        var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
+        var youBadge = entry.is_current
+            ? '<span class="you-badge">(' + t('lobby.you') + ')</span>'
+            : '';
         var streakBadge = entry.streak > 1
             ? '<span class="leaderboard-streak">' + entry.streak + 'x</span>'
             : '';

--- a/custom_components/quizify/www/js/player-lobby.js
+++ b/custom_components/quizify/www/js/player-lobby.js
@@ -477,8 +477,13 @@
             startBtn.addEventListener('click', function () {
                 if (!state.ws || state.ws.readyState !== WebSocket.OPEN) return;
 
+                // #625: was a hardcoded "Starting...". `admin.starting` exists
+                // in all three bundles. Local `t` per this file's convention.
+                var t = (window.QuizifyI18n && window.QuizifyI18n.t)
+                    || function (k) { return k; };
                 startBtn.disabled = true;
-                startBtn.innerHTML = '<span class="btn-icon" aria-hidden="true">🎉</span><span>Starting...</span>';
+                startBtn.innerHTML = '<span class="btn-icon" aria-hidden="true">🎉</span><span>'
+                    + t('admin.starting') + '</span>';
 
                 sendFn('start_game', {});
             });

--- a/custom_components/quizify/www/js/player-utils.js
+++ b/custom_components/quizify/www/js/player-utils.js
@@ -43,6 +43,13 @@
     // HTML Escaping
     // ============================================
 
+    // One place for the "translate or fall back to the key" shape this file
+    // uses; three copies of the same line invite the fourth to be forgotten.
+    function _tt(key) {
+        var fn = window.QuizifyI18n && window.QuizifyI18n.t;
+        return fn ? fn(key) : key;
+    }
+
     function escapeHtml(text) {
         return utils.escapeHtml(text);
     }
@@ -249,8 +256,12 @@
             .map(function (p, i) {
                 var rank = p.rank || i + 1;
                 var rankClass = rank <= 3 ? ' rank-' + rank : '';
+                // #625: the audit named only player-game.js, but the same
+                // literal sits twice more in this file. `lobby.you` exists in
+                // all three bundles.
                 var youBadge = (myName && p.name === myName)
-                    ? '<span class="you-badge">(you)</span>' : '';
+                    ? '<span class="you-badge">(' + _tt('lobby.you') + ')</span>'
+                    : '';
                 return '<div class="leaderboard-row">' +
                     '<span class="leaderboard-rank' + rankClass + '">' + rank + '</span>' +
                     '<span class="leaderboard-name">' + escapeHtml(p.name) + youBadge + '</span>' +
@@ -283,8 +294,14 @@
                     (isYou ? ' player-card--you' : '') +
                     (isDisconnected ? ' player-card--disconnected' : '');
                 var colorStyle = color ? ' style="--player-color:' + color + ';border-left:4px solid ' + color + ';"' : '';
-                var awayBadge = isDisconnected ? '<span class="away-badge">(away)</span>' : '';
-                var youBadge = isYou ? '<span class="you-badge">(you)</span>' : '';
+                // `(away)` was hardcoded English too, and `lobby.away` was
+                // already sitting there unused.
+                var awayBadge = isDisconnected
+                    ? '<span class="away-badge">(' + _tt('lobby.away') + ')</span>'
+                    : '';
+                var youBadge = isYou
+                    ? '<span class="you-badge">(' + _tt('lobby.you') + ')</span>'
+                    : '';
                 return '<div class="' + classes + '"' + colorStyle + ' data-player="' + escapeHtml(name) + '">' +
                     '<span class="player-color-dot" style="background:' + (color || '#888') + '"></span>' +
                     '<span class="player-name">' + escapeHtml(name) + youBadge + awayBadge + '</span>' +

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -48,6 +48,13 @@
     // HTML Escaping
     // ============================================
 
+    // One place for the "translate or fall back to the key" shape this file
+    // uses; three copies of the same line invite the fourth to be forgotten.
+    function _tt(key) {
+        var fn = window.QuizifyI18n && window.QuizifyI18n.t;
+        return fn ? fn(key) : key;
+    }
+
     function escapeHtml(text) {
         return utils.escapeHtml(text);
     }
@@ -254,8 +261,12 @@
             .map(function (p, i) {
                 var rank = p.rank || i + 1;
                 var rankClass = rank <= 3 ? ' rank-' + rank : '';
+                // #625: the audit named only player-game.js, but the same
+                // literal sits twice more in this file. `lobby.you` exists in
+                // all three bundles.
                 var youBadge = (myName && p.name === myName)
-                    ? '<span class="you-badge">(you)</span>' : '';
+                    ? '<span class="you-badge">(' + _tt('lobby.you') + ')</span>'
+                    : '';
                 return '<div class="leaderboard-row">' +
                     '<span class="leaderboard-rank' + rankClass + '">' + rank + '</span>' +
                     '<span class="leaderboard-name">' + escapeHtml(p.name) + youBadge + '</span>' +
@@ -288,8 +299,14 @@
                     (isYou ? ' player-card--you' : '') +
                     (isDisconnected ? ' player-card--disconnected' : '');
                 var colorStyle = color ? ' style="--player-color:' + color + ';border-left:4px solid ' + color + ';"' : '';
-                var awayBadge = isDisconnected ? '<span class="away-badge">(away)</span>' : '';
-                var youBadge = isYou ? '<span class="you-badge">(you)</span>' : '';
+                // `(away)` was hardcoded English too, and `lobby.away` was
+                // already sitting there unused.
+                var awayBadge = isDisconnected
+                    ? '<span class="away-badge">(' + _tt('lobby.away') + ')</span>'
+                    : '';
+                var youBadge = isYou
+                    ? '<span class="you-badge">(' + _tt('lobby.you') + ')</span>'
+                    : '';
                 return '<div class="' + classes + '"' + colorStyle + ' data-player="' + escapeHtml(name) + '">' +
                     '<span class="player-color-dot" style="background:' + (color || '#888') + '"></span>' +
                     '<span class="player-name">' + escapeHtml(name) + youBadge + awayBadge + '</span>' +
@@ -1342,8 +1359,13 @@
             startBtn.addEventListener('click', function () {
                 if (!state.ws || state.ws.readyState !== WebSocket.OPEN) return;
 
+                // #625: was a hardcoded "Starting...". `admin.starting` exists
+                // in all three bundles. Local `t` per this file's convention.
+                var t = (window.QuizifyI18n && window.QuizifyI18n.t)
+                    || function (k) { return k; };
                 startBtn.disabled = true;
-                startBtn.innerHTML = '<span class="btn-icon" aria-hidden="true">🎉</span><span>Starting...</span>';
+                startBtn.innerHTML = '<span class="btn-icon" aria-hidden="true">🎉</span><span>'
+                    + t('admin.starting') + '</span>';
 
                 sendFn('start_game', {});
             });
@@ -4655,7 +4677,15 @@
         var rankClass = rank <= 3 ? ' rank-' + rank : '';
         var currentClass = entry.is_current ? ' is-current' : '';
         var disconnectedClass = entry.connected === false ? ' is-disconnected' : '';
-        var youBadge = entry.is_current ? '<span class="you-badge">(you)</span>' : '';
+        // #625: `lobby.you` ships in all three bundles; this spot rendered a
+        // literal English "(you)" on every phone for the whole game. Same
+        // local-`t` shape the rest of this file uses — there is no module-wide
+        // helper here, so a bare `_t` would be a ReferenceError that takes the
+        // whole leaderboard render down with it.
+        var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
+        var youBadge = entry.is_current
+            ? '<span class="you-badge">(' + t('lobby.you') + ')</span>'
+            : '';
         var streakBadge = entry.streak > 1
             ? '<span class="leaderboard-streak">' + entry.streak + 'x</span>'
             : '';

--- a/tests/test_i18n_hardcoded_strings_625.py
+++ b/tests/test_i18n_hardcoded_strings_625.py
@@ -1,0 +1,130 @@
+"""Four high-traffic strings bypassed the i18n bundles (issue #625).
+
+The bundles are otherwise in exact parity — 616 leaf keys per language, the
+work of v1.5.0 and v1.9.0 — but four spots built their text by hand:
+
+* the pack-count summary and the questions-only line on the host's setup screen,
+* a flag chosen by ``selectedLanguage === 'en' ? 🇬🇧 : 🇩🇪``, so a Spanish game
+  flew a German flag,
+* a literal ``(you)`` on every phone's leaderboard, for the whole game,
+* a hardcoded ``Starting...`` on the player start button.
+
+Three of the four had a key waiting for them already (``lobby.you``,
+``admin.starting``); only the pack line needed new ones.
+
+Two traps this fix walked into, both worth naming because a test that only
+checked "no hardcoded German remains" would have missed both:
+
+1. ``player-game.js`` and ``player-lobby.js`` have **no** module-wide ``_t``.
+   They declare ``var t = (window.QuizifyI18n && window.QuizifyI18n.t) || …``
+   per function. A bare ``_t(…)`` there is a ReferenceError that takes the whole
+   leaderboard render down — worse than the untranslated string it replaces.
+2. ``player.html`` loads ``player.bundle.js``, not the individual modules, so
+   editing the sources alone ships nothing. The bundle has to be rebuilt.
+
+Both are pinned below.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WWW = _REPO_ROOT / "custom_components" / "quizify" / "www"
+_I18N = _WWW / "i18n"
+_JS = _WWW / "js"
+
+LANGUAGES = ("de", "en", "es")
+NEW_KEYS = ("packsAndQuestions", "questionsOnly")
+
+
+def _leaves(d: dict, prefix: str = "") -> dict[str, str]:
+    out: dict[str, str] = {}
+    for key, value in d.items():
+        name = f"{prefix}.{key}" if prefix else key
+        if isinstance(value, dict):
+            out.update(_leaves(value, name))
+        else:
+            out[name] = value
+    return out
+
+
+def _bundle(code: str) -> dict:
+    return json.loads((_I18N / f"{code}.json").read_text("utf-8"))
+
+
+def test_the_three_bundles_stay_in_key_parity() -> None:
+    """The property the four spots were quietly breaking.
+
+    Compares key sets rather than counts: two bundles can hold the same number
+    of keys and still disagree about which ones.
+    """
+    keysets = {code: set(_leaves(_bundle(code))) for code in LANGUAGES}
+    reference = keysets["de"]
+    for code in LANGUAGES:
+        assert keysets[code] == reference, (
+            f"{code} differs: "
+            f"missing={sorted(reference - keysets[code])} "
+            f"extra={sorted(keysets[code] - reference)}"
+        )
+
+
+def test_the_new_keys_exist_everywhere_and_interpolate() -> None:
+    """A key present in two of three bundles is how this class of bug starts."""
+    for code in LANGUAGES:
+        admin = _bundle(code)["admin"]
+        for key in NEW_KEYS:
+            assert key in admin, f"{code}.admin.{key} missing"
+        assert "{packs}" in admin["packsAndQuestions"]
+        assert "{questions}" in admin["packsAndQuestions"]
+        assert "{questions}" in admin["questionsOnly"]
+
+
+def test_the_setup_screen_no_longer_builds_german_by_hand() -> None:
+    source = (_JS / "admin.js").read_text("utf-8")
+
+    assert "' Packs · '" not in source
+    assert "' Fragen'" not in source
+    assert "admin.packsAndQuestions" in source
+    assert "admin.questionsOnly" in source
+
+
+def test_the_flag_is_a_map_with_spanish_in_it() -> None:
+    """The ternary was "English, or else German" — there is no third branch to
+    add, which is why it has to stop being a ternary."""
+    source = (_JS / "admin.js").read_text("utf-8")
+
+    assert "selectedLanguage === 'en' ? '🇬🇧' : '🇩🇪'" not in source
+    assert "es: '🇪🇸'" in source
+
+
+def test_the_player_files_use_their_own_translation_helper() -> None:
+    """Trap 1: neither file defines a module-wide ``_t``.
+
+    Calling one would raise instead of rendering, so this asserts the local
+    ``t`` shape is present in both edited spots and that no bare ``_t(`` crept
+    in with a copy-paste from admin.js.
+    """
+    for name in ("player-game.js", "player-lobby.js"):
+        source = (_JS / name).read_text("utf-8")
+        assert "_t(" not in source, f"{name} calls _t, which is not defined there"
+        assert "window.QuizifyI18n && window.QuizifyI18n.t" in source
+
+
+def test_the_translated_strings_reached_the_shipped_bundle() -> None:
+    """Trap 2: player.html loads the bundle, not the modules.
+
+    Without a rebuild every change here is a no-op on real phones. The drift
+    job in CI checks the same thing from the other side; this fails locally,
+    before the push.
+    """
+    bundle = (_JS / "player.bundle.js").read_text("utf-8")
+
+    assert "'lobby.you'" in bundle
+    assert "'admin.starting'" in bundle
+    assert '"you-badge">(you)' not in bundle
+    # Asserts the *rendered* markup, not the bare words: the fix's own comment
+    # quotes "Starting..." to explain what it replaced, and a substring check
+    # would trip over that and call a correct bundle broken.
+    assert "<span>Starting...</span>" not in bundle


### PR DESCRIPTION
Closes #625.

## What was bypassing the bundles

The i18n bundles are otherwise in exact parity — 616 leaf keys per language, the work of v1.5.0 and v1.9.0. Four spots built their text by hand:

| Spot | Effect |
|---|---|
| pack-count summary + questions-only line (`admin.js`) | German shown to every user, in every language |
| flag ternary `en ? 🇬🇧 : 🇩🇪` (`admin.js`) | a Spanish game flew a German flag |
| `(you)` on the phone leaderboard | literal English on every phone, all game |
| `Starting...` on the start button | same |

`lobby.you` and `admin.starting` already existed in all three bundles; only the pack line needed new keys. The flag is a map now with a globe fallback — a wrong-but-plausible flag for an unknown code is worse than a visibly neutral one.

## Two things the issue did not list

**More of the same literal.** `player-utils.js` holds two further `(you)` occurrences and a hardcoded `(away)` — and `lobby.away` was already sitting in the bundles, unused. Found by the bundle assertion in the new tests, not by reading the issue. Fixed with a small file-local helper, because three copies of the translate-or-fall-back line invite a fourth to be forgotten.

**The player files have no `_t`.** `player-game.js` and `player-lobby.js` declare `var t = (window.QuizifyI18n && window.QuizifyI18n.t) || …` per function. Copying `_t(…)` over from `admin.js` would be a ReferenceError that takes the whole leaderboard render down — strictly worse than the untranslated string it replaces. Both spots use the local shape, and a test pins it.

## The bundle

`player.html` loads `player.bundle.js`, not the individual modules, so editing the sources alone changes nothing on a real phone. Rebuilt via `scripts/build_bundle.py`; CI's drift job checks the same thing from the other side, but the test here fails locally, before the push.

## Tests

`tests/test_i18n_hardcoded_strings_625.py`:

1. key-set parity across the three bundles — compared as **sets**, since two bundles can hold the same number of keys and still disagree about which,
2. the new keys exist in all three and interpolate,
3. the setup screen no longer concatenates German,
4. the flag is a map containing Spanish,
5. the player files use their own helper and call no bare `_t`,
6. the translated strings actually reached the shipped bundle.

Test 6 asserts the rendered markup rather than the bare words: the fix's own comment quotes `"Starting..."` to explain what it replaced, and a naive substring check would call a correct bundle broken.

Run against the unfixed frontend: **4 of 6 failed**.

Suite 2016, `ruff` clean.