### PR TITLE
feat(#619): broadcast who has answered, and wire the renderers that waited for it

### DIFF
--- a/custom_components/quizify/server/serializers.py
+++ b/custom_components/quizify/server/serializers.py
@@ -334,6 +334,33 @@ def serialize_player_list(players: list[PlayerSession]) -> list[dict[str, Any]]:
     ]
 
 
+def serialize_answer_progress(players: list[PlayerSession]) -> dict[str, Any]:
+    """Who has answered this round, in the shape the phone tracker expects (#619).
+
+    Deliberately its own payload rather than a field on ``serialize_player_list``:
+    that list rides every join/leave frame, and per-round answer state has no
+    business in a roster message that also reaches the lobby.
+
+    The field names are not a free choice — ``renderSubmissionTracker`` was
+    written long before anything sent it data and already reads ``name``,
+    ``submitted`` and ``connected`` off each entry. The issue proposed a plain
+    list of names; that renderer could not have drawn it.
+
+    Scores are omitted on purpose. This goes out mid-question, and a live score
+    beside each name would leak who just answered correctly.
+    """
+    entries = [
+        {"name": p.name, "submitted": p.submitted, "connected": p.connected}
+        for p in players
+    ]
+    return {
+        "type": "answer_progress",
+        "players": entries,
+        "submitted": sum(1 for e in entries if e["submitted"]),
+        "total": len(entries),
+    }
+
+
 def build_share_payload(
     all_players: list[PlayerSession],
     packs: list[str] | None = None,

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -49,6 +49,7 @@ from custom_components.quizify.server.connection import ConnectionManager
 from custom_components.quizify.server.rate_limit import SlidingWindowLimiter
 from custom_components.quizify.server.round_message_builder import RoundMessageBuilder
 from custom_components.quizify.server.serializers import (
+    serialize_answer_progress,
     serialize_finale,
     serialize_leaderboard,
     serialize_player_list,
@@ -286,6 +287,12 @@ class QuizifyWebSocketHandler:
         self._roster_dirty: bool = False
         self._roster_last_type: str = "player_joined"
         self._roster_flush_task: asyncio.Task | None = None
+        # #619: answer-progress rides its own coalescing window, same shape as
+        # the roster one (#453). A broadcast per accepted answer would be the
+        # O(N²) fan-out that #453 removed, re-introduced on a hotter path — a
+        # room of eight taps eight times per round, not once per game.
+        self._progress_dirty = False
+        self._progress_flush_task: asyncio.Task | None = None
 
     # Coalescing window for visual reactions (#304), seconds.
     _REACTION_FLUSH_WINDOW = 0.15
@@ -1193,9 +1200,13 @@ class QuizifyWebSocketHandler:
             # answer in their own answer order, so the dots appear on the same
             # question for all of them.
             await self._broadcast_team_answer(game_state, result, setter=player.name)
+            self._mark_progress_dirty()
             return
 
         if isinstance(result, AnswerResult):
+            # #619: the room can see who it is waiting for. Coalesced, so a
+            # simultaneous tap-storm is one frame, not one per tap.
+            self._mark_progress_dirty()
             await self._conn.send(ws, {
                 "type": "answer_result",
                 "correct": result.correct,
@@ -1490,6 +1501,53 @@ class QuizifyWebSocketHandler:
                 self._flush_roster_after_window()
             )
             self._roster_flush_task.add_done_callback(self._log_task_exception)
+
+    def _mark_progress_dirty(self) -> None:
+        """Flag answer-progress as changed and (re)arm its coalescing flush."""
+        self._progress_dirty = True
+        if self._progress_flush_task is None or self._progress_flush_task.done():
+            self._progress_flush_task = asyncio.ensure_future(
+                self._flush_progress_after_window()
+            )
+            self._progress_flush_task.add_done_callback(self._log_task_exception)
+
+    async def _flush_progress_after_window(self) -> None:
+        """Wait one window, then broadcast ONE answer-progress frame (#619).
+
+        Mirrors ``_flush_roster_after_window`` down to the tail re-arm: taps
+        that land during the broadcast set the flag again, and no new task can
+        start while this one runs.
+
+        The list is serialized at flush time, not at tap time, so the frame
+        always carries the room as it is when it goes out rather than as it was
+        when the first tap of the window arrived.
+        """
+        try:
+            await asyncio.sleep(self._REACTION_FLUSH_WINDOW)
+        except asyncio.CancelledError:
+            self._progress_dirty = False
+            raise
+
+        if not self._progress_dirty:
+            return
+
+        self._progress_dirty = False
+        gs = self._get_game_state()
+        if gs is not None:
+            await self._conn.broadcast(serialize_answer_progress(gs.get_players()))
+
+        if self._progress_dirty:
+            self._progress_flush_task = asyncio.ensure_future(
+                self._flush_progress_after_window()
+            )
+            self._progress_flush_task.add_done_callback(self._log_task_exception)
+
+    def _cancel_progress_flush(self) -> None:
+        """Cancel any pending answer-progress flush (called on cleanup)."""
+        if self._progress_flush_task is not None:
+            self._progress_flush_task.cancel()
+            self._progress_flush_task = None
+        self._progress_dirty = False
 
     def _cancel_roster_flush(self) -> None:
         """Cancel any pending roster-flush task (called on cleanup)."""
@@ -3488,6 +3546,7 @@ class QuizifyWebSocketHandler:
         self._cancel_lightning_loop()
         self._cancel_reaction_flush()
         self._cancel_roster_flush()
+        self._cancel_progress_flush()
         # Also cancel the deferred admin-disconnect pause (#362): a game
         # teardown/reset that leaves it pending would fire a spurious pause
         # (or hold a reference) after the game is already gone.

--- a/custom_components/quizify/www/css/src/07-player.css
+++ b/custom_components/quizify/www/css/src/07-player.css
@@ -794,6 +794,34 @@
     box-shadow: 0 0 6px var(--color-success-neon);
 }
 
+/* #619: `renderSubmissionTracker` has always toggled `all-submitted` on the
+   tracker, and no rule ever read it — so the one moment the row is worth
+   looking at, when the last phone has tapped, looked exactly like every other
+   moment. A short lift and a warm tint, not a flash: this sits directly above
+   the answer buttons while the reveal is about to land. */
+.submission-tracker.all-submitted .submitted-players {
+    animation: submission-complete 420ms ease-out;
+}
+
+.submission-tracker.all-submitted .player-indicator {
+    border-color: var(--color-success-neon);
+    background: rgba(127, 168, 151, 0.14);
+}
+
+@keyframes submission-complete {
+    0%   { transform: translateY(0); }
+    45%  { transform: translateY(-3px); }
+    100% { transform: translateY(0); }
+}
+
+/* Anyone who asked the OS for less motion gets the colour change and no
+   movement — the state still reads, it just stops moving. */
+@media (prefers-reduced-motion: reduce) {
+    .submission-tracker.all-submitted .submitted-players {
+        animation: none;
+    }
+}
+
 .player-indicator.is-current-player {
     background: rgba(232, 138, 127, 0.12);
 }

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -4243,6 +4243,34 @@ footer {
     box-shadow: 0 0 6px var(--color-success-neon);
 }
 
+/* #619: `renderSubmissionTracker` has always toggled `all-submitted` on the
+   tracker, and no rule ever read it — so the one moment the row is worth
+   looking at, when the last phone has tapped, looked exactly like every other
+   moment. A short lift and a warm tint, not a flash: this sits directly above
+   the answer buttons while the reveal is about to land. */
+.submission-tracker.all-submitted .submitted-players {
+    animation: submission-complete 420ms ease-out;
+}
+
+.submission-tracker.all-submitted .player-indicator {
+    border-color: var(--color-success-neon);
+    background: rgba(127, 168, 151, 0.14);
+}
+
+@keyframes submission-complete {
+    0%   { transform: translateY(0); }
+    45%  { transform: translateY(-3px); }
+    100% { transform: translateY(0); }
+}
+
+/* Anyone who asked the OS for less motion gets the colour change and no
+   movement — the state still reads, it just stops moving. */
+@media (prefers-reduced-motion: reduce) {
+    .submission-tracker.all-submitted .submitted-players {
+        animation: none;
+    }
+}
+
 .player-indicator.is-current-player {
     background: rgba(232, 138, 127, 0.12);
 }

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -122,6 +122,19 @@
             overflow: hidden;
         }
 
+        .dashboard-answer-progress {
+            font-size: clamp(0.9rem, 1.4vw, 1.15rem);
+            color: var(--dash-text-muted);
+            text-align: right;
+            margin-bottom: 6px;
+            flex-shrink: 0;
+            font-variant-numeric: tabular-nums;
+        }
+
+        .dashboard-answer-progress.is-complete {
+            color: var(--dash-accent-primary);
+        }
+
         .dashboard-timer-fill {
             height: 100%;
             background: var(--dash-accent-primary);
@@ -1239,6 +1252,11 @@
             <div id="round-indicator" class="dashboard-round"></div>
         </div>
 
+        <!-- #619: how many of the room have answered. Sits above the bar
+             rather than inside it: the bar is 12px so a couch can read it,
+             and text inside would fight the fill for those pixels. -->
+        <div id="answer-progress" class="dashboard-answer-progress hidden"></div>
+
         <div id="timer-bar" class="dashboard-timer">
             <div id="timer-fill" class="dashboard-timer-fill" style="width:0%"></div>
         </div>
@@ -1418,6 +1436,7 @@
             lobbyPlayers: document.getElementById('lobby-players'),
             roundIndicator: document.getElementById('round-indicator'),
             timerFill: document.getElementById('timer-fill'),
+            answerProgress: document.getElementById('answer-progress'),
             questionCategory: document.getElementById('question-category'),
             questionImage: document.getElementById('question-image'),
             questionMedia: document.getElementById('question-media'),
@@ -1670,6 +1689,13 @@
                     handleGameState(msg);
                     break;
                 case 'question_started':
+                    // Clear last round's count before the new one arrives —
+                    // otherwise the TV shows "5/5" over a fresh question.
+                    if (els.answerProgress) {
+                        els.answerProgress.textContent = '';
+                        els.answerProgress.classList.add('hidden');
+                        els.answerProgress.classList.remove('is-complete');
+                    }
                     handleQuestionStarted(msg);
                     break;
                 case 'timer_tick':
@@ -1680,7 +1706,13 @@
                     handleRoundSummary(msg);
                     break;
                 case 'leaderboard_update':
+                    // Kept: nothing has ever sent this (#619 found zero
+                    // senders), but a live TV cached from an older build may
+                    // still be listening, and the handler costs nothing.
                     if (msg.leaderboard) renderLeaderboard(els.leaderboard, msg.leaderboard);
+                    break;
+                case 'answer_progress':
+                    handleAnswerProgress(msg);
                     break;
                 case 'finale':
                 case 'game_ended':
@@ -2001,6 +2033,19 @@
                     '</div>' +
                     '</div>';
             }).join('');
+        }
+
+        function handleAnswerProgress(msg) {
+            if (!els.answerProgress) return;
+            var total = msg.total || 0;
+            if (!total) {
+                els.answerProgress.classList.add('hidden');
+                return;
+            }
+            var submitted = msg.submitted || 0;
+            els.answerProgress.textContent = submitted + '/' + total;
+            els.answerProgress.classList.remove('hidden');
+            els.answerProgress.classList.toggle('is-complete', submitted === total);
         }
 
         function handleTimerTick(msg) {

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -327,6 +327,14 @@
                 game.updateTimer(msg.remaining);
                 break;
 
+            // #619: who the room is still waiting for. renderSubmissionTracker
+            // has existed since the tracker markup landed; its only caller was
+            // updateGameView(), which nothing ever invoked, so the row stayed
+            // empty for every game ever played.
+            case 'answer_progress':
+                game.renderSubmissionTracker(msg.players);
+                break;
+
             case 'answer_result':
                 game.handleAnswerResult(msg);
                 // Streak milestone toast

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -5322,6 +5322,14 @@
                 game.updateTimer(msg.remaining);
                 break;
 
+            // #619: who the room is still waiting for. renderSubmissionTracker
+            // has existed since the tracker markup landed; its only caller was
+            // updateGameView(), which nothing ever invoked, so the row stayed
+            // empty for every game ever played.
+            case 'answer_progress':
+                game.renderSubmissionTracker(msg.players);
+                break;
+
             case 'answer_result':
                 game.handleAnswerResult(msg);
                 // Streak milestone toast

--- a/tests/test_answer_progress_619.py
+++ b/tests/test_answer_progress_619.py
@@ -1,0 +1,216 @@
+"""The room can see who it is waiting for (issue #619).
+
+Every part of this existed and none of it was connected: ``player.html`` has a
+``#submission-tracker``, ``renderSubmissionTracker()`` was fully written, and its
+only caller ``updateGameView()`` was never invoked by anything. The TV handled a
+``leaderboard_update`` message that had zero senders. The server broadcast
+nothing at all when an answer landed.
+
+Meanwhile the round really does end early once everyone has answered — so when
+one guest dawdles, the whole room watches a timer with no idea who it is waiting
+for. That is the actual cost: not a missing pixel, a missing "Papa, tap
+something".
+
+Two design points are pinned here because both were decisions, not defaults:
+
+* the payload shape follows the renderer that already exists (``name`` /
+  ``submitted`` / ``connected``), not the plain name list the issue proposed —
+  that renderer draws initial circles and colours each one, and could not have
+  drawn a list of strings;
+* the broadcast is coalesced through the same window as the roster (#453).
+  Sending per accepted answer would re-create the O(N²) fan-out #453 removed,
+  on a hotter path: a room of eight taps eight times per round.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server.connection import (  # noqa: E402
+    ConnectionManager,
+)
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    serialize_answer_progress,
+)
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+_WWW = _REPO_ROOT / "custom_components" / "quizify" / "www"
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    def create_task(self, coro):
+        return asyncio.ensure_future(coro)
+
+    async def run_in_executor(self, func, *args):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func, *args)
+
+
+def _ws(closed: bool = False) -> MagicMock:
+    ws = MagicMock()
+    ws.closed = closed
+    ws.send_json = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+@pytest.fixture
+def handler(game: QuizifyGameState) -> QuizifyWebSocketHandler:
+    runtime = _FakeRuntime(game._runtime.data_dir)  # type: ignore[attr-defined]
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    h._conn = ConnectionManager(runtime, lambda: game)
+    h._conn.broadcast = AsyncMock()
+    h._REACTION_FLUSH_WINDOW = 0.02
+    return h
+
+
+# --- payload ---------------------------------------------------------------
+
+
+def test_the_payload_matches_what_the_renderer_reads(game: QuizifyGameState) -> None:
+    """``renderSubmissionTracker`` predates any sender and reads these keys."""
+    game.add_player("Anna", _ws())
+    game.add_player("Ben", _ws())
+    game.get_player("Anna").submit_answer(1, 0.0)
+
+    payload = serialize_answer_progress(game.get_players())
+
+    assert payload["type"] == "answer_progress"
+    assert payload["submitted"] == 1
+    assert payload["total"] == 2
+    assert {e["name"] for e in payload["players"]} == {"Anna", "Ben"}
+    for entry in payload["players"]:
+        assert set(entry) == {"name", "submitted", "connected"}
+
+
+def test_the_payload_carries_no_scores(game: QuizifyGameState) -> None:
+    """This goes out mid-question.
+
+    A live score next to each name would say who just answered correctly — the
+    same class of leak as #604, arriving through a different door.
+    """
+    game.add_player("Anna", _ws())
+    game.get_player("Anna").submit_answer(1, 0.0)
+
+    entry = serialize_answer_progress(game.get_players())["players"][0]
+
+    assert "score" not in entry
+    assert "streak" not in entry
+
+
+# --- coalescing ------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_tap_storm_is_one_broadcast(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState
+) -> None:
+    """Five simultaneous taps must not be five room-wide frames."""
+    for name in ("A", "B", "C", "D", "E"):
+        game.add_player(name, _ws())
+
+    for _ in range(5):
+        handler._mark_progress_dirty()
+    await asyncio.sleep(handler._REACTION_FLUSH_WINDOW * 4)
+
+    progress_frames = [
+        call.args[0]
+        for call in handler._conn.broadcast.call_args_list
+        if call.args and call.args[0].get("type") == "answer_progress"
+    ]
+    assert len(progress_frames) == 1
+    assert progress_frames[0]["total"] == 5
+
+
+@pytest.mark.asyncio
+async def test_the_frame_reflects_the_room_at_flush_time(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState
+) -> None:
+    """Serialized on flush, not on the first tap of the window.
+
+    Otherwise the frame describes the room as it was when the window opened,
+    which is exactly the state the room already saw.
+    """
+    game.add_player("Anna", _ws())
+    game.add_player("Ben", _ws())
+
+    handler._mark_progress_dirty()
+    game.get_player("Anna").submit_answer(0, 0.0)
+    game.get_player("Ben").submit_answer(1, 0.0)
+    await asyncio.sleep(handler._REACTION_FLUSH_WINDOW * 4)
+
+    frame = next(
+        call.args[0]
+        for call in handler._conn.broadcast.call_args_list
+        if call.args and call.args[0].get("type") == "answer_progress"
+    )
+    assert frame["submitted"] == 2
+
+
+@pytest.mark.asyncio
+async def test_cleanup_cancels_the_pending_flush(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState
+) -> None:
+    """A teardown with a flush in flight must not fire into a dead game."""
+    game.add_player("Anna", _ws())
+    handler._mark_progress_dirty()
+    assert handler._progress_flush_task is not None
+
+    handler._cancel_progress_flush()
+
+    assert handler._progress_flush_task is None
+    assert handler._progress_dirty is False
+
+
+# --- client wiring ---------------------------------------------------------
+
+
+def test_the_phone_routes_the_message_to_the_dead_renderer() -> None:
+    source = (_WWW / "js" / "player-core.js").read_text("utf-8")
+
+    assert "case 'answer_progress':" in source
+    assert "game.renderSubmissionTracker(msg.players)" in source
+
+
+def test_the_routing_reached_the_shipped_bundle() -> None:
+    """player.html loads the bundle; editing the module alone ships nothing."""
+    bundle = (_WWW / "js" / "player.bundle.js").read_text("utf-8")
+
+    assert "case 'answer_progress':" in bundle
+
+
+def test_the_tv_shows_a_count_and_clears_it_between_rounds() -> None:
+    """A stale "5/5" over a fresh question would be worse than no counter."""
+    source = (_WWW / "dashboard.html").read_text("utf-8")
+
+    assert "function handleAnswerProgress(" in source
+    assert "case 'answer_progress':" in source
+    question_started = source.split("case 'question_started':", 1)[1][:400]
+    assert "answerProgress" in question_started
+
+
+def test_the_all_submitted_state_finally_has_a_rule() -> None:
+    """The class was toggled from the start and styled by nothing, so the one
+    moment the row is worth looking at looked like every other moment."""
+    css = (_WWW / "css" / "styles.css").read_text("utf-8")
+
+    assert ".submission-tracker.all-submitted" in css
+    assert "prefers-reduced-motion" in css


### PR DESCRIPTION
Closes #619.

## Everything existed; nothing was connected

| Part | State before |
|---|---|
| `#submission-tracker` in `player.html` | present, always empty |
| `renderSubmissionTracker()` | fully written |
| its only caller `updateGameView()` | never invoked by anything |
| `leaderboard_update` handler on the TV | zero senders |
| server on `submit_answer` | broadcast nothing |

The round really does end early once everyone has answered. So one dawdling guest left the whole room watching a timer with no idea who it was waiting for — the "Papa, tap something" moment, with nothing to aim it at.

## Two decisions, not defaults

**The payload follows the renderer, not the issue.** The issue proposed `{submitted, total, names}`. `renderSubmissionTracker` was written long before anything sent it data and reads `name`, `submitted` and `connected` per entry — it draws initial circles and colours each one, so a list of strings was undrawable. It also carries **no scores**: this goes out mid-question, and a live score beside a name tells the room who just answered correctly, which is #604's leak arriving through a different door.

**It is coalesced.** One broadcast per accepted answer would rebuild the O(N²) fan-out #453 removed, on a hotter path: eight players tap eight times per round, not once per game. `answer_progress` rides the same window as the roster flush, tail re-arm included, and is serialized at flush time so the frame shows the room as it is when it goes out rather than as it was when the window opened.

## Clients

- **Phone:** `player-core.js` routes `answer_progress` to the renderer that has been waiting for it.
- **TV:** a `3/5` counter above the timer bar — above, not inside: the bar is 12px so a couch can read it, and text inside would fight the fill. Cleared at question start, or a stale `5/5` would sit over a fresh question.
- **The dead `leaderboard_update` branch stays.** It costs nothing, and a TV cached from an older build may still be listening.

## The CSS finding

`.submission-tracker.all-submitted` had **no rule at all**. The class has been toggled since the tracker landed, styled by nothing — so the one moment the row is worth looking at, the last phone tapping, looked exactly like every other moment.

It now gets a short lift and a warm tint. Colour only under `prefers-reduced-motion`: the state still reads, it just stops moving.

This was found by rendering the tracker at 390px with the real stylesheet to answer "how does this render?" — reading the code would not have shown it, because the code is correct and the stylesheet is silent.

## Tests

`tests/test_answer_progress_619.py`: payload shape against what the renderer reads, no scores in it, a five-tap storm collapsing to one frame, the frame reflecting flush-time state, cleanup cancelling a pending flush, and the client wiring on phone, bundle, TV and stylesheet.

Suite 2025, `ruff` clean, `mypy` clean.

**Honest limit:** the server side is covered behaviourally; the client side is structural, as elsewhere in this repo. The screenshots in the chat show the tracker rendering correctly from the real stylesheet, but no test drives a real socket into a real phone.