### PR TITLE
fix(#620): show the join address, not only the QR code

### DIFF
--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -704,8 +704,17 @@
                 </h2>
 
                 <div class="lobby-e-row">
-                    <div class="lobby-e-qr" id="qr-container" role="img"
-                         data-i18n-aria-label="a11y.qrCodeRegion" aria-label="QR Code"></div>
+                    <div class="lobby-e-qr-col">
+                        <div class="lobby-e-qr" id="qr-container" role="img"
+                             data-i18n-aria-label="a11y.qrCodeRegion" aria-label="QR Code"></div>
+                        <!-- #620: same escape hatch as the TV lobby. The host
+                             reads this one aloud when a guest's phone cannot
+                             reach the address the QR encodes. -->
+                        <div class="lobby-e-join-fallback">
+                            <div id="admin-join-url" class="lobby-e-join-url"></div>
+                            <div class="lobby-e-join-hint" data-i18n="lobby.sameWifiHint">Same Wi-Fi as this screen</div>
+                        </div>
+                    </div>
                     <div class="lobby-e-roster" aria-live="polite"
                          data-i18n-aria-label="a11y.playerListRegion" aria-label="Player list">
                         <div id="lobby-player-chips" class="lobby-e-rows">

--- a/custom_components/quizify/www/css/src/07-player.css
+++ b/custom_components/quizify/www/css/src/07-player.css
@@ -2166,18 +2166,41 @@
     padding: var(--space-md);
 }
 
-.lobby-e-qr {
+/* #620: the QR and the typed-address fallback are one grid child now, so the
+   width caps below move from the code itself to the column that holds both.
+   Without this the wrapper would take the full grid track and the QR would
+   dominate the card on a phone — the exact thing the 220px cap prevents. */
+.lobby-e-qr-col {
     /* On phones the QR shouldn't fill the whole card — cap at 220px so
        it's scannable from across a small room without dominating. */
     max-width: 220px;
     margin: 0 auto;
 }
 
+.lobby-e-join-fallback {
+    margin-top: var(--space-xs);
+    text-align: center;
+}
+
+.lobby-e-join-url {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    word-break: break-all;
+    line-height: 1.3;
+}
+
+.lobby-e-join-hint {
+    font-size: 0.7rem;
+    color: var(--color-text-neon-muted);
+    margin-top: 2px;
+}
+
 @media (min-width: 480px) {
     .lobby-e-row {
         grid-template-columns: minmax(160px, 200px) 1fr;
     }
-    .lobby-e-qr {
+    .lobby-e-qr-col {
         max-width: none;
         margin: 0;
     }

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -5615,18 +5615,41 @@ footer {
     padding: var(--space-md);
 }
 
-.lobby-e-qr {
+/* #620: the QR and the typed-address fallback are one grid child now, so the
+   width caps below move from the code itself to the column that holds both.
+   Without this the wrapper would take the full grid track and the QR would
+   dominate the card on a phone — the exact thing the 220px cap prevents. */
+.lobby-e-qr-col {
     /* On phones the QR shouldn't fill the whole card — cap at 220px so
        it's scannable from across a small room without dominating. */
     max-width: 220px;
     margin: 0 auto;
 }
 
+.lobby-e-join-fallback {
+    margin-top: var(--space-xs);
+    text-align: center;
+}
+
+.lobby-e-join-url {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    word-break: break-all;
+    line-height: 1.3;
+}
+
+.lobby-e-join-hint {
+    font-size: 0.7rem;
+    color: var(--color-text-neon-muted);
+    margin-top: 2px;
+}
+
 @media (min-width: 480px) {
     .lobby-e-row {
         grid-template-columns: minmax(160px, 200px) 1fr;
     }
-    .lobby-e-qr {
+    .lobby-e-qr-col {
         max-width: none;
         margin: 0;
     }

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -122,6 +122,38 @@
             overflow: hidden;
         }
 
+        /* #620: readable from the couch but clearly secondary to the QR —
+           this is the escape hatch, not the main route. */
+        .dashboard-join-fallback {
+            margin-top: 14px;
+            text-align: center;
+        }
+
+        .dashboard-join-or {
+            font-size: clamp(0.8rem, 1.1vw, 1rem);
+            color: var(--dash-text-muted);
+            margin-bottom: 4px;
+        }
+
+        .dashboard-join-url {
+            /* Sized from the render, not from a guess: at 1.6rem the address
+               was the loudest thing in the block and out-shouted the QR it is
+               meant to back up. This still reads from a couch — it has to,
+               someone is typing it from three metres away — without becoming
+               the primary route. */
+            font-size: clamp(1rem, 1.5vw, 1.35rem);
+            font-weight: 600;
+            color: var(--dash-text-white);
+            word-break: break-all;
+            line-height: 1.25;
+        }
+
+        .dashboard-join-hint {
+            font-size: clamp(0.8rem, 1.1vw, 1rem);
+            color: var(--dash-text-muted);
+            margin-top: 4px;
+        }
+
         .dashboard-answer-progress {
             font-size: clamp(0.9rem, 1.4vw, 1.15rem);
             color: var(--dash-text-muted);
@@ -1279,6 +1311,17 @@
                 <div id="lobby-qr" class="dashboard-qr-section">
                     <div id="lobby-qr-code"></div>
                     <div class="dashboard-waiting-text" data-i18n="lobby.scanToJoin">Scan to join the game</div>
+                    <!-- #620: the URL in plain sight, not only when the QR
+                         library fails to load. A guest on cellular data or on
+                         the guest network scans, lands on an unreachable LAN
+                         address and gets a spinner — and that is the one
+                         failure the join page can never explain, because the
+                         join page is what failed to load. -->
+                    <div class="dashboard-join-fallback">
+                        <div class="dashboard-join-or" data-i18n="lobby.orTypeUrl">Or type it into a browser</div>
+                        <div id="lobby-join-url" class="dashboard-join-url"></div>
+                        <div class="dashboard-join-hint" data-i18n="lobby.sameWifiHint">Same Wi-Fi as this screen</div>
+                    </div>
                 </div>
                 <div id="lobby-players" class="dashboard-player-list"></div>
             </div>
@@ -1433,6 +1476,7 @@
             reconnectPill: document.getElementById('reconnect-pill'),
             // #374: TV lobby join QR + live player roster.
             lobbyQrCode: document.getElementById('lobby-qr-code'),
+            lobbyJoinUrlEl: document.getElementById('lobby-join-url'),
             lobbyPlayers: document.getElementById('lobby-players'),
             roundIndicator: document.getElementById('round-indicator'),
             timerFill: document.getElementById('timer-fill'),
@@ -1491,6 +1535,17 @@
             if (!container) return;
             container.innerHTML = '';
             var url = lobbyJoinUrl();
+            // Written whether or not the QR renders: the text is the fallback
+            // for an unreachable address, which the QR itself cannot signal.
+            //
+            // Composed from location.host rather than stripped off `url` with a
+            // scheme regex. #540's guard bans that shape in render sites, and
+            // rightly so even here where it would only be cosmetic: a reader
+            // cannot tell a display strip from the scheme test that caused #540.
+            if (els.lobbyJoinUrlEl) {
+                els.lobbyJoinUrlEl.textContent =
+                    window.location.host + '/quizify/player';
+            }
             if (typeof QRCode !== 'undefined') {
                 // Large, high-contrast code so it scans from across the room.
                 new QRCode(container, {

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -43,6 +43,8 @@
     "joinGameQr": "Spiel beitreten – QR-Code",
     "scanQrHint": "Teile den QR-Code oder die URL oben",
     "scanToJoin": "Scannen, um beizutreten",
+    "orTypeUrl": "Oder im Browser eingeben",
+    "sameWifiHint": "Gleiches WLAN wie dieser Bildschirm",
     "startGame": "Spiel starten",
     "copied": "Kopiert!",
     "away": "abwesend",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -43,6 +43,8 @@
     "joinGameQr": "Join Game QR Code",
     "scanQrHint": "Share the QR code or URL above",
     "scanToJoin": "Scan to join the game",
+    "orTypeUrl": "Or type it into a browser",
+    "sameWifiHint": "Same Wi-Fi as this screen",
     "startGame": "Start Game",
     "copied": "Copied!",
     "away": "away",

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -43,6 +43,8 @@
     "joinGameQr": "Código QR para unirse",
     "scanQrHint": "Comparte el código QR o la URL de arriba",
     "scanToJoin": "Escanea para unirte a la partida",
+    "orTypeUrl": "O escríbelo en el navegador",
+    "sameWifiHint": "La misma wifi que esta pantalla",
     "startGame": "Empezar partida",
     "copied": "¡Copiado!",
     "away": "ausente",

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -1845,6 +1845,14 @@
         var container = document.getElementById('qr-container');
         if (!container) return;
         container.innerHTML = '';
+        // #620: the address in plain text next to the code, always — not only
+        // in the branch below where the QR library itself is missing. The
+        // failure this covers is a phone that cannot reach the address, and
+        // the code renders perfectly in that case.
+        var urlEl = document.getElementById('admin-join-url');
+        // location.host, not a scheme-stripping regex — see the note in
+        // dashboard.html's renderLobbyQr and the #540 guard.
+        if (urlEl) urlEl.textContent = window.location.host + '/quizify/player';
         if (typeof QRCode !== 'undefined') {
             _qrInstance = new QRCode(container, {
                 text: url, width: 180, height: 180,

--- a/tests/test_qr_join_url_fallback_620.py
+++ b/tests/test_qr_join_url_fallback_620.py
@@ -1,0 +1,90 @@
+"""The join address is visible without scanning (issue #620).
+
+Both lobbies showed the QR code and a "scan to join" line. The address itself
+appeared as text **only** in the branch that runs when the QR library fails to
+load — a case that has nothing to do with the failure this covers.
+
+The failure this covers: a guest on cellular data, or on the guest network,
+scans a perfectly rendered code, lands on a LAN address their phone cannot
+reach, and gets a spinner. And that is the one failure the join page can never
+explain, because the join page is what failed to load. ``errors.checkNetwork``
+exists in all three bundles and renders only on the post-load connection-lost
+view — where it is no longer needed.
+
+So the address and a "same Wi-Fi" line are now written on every render, not on
+the library-missing path.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WWW = _REPO_ROOT / "custom_components" / "quizify" / "www"
+
+LANGUAGES = ("de", "en", "es")
+NEW_KEYS = ("orTypeUrl", "sameWifiHint")
+
+
+def test_both_keys_ship_in_every_language() -> None:
+    """A hint that renders its own key would be worse than no hint."""
+    for code in LANGUAGES:
+        lobby = json.loads((_WWW / "i18n" / f"{code}.json").read_text("utf-8"))["lobby"]
+        for key in NEW_KEYS:
+            assert lobby.get(key), f"{code}.lobby.{key} missing or empty"
+
+
+def test_the_tv_lobby_shows_the_address_and_the_hint() -> None:
+    source = (_WWW / "dashboard.html").read_text("utf-8")
+
+    assert 'id="lobby-join-url"' in source
+    assert 'data-i18n="lobby.sameWifiHint"' in source
+    assert 'data-i18n="lobby.orTypeUrl"' in source
+
+
+def test_the_tv_writes_the_address_outside_the_library_check() -> None:
+    """The point of the whole change.
+
+    A fallback that only runs when ``QRCode`` is undefined does not help a guest
+    whose phone cannot reach a perfectly rendered code. This asserts the write
+    happens *before* that branch is entered.
+    """
+    source = (_WWW / "dashboard.html").read_text("utf-8")
+    body = source.split("function renderLobbyQr()", 1)[1].split("function ", 1)[0]
+
+    write_at = body.index("lobbyJoinUrlEl")
+    branch_at = body.index("typeof QRCode !== 'undefined'")
+    assert write_at < branch_at, (
+        "the address must be written on every render, not only when the QR "
+        "library is missing"
+    )
+
+
+def test_the_admin_lobby_got_the_same_treatment() -> None:
+    """The issue named both screens; shipping one covers half the cases.
+
+    The host reads this line aloud when a guest's phone cannot reach the code.
+    """
+    html = (_WWW / "admin.html").read_text("utf-8")
+    js = (_WWW / "js" / "admin.js").read_text("utf-8")
+
+    assert 'id="admin-join-url"' in html
+    assert 'data-i18n="lobby.sameWifiHint"' in html
+
+    body = js.split("function generateQR(url)", 1)[1].split("\n    }", 1)[0]
+    assert body.index("admin-join-url") < body.index("typeof QRCode !== 'undefined'")
+
+
+def test_the_admin_qr_column_keeps_its_width_cap() -> None:
+    """Wrapping the QR in a column moved the grid child.
+
+    The 220px cap lived on the code itself; without moving it, the wrapper takes
+    the whole grid track and the QR dominates the card on a phone — the exact
+    thing that cap was added to prevent.
+    """
+    css = (_WWW / "css" / "styles.css").read_text("utf-8")
+
+    assert ".lobby-e-qr-col" in css
+    column_block = css.split(".lobby-e-qr-col", 1)[1].split("}", 1)[0]
+    assert "max-width: 220px" in column_block


### PR DESCRIPTION
Closes #620.

## The failure this covers

Both lobbies showed the QR and "scan to join". The address appeared as text **only** inside `if (typeof QRCode === 'undefined')` — the branch for a missing vendor library, which is a different problem entirely.

The failure that actually happens at a party: a guest on cellular data, or on the guest network, scans a perfectly rendered code, lands on a LAN address their phone cannot reach, and gets a spinner.

**That failure can never explain itself.** The page that would show the explanation is the page that failed to load. `errors.checkNetwork` exists in all three bundles and renders only on the post-load connection-lost view — where it is no longer needed.

## The change

TV lobby and admin lobby both write the address and a "same Wi-Fi as this screen" line on **every** render. Two new `lobby.*` keys in all three bundles.

Built for both screens because the issue named both; shipping one covers half the cases, and the host reading the line aloud is the other half.

## Two things worth flagging

**The #540 guard fired, and it was right.** My first version stripped the scheme with `/^https?:\/\//` for display. `test_no_render_site_reimplements_the_scheme_test` rejected it. The use here was cosmetic, not a security check — but the guard is deliberately blunt, and a reader cannot tell a display strip from the scheme test that caused #540. The string is now composed from `window.location.host`, so the banned shape is gone rather than worked around.

**The admin QR grid child moved.** Wrapping the code in a column made the wrapper the grid child, and the 220px phone cap lived on the code itself. Left there, the wrapper takes the whole track and the QR dominates the card on a phone — exactly what that cap was added to prevent. The cap moved to the column, and a test pins it.

## Sizing

Set from the render rather than guessed: at `clamp(1.1rem, 1.9vw, 1.6rem)` the address was the loudest element in the block and out-shouted the QR it backs up. It is now `clamp(1rem, 1.5vw, 1.35rem)` — still readable from a couch, since someone is typing it from three metres away, without becoming the primary route.

## Tests

`tests/test_qr_join_url_fallback_620.py`: both keys in every language, the markup on both screens, the address written **before** the library check on both (the whole point — a fallback gated on the library does not help a phone that cannot reach a rendered code), and the width cap surviving the wrapper.

Run against the unfixed frontend: **5 of 5 failed**.

Suite 2030, `ruff` clean.