### PR TITLE
fix(#621): stop losing host and player taps in silence

### DIFF
--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -1282,9 +1282,31 @@
         ws.onerror = function () { if (ws) ws.close(); };
     }
 
+    // Returns whether the message actually went out (#621).
+    //
+    // This used to be the same three lines without the `else`: on a closed
+    // socket the command vanished with no toast, no log, nothing. #599 made
+    // *refused* commands visible; an *undelivered* one looks identical from the
+    // host's chair, so half the picture in #586 stayed dark.
+    //
+    // The boolean matters as much as the toast: callers were disabling their
+    // button for 1.5s afterwards, which is a success animation for something
+    // that never happened.
     function send(type, payload) {
         if (ws && ws.readyState === WebSocket.OPEN) {
             ws.send(JSON.stringify(Object.assign({ type: type }, payload)));
+            return true;
+        }
+        _LOG_UNDELIVERED(type);
+        showErrorToast(_t('connection.reconnecting'));
+        return false;
+    }
+
+    function _LOG_UNDELIVERED(type) {
+        // console, not _LOGGER — this is the browser. Kept separate so the
+        // toast text and the diagnostic can diverge without touching send().
+        if (window.console && console.warn) {
+            console.warn('[quizify] command not sent, socket not open:', type);
         }
     }
 
@@ -2694,7 +2716,13 @@
     function _debouncedSend(btn, msgType) {
         if (!btn || btn.disabled) return;
         btn.disabled = true;
-        send(msgType, {});
+        // #621: only hold the button if the command actually left. Disabling
+        // for 1.5s after an undelivered send tells the host "received, working
+        // on it" — the one thing that did not happen.
+        if (!send(msgType, {})) {
+            btn.disabled = false;
+            return;
+        }
         // Re-enable after 1.5s as a safety net (in case server doesn't respond).
         setTimeout(function () { btn.disabled = false; }, 1500);
     }

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -35,10 +35,22 @@
     // Send Helper
     // ============================================
 
+    // Returns whether the message actually went out (#621).
+    //
+    // The phone had the same silent drop as the admin page, and here it is
+    // worse: a guest taps an answer while the socket is down, the tile lights
+    // up, and the round closes without them. Nothing on screen ever said so.
     function send(type, payload) {
         if (state.ws && state.ws.readyState === WebSocket.OPEN) {
             state.ws.send(JSON.stringify(Object.assign({ type: type }, payload || {})));
+            return true;
         }
+        var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
+        if (pu && pu.showToast) pu.showToast(t('connection.reconnecting'), 2500);
+        if (window.console && console.warn) {
+            console.warn('[quizify] command not sent, socket not open:', type);
+        }
+        return false;
     }
 
     // ============================================

--- a/custom_components/quizify/www/js/player-lobby.js
+++ b/custom_components/quizify/www/js/player-lobby.js
@@ -475,12 +475,21 @@
         var startBtn = document.getElementById('start-game-btn');
         if (startBtn) {
             startBtn.addEventListener('click', function () {
-                if (!state.ws || state.ws.readyState !== WebSocket.OPEN) return;
-
                 // #625: was a hardcoded "Starting...". `admin.starting` exists
                 // in all three bundles. Local `t` per this file's convention.
                 var t = (window.QuizifyI18n && window.QuizifyI18n.t)
                     || function (k) { return k; };
+                // #621: this guard used to `return` in silence, so the host
+                // tapping Start during a reconnect saw the button do nothing
+                // at all — indistinguishable from a broken button.
+                if (!state.ws || state.ws.readyState !== WebSocket.OPEN) {
+                    var pu = window.QuizifyPlayerUtils;
+                    if (pu && pu.showToast) {
+                        pu.showToast(t('connection.reconnecting'), 2500);
+                    }
+                    return;
+                }
+
                 startBtn.disabled = true;
                 startBtn.innerHTML = '<span class="btn-icon" aria-hidden="true">🎉</span><span>'
                     + t('admin.starting') + '</span>';

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -1357,12 +1357,21 @@
         var startBtn = document.getElementById('start-game-btn');
         if (startBtn) {
             startBtn.addEventListener('click', function () {
-                if (!state.ws || state.ws.readyState !== WebSocket.OPEN) return;
-
                 // #625: was a hardcoded "Starting...". `admin.starting` exists
                 // in all three bundles. Local `t` per this file's convention.
                 var t = (window.QuizifyI18n && window.QuizifyI18n.t)
                     || function (k) { return k; };
+                // #621: this guard used to `return` in silence, so the host
+                // tapping Start during a reconnect saw the button do nothing
+                // at all — indistinguishable from a broken button.
+                if (!state.ws || state.ws.readyState !== WebSocket.OPEN) {
+                    var pu = window.QuizifyPlayerUtils;
+                    if (pu && pu.showToast) {
+                        pu.showToast(t('connection.reconnecting'), 2500);
+                    }
+                    return;
+                }
+
                 startBtn.disabled = true;
                 startBtn.innerHTML = '<span class="btn-icon" aria-hidden="true">🎉</span><span>'
                     + t('admin.starting') + '</span>';
@@ -5030,10 +5039,22 @@
     // Send Helper
     // ============================================
 
+    // Returns whether the message actually went out (#621).
+    //
+    // The phone had the same silent drop as the admin page, and here it is
+    // worse: a guest taps an answer while the socket is down, the tile lights
+    // up, and the round closes without them. Nothing on screen ever said so.
     function send(type, payload) {
         if (state.ws && state.ws.readyState === WebSocket.OPEN) {
             state.ws.send(JSON.stringify(Object.assign({ type: type }, payload || {})));
+            return true;
         }
+        var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
+        if (pu && pu.showToast) pu.showToast(t('connection.reconnecting'), 2500);
+        if (window.console && console.warn) {
+            console.warn('[quizify] command not sent, socket not open:', type);
+        }
+        return false;
     }
 
     // ============================================

--- a/tests/test_silent_send_failure_621.py
+++ b/tests/test_silent_send_failure_621.py
@@ -1,0 +1,106 @@
+"""Commands that cannot be delivered say so (issue #621).
+
+``send()`` on both the admin page and the phone was the same three lines: if the
+socket is OPEN, send — and nothing otherwise. No toast, no console line, no
+return value. During an HA restart or a Wi-Fi blip the host tapped "Next
+Question", the button disabled itself for 1.5s as if the command had landed, and
+re-enabled. The command never left the browser.
+
+This is the other half of #586. #599 made *refused* commands visible: the server
+answers with an error code and the client raises a toast. An *undelivered*
+command looks identical from the host's chair, and stayed dark.
+
+On the phone it is worse than on the admin page: a guest taps an answer while
+the socket is down, the tile lights up, and the round closes without them.
+
+Everything needed already existed — ``showErrorToast`` / ``showToast``, the
+connection indicator, and ``connection.reconnecting`` in all three bundles. What
+was missing was the ``else``.
+
+The return value matters as much as the toast: callers were disabling their
+button afterwards, which is a success animation for something that did not
+happen.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WWW = _REPO_ROOT / "custom_components" / "quizify" / "www"
+_JS = _WWW / "js"
+
+
+def _function_body(source: str, signature: str) -> str:
+    """Brace-matched body — slicing to the next dedent would stop at the first
+    nested block and make these assertions meaningless."""
+    start = source.index(signature)
+    depth = 0
+    for i in range(start, len(source)):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : i + 1]
+    raise AssertionError(f"unbalanced braces after {signature!r}")
+
+
+def test_the_string_exists_in_every_language() -> None:
+    for code in ("de", "en", "es"):
+        bundle = json.loads((_WWW / "i18n" / f"{code}.json").read_text("utf-8"))
+        assert bundle["connection"]["reconnecting"]
+
+
+def test_the_admin_send_reports_failure_instead_of_swallowing_it() -> None:
+    body = _function_body(
+        (_JS / "admin.js").read_text("utf-8"), "function send(type, payload)"
+    )
+
+    assert "return true" in body
+    assert "return false" in body
+    assert "connection.reconnecting" in body
+
+
+def test_the_phone_send_reports_failure_too() -> None:
+    """Not in the issue, same defect, worse consequence — a lost answer."""
+    body = _function_body(
+        (_JS / "player-core.js").read_text("utf-8"), "function send(type, payload)"
+    )
+
+    assert "return true" in body
+    assert "return false" in body
+    assert "connection.reconnecting" in body
+
+
+def test_the_button_is_not_held_when_nothing_was_sent() -> None:
+    """The half of the fix a toast alone would miss.
+
+    Holding the button for 1.5s after an undelivered send tells the host
+    "received, working on it" — precisely the thing that did not happen.
+    """
+    body = _function_body(
+        (_JS / "admin.js").read_text("utf-8"), "function _debouncedSend(btn, msgType)"
+    )
+
+    assert "if (!send(" in body
+    guard = body.index("if (!send(")
+    timeout = body.index("setTimeout")
+    assert guard < timeout, "the early return must come before the 1.5s hold"
+
+
+def test_the_lobby_start_button_no_longer_returns_in_silence() -> None:
+    body = _function_body(
+        (_JS / "player-lobby.js").read_text("utf-8"),
+        "function setupAdminControls(sendFn)",
+    )
+
+    assert "connection.reconnecting" in body
+
+
+def test_all_of_it_reached_the_shipped_bundle() -> None:
+    """player.html loads the bundle; the module edits alone ship nothing."""
+    bundle = (_JS / "player.bundle.js").read_text("utf-8")
+
+    assert bundle.count("connection.reconnecting") >= 2


### PR DESCRIPTION
Closes #621.

## The silence

`send()` on the admin page and on the phone was the same three lines: send if the socket is OPEN, and nothing otherwise. No toast, no console line, no return value.

During an HA restart or a Wi-Fi blip the host taps "Next Question", the button disables itself for 1.5s as if the command had landed, and re-enables. It never left the browser.

**This is the other half of #586.** #599 made *refused* commands visible — the server answers with an error code and the client raises a toast. An *undelivered* command looks identical from the host's chair, and stayed dark.

## The change

Both `send()` functions now toast `connection.reconnecting`, log the message type to the console, and **return whether delivery happened**.

That return value is half the fix. `_debouncedSend` was disabling the button for 1.5s afterwards — a success animation for something that did not happen. It now releases immediately when nothing went out.

## Two spots beyond the issue

**The phone's `send()`**, which had the identical silent drop and a worse consequence: a guest taps an answer while the socket is down, the tile lights up, and the round closes without them.

**The lobby Start button**, which did guard on `readyState` — and returned in silence, which from the outside is indistinguishable from a broken button.

## Nothing new was designed

`showErrorToast` / `showToast`, the connection indicator and `connection.reconnecting` in all three bundles all existed. What was missing was the `else`.

## Tests

`tests/test_silent_send_failure_621.py`: the string in every bundle, both `send()`s reporting failure, the button not being held when nothing was sent (asserting the early return comes *before* the 1.5s hold), the lobby guard, and the whole thing reaching the shipped bundle.

The body helper brace-matches rather than slicing to the next dedent, which would stop at the first nested block and make the assertions meaningless.

Run against the unfixed frontend: **5 of 6 failed**.

Suite 2036, `ruff` clean.

**Honest limit:** structural tests, as everywhere on this frontend. They pin that the branch exists and returns; no test opens a socket, closes it, and taps a button. That needs the live run.