### PR TITLE
fix(#622): the TV button stops promising a cast it never did

### DIFF
--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -728,7 +728,7 @@
 
                 <a href="#" id="dashboard-link" class="lobby-e-cast" target="_blank">
                     <span class="qz-icon qz-icon--sky" data-ui-icon="tv" aria-hidden="true">📺</span>
-                    <span data-i18n="dashboard.castToTv">Cast to TV</span>
+                    <span data-i18n="dashboard.castToTv">Open on the TV</span>
                     <span aria-hidden="true">→</span>
                 </a>
 
@@ -930,6 +930,24 @@
             <div class="modal-actions">
                 <button type="button" id="kick-player-confirm-btn" class="btn btn-danger" data-i18n="admin.kickConfirmBtn">Remove</button>
                 <button type="button" id="kick-player-cancel-btn" class="btn btn-secondary" data-i18n="common.cancel">Cancel</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- #622: "Cast to TV" never cast anything — it opened /quizify/dashboard
+         in a tab on the host's own phone. Renaming the button stops the false
+         promise; this sheet answers the question the button raises, namely how
+         the address is supposed to reach the television. The direct open stays
+         for a host who IS on the TV device. -->
+    <div id="cast-tv-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="cast-tv-modal-title">
+        <div class="modal-backdrop"></div>
+        <div class="modal-content">
+            <h2 id="cast-tv-modal-title" data-i18n="dashboard.castModalTitle">Get Quizify onto the TV</h2>
+            <p data-i18n="dashboard.castModalBody">Open this address in the browser on your TV.</p>
+            <div id="cast-tv-url" class="cast-tv-url"></div>
+            <div class="modal-actions">
+                <button type="button" id="cast-tv-open-btn" class="btn btn-secondary" data-i18n="dashboard.castOpenHere">Open here instead</button>
+                <button type="button" id="cast-tv-cancel-btn" class="btn btn-secondary" data-i18n="common.cancel">Cancel</button>
             </div>
         </div>
     </div>

--- a/custom_components/quizify/www/css/src/06-admin.css
+++ b/custom_components/quizify/www/css/src/06-admin.css
@@ -82,6 +82,26 @@
     background: rgba(31, 27, 20, 0.70);
 }
 
+/* #622: the dashboard address inside the "open on the TV" sheet. Big enough
+   to read off a phone while typing it on a TV remote, and selectable — the
+   host may want to copy it rather than retype it. */
+.cast-tv-url {
+    margin: var(--space-sm) 0 var(--space-md);
+    padding: var(--space-sm);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.06);
+    font-size: 0.95rem;
+    font-weight: 600;
+    /* `break-all` split mid-token and left a single stranded character on its
+       own line — bad for something a host reads out or types on a TV remote.
+       `anywhere` still wraps a long address, but prefers the slashes. */
+    overflow-wrap: anywhere;
+    word-break: normal;
+    line-height: 1.4;
+    text-align: center;
+    user-select: all;
+}
+
 .modal-content {
     position: relative;
     background: var(--color-dark-surface-hover);     /* surface-2 navy \u2014 not cream */

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -3285,6 +3285,26 @@ button, .btn {
     background: rgba(31, 27, 20, 0.70);
 }
 
+/* #622: the dashboard address inside the "open on the TV" sheet. Big enough
+   to read off a phone while typing it on a TV remote, and selectable — the
+   host may want to copy it rather than retype it. */
+.cast-tv-url {
+    margin: var(--space-sm) 0 var(--space-md);
+    padding: var(--space-sm);
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.06);
+    font-size: 0.95rem;
+    font-weight: 600;
+    /* `break-all` split mid-token and left a single stranded character on its
+       own line — bad for something a host reads out or types on a TV remote.
+       `anywhere` still wraps a long address, but prefers the slashes. */
+    overflow-wrap: anywhere;
+    word-break: normal;
+    line-height: 1.4;
+    text-align: center;
+    user-select: all;
+}
+
 .modal-content {
     position: relative;
     background: var(--color-dark-surface-hover);     /* surface-2 navy \u2014 not cream */

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -529,7 +529,10 @@
   "dashboard": {
     "waitingForStart": "Warte auf Spielstart…",
     "leaderboard": "Rangliste",
-    "castToTv": "Auf den TV streamen",
+    "castToTv": "Auf dem Fernseher öffnen",
+    "castModalTitle": "Quizify auf den Fernseher holen",
+    "castModalBody": "Öffne diese Adresse im Browser deines Fernsehers.",
+    "castOpenHere": "Hier öffnen",
     "didYouKnow": "Wusstest du?",
     "result": "Ergebnis",
     "questionCounter": "Frage {current} / {total}",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -529,7 +529,10 @@
   "dashboard": {
     "waitingForStart": "Waiting for game to start…",
     "leaderboard": "Leaderboard",
-    "castToTv": "Cast to TV",
+    "castToTv": "Open on the TV",
+    "castModalTitle": "Get Quizify onto the TV",
+    "castModalBody": "Open this address in the browser on your TV.",
+    "castOpenHere": "Open here instead",
     "didYouKnow": "Did you know?",
     "result": "Result",
     "questionCounter": "Question {current} / {total}",

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -529,7 +529,10 @@
   "dashboard": {
     "waitingForStart": "Esperando a que empiece la partida…",
     "leaderboard": "Clasificación",
-    "castToTv": "Enviar a la TV",
+    "castToTv": "Abrir en la tele",
+    "castModalTitle": "Llevar Quizify a la tele",
+    "castModalBody": "Abre esta dirección en el navegador de tu televisor.",
+    "castOpenHere": "Abrir aquí",
     "didYouKnow": "¿Sabías que...?",
     "result": "Resultado",
     "questionCounter": "Pregunta {current} / {total}",

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -2913,16 +2913,55 @@
         if (els.dashboardLink) {
             var dashboardUrl = window.location.origin + '/quizify/dashboard';
             els.dashboardLink.href = dashboardUrl;
-            // Android Companion: bypass the dead target="_blank" — navigate the
-            // current frame so the dashboard ("Cast to TV") actually loads (#377).
-            // Every other context keeps the native new-tab behaviour.
+            // #622: the button never cast anything — it opened this URL in a
+            // tab on the host's own phone. A first-time host tapped it, got the
+            // TV view at 390px in their hand, and no hint how it reaches the
+            // television. (The one external bug report we have, #586, said
+            // exactly this and it was filed as an unexplained symptom.)
+            //
+            // Tapping now explains the actual mechanic and offers the address
+            // to type on the TV. The direct open survives as the secondary
+            // action, for a host who IS sitting at the TV device.
             els.dashboardLink.addEventListener('click', function (evt) {
+                evt.preventDefault();
+                openCastModal(dashboardUrl, els.dashboardLink);
+            });
+        }
+    }
+
+    function openCastModal(dashboardUrl, triggerEl) {
+        var urlEl = document.getElementById('cast-tv-url');
+        // location.host, not a scheme regex — see the #540 guard note in
+        // generateQR. Same reason, same shape.
+        if (urlEl) urlEl.textContent = window.location.host + '/quizify/dashboard';
+
+        var openBtn = document.getElementById('cast-tv-open-btn');
+        if (openBtn && !openBtn._castWired) {
+            openBtn._castWired = true;
+            openBtn.addEventListener('click', function () {
+                closeConfirmModal('cast-tv-modal');
+                // Android Companion swallows target="_blank" (#377), so
+                // navigate the frame there instead of opening a tab.
                 if (isAndroidCompanion()) {
-                    evt.preventDefault();
                     window.location.href = dashboardUrl;
+                } else {
+                    window.open(dashboardUrl, '_blank');
                 }
             });
         }
+
+        var modal = document.getElementById('cast-tv-modal');
+        if (!modal) {
+            // Markup missing → fall back to the old behaviour rather than
+            // leaving the host with a button that does nothing at all.
+            if (isAndroidCompanion()) {
+                window.location.href = dashboardUrl;
+            } else {
+                window.open(dashboardUrl, '_blank');
+            }
+            return;
+        }
+        openConfirmModal('cast-tv-modal', 'cast-tv-cancel-btn', triggerEl);
     }
 
     // ---- Error toast ----

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -257,7 +257,7 @@
             <div id="player-qr-code" class="sr-only" role="button" tabindex="-1"
                  data-i18n-aria-label="a11y.tapToEnlargeQr" aria-label="QR Code"></div>
             <a href="#" id="player-dashboard-url" class="sr-only" target="_blank">
-                <span data-i18n="dashboard.castToTv">Cast to TV</span>
+                <span data-i18n="dashboard.castToTv">Open on the TV</span>
             </a>
 
             <!-- Lobby Status (for non-admin players) -->

--- a/tests/test_cast_to_tv_explains_itself_622.py
+++ b/tests/test_cast_to_tv_explains_itself_622.py
@@ -1,0 +1,122 @@
+"""The TV button stops promising something it does not do (issue #622).
+
+"Cast to TV" set `href` to `/quizify/dashboard` and opened it in a new tab **on
+the host's own phone**. No cast call, no device picker. A first-time host tapped
+it, got the TV view at 390px in their hand, and no hint how it reaches the
+television.
+
+This is also the second real finding inside #586, the only external bug report
+this project has. The reporter wrote "Cast to TV does not ask which TV and does
+not work" — filed as an unexplained symptom next to the round-hang, and left
+there for three days. It was never a bug: the button does exactly what it does,
+it just says something else.
+
+So both halves change. The label stops making the promise, and tapping explains
+the actual mechanic while still offering the direct open for a host who *is* at
+the TV device.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WWW = _REPO_ROOT / "custom_components" / "quizify" / "www"
+
+LANGUAGES = ("de", "en", "es")
+MODAL_KEYS = ("castModalTitle", "castModalBody", "castOpenHere")
+
+
+def _dashboard_bundle(code: str) -> dict:
+    return json.loads((_WWW / "i18n" / f"{code}.json").read_text("utf-8"))["dashboard"]
+
+
+def test_the_label_no_longer_promises_casting() -> None:
+    """Every language, because the promise was made in every language.
+
+    German said "Auf den TV streamen" and Spanish "Enviar a la TV" — both claim
+    a stream that does not exist, so fixing only the English string would leave
+    two thirds of the users misled.
+    """
+    forbidden = {"cast to tv", "auf den tv streamen", "enviar a la tv"}
+    for code in LANGUAGES:
+        label = _dashboard_bundle(code)["castToTv"]
+        assert label.strip().lower() not in forbidden, f"{code} still promises casting"
+
+
+def test_the_modal_strings_ship_everywhere() -> None:
+    for code in LANGUAGES:
+        bundle = _dashboard_bundle(code)
+        for key in MODAL_KEYS:
+            assert bundle.get(key), f"{code}.dashboard.{key} missing or empty"
+
+
+def test_the_markup_fallbacks_were_updated_too() -> None:
+    """The inline text renders until i18n boots.
+
+    Leaving "Cast to TV" in the HTML means the old promise flashes on every
+    load — the one moment a first-time host is most likely to read it.
+
+    Checks the rendered span, not the raw file: the fix's own comment quotes the
+    old label to explain what it replaced, and a substring scan would call a
+    correct page broken. (Second time today; see the "Starting..." assertion
+    in the #625 tests.)
+    """
+    pattern = re.compile(r'data-i18n="dashboard\.castToTv">([^<]*)<')
+    for page in ("admin.html", "player.html"):
+        source = (_WWW / page).read_text("utf-8")
+        rendered = pattern.findall(source)
+        assert rendered, f"{page} no longer has the castToTv span"
+        for text in rendered:
+            assert "Cast to TV" not in text, f"{page} still ships the old label"
+
+
+def test_tapping_opens_the_sheet_instead_of_a_tab() -> None:
+    source = (_WWW / "js" / "admin.js").read_text("utf-8")
+
+    assert "openCastModal(dashboardUrl" in source
+    assert 'id="cast-tv-modal"' in (_WWW / "admin.html").read_text("utf-8")
+
+
+def test_the_direct_open_survives_as_the_secondary_action() -> None:
+    """A host sitting at the TV must not lose the one-tap route.
+
+    And the #377 Android Companion workaround has to survive with it: that
+    WebView swallows target="_blank", so the frame is navigated instead.
+    """
+    source = (_WWW / "js" / "admin.js").read_text("utf-8")
+    body = source.split("function openCastModal(", 1)[1].split("\n    }", 1)[0]
+
+    assert "isAndroidCompanion()" in body
+    assert "window.open(dashboardUrl" in body
+
+
+def test_a_missing_modal_falls_back_to_the_old_behaviour() -> None:
+    """Markup drift must not leave the host with a dead button.
+
+    The kick-player modal sets this precedent (#480); the same reasoning
+    applies here, and the failure mode without it is worse than the bug.
+    """
+    source = (_WWW / "js" / "admin.js").read_text("utf-8")
+    body = source.split("function openCastModal(", 1)[1].split("\n    }", 1)[0]
+
+    assert "if (!modal)" in body
+
+
+def test_the_address_wraps_without_stranding_characters() -> None:
+    """`break-all` split mid-token and left a lone character on its own line.
+
+    Found in the render, not in review: the host reads this aloud or types it
+    on a TV remote.
+    """
+    css = (_WWW / "css" / "styles.css").read_text("utf-8")
+    block = css.split(".cast-tv-url", 1)[1].split("}", 1)[0]
+    # Strip comments before asserting: the rule's own comment names `break-all`
+    # to say why it is gone, and scanning raw text would read that as the
+    # declaration still being there.
+    declarations = re.sub(r"/\*.*?\*/", "", block, flags=re.S)
+
+    assert "overflow-wrap: anywhere" in declarations
+    assert "break-all" not in declarations


### PR DESCRIPTION
Closes #622.

## What the button actually did

`initJoinUrl` set `href` to `/quizify/dashboard` and opened it in a new tab **on the host's own phone**. There is no cast call and no device picker anywhere in the path. A first-time host taps "Cast to TV", gets the TV view at 390px in their hand, and has no idea how it is supposed to reach the television.

## This is the second finding inside #586

The only external bug report this project has said, verbatim:

> Cast to TV does not ask which TV and does not work.

It was filed as an unexplained third symptom next to the round-hang and sat there for three days. **It was never a bug.** The button does exactly what it does; it just said something else. Worth recording, because the report looked like one defect with three faces and was actually two defects and a naming problem.

## Both halves

**The label.** "Open on the TV" / "Auf dem Fernseher öffnen" / "Abrir en la tele". German and Spanish promised a stream as well ("Auf den TV streamen", "Enviar a la TV"), so fixing only the English string would have left two thirds of users misled. The inline HTML fallbacks moved too — they render until i18n boots, which is precisely when a first-time host reads the button.

**The sheet.** Tapping opens a modal with the dashboard address and one line of instruction. The direct open survives as the secondary action for a host who *is* at the TV device, and it carries the #377 Android Companion workaround with it (that WebView swallows `target="_blank"`). A missing modal falls back to the old behaviour rather than leaving a dead button — the precedent is the kick-player modal in #480.

The address is composed from `location.host` rather than stripped with a scheme regex, same as #620: the #540 guard bans that shape and is right to.

## From the render, not from review

`break-all` split the address mid-token and left a single stranded character on its own line. That is bad for a string a host reads aloud or types on a TV remote. Now `overflow-wrap: anywhere`, which prefers the slashes, at a slightly smaller size so a typical LAN address fits one line.

## Tests

`tests/test_cast_to_tv_explains_itself_622.py`: the label in all three languages, the modal strings, the HTML fallbacks, the sheet replacing the tab, the direct open and Android workaround surviving, the missing-modal fallback, and the wrapping rule.

Two assertions look at *declarations* rather than raw text, because the fix's own comments quote the old label and the old CSS property to explain what they replaced. A naive substring scan would call a correct file broken — the same trap as the `"Starting..."` assertion in #625, met twice in one day.

Run against the unfixed frontend: **7 of 7 failed**.

Suite 2043, `ruff` clean.