### PR TITLE
fix(#626): preset save and delete stay inside the product

### DIFF
--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -934,6 +934,46 @@
         </div>
     </div>
 
+    <!-- #626: saving a preset used window.prompt, its failures window.alert,
+         and deleting it window.confirm. The kick flow dropped window.confirm
+         for exactly this reason in #480 — same file, a few hundred lines
+         further down. Embedded WebViews render or suppress those dialogs
+         inconsistently, and the Android Companion has already produced two
+         such surprises (#348, #377). -->
+    <div id="save-preset-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="save-preset-modal-title">
+        <div class="modal-backdrop"></div>
+        <div class="modal-content">
+            <h2 id="save-preset-modal-title" data-i18n="setup.savePresetTitle">Save preset</h2>
+            <p data-i18n="setup.savePresetBody">Rounds, difficulty, timer and pack selection are stored under this name.</p>
+            <div class="form-group">
+                <input type="text" id="save-preset-input" class="name-input"
+                       data-i18n-placeholder="setup.savePresetPlaceholder"
+                       placeholder="Preset name" maxlength="30"
+                       autocomplete="off" autocapitalize="sentences">
+                <!-- The server writes its refusals for a person ("at most 20
+                     presets can be saved"), so they land here instead of in an
+                     alert — which keeps the typed name on screen to correct. -->
+                <p id="save-preset-error" class="validation-msg hidden" role="alert"></p>
+            </div>
+            <div class="modal-actions">
+                <button type="button" id="save-preset-confirm-btn" class="btn btn-primary" data-i18n="setup.savePresetBtn">Save</button>
+                <button type="button" id="save-preset-cancel-btn" class="btn btn-secondary" data-i18n="common.cancel">Cancel</button>
+            </div>
+        </div>
+    </div>
+
+    <div id="delete-preset-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="delete-preset-modal-title">
+        <div class="modal-backdrop"></div>
+        <div class="modal-content">
+            <h2 id="delete-preset-modal-title" data-i18n="setup.deletePresetTitle">Delete preset?</h2>
+            <p id="delete-preset-modal-text" data-i18n="setup.deletePresetBody">This preset will be removed for good.</p>
+            <div class="modal-actions">
+                <button type="button" id="delete-preset-confirm-btn" class="btn btn-danger" data-i18n="setup.deletePresetBtn">Delete</button>
+                <button type="button" id="delete-preset-cancel-btn" class="btn btn-secondary" data-i18n="common.cancel">Cancel</button>
+            </div>
+        </div>
+    </div>
+
     <!-- #622: "Cast to TV" never cast anything — it opened /quizify/dashboard
          in a tab on the host's own phone. Renaming the button stops the false
          promise; this sheet answers the question the button raises, namely how

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -470,6 +470,13 @@
     "myPresets": "Meine Presets",
     "savePreset": "Aktuelles speichern",
     "savePresetPrompt": "Name für dieses Preset:",
+    "savePresetTitle": "Vorlage speichern",
+    "savePresetBody": "Runden, Schwierigkeit, Timer und Pack-Auswahl werden unter diesem Namen gesichert.",
+    "savePresetPlaceholder": "Name der Vorlage",
+    "savePresetBtn": "Speichern",
+    "deletePresetTitle": "Vorlage löschen?",
+    "deletePresetBody": "„{name}“ wird dauerhaft entfernt.",
+    "deletePresetBtn": "Löschen",
     "deletePreset": "Preset löschen",
     "deletePresetConfirm": "Preset löschen:"
   },

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -470,6 +470,13 @@
     "myPresets": "My presets",
     "savePreset": "Save current",
     "savePresetPrompt": "Name for this preset:",
+    "savePresetTitle": "Save preset",
+    "savePresetBody": "Rounds, difficulty, timer and pack selection are stored under this name.",
+    "savePresetPlaceholder": "Preset name",
+    "savePresetBtn": "Save",
+    "deletePresetTitle": "Delete preset?",
+    "deletePresetBody": "\"{name}\" will be removed for good.",
+    "deletePresetBtn": "Delete",
     "deletePreset": "Delete preset",
     "deletePresetConfirm": "Delete preset:"
   },

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -470,6 +470,13 @@
     "myPresets": "Mis ajustes",
     "savePreset": "Guardar actual",
     "savePresetPrompt": "Nombre para este ajuste:",
+    "savePresetTitle": "Guardar ajuste",
+    "savePresetBody": "Se guardarán las rondas, la dificultad, el temporizador y los paquetes elegidos con este nombre.",
+    "savePresetPlaceholder": "Nombre del ajuste",
+    "savePresetBtn": "Guardar",
+    "deletePresetTitle": "¿Eliminar el ajuste?",
+    "deletePresetBody": "«{name}» se eliminará definitivamente.",
+    "deletePresetBtn": "Eliminar",
     "deletePreset": "Eliminar ajuste",
     "deletePresetConfirm": "¿Eliminar el ajuste:"
   },

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -876,7 +876,7 @@
             del.setAttribute('aria-label', _t('setup.deletePreset') + ' ' + p.name);
             del.addEventListener('click', function (ev) {
                 ev.stopPropagation();   // deleting must never also select
-                _deleteCustomPreset(p);
+                _deleteCustomPreset(p, del);
             });
             chip.appendChild(del);
 
@@ -888,7 +888,11 @@
         add.type = 'button';
         add.className = 'preset-chip preset-chip--add';
         add.textContent = '+ ' + _t('setup.savePreset');
-        add.addEventListener('click', _saveCurrentPreset);
+        // Pass the button, not the event: addEventListener hands the handler an
+        // Event, and openConfirmModal stores its argument to restore focus on
+        // close (#479). An Event there has no .focus() and the restore silently
+        // does nothing — the keyboard user lands back at the top of the page.
+        add.addEventListener('click', function () { _saveCurrentPreset(add); });
         row.appendChild(add);
 
         // Hidden entirely while nothing is saved: the label plus a lone
@@ -920,12 +924,56 @@
         if (typeof updateCategorySummary === 'function') updateCategorySummary();
     }
 
-    function _saveCurrentPreset() {
-        var name = window.prompt(_t('setup.savePresetPrompt'));
-        if (name === null) return;
-        name = name.trim();
-        if (!name) return;
+    function _saveCurrentPreset(triggerEl) {
+        // #626: themed modal instead of window.prompt. The dialog stays open on
+        // a server refusal so the typed name survives — an alert() throws it
+        // away and the host retypes from memory.
+        var modal = document.getElementById('save-preset-modal');
+        var input = document.getElementById('save-preset-input');
+        var errorEl = document.getElementById('save-preset-error');
+        if (!modal || !input) {
+            // Markup drift must not cost the host the feature entirely.
+            var fallbackName = window.prompt(_t('setup.savePresetPrompt'));
+            if (fallbackName === null) return;
+            fallbackName = fallbackName.trim();
+            if (fallbackName) _postPreset(fallbackName, null, null);
+            return;
+        }
 
+        input.value = '';
+        if (errorEl) {
+            errorEl.textContent = '';
+            errorEl.classList.add('hidden');
+        }
+
+        var confirmBtn = document.getElementById('save-preset-confirm-btn');
+        if (confirmBtn && !confirmBtn._presetWired) {
+            confirmBtn._presetWired = true;
+            confirmBtn.addEventListener('click', function () {
+                var name = (input.value || '').trim();
+                if (!name) {
+                    input.focus();
+                    return;
+                }
+                _postPreset(name, errorEl, 'save-preset-modal');
+            });
+        }
+        if (!input._presetWired) {
+            input._presetWired = true;
+            // Enter submits: this dialog has one field and one obvious action.
+            input.addEventListener('keydown', function (e) {
+                if (e.key === 'Enter' && confirmBtn) {
+                    e.preventDefault();
+                    confirmBtn.click();
+                }
+            });
+        }
+
+        openConfirmModal('save-preset-modal', 'save-preset-cancel-btn', triggerEl);
+        setTimeout(function () { input.focus(); }, 0);
+    }
+
+    function _postPreset(name, errorEl, modalId) {
         _presetFetch({
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -948,17 +996,55 @@
                     return body;
                 });
             })
+            .then(function (body) {
+                if (modalId) closeConfirmModal(modalId);
+                return body;
+            })
             .then(_loadCustomPresets)
-            .catch(function (err) { window.alert(err.message); });
+            .catch(function (err) {
+                // Stay open, show why, keep the name. Falls back to the toast
+                // when the modal is not the surface in play.
+                if (errorEl) {
+                    errorEl.textContent = err.message;
+                    errorEl.classList.remove('hidden');
+                } else {
+                    showErrorToast(err.message);
+                }
+            });
     }
 
-    function _deleteCustomPreset(p) {
-        if (!window.confirm(_t('setup.deletePresetConfirm') + ' „' + p.name + '"')) {
+    function _deleteCustomPreset(p, triggerEl) {
+        // #626: the themed danger modal, the same one kicks have used since
+        // #480. The name goes in the sentence — "delete preset?" alone makes
+        // the host guess which one they tapped.
+        var modal = document.getElementById('delete-preset-modal');
+        var textEl = document.getElementById('delete-preset-modal-text');
+        var confirmBtn = document.getElementById('delete-preset-confirm-btn');
+
+        function doDelete() {
+            _presetFetch({ method: 'DELETE', _q: '?id=' + encodeURIComponent(p.id) })
+                .then(_loadCustomPresets)
+                .catch(function () { /* stays on screen; next load reconciles */ });
+        }
+
+        if (!modal || !confirmBtn) {
+            if (window.confirm(_t('setup.deletePresetConfirm') + ' „' + p.name + '"')) {
+                doDelete();
+            }
             return;
         }
-        _presetFetch({ method: 'DELETE', _q: '?id=' + encodeURIComponent(p.id) })
-            .then(_loadCustomPresets)
-            .catch(function () { /* stays on screen; next load reconciles */ });
+
+        if (textEl) {
+            var tmpl = _t('setup.deletePresetBody') || '"{name}" will be removed for good.';
+            textEl.textContent = tmpl.replace('{name}', p.name);
+        }
+        // Re-wired per open: the closure carries THIS preset, and a stale
+        // listener from a previous open would delete the wrong one.
+        confirmBtn.onclick = function () {
+            closeConfirmModal('delete-preset-modal');
+            doDelete();
+        };
+        openConfirmModal('delete-preset-modal', 'delete-preset-cancel-btn', triggerEl);
     }
 
     // Apply preset: write to the active-chip state AND to the typed vars

--- a/tests/test_preset_modals_626.py
+++ b/tests/test_preset_modals_626.py
@@ -1,0 +1,167 @@
+"""Saving and deleting a preset stays inside the product (issue #626).
+
+Saving used `window.prompt`, its failures `window.alert`, deleting
+`window.confirm`. The host builds a game template in a carefully styled screen
+and then gets the grey operating-system box for the name.
+
+The argument is not looks. It is a decision this codebase already made and only
+half applied: #480 dropped `window.confirm` for player kicks in favour of a
+themed modal — same file, a few hundred lines further down. And some embedded
+WebViews render those dialogs poorly or suppress them outright, in which case
+the host cannot save a preset and never learns that anything tried to happen.
+The Android Companion has produced two such surprises already (#348, #377).
+
+The error path is the state that matters most, and the issue did not mention
+it: the server's refusal now lands under the input instead of in an alert, so
+the typed name stays on screen to be corrected rather than retyped from memory.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WWW = _REPO_ROOT / "custom_components" / "quizify" / "www"
+_ADMIN_JS = _WWW / "js" / "admin.js"
+
+LANGUAGES = ("de", "en", "es")
+NEW_KEYS = (
+    "savePresetTitle",
+    "savePresetBody",
+    "savePresetPlaceholder",
+    "savePresetBtn",
+    "deletePresetTitle",
+    "deletePresetBody",
+    "deletePresetBtn",
+)
+
+
+def _without_comments(source: str) -> str:
+    """Drop JS comments before asserting on code.
+
+    Third time this trap has been hit today (#625, #622, here): a fix explains
+    itself in a comment that quotes the very thing it removed, and a raw text
+    search then reads the explanation as the code. Assertions look at
+    declarations, never at prose.
+    """
+    source = re.sub(r"/\*.*?\*/", "", source, flags=re.S)
+    return re.sub(r"^\s*//.*$", "", source, flags=re.M)
+
+
+def _function_body(source: str, signature: str) -> str:
+    start = source.index(signature)
+    depth = 0
+    for i in range(start, len(source)):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : i + 1]
+    raise AssertionError(f"unbalanced braces after {signature!r}")
+
+
+def test_every_string_ships_in_every_language() -> None:
+    for code in LANGUAGES:
+        setup = json.loads((_WWW / "i18n" / f"{code}.json").read_text("utf-8"))["setup"]
+        for key in NEW_KEYS:
+            assert setup.get(key), f"{code}.setup.{key} missing or empty"
+
+
+def test_the_delete_body_names_the_preset() -> None:
+    """"Delete preset?" alone makes the host guess which one they tapped."""
+    for code in LANGUAGES:
+        setup = json.loads((_WWW / "i18n" / f"{code}.json").read_text("utf-8"))["setup"]
+        assert "{name}" in setup["deletePresetBody"], f"{code} has no name slot"
+
+
+def test_both_modals_exist_in_the_markup() -> None:
+    html = (_WWW / "admin.html").read_text("utf-8")
+
+    for modal_id in ("save-preset-modal", "delete-preset-modal"):
+        assert f'id="{modal_id}"' in html
+    assert 'id="save-preset-error"' in html
+    delete_block = html.split('id="delete-preset-modal"', 1)[1][:900]
+    assert 'class="btn btn-danger"' in delete_block
+
+
+def test_saving_opens_the_modal_rather_than_prompting() -> None:
+    body = _without_comments(
+        _function_body(_ADMIN_JS.read_text("utf-8"), "function _saveCurrentPreset(")
+    )
+
+    assert "openConfirmModal('save-preset-modal'" in body
+    prompt_at = body.index("window.prompt")
+    guard_at = body.index("if (!modal || !input)")
+    assert guard_at < prompt_at, (
+        "window.prompt may only survive inside the markup-missing fallback"
+    )
+
+
+def test_a_refusal_keeps_the_dialog_and_the_typed_name() -> None:
+    """The whole point of the error state.
+
+    An alert() throws the name away; this writes the server's sentence under
+    the field and leaves the input untouched.
+    """
+    body = _without_comments(
+        _function_body(_ADMIN_JS.read_text("utf-8"), "function _postPreset(")
+    )
+
+    assert "window.alert" not in body
+    assert "errorEl.textContent = err.message" in body
+    assert "errorEl.classList.remove('hidden')" in body
+
+
+def test_deleting_uses_the_themed_danger_modal() -> None:
+    body = _without_comments(
+        _function_body(_ADMIN_JS.read_text("utf-8"), "function _deleteCustomPreset(")
+    )
+
+    assert "openConfirmModal('delete-preset-modal'" in body
+    confirm_at = body.index("window.confirm")
+    guard_at = body.index("if (!modal || !confirmBtn)")
+    assert guard_at < confirm_at
+
+
+def test_the_delete_handler_is_rewired_per_open() -> None:
+    """A listener kept from a previous open would delete the wrong preset.
+
+    The closure carries the preset that was tapped, so it has to be replaced
+    each time rather than added once.
+    """
+    body = _function_body(_ADMIN_JS.read_text("utf-8"), "function _deleteCustomPreset(")
+
+    assert "confirmBtn.onclick =" in body
+    assert "confirmBtn.addEventListener" not in body
+
+
+def test_both_entry_points_hand_over_a_real_element() -> None:
+    """`openConfirmModal` stores its third argument to restore focus (#479).
+
+    `addEventListener('click', fn)` hands the handler an Event, which has no
+    `.focus()`. The restore would silently do nothing and a keyboard user would
+    land back at the top of the page.
+    """
+    source = _ADMIN_JS.read_text("utf-8")
+
+    assert "add.addEventListener('click', _saveCurrentPreset)" not in source
+    assert "_saveCurrentPreset(add)" in source
+    assert "_deleteCustomPreset(p, del)" in source
+
+
+def test_the_markup_missing_path_still_saves() -> None:
+    """Drift must not cost the host the feature outright.
+
+    The precedent is the kick modal in #480, which keeps its confirm() fallback
+    for the same reason.
+    """
+    save = _function_body(_ADMIN_JS.read_text("utf-8"), "function _saveCurrentPreset(")
+    delete = _function_body(
+        _ADMIN_JS.read_text("utf-8"), "function _deleteCustomPreset("
+    )
+
+    assert "window.prompt" in save
+    assert "window.confirm" in delete


### PR DESCRIPTION
Closes #626.

## The half-applied decision

Saving a preset used `window.prompt`, its failures `window.alert`, deleting `window.confirm`.

This is not a taste argument. #480 dropped `window.confirm` for player kicks in favour of a themed modal, for exactly this reason — **same file, a few hundred lines further down**. The preset flow, which is the host's most power-user moment, kept the system dialog.

And there is a concrete failure behind it: some embedded WebViews render those dialogs poorly or suppress them outright. When that happens the host cannot save a preset *and never learns that anything tried to happen*. The Android Companion has already produced two surprises of exactly this kind (#348, #377), so this is not hypothetical.

## The error state is the point

The issue did not mention it, and it is the state that changes the most: the server's refusal now lands **under the input** instead of in an alert, so the typed name stays on screen to correct. An `alert()` throws it away and the host retypes from memory.

The server writes those messages for a person ("at most 20 presets can be saved"), which is why they are worth showing properly rather than replacing with a generic failure.

## Three details

**The delete handler is assigned per open, not added once.** The closure carries the preset that was tapped; a listener kept from a previous open would delete the wrong one. `onclick =` replaces, `addEventListener` accumulates.

**Both entry points now pass a real element.** `add.addEventListener('click', _saveCurrentPreset)` handed the function the *Event*. `openConfirmModal` stores its third argument to restore focus on close (#479) — an Event has no `.focus()`, so the restore would silently do nothing and a keyboard user would land back at the top of the page. Found while wiring, not by review.

**Both native dialogs survive as markup-missing fallbacks**, the same shape #480 kept for kicks. Drift must not cost the host the feature outright.

## Tests

`tests/test_preset_modals_626.py`: strings in three languages, the delete sentence carrying `{name}`, both modals in the markup, saving opening the modal with `window.prompt` only reachable inside the fallback guard, a refusal keeping the dialog and the name, deletion using the danger modal, the per-open rewiring, both call sites passing an element, and the fallbacks still present.

The helper strips JS comments before asserting. **Third time today** a raw-text assertion tripped over the comment the fix itself writes to explain what it removed (#625, #622, here) — assertions look at declarations, not at prose.

Run against the unfixed frontend: **8 of 9 failed**.

Suite 2061, `ruff` clean.

**Not addressed here:** "Save" carries the accent colour and "Delete" the danger red, and on a small screen those two sit closer together than they should. That is a palette decision, flagged separately.