### PR TITLE
feat(#627): make the analytics page reachable

### DIFF
--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -111,10 +111,23 @@
                     <span aria-hidden="true">▶︎</span>
                     <span data-i18n="admin.openLobby">Open lobby</span>
                 </button>
-                <button type="button" id="setup-tweak-btn" class="setup-tweak-link"
-                        data-i18n="setup.tweak">
-                    Adjust settings…
-                </button>
+                <!-- #627: the analytics page is fully built and had zero
+                     inbound links from anywhere — a host could only reach their
+                     own play history by guessing the URL. Both links sit on one
+                     row: they are equally secondary, and the setup screen has no
+                     vertical room to spare (a second row pushes the primary
+                     action off a 390px viewport). -->
+                <div class="setup-links-row">
+                    <button type="button" id="setup-tweak-btn" class="setup-tweak-link"
+                            data-i18n="setup.tweak">
+                        Adjust settings…
+                    </button>
+                    <span class="setup-links-sep" aria-hidden="true">·</span>
+                    <button type="button" id="setup-stats-btn" class="setup-tweak-link"
+                            data-i18n="setup.stats">
+                        Stats
+                    </button>
+                </div>
             </div>
 
             <!-- DETAIL (variant B + Eigene/expanded chips) -->

--- a/custom_components/quizify/www/css/src/07-player.css
+++ b/custom_components/quizify/www/css/src/07-player.css
@@ -1250,6 +1250,22 @@
 }
 .setup-tweak-link:hover { color: var(--color-text-primary); }
 
+/* #627: "Adjust settings" and "Stats" share one row. Two rows would push the
+   primary action off a 390px viewport, which is the thing the host actually
+   came for. */
+.setup-links-row {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.setup-links-sep {
+    color: var(--color-text-light);
+    font-size: 0.85rem;
+}
+
 /* Featured pack spotlight on the hero — one-tap launch of a highlighted
    pack. Soft Parlor card: lifted paper, hairline border, soft shadow, sun
    "New" pill, coral play affordance. The whole card is the button. */

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -4719,6 +4719,22 @@ footer {
 }
 .setup-tweak-link:hover { color: var(--color-text-primary); }
 
+/* #627: "Adjust settings" and "Stats" share one row. Two rows would push the
+   primary action off a 390px viewport, which is the thing the host actually
+   came for. */
+.setup-links-row {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.setup-links-sep {
+    color: var(--color-text-light);
+    font-size: 0.85rem;
+}
+
 /* Featured pack spotlight on the hero — one-tap launch of a highlighted
    pack. Soft Parlor card: lifted paper, hairline border, soft shadow, sun
    "New" pill, coral play affordance. The whole card is the button. */

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -391,6 +391,7 @@
     "heroLine1": "Bereit für eine",
     "heroLine2": "Runde Quizify?",
     "tweak": "Einstellungen anpassen…",
+    "stats": "Statistik",
     "back": "Zurück",
     "pickMode": "Wähle einen Modus",
     "apply": "Übernehmen",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -391,6 +391,7 @@
     "heroLine1": "Ready for a",
     "heroLine2": "round of Quizify?",
     "tweak": "Adjust settings…",
+    "stats": "Stats",
     "back": "Back",
     "pickMode": "Pick a mode",
     "apply": "Apply",

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -391,6 +391,7 @@
     "heroLine1": "¿Listo para una",
     "heroLine2": "ronda de Quizify?",
     "tweak": "Ajustar configuración…",
+    "stats": "Estadísticas",
     "back": "Atrás",
     "pickMode": "Elige un modo",
     "apply": "Aplicar",

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -2759,6 +2759,7 @@
     on(els.startGameBtn, 'click', function () {
         showView('lobby');
         initJoinUrl();
+        initStatsLink();
     });
 
     // Featured pack spotlight (hero) → SELECT/DESELECT the World Cup pack, the
@@ -2993,6 +2994,25 @@
     }
 
     // ---- Generate join URL ----
+    function initStatsLink() {
+        var btn = document.getElementById('setup-stats-btn');
+        if (!btn) return;
+        btn.addEventListener('click', function () {
+            // Deliberately NO ?token= (#359, #608): analytics.html reads the
+            // admin token from localStorage via QuizifyUtils.readAdminToken()
+            // and only falls back to the URL param. Appending it here would put
+            // a full-control credential back into browser history for no gain.
+            var url = window.location.origin + '/quizify/analytics';
+            // Android Companion swallows target="_blank" (#348/#377), so
+            // navigate the frame there instead of opening a tab.
+            if (isAndroidCompanion()) {
+                window.location.href = url;
+            } else {
+                window.open(url, '_blank');
+            }
+        });
+    }
+
     function initJoinUrl() {
         var joinUrl = window.location.origin + '/quizify/player';
         generateQR(joinUrl);

--- a/tests/test_stats_link_627.py
+++ b/tests/test_stats_link_627.py
@@ -1,0 +1,124 @@
+"""The analytics page becomes reachable (issue #627).
+
+`/quizify/analytics` is served and fully built — `analytics.html` is 526 lines
+with a working period selector — and a grep for inbound links found **zero**.
+Not from admin.html, player.html, dashboard.html, launcher.html or any
+JavaScript. A host could only reach their own play history by guessing the URL.
+
+Third case in one day of the same shape: the submission tracker (#619) and the
+reveal controls (#618) were both finished code with no path to them. Nothing was
+missing here except a line.
+
+Placement was decided from a render, not a preference. A second row pushes the
+primary action off a 390px viewport, so both links share one row: they are
+equally secondary, which is also true of what they do.
+
+The link carries **no** `?token=`. `analytics.html` reads the admin token from
+localStorage via `QuizifyUtils.readAdminToken()` and only falls back to the URL
+param, so appending it would put a full-control credential back into browser
+history for nothing — the regression #359 removed and #608 found creeping back.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WWW = _REPO_ROOT / "custom_components" / "quizify" / "www"
+_ADMIN_JS = _WWW / "js" / "admin.js"
+
+LANGUAGES = ("de", "en", "es")
+
+
+def _without_comments(source: str) -> str:
+    source = re.sub(r"/\*.*?\*/", "", source, flags=re.S)
+    return re.sub(r"^\s*//.*$", "", source, flags=re.M)
+
+
+def _function_body(source: str, signature: str) -> str:
+    start = source.index(signature)
+    depth = 0
+    for i in range(start, len(source)):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : i + 1]
+    raise AssertionError(f"unbalanced braces after {signature!r}")
+
+
+def test_the_label_ships_in_every_language() -> None:
+    for code in LANGUAGES:
+        setup = json.loads((_WWW / "i18n" / f"{code}.json").read_text("utf-8"))["setup"]
+        assert setup.get("stats"), f"{code}.setup.stats missing or empty"
+
+
+def test_the_link_exists_on_the_setup_screen() -> None:
+    html = (_WWW / "admin.html").read_text("utf-8")
+
+    assert 'id="setup-stats-btn"' in html
+    assert 'data-i18n="setup.stats"' in html
+
+
+def test_both_links_share_one_row() -> None:
+    """A second row pushes the primary action off a 390px viewport.
+
+    That is what the design round showed, and it is the whole reason this is a
+    row rather than a stack.
+    """
+    html = (_WWW / "admin.html").read_text("utf-8")
+    css = (_WWW / "css" / "styles.css").read_text("utf-8")
+
+    row = html.split('class="setup-links-row"', 1)[1][:900]
+    assert 'id="setup-tweak-btn"' in row
+    assert 'id="setup-stats-btn"' in row
+
+    block = _without_comments(css.split(".setup-links-row {", 1)[1].split("}", 1)[0])
+    assert "display: flex" in block
+
+
+def test_the_separator_is_hidden_from_screen_readers() -> None:
+    """A middot between two links is decoration; read aloud it is noise."""
+    html = (_WWW / "admin.html").read_text("utf-8")
+    sep = html.split('class="setup-links-sep"', 1)[1][:120]
+
+    assert "aria-hidden" in sep
+
+
+def test_the_link_does_not_put_the_admin_token_in_the_url() -> None:
+    """The regression #359 removed and #608 caught creeping back.
+
+    `analytics.html` reads the token from localStorage and only falls back to
+    the query param, so the link works without it — appending it would write a
+    replayable full-control credential into browser history for no gain.
+    """
+    body = _without_comments(
+        _function_body(_ADMIN_JS.read_text("utf-8"), "function initStatsLink(")
+    )
+
+    assert "token" not in body, "the stats link must not carry a token"
+    assert "'/quizify/analytics'" in body
+
+
+def test_the_link_survives_the_android_companion() -> None:
+    """That WebView swallows target="_blank" (#348, #377).
+
+    Opening a tab there does nothing at all, which is exactly the dead-button
+    failure this issue is about — reintroducing it would be an unusually
+    circular bug.
+    """
+    body = _function_body(_ADMIN_JS.read_text("utf-8"), "function initStatsLink(")
+
+    assert "isAndroidCompanion()" in body
+    assert "window.location.href" in body
+    assert "window.open(" in body
+
+
+def test_the_wiring_actually_runs() -> None:
+    """A handler nobody calls is how this issue came to exist."""
+    source = _ADMIN_JS.read_text("utf-8")
+
+    assert "initStatsLink();" in source


### PR DESCRIPTION
Closes #627.

## A finished page nobody could find

`/quizify/analytics` is served and fully built. `analytics.html` is 526 lines with a working period selector. A grep for inbound links finds **zero** — not from `admin.html`, `player.html`, `dashboard.html`, `launcher.html`, or any JavaScript.

The only way to a host's own play history was guessing the URL.

**Third case in one day of the same shape.** The submission tracker (#619) and the reveal controls (#618) were both finished code with no path to them. Nothing was missing here except a line.

## Placement came from a render

"Adjust settings" and "Stats" share one row with a middot between them.

A second row was the obvious first try, and the render killed it: it pushes the primary action off a 390px viewport, which is the thing the host actually came for. One row costs nothing, and the two links are equally secondary — which is also true of what they do.

**No emoji**, unlike the issue's sketch. Rendered beside its neighbour, a coloured 📊 pulls more attention than the text it labels, on a link that is meant to be quiet. "Adjust settings…" next to it carries none either.

## Two things the link must not do

**Carry a token.** `analytics.html` reads the admin token from localStorage via `QuizifyUtils.readAdminToken()` and only *falls back* to `?token=`. Appending it here would write a replayable full-control credential into browser history for no gain — the regression #359 removed, and which #608 caught creeping back into four other call sites. The link is clean and the page still authenticates.

**Break in the Android Companion.** That WebView swallows `target="_blank"` (#348, #377). Shipping a link that silently does nothing there would be an unusually circular way to reintroduce this very issue, so it carries the same workaround the cast link uses.

## Not in the finale

The issue also suggests a link on the finale view. Left out on purpose: the finale belongs to the round just played, and a link into history pulls the wrong way in that moment.

## Tests

`tests/test_stats_link_627.py`: the label in three languages, the link on the setup screen, both links sharing one row, the separator hidden from screen readers, **no token in the URL**, the Companion workaround, and the initialiser actually being called — a handler nobody calls is how this issue came to exist in the first place.

Run against the unfixed frontend: **7 of 7 failed**.

Suite 2068, `ruff` clean.