### PR TITLE
feat(#624): show the season standing when it is finally true

### DIFF
--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -1789,6 +1789,16 @@ class QuizifyGameState:
                 )
             except Exception:  # noqa: BLE001
                 _LOGGER.exception("Failed to record analytics")
+                return
+            # #624: only NOW does the all-time table include the game that just
+            # finished. The finale is broadcast long before this — deliberately,
+            # so a slow disk never delays the end screen — so a standing sent
+            # with the finale would be the one from BEFORE this game and would
+            # contradict the podium the player is looking at.
+            #
+            # Hence a second, later event. A player who has already closed the
+            # tab simply never receives it, which is the correct outcome.
+            self._fire_broadcast("analytics_recorded")
 
         if self._runtime is not None:
             self._runtime.create_task(_do_record())

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -244,6 +244,7 @@ class QuizifyWebSocketHandler:
             handlers={
                 "round_evaluated": self._dispatch_round_evaluated,
                 "game_ended": self._dispatch_game_ended,
+                "analytics_recorded": self._dispatch_all_time_standings,
             },
             default=self._dispatch_full_state,
         )
@@ -3073,6 +3074,38 @@ class QuizifyWebSocketHandler:
             return True
         admin = game_state.get_admin()
         return admin is None or not admin.connected
+
+    async def _dispatch_all_time_standings(self) -> None:
+        """Send each player their own season standing, after the game landed.
+
+        Fired by ``analytics_recorded`` (#624), not with the finale: the record
+        is written in a detached task so a slow disk cannot delay the end
+        screen, which means the finale goes out while the all-time table still
+        describes the state BEFORE this game. A standing sent then would
+        contradict the podium the player is looking at.
+
+        Per-player rather than a broadcast, because the interesting number is
+        the player's own rank. Fail-soft throughout: no analytics, an unknown
+        name or a closed socket each just means no line, exactly as on join.
+        """
+        game_state = self._get_game_state()
+        if game_state is None:
+            return
+        sends = []
+        for player in game_state.get_players():
+            if player.ws is None or player.ws.closed:
+                continue
+            standing = self._all_time_standing(player.name)
+            if standing is None:
+                continue
+            sends.append(
+                self._conn.send(
+                    player.ws,
+                    {"type": "all_time_update", "all_time": standing},
+                )
+            )
+        if sends:
+            await asyncio.gather(*sends)
 
     def _all_time_standing(self, name: str) -> PlayerStanding | None:
         """This player's own all-time placing for the lobby line (#371).

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -343,6 +343,15 @@
             // has existed since the tracker markup landed; its only caller was
             // updateGameView(), which nothing ever invoked, so the row stayed
             // empty for every game ever played.
+            // #624: the season standing, sent once the finished game has
+            // actually been written to analytics — which happens after the
+            // finale, not with it.
+            case 'all_time_update':
+                if (msg.all_time !== undefined && lobby && lobby.renderAllTime) {
+                    lobby.renderAllTime(msg.all_time, 'end-alltime');
+                }
+                break;
+
             case 'answer_progress':
                 game.renderSubmissionTracker(msg.players);
                 break;

--- a/custom_components/quizify/www/js/player-lobby.js
+++ b/custom_components/quizify/www/js/player-lobby.js
@@ -98,8 +98,10 @@
      * @param {Object|null} standing - {rank, total_players, wins, games_played}
      *                                 or null for a player with no history.
      */
-    function renderAllTime(standing) {
-        var el = document.getElementById('pl-alltime');
+    // #624: `elementId` lets the same line render on the end screen too. It
+    // defaults to the lobby element, so every existing caller is unchanged.
+    function renderAllTime(standing, elementId) {
+        var el = document.getElementById(elementId || 'pl-alltime');
         if (!el) return;  // legacy markup
         if (!standing || !standing.total_players) {
             // First-timer, or analytics not wired: show nothing at all

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -980,8 +980,10 @@
      * @param {Object|null} standing - {rank, total_players, wins, games_played}
      *                                 or null for a player with no history.
      */
-    function renderAllTime(standing) {
-        var el = document.getElementById('pl-alltime');
+    // #624: `elementId` lets the same line render on the end screen too. It
+    // defaults to the lobby element, so every existing caller is unchanged.
+    function renderAllTime(standing, elementId) {
+        var el = document.getElementById(elementId || 'pl-alltime');
         if (!el) return;  // legacy markup
         if (!standing || !standing.total_players) {
             // First-timer, or analytics not wired: show nothing at all
@@ -5377,6 +5379,15 @@
             // has existed since the tracker markup landed; its only caller was
             // updateGameView(), which nothing ever invoked, so the row stayed
             // empty for every game ever played.
+            // #624: the season standing, sent once the finished game has
+            // actually been written to analytics — which happens after the
+            // finale, not with it.
+            case 'all_time_update':
+                if (msg.all_time !== undefined && lobby && lobby.renderAllTime) {
+                    lobby.renderAllTime(msg.all_time, 'end-alltime');
+                }
+                break;
+
             case 'answer_progress':
                 game.renderSubmissionTracker(msg.players);
                 break;

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -638,6 +638,13 @@
                     </div>
                 </div>
 
+                <!-- #624: the season standing, in the same shape the lobby
+                     uses. It arrives AFTER the finale (analytics is recorded in
+                     a detached task), so this stays hidden until the
+                     all_time_update message lands — an empty slot is better
+                     than a rank that predates the game just played. -->
+                <p class="pl-allTime hidden" id="end-alltime" aria-live="polite"></p>
+
                 <!-- Shareable result card (#369) — a score slip the player can
                      send into a chat. Hidden until the finale payload carries a
                      ``share`` block for this player. -->

--- a/tests/test_end_screen_standing_624.py
+++ b/tests/test_end_screen_standing_624.py
@@ -1,0 +1,134 @@
+"""The season standing reaches the end screen — and only once it is true (#624).
+
+The all-time table (#371) rendered in the lobby only: before the game, the
+moment it is least interesting. The end screen, where "you just overtook Anna"
+belongs, never showed it.
+
+**The issue calls this "a serializer field plus one render line" because the
+server already computes the standing. It is not.** `_record_analytics` writes
+the finished game in a *detached* task — deliberately, so a slow disk cannot
+delay the end screen. The finale therefore goes out while the all-time table
+still describes the state BEFORE this game.
+
+Attaching the standing to the finale would show the player a rank that predates
+the round they just watched, contradicting the podium on screen. A line that
+lies is worse than no line.
+
+So the standing is sent as its own later message, fired when the record lands.
+A player who has already closed the tab never receives it, which is correct.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_CC = _REPO_ROOT / "custom_components" / "quizify"
+_WWW = _CC / "www"
+
+
+def _without_comments(source: str) -> str:
+    source = re.sub(r"/\*.*?\*/", "", source, flags=re.S)
+    return re.sub(r"^\s*//.*$", "", source, flags=re.M)
+
+
+def _py_function(source: str, signature: str) -> str:
+    start = source.index(signature)
+    lines = source[start:].splitlines()
+    out = [lines[0]]
+    for line in lines[1:]:
+        if line and not line[0].isspace():
+            break
+        if re.match(r"^    (async )?def ", line):
+            break
+        out.append(line)
+    return "\n".join(out)
+
+
+def test_the_event_fires_only_after_the_record_succeeds() -> None:
+    """Firing it regardless would send the pre-game standing on a failed write.
+
+    The `return` in the except branch is the whole guarantee here.
+    """
+    source = (_CC / "game" / "state.py").read_text("utf-8")
+    body = _py_function(source, "    def _record_analytics(self)")
+
+    assert 'self._fire_broadcast("analytics_recorded")' in body
+    except_at = body.index("Failed to record analytics")
+    fire_at = body.index('_fire_broadcast("analytics_recorded")')
+    assert except_at < fire_at, "the fire must sit after the failure path"
+    tail = body[except_at:fire_at]
+    assert "return" in tail, "a failed record must not fire the event"
+
+
+def test_the_dispatcher_is_registered_for_that_event() -> None:
+    source = (_CC / "server" / "websocket.py").read_text("utf-8")
+
+    assert '"analytics_recorded": self._dispatch_all_time_standings' in source
+
+
+def test_each_player_gets_their_own_standing() -> None:
+    """A broadcast would be wrong: the interesting number is your own rank."""
+    source = (_CC / "server" / "websocket.py").read_text("utf-8")
+    body = _without_comments(
+        _py_function(source, "    async def _dispatch_all_time_standings(self)")
+    )
+
+    assert "for player in game_state.get_players()" in body
+    assert "self._all_time_standing(player.name)" in body
+    assert '"type": "all_time_update"' in body
+    # Asserts the absent CALL, not the absent word: the docstring above
+    # explains why this is not a broadcast, and `_without_comments` strips
+    # comments, not docstrings. Fourth time today an assertion nearly tripped
+    # over the prose the fix writes about itself — so pin behaviour, never
+    # vocabulary.
+    assert "self._conn.broadcast(" not in body
+
+
+def test_it_skips_closed_sockets_and_missing_standings() -> None:
+    """Fail-soft, exactly as the join path is.
+
+    A first-timer has no standing, and someone who closed the tab has no
+    socket; neither may raise on what is decoration.
+    """
+    body = _without_comments(
+        _py_function(
+            (_CC / "server" / "websocket.py").read_text("utf-8"),
+            "    async def _dispatch_all_time_standings(self)",
+        )
+    )
+
+    assert "player.ws is None or player.ws.closed" in body
+    assert "if standing is None" in body
+
+
+def test_the_end_screen_has_a_slot_that_starts_hidden() -> None:
+    """Hidden until the message lands: the standing arrives after the finale,
+    and an empty slot beats a rank that predates the game."""
+    html = (_WWW / "player.html").read_text("utf-8")
+    slot = html.split('id="end-alltime"', 1)[0].rsplit("<p", 1)[1] + 'id="end-alltime"'
+
+    assert "hidden" in slot
+    assert "pl-allTime" in slot
+
+
+def test_the_renderer_can_target_the_end_screen() -> None:
+    """Same renderer, same phrasing, including the no-win variant.
+
+    Writing a second renderer would have meant two places to keep the
+    zero-wins wording right.
+    """
+    source = (_WWW / "js" / "player-lobby.js").read_text("utf-8")
+
+    assert "function renderAllTime(standing, elementId)" in source
+    assert "elementId || 'pl-alltime'" in source
+
+
+def test_the_router_sends_it_to_the_end_screen_slot() -> None:
+    core = (_WWW / "js" / "player-core.js").read_text("utf-8")
+    bundle = (_WWW / "js" / "player.bundle.js").read_text("utf-8")
+
+    assert "case 'all_time_update':" in core
+    assert "lobby.renderAllTime(msg.all_time, 'end-alltime')" in core
+    assert "case 'all_time_update':" in bundle

--- a/tests/test_lobby_all_time_standing_371.py
+++ b/tests/test_lobby_all_time_standing_371.py
@@ -267,7 +267,10 @@ class TestFrontendWiring:
 
     def test_bundle_renders_and_core_calls_it(self) -> None:
         bundle = (WWW / "js" / "player.bundle.js").read_text("utf-8")
-        assert "function renderAllTime(standing)" in bundle
+        # #624 widened the signature with an optional target element so the same
+        # line can render on the end screen. The lobby call site is unchanged
+        # and still passes one argument — that is what this guard is for.
+        assert "function renderAllTime(standing" in bundle
         assert "renderAllTime: renderAllTime" in bundle
         assert "lobby.renderAllTime(msg.all_time)" in bundle
         # Zero-win phrasing exists rather than rendering "0 wins".


### PR DESCRIPTION
Closes #624.

## The issue underestimates the work, and the reason matters

It calls this "a serializer field plus one render line" because the server already computes the standing for the join path.

`_record_analytics` writes the finished game in a **detached task** — on purpose, so a slow disk cannot delay the end screen. The finale is broadcast long before that write lands, which means at finale time the all-time table still describes the state **before this game**.

Attaching the standing to the finale would therefore show a rank that predates the round the player just watched, contradicting the podium on screen. **A line that lies is worse than no line**, and this one would lie precisely in the moment the feature exists for: "you just overtook Anna".

## The shape

`_record_analytics` fires `analytics_recorded` when the write **succeeds** — a failed write returns before firing rather than sending a pre-game rank.

A dispatcher then sends each player their own standing. Per player, not a broadcast: the interesting number is your own rank. Fail-soft throughout — no analytics, an unknown name, or a closed socket each just mean no line, exactly as on join. A player who already closed the tab never receives it, which is the correct outcome rather than a missing feature.

## Client

Variant A from the design round: the same line the lobby already renders, on the end screen above the share card, hidden until the message lands.

`renderAllTime` takes an optional target element and defaults to the lobby one. Writing a second renderer would have meant two places to keep the zero-wins phrasing right — that phrasing exists because "0 wins" reads like a taunt.

## One existing guard adjusted

`test_lobby_all_time_standing_371.py` pinned the exact signature `function renderAllTime(standing)`, which the optional second parameter breaks. The assertion now checks the prefix; the lobby call site is unchanged and the guard still verifies it passes one argument. Flagging it because editing someone else's guard deserves to be visible in review rather than buried in the diff.

## Tests

`tests/test_end_screen_standing_624.py`: the event firing only after a successful record (with the failure path returning first), the dispatcher registered, per-player sends rather than a broadcast, closed sockets and missing standings skipped, the end-screen slot starting hidden, the renderer able to target it, and the router wiring reaching the shipped bundle.

Run against the unfixed code: **7 of 7 failed**.

Suite 2075, `ruff` clean, `mypy` clean.