### PR TITLE
feat(#612): tonight's running score on the TV

### DIFF
--- a/custom_components/quizify/analytics.py
+++ b/custom_components/quizify/analytics.py
@@ -63,6 +63,13 @@ class PlayerStanding(TypedDict):
     total_score: int
 
 
+class EveningTally(TypedDict):
+    """Tonight's running score across several games (#612)."""
+
+    games: int
+    leaders: list[dict[str, Any]]
+
+
 class AnalyticsData(TypedDict):
     """Complete analytics data schema."""
 
@@ -380,6 +387,62 @@ class QuizifyAnalytics:
                 original_count,
                 len(games),
             )
+
+    # More than this between two games and they belong to different evenings
+    # (#612). A calendar day was the obvious alternative and is worse: it cuts
+    # every party that runs past midnight, which is exactly the party this line
+    # exists for — at 00:05 the TV would say "tonight: 1 game" after the fourth.
+    EVENING_GAP_SECONDS = 6 * 60 * 60
+
+    def get_evening_tally(self, now: float | None = None) -> EveningTally | None:
+        """Wins per player for the current sitting, most recent games backwards.
+
+        Walks back from the latest game while consecutive games sit closer
+        together than ``EVENING_GAP_SECONDS``, so "tonight" means the session in
+        progress rather than a date.
+
+        Returns ``None`` for a single game: "tonight: Anna 1 win" after the only
+        game of the evening restates the podium directly above it. The line is
+        worth showing from the second game on, which is also when the rivalry it
+        is meant to feed starts existing.
+        """
+        games = self._data.get("games", [])
+        if len(games) < 2:
+            return None
+
+        ordered = sorted(games, key=lambda g: g["ended_at"], reverse=True)
+        reference = ordered[0]["ended_at"] if now is None else now
+        # A stale last game means no evening in progress at all.
+        if reference - ordered[0]["ended_at"] > self.EVENING_GAP_SECONDS:
+            return None
+
+        session: list[GameRecord] = [ordered[0]]
+        for game in ordered[1:]:
+            if session[-1]["ended_at"] - game["ended_at"] > self.EVENING_GAP_SECONDS:
+                break
+            session.append(game)
+
+        if len(session) < 2:
+            return None
+
+        wins: dict[str, int] = {}
+        for game in session:
+            winner = game.get("winner")
+            # A game can end with no winner (everyone left, a reset); it still
+            # counts towards the evening's game total but crowns nobody.
+            if winner:
+                wins[winner] = wins.get(winner, 0) + 1
+
+        if not wins:
+            return None
+        # Sort the tuples, then shape them: keying a dict[str, Any] sort on its
+        # own values needs casts that hide what the ordering actually is.
+        # Most wins first, then name, so a tie reads the same on every render.
+        ranked = sorted(wins.items(), key=lambda item: (-item[1], item[0]))
+        leaders: list[dict[str, Any]] = [
+            {"name": name, "wins": count} for name, count in ranked
+        ]
+        return {"games": len(session), "leaders": leaders}
 
     def get_games(
         self, start_date: int | None = None, end_date: int | None = None

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -244,7 +244,7 @@ class QuizifyWebSocketHandler:
             handlers={
                 "round_evaluated": self._dispatch_round_evaluated,
                 "game_ended": self._dispatch_game_ended,
-                "analytics_recorded": self._dispatch_all_time_standings,
+                "analytics_recorded": self._dispatch_analytics_followups,
             },
             default=self._dispatch_full_state,
         )
@@ -3074,6 +3074,41 @@ class QuizifyWebSocketHandler:
             return True
         admin = game_state.get_admin()
         return admin is None or not admin.connected
+
+    async def _dispatch_analytics_followups(self) -> None:
+        """Everything that can only be true once the game is recorded (#624, #612).
+
+        One handler because one event: the season standing per player and the
+        evening tally for the room both become correct at the same instant, and
+        registering two handlers for the same event would make their order an
+        accident of dict insertion.
+        """
+        await self._dispatch_all_time_standings()
+        await self._dispatch_evening_tally()
+
+    async def _dispatch_evening_tally(self) -> None:
+        """Broadcast tonight's running score to the TV (#612).
+
+        Rides the same ``analytics_recorded`` event as the season standing: the
+        game that just finished is only part of the tally once it is written.
+
+        Broadcast rather than per-player — unlike the season standing, this is
+        the room's number, and the TV is the screen it belongs on.
+        """
+        gs = self._get_game_state()
+        if gs is None:
+            return
+        analytics = gs.stats_service
+        if analytics is None:
+            return
+        tally = analytics.get_evening_tally()
+        if tally is None:
+            # One game so far, or no sitting in progress. Saying nothing beats
+            # restating the podium that is already on screen.
+            return
+        await self._conn.broadcast_to_admins_and_dashboards(
+            {"type": "evening_tally", **tally}
+        )
 
     async def _dispatch_all_time_standings(self) -> None:
         """Send each player their own season standing, after the game landed.

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -154,6 +154,20 @@
             margin-top: 4px;
         }
 
+        .dashboard-evening-tally {
+            font-size: clamp(1rem, 1.7vw, 1.4rem);
+            color: var(--dash-text-white);
+            text-align: center;
+            margin-bottom: 10px;
+            flex-shrink: 0;
+            font-variant-numeric: tabular-nums;
+        }
+
+        .dashboard-evening-tally .tally-label {
+            color: var(--dash-text-muted);
+            margin-right: 8px;
+        }
+
         .dashboard-answer-progress {
             font-size: clamp(0.9rem, 1.4vw, 1.15rem);
             color: var(--dash-text-muted);
@@ -1289,6 +1303,12 @@
              and text inside would fight the fill for those pixels. -->
         <div id="answer-progress" class="dashboard-answer-progress hidden"></div>
 
+        <!-- #612: tonight's running score across several games. Arrives via
+             evening_tally after the finished game is recorded, and stays hidden
+             for a single-game evening — restating the podium above it would add
+             nothing. -->
+        <div id="evening-tally" class="dashboard-evening-tally hidden"></div>
+
         <div id="timer-bar" class="dashboard-timer">
             <div id="timer-fill" class="dashboard-timer-fill" style="width:0%"></div>
         </div>
@@ -1481,6 +1501,7 @@
             roundIndicator: document.getElementById('round-indicator'),
             timerFill: document.getElementById('timer-fill'),
             answerProgress: document.getElementById('answer-progress'),
+            eveningTally: document.getElementById('evening-tally'),
             questionCategory: document.getElementById('question-category'),
             questionImage: document.getElementById('question-image'),
             questionMedia: document.getElementById('question-media'),
@@ -1768,6 +1789,9 @@
                     break;
                 case 'answer_progress':
                     handleAnswerProgress(msg);
+                    break;
+                case 'evening_tally':
+                    handleEveningTally(msg);
                     break;
                 case 'finale':
                 case 'game_ended':
@@ -2088,6 +2112,32 @@
                     '</div>' +
                     '</div>';
             }).join('');
+        }
+
+        function handleEveningTally(msg) {
+            if (!els.eveningTally) return;
+            var leaders = (msg && msg.leaders) || [];
+            if (!leaders.length) {
+                els.eveningTally.classList.add('hidden');
+                return;
+            }
+            var t = (window.QuizifyI18n && window.QuizifyI18n.t)
+                || function (k) { return k; };
+            // Three names is what reads from a couch; a fourth turns the line
+            // into a table nobody parses mid-celebration.
+            var parts = leaders.slice(0, 3).map(function (entry) {
+                var wins = entry.wins === 1
+                    ? t('dashboard.tonightWinsOne')
+                    : t('dashboard.tonightWins', { wins: entry.wins });
+                return escapeHtml(entry.name) + ' ' + wins;
+            });
+            // parts[] is already escaped per entry — escaping the joined
+            // string again would turn a name like "Jan & Anna" into
+            // "Jan &amp;amp; Anna" on screen.
+            els.eveningTally.innerHTML =
+                '<span class="tally-label">' + escapeHtml(t('dashboard.tonightLabel'))
+                + '</span>' + parts.join(' · ');
+            els.eveningTally.classList.remove('hidden');
         }
 
         function handleAnswerProgress(msg) {

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -552,7 +552,11 @@
     "pointsShort": "Pkt.",
     "awards": "Auszeichnungen",
     "runnersUp": "Außerdem dabei",
-    "leaderboardMore": "+{count} weitere"
+    "leaderboardMore": "+{count} weitere",
+    "tonightLabel": "Heute Abend",
+    "tonightGames": "{games} Spiele",
+    "tonightWins": "{wins} Siege",
+    "tonightWinsOne": "1 Sieg"
   },
   "connection": {
     "connected": "Verbunden",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -552,7 +552,11 @@
     "pointsShort": "pts",
     "awards": "Awards",
     "runnersUp": "Also playing",
-    "leaderboardMore": "+{count} more"
+    "leaderboardMore": "+{count} more",
+    "tonightLabel": "Tonight",
+    "tonightGames": "{games} games",
+    "tonightWins": "{wins} wins",
+    "tonightWinsOne": "1 win"
   },
   "connection": {
     "connected": "Connected",

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -552,7 +552,11 @@
     "pointsShort": "pts",
     "awards": "Premios",
     "runnersUp": "También juegan",
-    "leaderboardMore": "+{count} más"
+    "leaderboardMore": "+{count} más",
+    "tonightLabel": "Esta noche",
+    "tonightGames": "{games} partidas",
+    "tonightWins": "{wins} victorias",
+    "tonightWinsOne": "1 victoria"
   },
   "connection": {
     "connected": "Conectado",

--- a/tests/test_end_screen_standing_624.py
+++ b/tests/test_end_screen_standing_624.py
@@ -63,9 +63,14 @@ def test_the_event_fires_only_after_the_record_succeeds() -> None:
 
 
 def test_the_dispatcher_is_registered_for_that_event() -> None:
+    """#612 added a second follow-up on the same event, so both now hang off a
+    combined handler — one event, one handler, rather than two registrations
+    whose order would be an accident of dict insertion."""
     source = (_CC / "server" / "websocket.py").read_text("utf-8")
 
-    assert '"analytics_recorded": self._dispatch_all_time_standings' in source
+    assert '"analytics_recorded": self._dispatch_analytics_followups' in source
+    followups = source.split("async def _dispatch_analytics_followups", 1)[1][:600]
+    assert "self._dispatch_all_time_standings()" in followups
 
 
 def test_each_player_gets_their_own_standing() -> None:

--- a/tests/test_evening_tally_612.py
+++ b/tests/test_evening_tally_612.py
@@ -1,0 +1,172 @@
+"""Tonight's running score across several games (issue #612).
+
+Multi-game evenings are a supported flow — "play again" is a button — but each
+game forgot the last one. Between "this game" and the all-time table sat the
+evening, which is the unit people actually argue about: "best of three".
+
+**The evening boundary was the real decision, not the line.** A calendar day is
+one comparison and it cuts every party that runs past midnight — at 00:05 the TV
+would say "tonight: 1 game" after the fourth, failing exactly the evenings this
+line exists for. So a session is a run of games less than six hours apart,
+walked backwards from the most recent.
+
+Deliberately silent for a single game: "Tonight: Anna 1 win" directly under the
+podium that just said the same thing adds nothing.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_CC = _REPO_ROOT / "custom_components" / "quizify"
+_WWW = _CC / "www"
+
+HOUR = 3600
+
+
+class _Analytics:
+    """The tally logic under test, with a hand-built game history."""
+
+    def __init__(self, games: list[dict]) -> None:
+        from custom_components.quizify.analytics import QuizifyAnalytics
+
+        self._impl = QuizifyAnalytics.__new__(QuizifyAnalytics)
+        self._impl._data = {"games": games}
+
+    def tally(self, now: float | None = None):
+        return self._impl.get_evening_tally(now=now)
+
+
+def _game(ended_at: int, winner: str | None) -> dict:
+    return {"ended_at": ended_at, "winner": winner}
+
+
+def test_a_single_game_says_nothing() -> None:
+    """It would restate the podium standing directly above it."""
+    assert _Analytics([_game(1000, "Anna")]).tally() is None
+
+
+def test_two_games_close_together_are_one_evening() -> None:
+    tally = _Analytics([
+        _game(10_000, "Anna"),
+        _game(10_000 + HOUR, "Anna"),
+    ]).tally()
+
+    assert tally == {"games": 2, "leaders": [{"name": "Anna", "wins": 2}]}
+
+
+def test_a_long_gap_starts_a_new_evening() -> None:
+    """Last week's rematch is not part of tonight."""
+    tally = _Analytics([
+        _game(10_000, "Ben"),
+        _game(10_000 + 8 * HOUR, "Anna"),
+        _game(10_000 + 9 * HOUR, "Anna"),
+    ]).tally()
+
+    assert tally is not None
+    assert tally["games"] == 2
+    assert tally["leaders"] == [{"name": "Anna", "wins": 2}]
+
+
+def test_a_party_past_midnight_stays_one_evening() -> None:
+    """The case that killed the calendar-day rule.
+
+    Games at 22:00, 23:30, 00:30 and 01:15 are one party. A date comparison
+    would report two of them.
+    """
+    base = 1_700_000_000
+    midnight = base + 2 * HOUR
+    tally = _Analytics([
+        _game(base, "Anna"),
+        _game(base + 90 * 60, "Ben"),
+        _game(midnight + 30 * 60, "Ben"),
+        _game(midnight + 75 * 60, "Anna"),
+    ]).tally()
+
+    assert tally is not None
+    assert tally["games"] == 4
+
+
+def test_leaders_are_ordered_by_wins_then_name() -> None:
+    """A tie must render the same way every time, not in dict order."""
+    tally = _Analytics([
+        _game(10_000, "Ben"),
+        _game(10_000 + HOUR, "Anna"),
+        _game(10_000 + 2 * HOUR, "Anna"),
+        _game(10_000 + 3 * HOUR, "Cara"),
+    ]).tally()
+
+    assert tally is not None
+    assert tally["leaders"] == [
+        {"name": "Anna", "wins": 2},
+        {"name": "Ben", "wins": 1},
+        {"name": "Cara", "wins": 1},
+    ]
+
+
+def test_a_game_with_no_winner_counts_but_crowns_nobody() -> None:
+    """Everyone left, or the host reset it. Still part of the evening."""
+    tally = _Analytics([
+        _game(10_000, "Anna"),
+        _game(10_000 + HOUR, None),
+    ]).tally()
+
+    assert tally is not None
+    assert tally["games"] == 2
+    assert tally["leaders"] == [{"name": "Anna", "wins": 1}]
+
+
+def test_an_evening_that_ended_hours_ago_is_not_tonight() -> None:
+    """Opening the TV the next morning must not show yesterday's tally."""
+    games = [_game(10_000, "Anna"), _game(10_000 + HOUR, "Ben")]
+
+    assert _Analytics(games).tally(now=10_000 + 20 * HOUR) is None
+
+
+@pytest.mark.parametrize("code", ["de", "en", "es"])
+def test_the_strings_ship_in_every_language(code: str) -> None:
+    import json
+
+    dashboard = json.loads((_WWW / "i18n" / f"{code}.json").read_text("utf-8"))[
+        "dashboard"
+    ]
+    for key in ("tonightLabel", "tonightWins", "tonightWinsOne"):
+        assert dashboard.get(key), f"{code}.dashboard.{key} missing"
+    assert "{wins}" in dashboard["tonightWins"]
+    # The singular must not carry a placeholder — "1 wins" is the bug this
+    # separate key exists to prevent.
+    assert "{wins}" not in dashboard["tonightWinsOne"]
+
+
+def test_the_tv_renders_it_and_does_not_double_escape() -> None:
+    """`parts[]` is escaped per entry; escaping the join again would render
+    "Jan &amp;amp; Anna" for a name containing an ampersand."""
+    source = (_WWW / "dashboard.html").read_text("utf-8")
+    body = source.split("function handleEveningTally(", 1)[1].split("\n        }", 1)[0]
+    body = re.sub(r"//.*$", "", body, flags=re.M)
+
+    assert "escapeHtml(entry.name)" in body
+    assert "escapeHtml(parts.join(" not in body
+    assert "leaders.slice(0, 3)" in body
+
+
+def test_it_rides_the_same_recorded_event_as_the_standing() -> None:
+    """Both become true at the same instant — when the game is written."""
+    source = (_CC / "server" / "websocket.py").read_text("utf-8")
+    followups = source.split("async def _dispatch_analytics_followups", 1)[1][:600]
+
+    assert "self._dispatch_evening_tally()" in followups
+
+
+def test_the_tally_goes_to_the_tv_not_to_every_phone() -> None:
+    """Unlike the season standing, this is the room's number."""
+    source = (_CC / "server" / "websocket.py").read_text("utf-8")
+    body = source.split("async def _dispatch_evening_tally", 1)[1].split(
+        "\n    async def ", 1
+    )[0]
+
+    assert "broadcast_to_admins_and_dashboards" in body


### PR DESCRIPTION
Closes #612.

## The gap

Multi-game evenings are a supported flow — "play again" is a button — but each game forgot the last one. Between "this game" and the all-time table sits the evening, which is the unit people actually argue about: best of three, rematch.

No new storage: `GameRecord` already carries `ended_at` and `winner`.

## The evening boundary was the decision

Not the line — the rule behind it. Markus picked the gap rule after the tradeoff was laid out:

**Calendar day** is one comparison and it cuts every party that runs past midnight. At 00:05 the TV would say "tonight: 1 game" after the fourth — failing precisely the evenings this line exists for.

**Gap rule**: a session is a run of games less than six hours apart, walked backwards from the most recent. Harder to state in one word, but nobody reads the rule — the screen only says "Tonight".

## Deliberate silences

- **One game:** returns `None`. "Tonight: Anna 1 win" directly under the podium that just said so adds nothing.
- **A stale last game:** returns `None`, so opening the TV the next morning does not show yesterday's tally as tonight's.
- **A game with no winner** (everyone left, a reset) still counts towards the evening's total but crowns nobody.

## Wiring

Rides the same `analytics_recorded` event as the season standing (#624) — both become true at the instant the finished game is written. They now hang off one combined handler rather than two registrations for one event, whose order would otherwise be an accident of dict insertion. `test_end_screen_standing_624.py` is updated to match, with the reason in the test.

**Broadcast to admin and dashboards, not per player.** Unlike the season standing, this is the room's number and the TV is the screen it belongs on. Three names max: a fourth turns the line into a table nobody parses mid-celebration.

A separate singular key means a single win never renders "1 wins".

## Two things caught while building

`mypy` rejected sorting a `dict[str, Any]` on its own values. Rather than casting, the tuples are sorted and then shaped — which also makes the ordering rule readable instead of buried in a lambda.

The first render double-escaped: entries are escaped individually and the joined string was escaped again, so "Jan & Anna" would have appeared as "Jan &amp;amp; Anna". A test now pins it.

## Tests

`tests/test_evening_tally_612.py`, 13 cases including the past-midnight party that killed the calendar-day rule, the tie ordering, the winner-less game, the stale evening, the three-language strings, and the escaping.

Run against the unfixed code: **13 of 13 failed**.

Suite 2088, `ruff` clean, `mypy` clean.