### PR TITLE
fix(#608): the admin token leaves the query string

### DIFF
--- a/custom_components/quizify/www/analytics.html
+++ b/custom_components/quizify/www/analytics.html
@@ -345,27 +345,28 @@
         });
 
         // #356: the analytics/flags endpoints are admin-token gated. The token
-        // is the admin session token the host holds; read it through
-        // QuizifyUtils (durable localStorage, with the legacy per-tab value as
-        // a migration fallback) or from a ?token= URL param so the dashboard
-        // keeps working when opened straight from the admin panel.
+        // is the admin session token the host holds, read through QuizifyUtils
+        // (durable localStorage since #530, with the legacy per-tab value as a
+        // migration fallback).
+        //
+        // #608: the ?token= URL param is gone, in both directions. Reading it
+        // meant the credential sat in this page's address bar and therefore in
+        // browser history; sending it put it in aiohttp's access log and every
+        // reverse proxy in front of HA. Since #530 localStorage always has it,
+        // so the param bought nothing — the link from the admin page (#627)
+        // deliberately carries no token and the page authenticates anyway.
         function adminToken() {
             try {
-                var fromUrl = new URLSearchParams(window.location.search).get('token');
-                return fromUrl
-                    || (window.QuizifyUtils && QuizifyUtils.readAdminToken())
-                    || '';
+                return (window.QuizifyUtils && QuizifyUtils.readAdminToken()) || '';
             } catch (e) { return ''; }
         }
-        function withToken(url) {
+        function adminInit() {
             var tok = adminToken();
-            if (!tok) { return url; }
-            return url + (url.indexOf('?') === -1 ? '?' : '&')
-                + 'token=' + encodeURIComponent(tok);
+            return tok ? { headers: { 'X-Quizify-Token': tok } } : {};
         }
 
         function loadData() {
-            fetch(withToken('/api/quizify/analytics/data?period=' + currentPeriod))
+            fetch('/api/quizify/analytics/data?period=' + currentPeriod, adminInit())
                 .then(function(r) {
                     if (r.status === 401) {
                         var tAuth = (window.QuizifyI18n && window.QuizifyI18n.t)
@@ -482,7 +483,7 @@
         }
 
         function loadFlags() {
-            fetch(withToken('/api/quizify/flags'))
+            fetch('/api/quizify/flags', adminInit())
                 .then(function (r) { return r.ok ? r.json() : null; })
                 .then(function (data) {
                     var flags = (data && data.flags) || [];

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -830,14 +830,24 @@
     // the host's phone too. The four built-in cards below are untouched by
     // all of this; this only adds a chip row above them.
 
-    function _presetFetch(opts) {
-        // Header rather than ?token= — #359 moved the token out of URLs, and
-        // new call sites should not put it back in.
+    // #608: one place that turns "I hold the admin token" into a request.
+    //
+    // The token used to ride along as ?token=, which put a replayable
+    // full-control credential into aiohttp's access log and every reverse proxy
+    // in front of HA — the leak #359 removed. The rule was even written down,
+    // three lines above one of the four sites that broke it, which is why this
+    // is now a function rather than a comment.
+    function _adminFetch(url, opts) {
         var tok = QuizifyUtils.readAdminToken();
         var init = opts || {};
         init.headers = init.headers || {};
         if (tok) init.headers['X-Quizify-Token'] = tok;
-        return fetch('/api/quizify/presets' + (init._q || ''), init);
+        return fetch(url, init);
+    }
+
+    function _presetFetch(opts) {
+        var init = opts || {};
+        return _adminFetch('/api/quizify/presets' + (init._q || ''), init);
     }
 
     function _loadCustomPresets() {
@@ -2133,10 +2143,7 @@
     function _loadTtsEntities(cfg) {
         // #356: the tts-entities endpoint is admin-token gated. Send the
         // session token the admin page already holds.
-        var _tok = QuizifyUtils.readAdminToken();
-        var _url = '/api/quizify/tts-entities'
-            + (_tok ? '?token=' + encodeURIComponent(_tok) : '');
-        fetch(_url)
+        _adminFetch('/api/quizify/tts-entities')
             .then(function (resp) { return resp.ok ? resp.json() : null; })
             .then(function (data) {
                 if (!data) {
@@ -2508,10 +2515,7 @@
     // HTTP fallback for an older server that doesn't put house_entities on the
     // admin frame. Admin-token gated like /api/quizify/tts-entities (#356).
     function _loadHouseEntities(cfg) {
-        var _tok = QuizifyUtils.readAdminToken();
-        var _url = '/api/quizify/house-entities'
-            + (_tok ? '?token=' + encodeURIComponent(_tok) : '');
-        fetch(_url)
+        _adminFetch('/api/quizify/house-entities')
             .then(function (resp) { return resp.ok ? resp.json() : null; })
             .then(function (data) {
                 if (!data) {

--- a/custom_components/quizify/www/js/pack-submit.js
+++ b/custom_components/quizify/www/js/pack-submit.js
@@ -398,12 +398,12 @@ window.QuizifyPackSubmit = (function () {
         var card = el('pack-submit-list-card');
         if (!listEl) { return; }
         try {
-            // #356: submissions list is admin-token gated; forward the token
-            // the admin page holds.
+            // #356: submissions list is admin-token gated. #608: as a header,
+            // not ?token= — the query string ends up in aiohttp's access log
+            // and in any reverse proxy in front of HA.
             var _tok = QuizifyUtils.readAdminToken();
-            var _url = SUBMISSIONS_URL
-                + (_tok ? '?token=' + encodeURIComponent(_tok) : '');
-            var resp = await fetch(_url);
+            var _init = _tok ? { headers: { 'X-Quizify-Token': _tok } } : {};
+            var resp = await fetch(SUBMISSIONS_URL, _init);
             if (!resp.ok) { return; }
             var data = await resp.json();
             var subs = (data && data.submissions) || [];

--- a/tests/test_token_out_of_urls_608.py
+++ b/tests/test_token_out_of_urls_608.py
@@ -1,0 +1,107 @@
+"""The admin token leaves the query string for good (issue #608).
+
+Four call sites put a replayable full-control credential into `?token=`, which
+lands in aiohttp's access log and in every reverse proxy in front of HA. The
+analytics page also *read* it from its own address bar, so it sat in browser
+history too. Since #530 the token is long-lived, so anyone who can read those
+logs has admin.
+
+The rule already existed. `admin.js` states it three lines above one of the four
+violations: "Header rather than ?token= — #359 moved the token out of URLs, and
+new call sites should not put it back in." It was broken four times anyway,
+which is why this fix replaces the comment with a function: `_adminFetch` is now
+the single way the admin page attaches its credential.
+
+Scope is client-only on purpose. `views.py` still accepts `?token=` so a phone
+holding a cached older `admin.js` keeps working; removing that fallback is a
+separate change for a later release, once no client sends it.
+
+These assertions look for the absent CALL, never the absent WORD — the comments
+here quote `?token=` to explain what was removed, and four separate assertions
+today tripped over exactly that.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WWW = _REPO_ROOT / "custom_components" / "quizify" / "www"
+
+# Every file that talks to an admin-gated endpoint from the browser.
+CLIENT_FILES = (
+    _WWW / "js" / "admin.js",
+    _WWW / "js" / "pack-submit.js",
+    _WWW / "analytics.html",
+    _WWW / "js" / "player.bundle.js",
+)
+
+# The shape that leaked: building a URL with the credential glued on.
+TOKEN_IN_URL = re.compile(r"""['"]\?token=['"]|token=['"]\s*\+\s*encodeURIComponent""")
+
+
+def _strip_comments(source: str) -> str:
+    source = re.sub(r"/\*.*?\*/", "", source, flags=re.S)
+    return re.sub(r"^\s*//.*$", "", source, flags=re.M)
+
+
+def test_no_client_builds_a_token_query_string() -> None:
+    """The core guard. Comments are stripped first, deliberately."""
+    offenders = [
+        path.name
+        for path in CLIENT_FILES
+        if path.exists()
+        and TOKEN_IN_URL.search(_strip_comments(path.read_text("utf-8")))
+    ]
+
+    assert not offenders, (
+        f"{offenders} still put the admin token in a URL — send the "
+        "X-Quizify-Token header instead (#359, #608)"
+    )
+
+
+def test_the_analytics_page_no_longer_reads_the_token_from_its_url() -> None:
+    """That read is why the credential reached browser history.
+
+    Since #530 localStorage always has it, so the param bought nothing — and
+    the link built in #627 carries no token, yet the page still authenticates.
+    """
+    source = _strip_comments((_WWW / "analytics.html").read_text("utf-8"))
+
+    assert "URLSearchParams(window.location.search).get('token')" not in source
+    assert "QuizifyUtils.readAdminToken()" in source
+
+
+def test_the_admin_page_has_one_place_that_attaches_the_credential() -> None:
+    """A comment asking for a header was broken four times; a function cannot be."""
+    source = _strip_comments((_WWW / "js" / "admin.js").read_text("utf-8"))
+
+    assert "function _adminFetch(url, opts)" in source
+    assert "'X-Quizify-Token'" in source
+    for endpoint in ("tts-entities", "house-entities"):
+        call = f"_adminFetch('/api/quizify/{endpoint}')"
+        assert call in source, f"{endpoint} does not route through _adminFetch"
+
+
+def test_the_preset_helper_routes_through_it_too() -> None:
+    """It had the header already; leaving it separate would keep two copies of
+    the same three lines and invite a third."""
+    source = _strip_comments((_WWW / "js" / "admin.js").read_text("utf-8"))
+    body = source.split("function _presetFetch(opts)", 1)[1].split("\n    }", 1)[0]
+
+    assert "_adminFetch(" in body
+
+
+def test_the_server_still_accepts_the_query_param() -> None:
+    """Scope is client-only on purpose.
+
+    A phone holding a cached older `admin.js` still sends `?token=`. Dropping
+    the server fallback in the same change would answer it 401 on the entity
+    lists — the #530 lockout shape, reintroduced by a security fix.
+    """
+    views = (_REPO_ROOT / "custom_components" / "quizify" / "server" / "views.py")
+    source = views.read_text("utf-8")
+
+    assert 'request.query.get("token")' in source
+    assert 'request.headers.get("X-Quizify-Token")' in source


### PR DESCRIPTION
Closes #608.

## The leak

Four call sites glued a replayable full-control credential onto a URL:

| Site | Endpoint |
|---|---|
| `admin.js` | `/api/quizify/tts-entities` |
| `admin.js` | `/api/quizify/house-entities` |
| `pack-submit.js` | submissions list |
| `analytics.html` | `analytics/data`, `flags` |

Query strings land in aiohttp's access log and in every reverse proxy in front of HA. `analytics.html` also *read* the token out of its own address bar, so it reached browser history as well. Since #530 the token is long-lived — anyone who can read those logs has admin.

## A comment was not enough

The rule was already written down, three lines above one of the four violations:

> Header rather than `?token=` — #359 moved the token out of URLs, and new call sites should not put it back in.

It was broken four times anyway. So the comment becomes a function: `_adminFetch(url, opts)` is the single place the admin page attaches its credential, and `_presetFetch` — which had the header already — routes through it rather than keeping a second copy of the same three lines.

## Client-only, on purpose

`views.py` keeps accepting `?token=`. A phone holding a cached older `admin.js` still sends it, and answering 401 on the entity lists is exactly the #530 lockout shape — reintroduced by a security fix, which would be a poor trade. Removing the server fallback belongs in a later release, once no shipped client sends it.

That is also why the analytics page can stop reading the param: since #530 localStorage always has it, so it bought nothing. The link added in #627 already carries no token and the page authenticates anyway — that was verified there, not assumed here.

## Tests

`tests/test_token_out_of_urls_608.py`: no client builds a token query string (bundle included), the analytics page no longer reads one, the admin page has exactly one credential-attaching function, `_presetFetch` uses it, and the server still accepts both forms.

The main guard searches for the absent **call**, not the absent **word**, and strips comments first. Four separate assertions today tripped over a fix's own comment quoting the thing it removed; this one is written so it cannot.

Run against the unfixed frontend: **4 of 5 failed**.

Suite 2093, `ruff` clean.