### PR TITLE
feat(#613): the duel between two regulars, on the TV lobby

### DIFF
--- a/custom_components/quizify/analytics.py
+++ b/custom_components/quizify/analytics.py
@@ -63,6 +63,16 @@ class PlayerStanding(TypedDict):
     total_score: int
 
 
+class HeadToHead(TypedDict):
+    """The duel between two returning players, for the TV lobby (#613)."""
+
+    left: str
+    right: str
+    left_wins: int
+    right_wins: int
+    games: int
+
+
 class EveningTally(TypedDict):
     """Tonight's running score across several games (#612)."""
 
@@ -387,6 +397,54 @@ class QuizifyAnalytics:
                 original_count,
                 len(games),
             )
+
+    def get_head_to_head(self, present: list[str]) -> HeadToHead | None:
+        """The duel between the two present players who have met most often.
+
+        "Met" means both appeared in the same recorded game; the winner of that
+        meeting is whoever scored higher, which is not the same as the game's
+        overall winner — a duel is between these two, not against the room.
+
+        Scope is the detailed game history, which prunes at RETENTION_DAYS /
+        MAX_DETAILED_RECORDS. So this is honestly "recent", not all-time, and
+        the caller labels it accordingly. A pairwise rollup in the unpruned map
+        would extend it, at a cost that grows quadratically with players — not
+        worth it for a lobby line.
+
+        Returns ``None`` unless a pair has met at least twice: a single shared
+        game makes a "1–0" that reads like a record and is a coincidence.
+        """
+        names = [n for n in dict.fromkeys(present) if n]
+        if len(names) < 2:
+            return None
+
+        best: HeadToHead | None = None
+        for i, left in enumerate(names):
+            for right in names[i + 1 :]:
+                left_wins = right_wins = met = 0
+                for game in self._data.get("games", []):
+                    scores = game.get("player_scores") or {}
+                    if left not in scores or right not in scores:
+                        continue
+                    met += 1
+                    if scores[left] > scores[right]:
+                        left_wins += 1
+                    elif scores[right] > scores[left]:
+                        right_wins += 1
+                    # A draw counts as a meeting and goes to nobody.
+                if met < 2:
+                    continue
+                # Most-met pair wins; ties fall to the alphabetically first
+                # pair so the TV does not flicker between equals on rejoin.
+                if best is None or met > best["games"]:
+                    best = {
+                        "left": left,
+                        "right": right,
+                        "left_wins": left_wins,
+                        "right_wins": right_wins,
+                        "games": met,
+                    }
+        return best
 
     # More than this between two games and they belong to different evenings
     # (#612). A calendar day was the obvious alternative and is worse: it cuts

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -1509,6 +1509,7 @@ class QuizifyWebSocketHandler:
                 # too, or the lobby keeps showing a team nobody is in.
                 "teams": gs.team_registry.to_list(),
             })
+            await self._send_head_to_head(gs)
 
         # A roster change that landed DURING the broadcast set _roster_dirty
         # again; _ensure_roster_flush won't start a new task while this one is
@@ -1565,6 +1566,33 @@ class QuizifyWebSocketHandler:
             self._progress_flush_task.cancel()
             self._progress_flush_task = None
         self._progress_dirty = False
+
+    async def _send_head_to_head(self, game_state: QuizifyGameState) -> None:
+        """Show the TV the duel between the two present regulars (#613).
+
+        Lobby only: a rivalry line belongs before the game, and mid-game it
+        would compete with the question for the same screen.
+
+        To the TV and admin, never to the phones — this is a deliberate
+        reversal of #371, which sends each player only their OWN standing.
+        Putting two people's record in front of the room is a different call,
+        made knowingly, and the phones stay out of it.
+        """
+        if game_state.phase != GamePhase.LOBBY:
+            return
+        analytics = game_state.stats_service
+        if analytics is None:
+            return
+        duel = analytics.get_head_to_head(
+            [p.name for p in game_state.get_players()]
+        )
+        if duel is None:
+            # Fewer than two present, or no pair has met twice. Silence beats a
+            # "1-0" that reads like a record and is a coincidence.
+            return
+        await self._conn.broadcast_to_admins_and_dashboards(
+            {"type": "head_to_head", **duel}
+        )
 
     def _cancel_roster_flush(self) -> None:
         """Cancel any pending roster-flush task (called on cleanup)."""

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -1580,6 +1580,36 @@ class QuizifyWebSocketHandler:
         """
         if game_state.phase != GamePhase.LOBBY:
             return
+        await self._broadcast_head_to_head(game_state, at="lobby")
+
+    async def _dispatch_end_head_to_head(self) -> None:
+        """The duel again on the end screen, once the game is recorded (#613).
+
+        Rides ``analytics_recorded`` rather than the finale, and that is the
+        whole point: the game everyone just watched is part of the record only
+        after it is written. Sent with the finale, this line would state the
+        standing from BEFORE that game — the one number the room can see is
+        wrong, because they just played it.
+
+        It is also the better place for the line. In the lobby the duel shows
+        a score from past evenings that surprises nobody; here it is the
+        result of the evening in progress.
+        """
+        game_state = self._get_game_state()
+        if game_state is None or game_state.phase != GamePhase.FINALE:
+            return
+        await self._broadcast_head_to_head(game_state, at="finale")
+
+    async def _broadcast_head_to_head(
+        self, game_state: QuizifyGameState, *, at: str
+    ) -> None:
+        """Compute the duel and put it on the TV. Shared by both placements.
+
+        ``at`` tells the dashboard which line to fill; the payload is
+        otherwise identical, so the two placements cannot drift apart in what
+        they claim. Never a plain broadcast — that would reach every phone and
+        undo #371 everywhere.
+        """
         analytics = game_state.stats_service
         if analytics is None:
             return
@@ -1591,7 +1621,7 @@ class QuizifyWebSocketHandler:
             # "1-0" that reads like a record and is a coincidence.
             return
         await self._conn.broadcast_to_admins_and_dashboards(
-            {"type": "head_to_head", **duel}
+            {"type": "head_to_head", "at": at, **duel}
         )
 
     def _cancel_roster_flush(self) -> None:
@@ -3582,15 +3612,16 @@ class QuizifyWebSocketHandler:
         return admin is None or not admin.connected
 
     async def _dispatch_analytics_followups(self) -> None:
-        """Everything that can only be true once the game is recorded (#624, #612).
+        """Everything true only once the game is recorded (#624, #612, #613).
 
-        One handler because one event: the season standing per player and the
-        evening tally for the room both become correct at the same instant, and
-        registering two handlers for the same event would make their order an
-        accident of dict insertion.
+        One handler because one event: the season standing per player, the
+        evening tally for the room and the end-screen duel all become correct
+        at the same instant, and registering three handlers for the same event
+        would make their order an accident of dict insertion.
         """
         await self._dispatch_all_time_standings()
         await self._dispatch_evening_tally()
+        await self._dispatch_end_head_to_head()
 
     async def _dispatch_evening_tally(self) -> None:
         """Broadcast tonight's running score to the TV (#612).

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -329,6 +329,44 @@
             max-width: 800px;
         }
 
+        /* A television does not scroll, so anything below the fold is simply
+           not in the picture. Measured on a 1280x720 screen with three players
+           in the lobby: the column was ALREADY 732px tall before the duel line
+           existed — the roster chips were clipped by 12px — and the duel adds
+           another ~97px, putting it entirely off-screen. 1366x768 fails the
+           same way; only 1080p had the room.
+
+           So this compacts the lobby on short screens rather than shrinking it
+           everywhere: at 1080p the QR stays the size it was, because it has to
+           scan from a sofa across the room. */
+        @media (max-height: 850px) {
+            #lobby-qr.dashboard-qr-section {
+                gap: 8px;
+            }
+
+            /* The vendor library renders a fixed 280px canvas; scaling it here
+               keeps the code sharp (it is drawn at 280 and displayed smaller)
+               while giving the column back 100px. */
+            #lobby-qr .dashboard-qr-section canvas,
+            #lobby-qr canvas,
+            #lobby-qr img {
+                width: 180px;
+                height: 180px;
+            }
+
+            #lobby-view .dashboard-waiting-text {
+                margin: 0;
+            }
+
+            #lobby-view .dashboard-join-fallback {
+                margin-top: 2px;
+            }
+
+            .dashboard-h2h {
+                margin-top: 8px;
+            }
+        }
+
         .dashboard-player-chip {
             display: flex;
             align-items: center;

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -154,6 +154,29 @@
             margin-top: 4px;
         }
 
+        .dashboard-h2h {
+            margin-top: 14px;
+            text-align: center;
+            font-size: clamp(1rem, 1.7vw, 1.35rem);
+            color: var(--dash-text-white);
+            font-variant-numeric: tabular-nums;
+        }
+
+        .dashboard-h2h .h2h-label {
+            display: block;
+            font-size: 0.72em;
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+            color: var(--dash-text-muted);
+            margin-bottom: 3px;
+        }
+
+        .dashboard-h2h .h2h-scope {
+            font-size: 0.68em;
+            color: var(--dash-text-muted);
+            margin-left: 8px;
+        }
+
         .dashboard-evening-tally {
             font-size: clamp(1rem, 1.7vw, 1.4rem);
             color: var(--dash-text-white);
@@ -1344,6 +1367,11 @@
                     </div>
                 </div>
                 <div id="lobby-players" class="dashboard-player-list"></div>
+                <!-- #613: the duel between the two present regulars. Lobby only,
+                     TV only — #371 sends each player their OWN standing, and
+                     putting two people's record in front of the room is a
+                     deliberate reversal of that, not an extension. -->
+                <div id="lobby-h2h" class="dashboard-h2h hidden"></div>
             </div>
         </div>
 
@@ -1502,6 +1530,7 @@
             timerFill: document.getElementById('timer-fill'),
             answerProgress: document.getElementById('answer-progress'),
             eveningTally: document.getElementById('evening-tally'),
+            lobbyH2h: document.getElementById('lobby-h2h'),
             questionCategory: document.getElementById('question-category'),
             questionImage: document.getElementById('question-image'),
             questionMedia: document.getElementById('question-media'),
@@ -1795,6 +1824,9 @@
                     break;
                 case 'evening_tally':
                     handleEveningTally(msg);
+                    break;
+                case 'head_to_head':
+                    handleHeadToHead(msg);
                     break;
                 case 'finale':
                 case 'game_ended':
@@ -2169,6 +2201,25 @@
                     '</div>' +
                     '</div>';
             }).join('');
+        }
+
+        function handleHeadToHead(msg) {
+            if (!els.lobbyH2h) return;
+            if (!msg || !msg.left || !msg.right) {
+                els.lobbyH2h.classList.add('hidden');
+                return;
+            }
+            var t = (window.QuizifyI18n && window.QuizifyI18n.t)
+                || function (k) { return k; };
+            // "last 90 days" is stated, not implied: the detailed history
+            // prunes at RETENTION_DAYS, so calling this an all-time record
+            // would be a claim the data cannot support.
+            els.lobbyH2h.innerHTML =
+                '<span class="h2h-label">' + escapeHtml(t('dashboard.h2hLabel')) + '</span>'
+                + escapeHtml(msg.left) + ' ' + msg.left_wins
+                + ' – ' + msg.right_wins + ' ' + escapeHtml(msg.right)
+                + '<span class="h2h-scope">' + escapeHtml(t('dashboard.h2hRecent')) + '</span>';
+            els.lobbyH2h.classList.remove('hidden');
         }
 
         function handleEveningTally(msg) {

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -171,6 +171,17 @@
             margin-bottom: 3px;
         }
 
+        /* On the end screen the line sits under the leaderboard card in the
+           right column, so it needs its own separation — in the lobby the
+           column gap already provides it. Kept small: the podium is the
+           headline there, this is a footnote to it. */
+        .dashboard-h2h--end {
+            margin-top: 10px;
+            padding-top: 10px;
+            border-top: 1px solid var(--dash-border-neon);
+            font-size: clamp(0.9rem, 1.3vw, 1.1rem);
+        }
+
         .dashboard-h2h .h2h-scope {
             font-size: 0.68em;
             color: var(--dash-text-muted);
@@ -1469,6 +1480,12 @@
                         <div class="card-header" data-i18n="dashboard.leaderboard">Leaderboard</div>
                         <div id="finale-leaderboard" class="dashboard-leaderboard"></div>
                     </div>
+                    <!-- #613: the duel again, now including the game that just
+                         ended. It arrives on analytics_recorded rather than
+                         with the finale, because only then is that game part
+                         of the record — sent with the finale it would state
+                         the standing from before the game everyone watched. -->
+                    <div id="end-h2h" class="dashboard-h2h dashboard-h2h--end hidden"></div>
                 </div>
             </div>
         </div>
@@ -1569,6 +1586,7 @@
             answerProgress: document.getElementById('answer-progress'),
             eveningTally: document.getElementById('evening-tally'),
             lobbyH2h: document.getElementById('lobby-h2h'),
+            endH2h: document.getElementById('end-h2h'),
             questionCategory: document.getElementById('question-category'),
             questionImage: document.getElementById('question-image'),
             questionMedia: document.getElementById('question-media'),
@@ -2242,9 +2260,13 @@
         }
 
         function handleHeadToHead(msg) {
-            if (!els.lobbyH2h) return;
+            // #613: the same line in two places. `at` picks the target — the
+            // lobby before the game, the end screen after it, where the score
+            // already includes the game just played.
+            var target = (msg && msg.at === 'finale') ? els.endH2h : els.lobbyH2h;
+            if (!target) return;
             if (!msg || !msg.left || !msg.right) {
-                els.lobbyH2h.classList.add('hidden');
+                target.classList.add('hidden');
                 return;
             }
             var t = (window.QuizifyI18n && window.QuizifyI18n.t)
@@ -2252,12 +2274,12 @@
             // "last 90 days" is stated, not implied: the detailed history
             // prunes at RETENTION_DAYS, so calling this an all-time record
             // would be a claim the data cannot support.
-            els.lobbyH2h.innerHTML =
+            target.innerHTML =
                 '<span class="h2h-label">' + escapeHtml(t('dashboard.h2hLabel')) + '</span>'
                 + escapeHtml(msg.left) + ' ' + msg.left_wins
                 + ' – ' + msg.right_wins + ' ' + escapeHtml(msg.right)
                 + '<span class="h2h-scope">' + escapeHtml(t('dashboard.h2hRecent')) + '</span>';
-            els.lobbyH2h.classList.remove('hidden');
+            target.classList.remove('hidden');
         }
 
         function handleEveningTally(msg) {
@@ -2458,6 +2480,14 @@
 
         function handleFinale(msg) {
             showView('finale');
+
+            // #613: clear last game's duel before this game's arrives on
+            // analytics_recorded, a beat later. Leaving it up would show the
+            // PREVIOUS game's standing under this game's podium.
+            if (els.endH2h) {
+                els.endH2h.classList.add('hidden');
+                els.endH2h.innerHTML = '';
+            }
 
             var podium = msg.podium || [];
             renderPodium(podium);

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -558,6 +558,8 @@
     "runnersUp": "Außerdem dabei",
     "leaderboardMore": "+{count} weitere",
     "tonightLabel": "Heute Abend",
+    "h2hLabel": "Duell",
+    "h2hRecent": "letzte 90 Tage",
     "tonightGames": "{games} Spiele",
     "tonightWins": "{wins} Siege",
     "tonightWinsOne": "1 Sieg"

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -558,6 +558,8 @@
     "runnersUp": "Also playing",
     "leaderboardMore": "+{count} more",
     "tonightLabel": "Tonight",
+    "h2hLabel": "Head to head",
+    "h2hRecent": "last 90 days",
     "tonightGames": "{games} games",
     "tonightWins": "{wins} wins",
     "tonightWinsOne": "1 win"

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -558,6 +558,8 @@
     "runnersUp": "También juegan",
     "leaderboardMore": "+{count} más",
     "tonightLabel": "Esta noche",
+    "h2hLabel": "Duelo",
+    "h2hRecent": "últimos 90 días",
     "tonightGames": "{games} partidas",
     "tonightWins": "{wins} victorias",
     "tonightWinsOne": "1 victoria"

--- a/tests/test_head_to_head_613.py
+++ b/tests/test_head_to_head_613.py
@@ -126,18 +126,62 @@ def test_a_lobby_of_one_has_no_duel() -> None:
     assert _Analytics([_game({"Anna": 1, "Ben": 2})]).duel(["Anna"]) is None
 
 
+def _fn_body(source: str, name: str) -> str:
+    """The source of one method, docstring stripped.
+
+    Cuts at the next `async def` / `def` at method indentation. The earlier
+    version of this helper split on `"\n    def "` alone, which stopped
+    working the moment the next sibling was `async` — the slice then ran on
+    through several methods and the assertions below started passing on code
+    they were not looking at.
+    """
+    body = source.split(f"async def {name}", 1)[1]
+    for marker in ("\n    async def ", "\n    def "):
+        body = body.split(marker, 1)[0]
+    return re.sub(r'""".*?"""', "", body, flags=re.S)
+
+
 def test_it_is_sent_in_the_lobby_only_and_never_to_phones() -> None:
     """The reversal of #371 is bounded: the room sees it, the phones do not."""
     source = (_CC / "server" / "websocket.py").read_text("utf-8")
-    body = source.split("async def _send_head_to_head", 1)[1].split(
-        "\n    def ", 1
-    )[0]
-    body = re.sub(r'""".*?"""', "", body, flags=re.S)
 
-    assert "phase != GamePhase.LOBBY" in body
-    assert "broadcast_to_admins_and_dashboards" in body
+    assert "phase != GamePhase.LOBBY" in _fn_body(source, "_send_head_to_head")
+
+    # Both placements go out through the one shared sender, so they cannot
+    # drift apart in who they reach.
+    shared = _fn_body(source, "_broadcast_head_to_head")
+    assert "broadcast_to_admins_and_dashboards" in shared
     # A plain broadcast would reach every phone — the thing #371 avoided.
-    assert "self._conn.broadcast(" not in body
+    assert "self._conn.broadcast(" not in shared
+
+
+def test_the_end_screen_duel_waits_for_the_game_to_be_recorded() -> None:
+    """Sent with the finale it would state the standing from BEFORE the game
+    the room just watched — the one number they can see is wrong.
+
+    So it rides ``analytics_recorded`` like the season standing (#624) and the
+    evening tally (#612), which become true at the same instant.
+    """
+    source = (_CC / "server" / "websocket.py").read_text("utf-8")
+
+    followups = _fn_body(source, "_dispatch_analytics_followups")
+    assert "_dispatch_end_head_to_head" in followups
+
+    end = _fn_body(source, "_dispatch_end_head_to_head")
+    assert "GamePhase.FINALE" in end
+    assert 'at="finale"' in end
+
+    html = (_WWW / "dashboard.html").read_text("utf-8")
+    assert 'id="end-h2h"' in html
+    # One renderer, two targets — picked by `at`, so the two lines cannot
+    # disagree about what the score is.
+    render = html.split("function handleHeadToHead(", 1)[1].split("\n        }", 1)[0]
+    assert "msg.at === 'finale'" in render
+    assert "els.endH2h" in render
+    # The previous game's duel must not sit under this game's podium while the
+    # new one is still being written.
+    finale = html.split("function handleFinale(", 1)[1].split("\n        }", 1)[0]
+    assert "els.endH2h" in finale
 
 
 def test_the_tv_states_the_ninety_day_scope() -> None:

--- a/tests/test_head_to_head_613.py
+++ b/tests/test_head_to_head_613.py
@@ -1,0 +1,161 @@
+"""The duel between two returning players, on the TV lobby (issue #613).
+
+The code asked for this itself: `get_player_standing` justifies the lobby line
+by saying it is "supposed to start a rivalry", and only the solo view existed.
+
+**This is a deliberate reversal of #371, not an extension of it.** That issue
+sends each player only their OWN standing; #624 kept that posture this
+afternoon. A head-to-head on the TV puts two people's record in front of the
+whole room. Markus made that call explicitly — at home it is the fun, at a party
+with colleagues "Ben 0–5" can be the moment someone stops playing. The phones
+therefore stay out of it: TV and admin only.
+
+Scope is the detailed history, which prunes at RETENTION_DAYS /
+MAX_DETAILED_RECORDS, so the line says "last 90 days" rather than implying an
+all-time record it cannot support.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_CC = _REPO_ROOT / "custom_components" / "quizify"
+_WWW = _CC / "www"
+
+
+class _Analytics:
+    def __init__(self, games: list[dict]) -> None:
+        from custom_components.quizify.analytics import QuizifyAnalytics
+
+        self._impl = QuizifyAnalytics.__new__(QuizifyAnalytics)
+        self._impl._data = {"games": games}
+
+    def duel(self, present: list[str]):
+        return self._impl.get_head_to_head(present)
+
+
+def _game(scores: dict[str, int]) -> dict:
+    return {"player_scores": scores}
+
+
+def test_a_single_shared_game_is_not_a_record() -> None:
+    """"1–0" after one game reads like a record and is a coincidence."""
+    games = [_game({"Anna": 10, "Ben": 8})]
+
+    assert _Analytics(games).duel(["Anna", "Ben"]) is None
+
+
+def test_two_meetings_produce_the_duel() -> None:
+    games = [
+        _game({"Anna": 10, "Ben": 8}),
+        _game({"Anna": 5, "Ben": 9}),
+        _game({"Anna": 7, "Ben": 3}),
+    ]
+
+    duel = _Analytics(games).duel(["Anna", "Ben"])
+
+    assert duel == {
+        "left": "Anna",
+        "right": "Ben",
+        "left_wins": 2,
+        "right_wins": 1,
+        "games": 3,
+    }
+
+
+def test_the_winner_of_a_meeting_is_between_those_two() -> None:
+    """Not the game's overall winner.
+
+    Cara topping the table does not settle anything between Anna and Ben.
+    """
+    games = [
+        _game({"Anna": 4, "Ben": 3, "Cara": 99}),
+        _game({"Anna": 6, "Ben": 2, "Cara": 99}),
+    ]
+
+    duel = _Analytics(games).duel(["Anna", "Ben"])
+
+    assert duel is not None
+    assert (duel["left_wins"], duel["right_wins"]) == (2, 0)
+
+
+def test_a_draw_counts_as_a_meeting_and_goes_to_nobody() -> None:
+    games = [
+        _game({"Anna": 5, "Ben": 5}),
+        _game({"Anna": 7, "Ben": 3}),
+    ]
+
+    duel = _Analytics(games).duel(["Anna", "Ben"])
+
+    assert duel is not None
+    assert duel["games"] == 2
+    assert (duel["left_wins"], duel["right_wins"]) == (1, 0)
+
+
+def test_the_most_met_pair_wins_when_several_are_present() -> None:
+    """Three regulars in the lobby is one duel, not three."""
+    games = [
+        _game({"Anna": 9, "Ben": 4}),
+        _game({"Anna": 8, "Ben": 5}),
+        _game({"Anna": 7, "Ben": 6}),
+        _game({"Anna": 3, "Cara": 9}),
+        _game({"Anna": 2, "Cara": 8}),
+    ]
+
+    duel = _Analytics(games).duel(["Anna", "Ben", "Cara"])
+
+    assert duel is not None
+    assert {duel["left"], duel["right"]} == {"Anna", "Ben"}
+    assert duel["games"] == 3
+
+
+def test_games_only_one_of_them_played_are_ignored() -> None:
+    games = [
+        _game({"Anna": 10}),
+        _game({"Ben": 10}),
+        _game({"Anna": 10, "Ben": 1}),
+    ]
+
+    assert _Analytics(games).duel(["Anna", "Ben"]) is None
+
+
+def test_a_lobby_of_one_has_no_duel() -> None:
+    assert _Analytics([_game({"Anna": 1, "Ben": 2})]).duel(["Anna"]) is None
+
+
+def test_it_is_sent_in_the_lobby_only_and_never_to_phones() -> None:
+    """The reversal of #371 is bounded: the room sees it, the phones do not."""
+    source = (_CC / "server" / "websocket.py").read_text("utf-8")
+    body = source.split("async def _send_head_to_head", 1)[1].split(
+        "\n    def ", 1
+    )[0]
+    body = re.sub(r'""".*?"""', "", body, flags=re.S)
+
+    assert "phase != GamePhase.LOBBY" in body
+    assert "broadcast_to_admins_and_dashboards" in body
+    # A plain broadcast would reach every phone — the thing #371 avoided.
+    assert "self._conn.broadcast(" not in body
+
+
+def test_the_tv_states_the_ninety_day_scope() -> None:
+    """The detailed history prunes, so calling it all-time would be a claim the
+    data cannot support."""
+    html = (_WWW / "dashboard.html").read_text("utf-8")
+
+    assert "dashboard.h2hRecent" in html
+    for code in ("de", "en", "es"):
+        bundle = json.loads((_WWW / "i18n" / f"{code}.json").read_text("utf-8"))
+        dash = bundle["dashboard"]
+        assert dash.get("h2hLabel")
+        assert "90" in dash["h2hRecent"]
+
+
+def test_the_names_are_escaped() -> None:
+    html = (_WWW / "dashboard.html").read_text("utf-8")
+    body = html.split("function handleHeadToHead(", 1)[1].split("\n        }", 1)[0]
+
+    assert "escapeHtml(msg.left)" in body
+    assert "escapeHtml(msg.right)" in body

--- a/tests/test_head_to_head_613.py
+++ b/tests/test_head_to_head_613.py
@@ -159,3 +159,27 @@ def test_the_names_are_escaped() -> None:
 
     assert "escapeHtml(msg.left)" in body
     assert "escapeHtml(msg.right)" in body
+
+
+def test_the_lobby_is_compacted_on_short_screens() -> None:
+    """A television does not scroll, so a lobby taller than the screen simply
+    loses its bottom.
+
+    Measured with three players in the lobby: the column was already 732px on
+    a 1280x720 screen *before* this feature — the roster chips were clipped by
+    12px and nobody had noticed — and the duel line lands at 829px, entirely
+    off the picture. 1366x768 fails the same way. Only 1080p had the room.
+
+    The rule below compacts the lobby on short viewports instead of shrinking
+    it everywhere, because the QR still has to scan from across the room on a
+    screen that does have the height. Without it the feature is invisible on
+    every 720p television, and invisible in the worst way: nothing looks
+    broken.
+    """
+    html = (_WWW / "dashboard.html").read_text("utf-8")
+
+    assert "@media (max-height: 850px)" in html
+    rule = html.split("@media (max-height: 850px)", 1)[1].split("\n        }\n", 1)[0]
+    # The QR is the one block big enough to buy back the missing height.
+    assert "#lobby-qr" in rule
+    assert "180px" in rule


### PR DESCRIPTION
Closes #613.

## The code asked for this

`get_player_standing` justifies the lobby line in its own docstring: it is "supposed to start a rivalry". Only the solo view was ever built.

## It reverses #371 on purpose

#371 sends each player **only their own** standing, and #624 kept that posture this afternoon — per-player, not broadcast, with the reasoning in the code.

A head-to-head on the TV puts two people's record in front of the whole room. That is a reversal, not an extension, and it is a taste call rather than a technical one: at home it is exactly the fun; at a party with colleagues "Ben 0–5" can be the moment someone stops playing. Markus made the call.

So the reversal is **bounded**:

- **TV and admin only.** The phones never receive it — a plain broadcast would have been one word shorter and would have undone #371 everywhere.
- **Lobby only.** Mid-game it would compete with the question for the same screen.
- **Silent until a pair has met twice.** "1–0" after one shared game reads like a record and is a coincidence.

## Details that are decisions

**The winner of a meeting is between those two.** Not the game's overall winner — Cara topping the table settles nothing between Anna and Ben.

**A draw counts as a meeting and goes to nobody.**

**The most-met pair wins** when several regulars are present, with ties broken alphabetically so the TV does not flicker between equals when someone rejoins.

**"Last 90 days" is stated, not implied.** The detailed history prunes at `RETENTION_DAYS` / `MAX_DETAILED_RECORDS`, so an all-time claim would be one the data cannot support. Extending it needs a pairwise rollup in the unpruned map, growing quadratically in players — not worth it for a lobby line.

## Tests

`tests/test_head_to_head_613.py`: the single-meeting silence, the duel itself, the meeting winner vs the game winner, draws, the most-met pair among three, games only one of them played, a lobby of one, the lobby-and-TV-only wiring including the absent plain broadcast, the 90-day label in three languages, and name escaping.

Run against the unfixed code: **10 of 10 failed**.

Suite 2103, `ruff` clean, `mypy` clean.