### PR TITLE
Start the countdown pulse with the digit instead of on its own clock

### DIFF
--- a/custom_components/quizify/www/css/src/07-player.css
+++ b/custom_components/quizify/www/css/src/07-player.css
@@ -568,7 +568,19 @@
 .timer--critical {
     color: var(--color-error-neon);
     text-shadow: 0 0 15px var(--color-error-neon);
-    animation: timer-pulse-intense 0.5s ease-in-out infinite;
+}
+
+/* One pulse per digit, restarted by the same tick that writes the number
+   (#650). Deliberately not `infinite`: an endless 0.5s loop beats twice per
+   second against a digit that changes once, and its phase is set by whenever
+   the critical class happened to be added — so it can never land on the
+   change, and setInterval drift pushes the two further apart as the question
+   runs. The audible tick rides the same interval as the digit, which is what
+   made the mismatch read as broken: sound and animation disagreed about when
+   a second was. Kept under a second so each pulse finishes before the next
+   digit arrives. */
+.timer--tick {
+    animation: timer-pulse-intense 0.4s ease-in-out;
 }
 
 /* Answer section */

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -4037,7 +4037,19 @@ footer {
 .timer--critical {
     color: var(--color-error-neon);
     text-shadow: 0 0 15px var(--color-error-neon);
-    animation: timer-pulse-intense 0.5s ease-in-out infinite;
+}
+
+/* One pulse per digit, restarted by the same tick that writes the number
+   (#650). Deliberately not `infinite`: an endless 0.5s loop beats twice per
+   second against a digit that changes once, and its phase is set by whenever
+   the critical class happened to be added — so it can never land on the
+   change, and setInterval drift pushes the two further apart as the question
+   runs. The audible tick rides the same interval as the digit, which is what
+   made the mismatch read as broken: sound and animation disagreed about when
+   a second was. Kept under a second so each pulse finishes before the next
+   digit arrives. */
+.timer--tick {
+    animation: timer-pulse-intense 0.4s ease-in-out;
 }
 
 /* Answer section */

--- a/custom_components/quizify/www/js/player-game.js
+++ b/custom_components/quizify/www/js/player-game.js
@@ -40,6 +40,25 @@
     }
 
     /**
+     * Restart the timer's one-shot pulse so it begins with the digit (#650).
+     *
+     * The animation used to be `infinite` in CSS, which left it free-running
+     * at its own rate and phase while the number changed once a second — two
+     * clocks that could never agree. Retriggering it here binds the pulse to
+     * the tick that writes the digit, so they start together every second and
+     * cannot drift apart.
+     *
+     * The reflow between remove and add is required, not defensive: without
+     * it the browser coalesces both class changes into no change at all and
+     * the running animation simply continues.
+     */
+    function pulseTimer(el) {
+        el.classList.remove('timer--tick');
+        void el.offsetWidth;
+        el.classList.add('timer--tick');
+    }
+
+    /**
      * Start countdown timer
      * @param {number} deadline - Server deadline timestamp in milliseconds
      */
@@ -50,7 +69,7 @@
         var timerElement = document.getElementById('timer');
         if (!timerElement) return;
 
-        timerElement.classList.remove('timer--warning', 'timer--critical');
+        timerElement.classList.remove('timer--warning', 'timer--critical', 'timer--tick');
 
         function updateCountdown() {
             var now = Date.now();
@@ -65,11 +84,12 @@
             if (remaining <= 5) {
                 timerElement.classList.remove('timer--warning');
                 timerElement.classList.add('timer--critical');
+                pulseTimer(timerElement);
             } else if (remaining <= 10) {
-                timerElement.classList.remove('timer--critical');
+                timerElement.classList.remove('timer--critical', 'timer--tick');
                 timerElement.classList.add('timer--warning');
             } else {
-                timerElement.classList.remove('timer--warning', 'timer--critical');
+                timerElement.classList.remove('timer--warning', 'timer--critical', 'timer--tick');
             }
 
             var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -3782,6 +3782,25 @@
     }
 
     /**
+     * Restart the timer's one-shot pulse so it begins with the digit (#650).
+     *
+     * The animation used to be `infinite` in CSS, which left it free-running
+     * at its own rate and phase while the number changed once a second — two
+     * clocks that could never agree. Retriggering it here binds the pulse to
+     * the tick that writes the digit, so they start together every second and
+     * cannot drift apart.
+     *
+     * The reflow between remove and add is required, not defensive: without
+     * it the browser coalesces both class changes into no change at all and
+     * the running animation simply continues.
+     */
+    function pulseTimer(el) {
+        el.classList.remove('timer--tick');
+        void el.offsetWidth;
+        el.classList.add('timer--tick');
+    }
+
+    /**
      * Start countdown timer
      * @param {number} deadline - Server deadline timestamp in milliseconds
      */
@@ -3792,7 +3811,7 @@
         var timerElement = document.getElementById('timer');
         if (!timerElement) return;
 
-        timerElement.classList.remove('timer--warning', 'timer--critical');
+        timerElement.classList.remove('timer--warning', 'timer--critical', 'timer--tick');
 
         function updateCountdown() {
             var now = Date.now();
@@ -3807,11 +3826,12 @@
             if (remaining <= 5) {
                 timerElement.classList.remove('timer--warning');
                 timerElement.classList.add('timer--critical');
+                pulseTimer(timerElement);
             } else if (remaining <= 10) {
-                timerElement.classList.remove('timer--critical');
+                timerElement.classList.remove('timer--critical', 'timer--tick');
                 timerElement.classList.add('timer--warning');
             } else {
-                timerElement.classList.remove('timer--warning', 'timer--critical');
+                timerElement.classList.remove('timer--warning', 'timer--critical', 'timer--tick');
             }
 
             var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };

--- a/tests/test_countdown_pulse_650.py
+++ b/tests/test_countdown_pulse_650.py
@@ -1,0 +1,117 @@
+"""Issue #650 — the countdown pulse has to start with the digit.
+
+Reported from live play on v1.10.0-RC1: the number pulses, but not in time
+with the number. The two were never able to agree. The digit is rewritten by
+a one-second interval; the pulse was a CSS animation declared `infinite` at
+half a second, so it beat twice per second with a phase set by whichever tick
+first added the critical class, and `setInterval` drift pushed them further
+apart as the question ran. The audible tick rides the same interval as the
+digit, so sound and animation openly disagreed about when a second was.
+
+The fix binds the pulse to the tick that writes the digit: one shot per
+update, restarted from JS. These tests pin the two halves that make that
+work — a non-infinite animation in the CSS, and a retrigger that survives the
+browser's tendency to collapse remove+add into nothing.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+WWW = _REPO_ROOT / "custom_components" / "quizify" / "www"
+_PLAYER_JS = (WWW / "js" / "player-game.js").read_text(encoding="utf-8")
+_CSS_SRC = (WWW / "css" / "src" / "07-player.css").read_text(encoding="utf-8")
+_CSS_BUILT = (WWW / "css" / "styles.css").read_text(encoding="utf-8")
+
+
+def _rule(css: str, selector: str) -> str:
+    """Return the declaration block for *selector*, or '' if absent."""
+    match = re.search(re.escape(selector) + r"\s*\{([^}]*)\}", css)
+    return match.group(1) if match else ""
+
+
+class TestThePulseIsNoLongerFreeRunning:
+    def test_critical_state_carries_no_animation(self) -> None:
+        """The urgency colour must not drag a self-running animation with it.
+
+        `.timer--critical` is added once, on the first tick at or below five
+        seconds, and then stays. Any animation declared on it therefore runs
+        on its own clock for the rest of the question — which is exactly the
+        defect.
+        """
+        assert "animation" not in _rule(_CSS_SRC, ".timer--critical")
+
+    def test_the_pulse_runs_once_per_trigger(self) -> None:
+        rule = _rule(_CSS_SRC, ".timer--tick")
+        assert "timer-pulse-intense" in rule
+        assert "infinite" not in rule
+
+    def test_the_pulse_finishes_before_the_next_digit(self) -> None:
+        """A pulse longer than a second would still be running when the next
+        one starts, which re-creates the overlap the fix removes."""
+        rule = _rule(_CSS_SRC, ".timer--tick")
+        seconds = re.search(r"animation:[^;]*?([\d.]+)s", rule)
+        assert seconds, rule
+        assert float(seconds.group(1)) < 1.0
+
+    def test_the_built_stylesheet_has_it(self) -> None:
+        """styles.css is committed; a forgotten rebuild ships a dead class."""
+        assert ".timer--tick" in _CSS_BUILT, "run scripts/build_css.py"
+        assert "animation" not in _rule(_CSS_BUILT, ".timer--critical")
+
+
+class TestTheRetriggerIsBoundToTheDigit:
+    def test_the_pulse_fires_from_the_same_update_as_the_digit(self) -> None:
+        """`pulseTimer` has to be called on the branch that renders the
+        critical state, not on entry into it — one pulse per digit is the
+        whole point."""
+        body = re.search(
+            r"if \(remaining <= 5\) \{(.*?)\} else if", _PLAYER_JS, re.S
+        )
+        assert body, "the critical branch moved — re-check the binding"
+        assert "pulseTimer(timerElement)" in body.group(1)
+
+    def test_the_reflow_between_remove_and_add_is_there(self) -> None:
+        """Without it the browser coalesces both class changes into no change
+        and the animation keeps running — the fix would silently do nothing.
+
+        Asserted on the read of `offsetWidth` between the two calls rather
+        than on a comment, because only the read forces the layout.
+        """
+        body = re.search(
+            r"function pulseTimer\(el\) \{(.*?)\n    \}", _PLAYER_JS, re.S
+        )
+        assert body, "pulseTimer is gone"
+        order = body.group(1)
+        assert order.index("classList.remove") < order.index("offsetWidth")
+        assert order.index("offsetWidth") < order.index("classList.add")
+
+
+class TestTheClassDoesNotOutliveTheUrgency:
+    def test_a_fresh_question_starts_clean(self) -> None:
+        """A question that begins above five seconds must not inherit a pulse
+        left over from the last one."""
+        start = re.search(
+            r"function startCountdown\(deadline\) \{(.*?)function updateCountdown",
+            _PLAYER_JS,
+            re.S,
+        )
+        assert start
+        assert "'timer--tick'" in start.group(1)
+
+    def test_leaving_the_critical_range_drops_it(self) -> None:
+        """Only reachable when the deadline moves (a paused or extended
+        round), but a stuck pulse on a calm timer would be worse than the
+        bug being fixed."""
+        for branch in (
+            r"\} else if \(remaining <= 10\) \{(.*?)\} else \{",
+            r"\} else \{(.*?)\n            \}",
+        ):
+            body = re.search(branch, _PLAYER_JS, re.S)
+            assert body, branch
+            assert "timer--tick" in body.group(1)


### PR DESCRIPTION
Closes #650.

## The two clocks

The digit is rewritten by `setInterval(updateCountdown, 1000)`. The pulse was CSS:

```css
.timer--critical {
    animation: timer-pulse-intense 0.5s ease-in-out infinite;
}
```

Two beats per second against a digit that changes once, with a phase set by whichever tick first added `.timer--critical` — and `setInterval` drift moving them further apart as the question runs. There is no pairing of those numbers in which the pulse lands on the digit change.

What made it read as broken rather than merely busy: the audible tick rides the *same* interval as the digit (`player-sound.js`), so sound and animation openly disagreed about when a second was.

## The fix

The animation moves off `.timer--critical` — which is added once, at the first tick at or below five seconds, and then stays, so it can only ever host a free-running loop — onto a one-shot `.timer--tick` that JS restarts from the same update that writes the digit.

```js
function pulseTimer(el) {
    el.classList.remove('timer--tick');
    void el.offsetWidth;
    el.classList.add('timer--tick');
}
```

The reflow is load-bearing, not defensive: without it the browser coalesces remove+add into no change at all and the old animation simply continues, so the fix would silently do nothing. There is a test asserting the *order* of those three statements for that reason.

Colour and glow stay on `.timer--critical`, so urgency still reads with animations off — which also settles the open question in the issue. Markus confirmed from the device that the number does pulse, it just does not line up, so the reduced-motion branch does not apply.

## Not in scope, and why

The admin lightning timer looks like it has the same defect — `.timer-text.critical` carries the same infinite animation. It does not: nothing in `admin.js` ever adds that class, so those digits never pulsed and there is no mismatch to fix. Left alone rather than "fixed" into a behaviour it never had.

## Tests

8 new tests in `tests/test_countdown_pulse_650.py`. All eight fail against the unfixed code (verified by stashing the change and re-running). Suite 2,093 → 2,101.

## Not verified on hardware

Same caveat as the rest of v1.10.0-RC1. This one is visual and sub-second, so it needs a real phone in a real round to confirm — a test can pin the wiring, not the rhythm.
