### PR TITLE
Bet before the question, not against its clock (#656)

### DIFF
--- a/custom_components/quizify/const.py
+++ b/custom_components/quizify/const.py
@@ -13,6 +13,14 @@ MIN_PLAYERS = 1
 # just show the personal stats card.
 MIN_PLAYERS_FOR_AWARDS = 2
 DEFAULT_ROUND_DURATION = 30  # seconds
+# How long the final round's betting window stays open before the question is
+# revealed and the round clock starts (#656). Until v1.10.0 the wager UI was
+# rendered from ``question_started`` — so the answer clock was already draining
+# while the table discussed its bet, and the question was readable while
+# betting, which made a high wager risk-free. The window is its own phase now:
+# category only, no answer timer. It closes early as soon as every connected
+# player has locked a bet, so a quick table never waits out the full 20s.
+WAGER_WINDOW_DURATION = 20  # seconds
 MAX_NAME_LENGTH = 20
 MIN_NAME_LENGTH = 1
 LOBBY_DISCONNECT_GRACE_PERIOD = 5  # seconds before removing disconnected player

--- a/custom_components/quizify/game/phase_controller.py
+++ b/custom_components/quizify/game/phase_controller.py
@@ -30,7 +30,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
 
-from ..const import DEFAULT_ROUND_DURATION
+from ..const import DEFAULT_ROUND_DURATION, WAGER_WINDOW_DURATION
 from .timer import QuestionTimer
 
 _LOGGER = logging.getLogger(__name__)
@@ -65,6 +65,17 @@ class GamePhase(str, Enum):  # noqa: UP042 — StrEnum changes str()/serializati
     """Game phase states."""
 
     LOBBY = "LOBBY"
+    # WAGER_ACTIVE (#656) — the final round's betting window. The question is
+    # loaded, but its text has not been sent and no timer is running: players
+    # see the category and place their bet on that alone, Jeopardy-style.
+    # Closing the window arms the timers and flips to QUESTION_ACTIVE.
+    #
+    # It is a real phase rather than a flag on QUESTION_ACTIVE because
+    # everything that reads QUESTION_ACTIVE would be wrong here: the tick
+    # loop's "connected players, no timers" fallback (#586) would end the
+    # round instantly, and the reconnect snapshot would hand out the very
+    # question text the window exists to withhold.
+    WAGER_ACTIVE = "WAGER_ACTIVE"
     QUESTION_ACTIVE = "QUESTION_ACTIVE"
     ANSWER_REVEAL = "ANSWER_REVEAL"
     FINALE = "FINALE"
@@ -113,6 +124,12 @@ class PhaseController:
         self.timers: dict[str, QuestionTimer] = {}  # player_id → timer
         self.round_start_time: float | None = None
         self.round_duration: float = DEFAULT_ROUND_DURATION
+
+        # Final-round betting window (#656). Its own clock, deliberately kept
+        # apart from the round timing above: the round has not started while
+        # this one runs. None outside WAGER_ACTIVE.
+        self.wager_window_start: float | None = None
+        self.wager_window_duration: float = WAGER_WINDOW_DURATION
 
         # Pause bookkeeping.
         self.paused_from: GamePhase | None = None
@@ -191,8 +208,43 @@ class PhaseController:
             timer.start()
             self.timers[name] = timer
 
+    def begin_wager_window(
+        self, round_duration: float, window_duration: float
+    ) -> None:
+        """Open the final round's betting window (#656).
+
+        Records the duration the round *will* run for without stamping
+        ``round_start_time`` or building a single timer — nothing is counting
+        down towards the answer yet. That is the whole point: the window has
+        its own clock (``wager_window_remaining``), and the round proper only
+        starts when the caller follows up with ``begin_round``.
+
+        Leaving ``round_start_time`` at None also keeps
+        ``round_wall_clock_expired`` False for the duration of the window, so
+        no fallback can evaluate a round that has not started.
+        """
+        self.round_duration = round_duration
+        self.round_start_time = None
+        self.timers.clear()
+        self.wager_window_duration = window_duration
+        self.wager_window_start = time.monotonic()
+        self.phase = GamePhase.WAGER_ACTIVE
+
+    def wager_window_remaining(self) -> float:
+        """Seconds left in the betting window, clamped at zero.
+
+        Feeds the reconnect snapshot so a phone that drops mid-window comes
+        back to the countdown the rest of the room is watching, rather than a
+        fresh 20 seconds.
+        """
+        if self.wager_window_start is None:
+            return 0.0
+        elapsed = time.monotonic() - self.wager_window_start
+        return max(0.0, self.wager_window_duration - elapsed)
+
     def enter_question_active(self) -> None:
         """Flip the phase to QUESTION_ACTIVE."""
+        self.wager_window_start = None
         self.phase = GamePhase.QUESTION_ACTIVE
 
     def get_timer(self, name: str) -> QuestionTimer | None:

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -26,6 +26,7 @@ from ..const import (
     ERR_NOT_IN_GAME,
     ERR_ROUND_EXPIRED,
     ERR_TEAM_LOCKED,
+    WAGER_WINDOW_DURATION,
 )
 from .calibration import GroupCalibrator
 from .highlights import compute_superlatives
@@ -758,8 +759,18 @@ class QuizifyGameState:
         self._team_registry.reset_round()
         self._powerup_manager.reset_round()
 
-        # Stamp round timing + create+start per-player timers (PhaseController).
-        self._phase_controller.begin_round(round_duration)
+        # #656: the final round opens with a betting window instead of the
+        # question. Hold the round back — no start stamp, no timers — so the
+        # answer clock cannot drain while the table is still deciding what to
+        # stake. ``arm_round_timers`` starts the round once the window closes.
+        needs_wager_window = self._needs_wager_window(question)
+        if needs_wager_window:
+            self._phase_controller.begin_wager_window(
+                round_duration, WAGER_WINDOW_DURATION
+            )
+        else:
+            # Stamp round timing + create+start per-player timers.
+            self._phase_controller.begin_round(round_duration)
 
         # Randomly assign a power-up to one player who has not yet received one
         # this game (#340 — at most one power-up per player per game). The
@@ -794,7 +805,10 @@ class QuizifyGameState:
                 "(all connected players already granted)"
             )
 
-        self._phase_controller.enter_question_active()
+        if not needs_wager_window:
+            # begin_wager_window already put us in WAGER_ACTIVE; flipping to
+            # QUESTION_ACTIVE here would advertise a round that has no timers.
+            self._phase_controller.enter_question_active()
         self._round_summary = None
         # Invalidate the memoized round-summary message (#414): a new round is
         # live, so the previous round's cached dict must not be served.
@@ -2486,6 +2500,54 @@ class QuizifyGameState:
         """Get the power-up held by a player."""
         return self._powerup_manager.get_powerup(player_name)
 
+    def _needs_wager_window(self, question: Question) -> bool:
+        """Whether this round opens with a betting window (#656).
+
+        Mirrors exactly the rule the player payload advertises the wager UI
+        by: the last round, and never an estimate final. Estimate rounds score
+        through ``_evaluate_estimate_round``, which never reads
+        ``player.wager`` (#353) — opening a window there would collect bets
+        nothing settles.
+        """
+        return self.round == self.total_rounds and not question.is_estimate
+
+    def arm_round_timers(self) -> bool:
+        """Close the betting window and start the round proper (#656).
+
+        Stamps the round start, builds the per-player timers and flips to
+        QUESTION_ACTIVE. Returns False when no window is open, which is what
+        makes the window's two triggers safe to race: the last player locking
+        in and the deadline elapsing can arrive in either order, and whichever
+        loses the race does nothing instead of restarting the round with a
+        fresh set of timers.
+        """
+        if self.phase != GamePhase.WAGER_ACTIVE:
+            return False
+        self._phase_controller.begin_round(self._phase_controller.round_duration)
+        self._phase_controller.enter_question_active()
+        self._notify_state_callbacks()
+        return True
+
+    def wager_window_remaining(self) -> float:
+        """Seconds left in the betting window (0.0 outside WAGER_ACTIVE)."""
+        if self.phase != GamePhase.WAGER_ACTIVE:
+            return 0.0
+        return self._phase_controller.wager_window_remaining()
+
+    def players_missing_wager(self) -> list[str]:
+        """Connected players who have not locked a bet yet (#656).
+
+        The window closes early once this is empty, so a table that decides
+        fast is not held for the full 20 seconds. Disconnected players are
+        excluded — waiting on a phone that has left the room would strand the
+        window until the deadline for everybody else.
+        """
+        return [
+            p.name
+            for p in self._player_registry.players.values()
+            if p.connected and p.wager is None
+        ]
+
     def get_current_question(self) -> Question | None:
         """Return the current question, or None."""
         return self._current_question
@@ -2622,6 +2684,26 @@ class QuizifyGameState:
             # team indicator and believes they are playing alone.
             "teams": self._team_registry.to_list(),
         }
+
+        if self.phase == GamePhase.WAGER_ACTIVE and self._current_question:
+            q = self._current_question
+            # #656: the betting window carries category and difficulty and
+            # NOTHING else. A phone that reconnects here must not be handed
+            # the question text — that text has not been sent to anyone yet,
+            # and a player who could read it while betting would be betting
+            # on a certainty. The remaining seconds are the room's, not a
+            # fresh window, so a reconnect can't buy extra thinking time.
+            connected = [p for p in self.get_players() if p.connected]
+            snapshot["wager"] = {
+                "category": q.category,
+                "difficulty": q.difficulty,
+                "window_remaining": round(self.wager_window_remaining(), 1),
+                "window_duration": self._phase_controller.wager_window_duration,
+                # The tally, so a TV reconnecting mid-window shows the bets
+                # already in rather than restarting the count at zero.
+                "locked_in": len(connected) - len(self.players_missing_wager()),
+                "player_count": len(connected),
+            }
 
         if self.phase == GamePhase.QUESTION_ACTIVE and self._current_question:
             q = self._current_question

--- a/custom_components/quizify/server/protocol.py
+++ b/custom_components/quizify/server/protocol.py
@@ -64,6 +64,49 @@ class PlayerListMessage:
 
 
 @dataclass
+class WagerWindowMessage:
+    """The final round's betting window (#656), sent per-player.
+
+    Per-player because ``player_score`` is the bank the slider bets against.
+    Note what is NOT here: ``question_text`` and ``answers``. The bet is
+    placed on the category alone — the question follows in a separate
+    ``question_started`` once the window closes, and only then does a clock
+    start.
+    """
+
+    type: Literal["wager_window"]
+    round_num: int
+    total_rounds: int
+    category: str
+    difficulty: str
+    window_duration: float
+    player_score: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class WagerProgressMessage:
+    """Host/TV view of the betting window (#656).
+
+    Carries the tally and who the room is waiting for — never the amounts.
+    ``window_duration`` is present only on the opening message; the refreshes
+    sent as bets arrive omit it so the TV countdown is not restarted.
+    """
+
+    type: Literal["wager_progress"]
+    round_num: int
+    total_rounds: int
+    locked_in: int
+    player_count: int
+    waiting_on: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
 class QuestionStartedMessage:
     """One round's question, sent per-player so each phone gets its own
     shuffled A/B/C order (anti-cheat against couch-neighbour collusion).
@@ -268,6 +311,12 @@ TYPESCRIPT_DECLARATIONS = """
 //   | { type: 'joined' | 'reconnected'; player_id: string; session_token: string;
 //       color: string; is_admin: boolean; powerup: string | null; }
 //   | { type: 'player_joined' | 'player_left'; players: Player[]; }
+//   | { type: 'wager_window'; round_num: number; total_rounds: number;
+//       category: string; difficulty: string; window_duration: number;
+//       player_score: number; }
+//   | { type: 'wager_progress'; round_num: number; total_rounds: number;
+//       locked_in: number; player_count: number; waiting_on: string[];
+//       window_duration?: number; category?: string; difficulty?: string; }
 //   | { type: 'question_started'; question_text: string; answers: string[];
 //       timer_duration: number; round_num: number; total_rounds: number;
 //       category: string; difficulty: string; image_url?: string;

--- a/custom_components/quizify/server/round_message_builder.py
+++ b/custom_components/quizify/server/round_message_builder.py
@@ -26,6 +26,7 @@ from custom_components.quizify.server.serializers import (
     serialize_question_for_admin,
     serialize_question_for_player,
     serialize_round_summary,
+    serialize_wager_window,
 )
 
 if TYPE_CHECKING:
@@ -42,6 +43,58 @@ class RoundMessageBuilder:
     dicts. No connection access, no mutation — the handler keeps ownership of
     both. Behaviour mirrors the previous inline assembly exactly.
     """
+
+    def build_wager_window(
+        self,
+        game_state: QuizifyGameState,
+        *,
+        question: Question,
+        player: PlayerSession,
+        window_duration: float,
+    ) -> dict[str, Any]:
+        """Build one player's betting-window payload (#656).
+
+        Per-player because the bank shown on the slider is that player's own
+        score. Carries no question text — see ``serialize_wager_window``.
+        """
+        return serialize_wager_window(
+            question=question,
+            round_num=game_state.round,
+            total_rounds=game_state.total_rounds,
+            window_duration=window_duration,
+            player_score=player.score,
+        )
+
+    def build_wager_progress(
+        self,
+        game_state: QuizifyGameState,
+        *,
+        window_duration: float | None = None,
+    ) -> dict[str, Any]:
+        """Build the host/TV view of the betting window (#656).
+
+        Counts locked-in bets and names who the room is still waiting for —
+        never the amounts. A bet the TV gave away would not be a bet. The
+        optional ``window_duration`` marks the opening message; refreshes sent
+        on each incoming wager leave it out so the TV countdown, already
+        running, is not restarted.
+        """
+        players = [p for p in game_state.get_players() if p.connected]
+        waiting = game_state.players_missing_wager()
+        payload: dict[str, Any] = {
+            "type": "wager_progress",
+            "round_num": game_state.round,
+            "total_rounds": game_state.total_rounds,
+            "locked_in": len(players) - len(waiting),
+            "player_count": len(players),
+            "waiting_on": waiting,
+        }
+        if window_duration is not None:
+            question = game_state.get_current_question()
+            payload["window_duration"] = window_duration
+            payload["category"] = question.category if question else ""
+            payload["difficulty"] = question.difficulty if question else ""
+        return payload
 
     def build_player_question(
         self,

--- a/custom_components/quizify/server/serializers.py
+++ b/custom_components/quizify/server/serializers.py
@@ -107,8 +107,38 @@ def build_game_status_response(
     return {
         "exists": True,
         "phase": game_state.phase.value,
+        # WAGER_ACTIVE joins like a live round (#656) — the betting window is
+        # part of the final round, and locking newcomers out of it would put a
+        # dead spot in the one place a late guest is most likely to arrive.
         "can_join": game_state.phase.value
-        in ("LOBBY", "QUESTION_ACTIVE", "ANSWER_REVEAL"),
+        in ("LOBBY", "WAGER_ACTIVE", "QUESTION_ACTIVE", "ANSWER_REVEAL"),
+    }
+
+
+def serialize_wager_window(
+    question: Question,
+    round_num: int,
+    total_rounds: int,
+    window_duration: float,
+    player_score: int,
+) -> dict[str, Any]:
+    """Serialize the final round's betting window (#656).
+
+    Deliberately withholds ``question_text`` and ``answers``: the bet is
+    placed on the category alone, the way a Jeopardy final is. Sending the
+    text here would reproduce the bug this window exists to fix — with the
+    question in hand, a player who knows the answer stakes everything at no
+    risk. The text only leaves the server with ``question_started``, after
+    the window has closed.
+    """
+    return {
+        "type": "wager_window",
+        "round_num": round_num,
+        "total_rounds": total_rounds,
+        "category": question.category,
+        "difficulty": question.difficulty,
+        "window_duration": window_duration,
+        "player_score": player_score,
     }
 
 

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -3037,10 +3037,21 @@ class QuizifyWebSocketHandler:
         self._wager_window_task = asyncio.create_task(window())
 
     def _cancel_wager_window(self) -> None:
-        """Cancel the pending betting-window deadline, if any."""
-        if self._wager_window_task and not self._wager_window_task.done():
-            self._wager_window_task.cancel()
+        """Cancel the pending betting-window deadline, if any.
+
+        Never cancels the *calling* task. ``_close_wager_window`` clears the
+        deadline before doing its work, and the deadline itself is one of its
+        two callers — so a blind ``cancel()`` here kills the very coroutine
+        that is closing the window, and the CancelledError lands on the first
+        await inside ``_emit_question``. The question then never goes out and
+        the final round hangs on the betting screen with a countdown reading
+        zero. Found on the live server, not by a unit test; there is one for
+        it now.
+        """
+        task = self._wager_window_task
         self._wager_window_task = None
+        if task is not None and not task.done() and task is not asyncio.current_task():
+            task.cancel()
 
     async def _close_wager_window(self, game_state: QuizifyGameState) -> None:
         """Close the betting window: arm the timers, then send the question.

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -26,6 +26,7 @@ from custom_components.quizify.const import (
     ERR_ROUND_EXPIRED,
     ERR_TEAM_CLOSED,
     LOBBY_DISCONNECT_GRACE_PERIOD,
+    WAGER_WINDOW_DURATION,
 )
 from custom_components.quizify.game.highlights import compute_superlatives
 from custom_components.quizify.game.hot_seat import stake_of as hot_seat_stake
@@ -201,6 +202,10 @@ class QuizifyWebSocketHandler:
         # of reaching into the private ``_conn`` attribute. Backed by
         # ``_conn`` so test fixtures that assign ``handler._conn`` still work.
         self._timer_tick_task: asyncio.Task | None = None
+        # Closes the final round's betting window at its deadline (#656).
+        # Cancelled together with the tick task, so every path that stops a
+        # round (reset, end, skip, next question) stops this too.
+        self._wager_window_task: asyncio.Task | None = None
         # Deferred-pause task scheduled by _handle_disconnect when the
         # admin-as-player WS closes mid-question. Cancelled by reconnect
         # or join when admin comes back within ADMIN_REDIRECT_GRACE.
@@ -1575,19 +1580,22 @@ class QuizifyWebSocketHandler:
     async def _handle_submit_wager(
         self, ws: web.WebSocketResponse, data: dict, game_state: QuizifyGameState
     ) -> None:
-        """Accept a player's wager for the final round. Only valid when
-        we're on the last round and still in QUESTION_ACTIVE. The wager
-        is a PERCENT (0-100) of the player's current score — server
-        translates to absolute points at evaluation time so the
-        percentage stays meaningful even after a late-arriving reaction
-        bonus shifts scores."""
+        """Accept a player's wager for the final round. Only valid while the
+        betting window is open (WAGER_ACTIVE). The wager is a PERCENT (0-100)
+        of the player's current score — server translates to absolute points
+        at evaluation time so the percentage stays meaningful even after a
+        late-arriving reaction bonus shifts scores.
+
+        Until #656 this accepted wagers during QUESTION_ACTIVE, i.e. with the
+        question already on screen: a player who knew the answer could stake
+        everything at no risk. The phase check below is the fix — once the
+        question is out, the betting is over.
+        """
         player = game_state.get_player_by_ws(ws)
         if not player:
             await self._conn.send_error(ws, ERR_NOT_IN_GAME, "Not in game")
             return
 
-        if game_state.phase != GamePhase.QUESTION_ACTIVE:
-            return  # silent: wager window closed
         if game_state.round != game_state.total_rounds:
             return  # only final round accepts a wager
 
@@ -1597,12 +1605,20 @@ class QuizifyWebSocketHandler:
         # effect on scoring. Reject it explicitly (and the serializer withholds
         # the wager UI for estimate finals, so a compliant client never sends
         # this). (#353.)
+        #
+        # Checked BEFORE the phase gate on purpose: an estimate final never
+        # opens a betting window (#656), so the phase check below would
+        # otherwise swallow this case silently and #353's explicit rejection
+        # would quietly stop existing.
         question = game_state.get_current_question()
         if question is not None and question.is_estimate:
             await self._conn.send_error(
                 ws, ERR_INVALID_ACTION, "Wager not available on estimate rounds"
             )
             return
+
+        if game_state.phase != GamePhase.WAGER_ACTIVE:
+            return  # silent: betting window not open (or already closed)
 
         # A wager only makes sense *before* the answer is locked in — the wager
         # stakes points on getting that answer right. Once the player has
@@ -1633,6 +1649,14 @@ class QuizifyWebSocketHandler:
             "type": "wager_accepted",
             "wager": wager_int,
         })
+        # Host/TV tally — how many bets are in, never how big they are (#656).
+        await self._conn.broadcast_to_admins_and_dashboards(
+            self._round_messages.build_wager_progress(game_state)
+        )
+        # Everyone in: close early rather than making a decided table sit out
+        # the rest of the deadline.
+        if not game_state.players_missing_wager():
+            await self._close_wager_window(game_state)
 
     async def _handle_use_powerup(
         self, ws: web.WebSocketResponse, data: dict, game_state: QuizifyGameState
@@ -1993,6 +2017,12 @@ class QuizifyWebSocketHandler:
         transitioning to ANSWER_REVEAL — so the admin can then advance past it.
         Outside QUESTION_ACTIVE it behaves like the normal advance.
         """
+        if game_state.phase == GamePhase.WAGER_ACTIVE:
+            # #656: mid-window, skip means "stop waiting for bets" — the
+            # question has not been asked yet, so there is nothing to abandon.
+            # Close the window and ask it; anyone who has not bet has no bet.
+            await self._close_wager_window(game_state)
+            return
         if game_state.phase == GamePhase.QUESTION_ACTIVE:
             # Stop the countdown and evaluate now. evaluate_round()'s
             # state-machine event (_fire_broadcast("round_evaluated")) drives
@@ -2301,7 +2331,7 @@ class QuizifyWebSocketHandler:
         question = game_state.start_next_question()
         if question is None:
             return
-        await self._emit_question(game_state, question)
+        await self._deliver_question(game_state, question)
 
     async def _broadcast_lightning_splash(
         self, game_state: QuizifyGameState
@@ -2925,6 +2955,105 @@ class QuizifyWebSocketHandler:
             # finale broadcast source). No direct broadcast here. (#255.)
             return
 
+        await self._deliver_question(game_state, question)
+
+    async def _deliver_question(
+        self, game_state: QuizifyGameState, question: Any
+    ) -> None:
+        """Send a freshly-started question — or open its betting window (#656).
+
+        On an MC final ``start_next_question`` parks the state machine in
+        WAGER_ACTIVE instead of QUESTION_ACTIVE: bets first, question after.
+        Every path that starts a question goes through here, so none of them
+        can emit a question into a phase that has no timers — which would
+        exit the tick loop on its first iteration and hang the round.
+        """
+        if game_state.phase == GamePhase.WAGER_ACTIVE:
+            await self._open_wager_window(game_state, question)
+            return
+        await self._emit_question(game_state, question)
+
+    async def _open_wager_window(
+        self, game_state: QuizifyGameState, question: Any
+    ) -> None:
+        """Announce the betting window and arm its deadline (#656).
+
+        Sends every phone its own bank, gives the host/TV the lock-in tally,
+        and starts the one task that guarantees the window ends — with or
+        without the players.
+        """
+        players = game_state.get_players()
+        sends = [
+            self._conn.send(
+                player.ws,
+                self._round_messages.build_wager_window(
+                    game_state,
+                    question=question,
+                    player=player,
+                    window_duration=WAGER_WINDOW_DURATION,
+                ),
+            )
+            for player in players
+            if player.connected
+        ]
+        if sends:
+            await asyncio.gather(*sends)
+
+        await self._conn.broadcast_to_admins_and_dashboards(
+            self._round_messages.build_wager_progress(
+                game_state, window_duration=WAGER_WINDOW_DURATION
+            )
+        )
+        # Phase broadcast last: the phones already hold the window payload, so
+        # a client driving off the phase alone (reconnect path) lands on a view
+        # it can render rather than an empty one.
+        await self._conn.broadcast(
+            self._round_messages.build_game_state_with_leaderboard(
+                game_state, players=players
+            )
+        )
+        self._start_wager_window(game_state)
+
+    def _start_wager_window(self, game_state: QuizifyGameState) -> None:
+        """Arm the task that closes the betting window at the deadline (#656).
+
+        The deadline is what keeps the final round from hanging on a player
+        who never bets — an AFK phone, or a room that all walked out. It is
+        the same class of hang as #586, so it gets an unconditional timer
+        rather than a condition that depends on clients behaving.
+        """
+        self._cancel_wager_window()
+
+        async def window() -> None:
+            try:
+                await asyncio.sleep(WAGER_WINDOW_DURATION)
+            except asyncio.CancelledError:
+                return
+            try:
+                await self._close_wager_window(game_state)
+            except Exception:  # noqa: BLE001 — a stuck window strands the game
+                _LOGGER.exception("Wager window failed to close")
+
+        self._wager_window_task = asyncio.create_task(window())
+
+    def _cancel_wager_window(self) -> None:
+        """Cancel the pending betting-window deadline, if any."""
+        if self._wager_window_task and not self._wager_window_task.done():
+            self._wager_window_task.cancel()
+        self._wager_window_task = None
+
+    async def _close_wager_window(self, game_state: QuizifyGameState) -> None:
+        """Close the betting window: arm the timers, then send the question.
+
+        ``arm_round_timers`` returns False when the window is already shut,
+        which is what makes the two closing triggers safe to race — the last
+        player locking in, and the deadline. Whoever arrives second finds the
+        phase already flipped and returns without re-emitting the question.
+        """
+        self._cancel_wager_window()
+        question = game_state.get_current_question()
+        if question is None or not game_state.arm_round_timers():
+            return
         await self._emit_question(game_state, question)
 
     async def _emit_question(
@@ -3144,10 +3273,18 @@ class QuizifyWebSocketHandler:
         self._timer_tick_task.add_done_callback(self._log_task_exception)
 
     def _cancel_timer_tick(self) -> None:
-        """Cancel the timer tick task."""
+        """Cancel the timer tick task — and the betting window with it.
+
+        The two are the same thing from the caller's side: the round's
+        background clock. Cancelling both here rather than at each of the
+        eight ``_cancel_timer_tick`` call sites (reset, end game, skip,
+        pause, disconnect, next question, …) is what guarantees no path can
+        leave a window armed over a round that has already moved on (#656).
+        """
         if self._timer_tick_task is not None:
             self._timer_tick_task.cancel()
             self._timer_tick_task = None
+        self._cancel_wager_window()
 
     @staticmethod
     def _log_task_exception(task: asyncio.Task) -> None:

--- a/custom_components/quizify/www/css/src/00-tokens.css
+++ b/custom_components/quizify/www/css/src/00-tokens.css
@@ -255,10 +255,20 @@ a:focus-visible,
     font-weight: 600;
     color: var(--color-text-primary);
 }
+/* Collapsed = the reminder that rides along with the question. #656 made it
+   a certainty on every MC final (before, only a player who had bet during the
+   question saw it), so it has to earn its vertical space on a 390x844 phone:
+   at the old card metrics it pushed the third answer below the fold on the
+   one round where the answer matters most. Same card, tighter. */
 .wager-panel--collapsed {
-    padding: var(--space-sm) var(--space-md);
+    padding: var(--space-xs) var(--space-md);
+    margin-bottom: var(--space-sm);
     background: var(--color-accent-brand-bg);
     box-shadow: none;
+}
+.wager-panel--collapsed .wager-panel-title {
+    margin: 0;
+    font-size: 0.95rem;
 }
 .wager-panel--collapsed .wager-panel-hint,
 .wager-panel--collapsed .wager-slider-row,

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -257,10 +257,20 @@ a:focus-visible,
     font-weight: 600;
     color: var(--color-text-primary);
 }
+/* Collapsed = the reminder that rides along with the question. #656 made it
+   a certainty on every MC final (before, only a player who had bet during the
+   question saw it), so it has to earn its vertical space on a 390x844 phone:
+   at the old card metrics it pushed the third answer below the fold on the
+   one round where the answer matters most. Same card, tighter. */
 .wager-panel--collapsed {
-    padding: var(--space-sm) var(--space-md);
+    padding: var(--space-xs) var(--space-md);
+    margin-bottom: var(--space-sm);
     background: var(--color-accent-brand-bg);
     box-shadow: none;
+}
+.wager-panel--collapsed .wager-panel-title {
+    margin: 0;
+    font-size: 0.95rem;
 }
 .wager-panel--collapsed .wager-panel-hint,
 .wager-panel--collapsed .wager-slider-row,

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -1764,6 +1764,9 @@
                 case 'game_state':
                     handleGameState(msg);
                     break;
+                case 'wager_progress':
+                    handleWagerProgress(msg);
+                    break;
                 case 'question_started':
                     // Clear last round's count before the new one arrives —
                     // otherwise the TV shows "5/5" over a fresh question.
@@ -1854,6 +1857,23 @@
                     // connects late still shows who is playing with whom.
                     if (msg.teams) lobbyTeams = msg.teams;
                     renderLobby(msg.players);
+                    break;
+                case 'WAGER_ACTIVE':
+                    // #656: a TV that (re)connects mid-window. The snapshot
+                    // has the category and the room's remaining seconds; the
+                    // tally arrives with the next bet.
+                    if (msg.wager) {
+                        handleWagerProgress({
+                            round_num: msg.round,
+                            total_rounds: msg.total_rounds,
+                            category: msg.wager.category,
+                            locked_in: msg.wager.locked_in,
+                            player_count: msg.wager.player_count,
+                            window_duration: msg.wager.window_remaining,
+                        });
+                    } else {
+                        showView('question');
+                    }
                     break;
                 case 'QUESTION_ACTIVE':
                     if (msg.question) {
@@ -2041,6 +2061,43 @@
                         ' <span class="lr-correct">→ ' + escapeHtml(q.correct_answer) + '</span>' +
                         '</div>';
                 }).join('');
+            }
+        }
+
+        /**
+         * The final round's betting window (#656).
+         *
+         * The TV shows the category and the lock-in tally, and nothing else:
+         * no question (it has not been sent) and no amounts (a bet the room
+         * can read off the screen is not a bet). Its bar counts the window
+         * down, not the answer clock — that one has not started yet.
+         */
+        function handleWagerProgress(msg) {
+            showView('question');
+            els.funFact.classList.remove('visible');
+
+            els.roundIndicator.textContent = window.QuizifyI18n
+                ? window.QuizifyI18n.t('dashboard.questionCounter', { current: msg.round_num, total: msg.total_rounds })
+                : 'Question ' + msg.round_num + ' / ' + msg.total_rounds;
+            els.questionCategory.textContent = msg.category || '';
+            var title = window.QuizifyI18n
+                ? window.QuizifyI18n.t('wager.hostWindowTitle') : 'Placing bets';
+            var progress = window.QuizifyI18n
+                ? window.QuizifyI18n.t('wager.hostProgress', { locked: msg.locked_in, total: msg.player_count })
+                : msg.locked_in + ' / ' + msg.player_count;
+            els.questionText.textContent = title + ' — ' + progress;
+            renderQuestionImage('', '');
+            if (els.answersGrid) els.answersGrid.innerHTML = '';
+            if (els.dashboardEstimate) els.dashboardEstimate.classList.add('hidden');
+
+            // Only the opening message carries the duration. Restarting the
+            // bar on every incoming bet would make the window look longer the
+            // more people play.
+            if (typeof msg.window_duration === 'number') {
+                timerDuration = msg.window_duration;
+                timerRemaining = timerDuration;
+                els.timerFill.style.width = '100%';
+                els.timerFill.className = 'dashboard-timer-fill';
             }
         }
 

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -492,13 +492,17 @@
   },
   "wager": {
     "title": "Letzte Runde — Wagerunde",
-    "hint": "Setze einen Teil deiner Punkte. Richtig = gewinnen, falsch = verlieren.",
+    "hint": "Du siehst nur die Kategorie. Setze einen Teil deiner Punkte — richtig = gewinnen, falsch = verlieren.",
     "timeoutNote": "Der Einsatz zählt immer — auch wenn du nicht antwortest. Keine Antwort kostet dich den Einsatz genauso wie eine falsche.",
     "bank": "Punktestand",
     "submit": "Einsatz festlegen",
     "sliderAria": "Einsatz in Prozent",
     "valueFmt": "{pct}% ({pts} Pkt.)",
     "locked": "Eingesetzt: {pct}%",
+    "questionPending": "Die Frage kommt, sobald die Einsätze stehen.",
+    "waitingForOthers": "Einsatz steht. Warte auf die anderen …",
+    "hostWindowTitle": "Einsätze werden gesetzt",
+    "hostProgress": "{locked} von {total} haben gesetzt",
     "bonusFromReaction": "+1 von {from}"
   },
   "estimate": {
@@ -636,6 +640,7 @@
     "titleJoin": "Quizify — Beitreten",
     "titleLobby": "Quizify — Lobby",
     "titleQuestion": "Quizify — Frage {current}",
+    "titleWager": "Quizify — Einsätze",
     "titleReveal": "Quizify — Auflösung",
     "titleFinale": "Quizify — Endergebnis"
   },

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -492,13 +492,17 @@
   },
   "wager": {
     "title": "Final Round — Wager",
-    "hint": "Bet a chunk of your points. Right = double, wrong = lose.",
+    "hint": "You only see the category. Bet a chunk of your points — right = win, wrong = lose.",
     "timeoutNote": "The wager always counts — including if you never answer. No answer costs you the stake just like a wrong one.",
     "bank": "Current points",
     "submit": "Lock in wager",
     "sliderAria": "Wager percent",
     "valueFmt": "{pct}% ({pts} pts)",
     "locked": "Wagered: {pct}%",
+    "questionPending": "The question follows once the bets are in.",
+    "waitingForOthers": "Bet locked. Waiting for the others …",
+    "hostWindowTitle": "Placing bets",
+    "hostProgress": "{locked} of {total} have bet",
     "bonusFromReaction": "+1 from {from}"
   },
   "estimate": {
@@ -636,6 +640,7 @@
     "titleJoin": "Quizify — Join Game",
     "titleLobby": "Quizify — Lobby",
     "titleQuestion": "Quizify — Question {current}",
+    "titleWager": "Quizify — Wagers",
     "titleReveal": "Quizify — Reveal",
     "titleFinale": "Quizify — Final Results"
   },

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -492,13 +492,17 @@
   },
   "wager": {
     "title": "Ronda final — Apuesta",
-    "hint": "Apuesta una parte de tus puntos. Acierto = doble, fallo = pierdes.",
+    "hint": "Solo ves la categoría. Apuesta una parte de tus puntos: acierto = ganas, fallo = pierdes.",
     "timeoutNote": "La apuesta cuenta siempre, también si no respondes. No responder te cuesta la apuesta igual que fallar.",
     "bank": "Puntos actuales",
     "submit": "Confirmar apuesta",
     "sliderAria": "Porcentaje de apuesta",
     "valueFmt": "{pct}% ({pts} pts)",
     "locked": "Apostado: {pct}%",
+    "questionPending": "La pregunta llega en cuanto estén las apuestas.",
+    "waitingForOthers": "Apuesta confirmada. Esperando a los demás …",
+    "hostWindowTitle": "Se están haciendo las apuestas",
+    "hostProgress": "{locked} de {total} han apostado",
     "bonusFromReaction": "+1 de {from}"
   },
   "estimate": {
@@ -636,6 +640,7 @@
     "titleJoin": "Quizify — Unirse a la partida",
     "titleLobby": "Quizify — Sala de espera",
     "titleQuestion": "Quizify — Pregunta {current}",
+    "titleWager": "Quizify — Apuestas",
     "titleReveal": "Quizify — Revelación",
     "titleFinale": "Quizify — Resultados finales"
   },

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -1463,6 +1463,9 @@
             case 'player_left':
                 if (msg.players) renderLobbyPlayers(msg.players);
                 break;
+            case 'wager_progress':
+                handleWagerProgress(msg);
+                break;
             case 'question_started':
                 handleQuestionStarted(msg);
                 break;
@@ -1728,6 +1731,41 @@
         var d = document.createElement('div');
         d.textContent = s == null ? '' : String(s);
         return d.innerHTML;
+    }
+
+    /**
+     * The final round's betting window (#656).
+     *
+     * The host screen shows the same thing the phones do — category, and how
+     * many bets are in. Never the amounts: a tally the TV gave away would not
+     * be a bet. The opening message carries ``window_duration`` and starts the
+     * countdown; the refreshes that arrive with each bet leave it out, so the
+     * clock keeps running instead of restarting on every tap.
+     */
+    function handleWagerProgress(msg) {
+        if (_redirecting) return;
+        currentPhase = 'WAGER_ACTIVE';
+        showView('game');
+
+        els.adminRound.textContent = _t('admin.questionCounter', {
+            current: msg.round_num,
+            total: msg.total_rounds,
+        });
+        els.adminQuestion.textContent =
+            _t('wager.hostWindowTitle') + ' — ' +
+            _t('wager.hostProgress', {
+                locked: msg.locked_in,
+                total: msg.player_count,
+            });
+        if (els.adminCorrect) {
+            els.adminCorrect.textContent = '';
+            els.adminCorrect.style.display = 'none';
+        }
+        if (typeof msg.window_duration === 'number') {
+            adminTimer.start(msg.window_duration);
+        }
+        if (els.nextQuestionBtn) els.nextQuestionBtn.classList.add('hidden');
+        if (els.endGameBtn) els.endGameBtn.classList.add('hidden');
     }
 
     function handleQuestionStarted(msg) {

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -192,6 +192,11 @@
             case 'LOBBY':
                 title = state.playerName ? t('page.titleLobby') : t('page.titleJoin');
                 break;
+            case 'WAGER_ACTIVE':
+                // #656: without this the betting window fell to the default
+                // and the tab said "Join" mid-game.
+                title = t('page.titleWager');
+                break;
             case 'QUESTION_ACTIVE':
             case 'PLAYING':
                 title = t('page.titleQuestion', { current: (msg && msg.round) || 1 });
@@ -322,6 +327,13 @@
 
             case 'team_answer':
                 if (team) team.handleTeamAnswer(msg);
+                break;
+
+            case 'wager_window':
+                // #656: the final round's betting window. Arrives BEFORE the
+                // question — that is the whole fix — so there is no flourish
+                // to play here; the 3·2·1 still runs on question_started.
+                handleWagerWindow(msg);
                 break;
 
             case 'question_started':
@@ -563,6 +575,27 @@
                 }
                 break;
 
+            case 'WAGER_ACTIVE':
+                // #656: reconnect (or first snapshot) landing in the betting
+                // window. The snapshot carries category and the room's
+                // remaining seconds — never the question text, so a phone that
+                // drops mid-window cannot come back knowing what it is
+                // betting on. The bank comes from the leaderboard, which the
+                // snapshot already carries.
+                if (msg.wager) {
+                    handleWagerWindow({
+                        round_num: msg.round,
+                        total_rounds: msg.total_rounds,
+                        category: msg.wager.category,
+                        difficulty: msg.wager.difficulty,
+                        window_duration: msg.wager.window_remaining,
+                        player_score: _myScore(msg)
+                    });
+                } else {
+                    pu.showView('game-view');
+                }
+                break;
+
             case 'QUESTION_ACTIVE':
             case 'PLAYING':
                 if (msg.question) {
@@ -748,6 +781,64 @@
         } catch (e) {
             finish();
         }
+    }
+
+    /**
+     * This player's score out of a game_state snapshot's leaderboard (#656).
+     * The wager slider bets against it, so a reconnect that guessed wrong
+     * would show the player a bank they do not have.
+     */
+    function _myScore(msg) {
+        var board = msg.leaderboard || msg.players || [];
+        for (var i = 0; i < board.length; i++) {
+            if (board[i] && board[i].name === state.playerName) {
+                return board[i].score || 0;
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * The final round's betting window (#656).
+     *
+     * Same view as the question, minus the question: category, bank, slider,
+     * and the window's own countdown. Nothing here starts the answer clock —
+     * that begins with the question_started that follows.
+     */
+    function handleWagerWindow(msg) {
+        state.currentPhase = 'WAGER_ACTIVE';
+        pu.showView('game-view');
+        game.resetSubmissionState();
+        game.stopFrozenOverlay();
+        if (team) team.resetRound();
+
+        var currentRound = document.getElementById('current-round');
+        var totalRounds = document.getElementById('total-rounds');
+        if (currentRound) currentRound.textContent = msg.round_num || 1;
+        if (totalRounds) totalRounds.textContent = msg.total_rounds || 10;
+
+        var banner = document.getElementById('last-round-banner');
+        if (banner) banner.classList.remove('hidden');
+
+        // Admin control bar: End + Skip, no Pause. Pausing a window that has
+        // no timer does nothing (the backend refuses it), and Skip is the one
+        // useful host action here — it closes the window and asks the
+        // question instead of waiting the deadline out.
+        var adminBar = document.getElementById('admin-control-bar');
+        if (adminBar) adminBar.classList.toggle('hidden', !state.isAdmin);
+        var nextRoundAdminBtn = document.getElementById('next-round-admin-btn');
+        var skipBtn = document.getElementById('skip-question-btn');
+        var pauseBtn = document.getElementById('pause-game-btn');
+        var resumeBtn = document.getElementById('resume-game-btn');
+        if (nextRoundAdminBtn) nextRoundAdminBtn.classList.add('hidden');
+        if (skipBtn) skipBtn.classList.toggle('hidden', !state.isAdmin);
+        if (pauseBtn) pauseBtn.classList.add('hidden');
+        if (resumeBtn) resumeBtn.classList.add('hidden');
+
+        var reactionBar = document.getElementById('reaction-bar');
+        if (reactionBar) reactionBar.classList.add('hidden');
+
+        game.renderWagerWindow(msg);
     }
 
     function handleQuestionStarted(msg) {

--- a/custom_components/quizify/www/js/player-game.js
+++ b/custom_components/quizify/www/js/player-game.js
@@ -251,11 +251,14 @@
      * Render question text and answer buttons
      * @param {Object} data - Question data with text, answers, category
      */
-    // Wager gate (gameplay idea #3). On the final round we block the
-    // answer buttons until the player submits a wager. Without this
-    // gate the player could just tap their answer instantly and never
-    // commit to a bet — which would defeat the Jeopardy-final tension.
-    var _wagerGate = { active: false, submitted: false };
+    // Wager state (gameplay idea #3, reworked by #656). The bet used to be
+    // placed on the question screen, with the answer buttons disabled until it
+    // was in — which meant the answer clock was already draining while the
+    // table argued about the stake, and the question could be read before
+    // betting. Betting is its own phase now (``wager_window``), so nothing
+    // here gates the answer buttons; this only remembers what was locked in,
+    // so the question screen can show it back.
+    var _wagerState = { active: false, submitted: false, pct: 0, round: 0 };
 
     // #434: progressive reveal on the player's banner. The dashboard blurs
     // the picture as the timer drains; the phone has to do the same, or a
@@ -401,18 +404,18 @@
         if (_isEstimateRound) {
             if (estimateContainer) estimateContainer.classList.remove('hidden');
             if (answersContainer) answersContainer.classList.add('hidden');
-            _renderWagerPanel(false, 0);
+            _showWagerBadge(false);
             renderEstimateInput(data);
             return;
         }
         if (estimateContainer) estimateContainer.classList.add('hidden');
         if (answersContainer) answersContainer.classList.remove('hidden');
 
-        // Wager round detection — set BEFORE we touch buttons so we can
-        // disable them up-front, then enable once the wager is in.
-        _wagerGate.active = !!data.is_final_round;
-        _wagerGate.submitted = false;
-        _renderWagerPanel(data.is_final_round, data.player_score || 0);
+        // #656: the bet was placed and closed before this message existed, so
+        // the panel is only a reminder here. Deliberately no button gating —
+        // gating on "has wagered" would lock a player who let the window lapse
+        // out of answering at all.
+        _showWagerBadge(!!data.is_final_round);
 
         if (answerButtons) {
             var answers = data.answers || [];
@@ -439,8 +442,7 @@
                     btn.disabled = true;
                     btn.classList.remove('is-selected', 'is-correct', 'is-wrong', 'is-eliminated', 'hidden');
                 } else {
-                    // Wager round: keep buttons disabled until wager submitted.
-                    btn.disabled = _wagerGate.active && !_wagerGate.submitted;
+                    btn.disabled = false;
                     btn.classList.remove('is-selected', 'is-correct', 'is-wrong', 'is-eliminated', 'hidden');
                 }
             }
@@ -549,17 +551,85 @@
         sendFn('submit_answer', { guess: guess });
     }
 
-    function _renderWagerPanel(isFinal, currentScore) {
+    /**
+     * Render the final round's betting window (#656).
+     *
+     * The screen deliberately has no question on it: category, bank, slider.
+     * Betting on a question you can already read is not betting, and the
+     * countdown here is the *window's*, not the answer clock — that one does
+     * not start until this screen goes away.
+     *
+     * @param {Object} data - wager_window payload (category, player_score,
+     *                        window_duration, round_num)
+     */
+    function renderWagerWindow(data) {
         var panel = document.getElementById('wager-panel');
         if (!panel) return;
 
         var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
+        var round = data.round_num || 0;
 
-        if (!isFinal) {
+        // A reconnect snapshot can arrive right behind the live message.
+        // Re-rendering then would snap the slider back to 25% under the
+        // player's thumb, or re-open a bet they had already locked in.
+        if (_wagerState.active && _wagerState.round === round) return;
+        _wagerState = { active: true, submitted: false, pct: 0, round: round };
+
+        // Clear the question furniture: no text, no image, no answers. The
+        // category is the only clue the bet is placed on.
+        var categoryEl = document.getElementById('question-category');
+        var questionText = document.getElementById('question-text');
+        var media = document.getElementById('question-media');
+        var answersContainer = document.getElementById('answers-container');
+        var estimateContainer = document.getElementById('estimate-container');
+        var tracker = document.getElementById('submission-tracker');
+        var confirmation = document.getElementById('submitted-confirmation');
+        if (categoryEl) categoryEl.textContent = data.category || '';
+        if (questionText) questionText.textContent = t('wager.questionPending');
+        if (media) media.hidden = true;
+        if (answersContainer) answersContainer.classList.add('hidden');
+        if (estimateContainer) estimateContainer.classList.add('hidden');
+        if (tracker) tracker.classList.add('hidden');
+        if (confirmation) confirmation.classList.add('hidden');
+
+        // The window's own countdown. Reuses the round timer element, which is
+        // free: no answer clock is running yet, which is the entire point.
+        var seconds = data.window_duration || 0;
+        if (seconds > 0) startCountdown(Date.now() + seconds * 1000);
+
+        panel.classList.remove('hidden', 'wager-panel--collapsed');
+        _paintWagerPanel(data.player_score || 0);
+    }
+
+    /**
+     * Put the game screen back together after the window closes (#656).
+     * Called from renderQuestion, which then fills in the real question.
+     */
+    function _showWagerBadge(isFinal) {
+        var panel = document.getElementById('wager-panel');
+        var tracker = document.getElementById('submission-tracker');
+        if (tracker) tracker.classList.remove('hidden');
+        _wagerState.active = false;
+        if (!panel) return;
+        // A bet from an earlier game (rematch keeps this module alive) must
+        // not surface as a badge on an ordinary round.
+        if (!isFinal || !_wagerState.submitted) {
+            // No bet placed — nothing to remind anybody of.
             panel.classList.add('hidden');
             return;
         }
+        var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
         panel.classList.remove('hidden');
+        panel.classList.add('wager-panel--collapsed');
+        var titleEl = document.getElementById('wager-panel-title');
+        if (titleEl) titleEl.textContent = t('wager.locked', { pct: _wagerState.pct });
+    }
+
+    function _paintWagerPanel(currentScore) {
+        var panel = document.getElementById('wager-panel');
+        if (!panel) return;
+
+        var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
 
         var titleEl = document.getElementById('wager-panel-title');
         var hintEl = document.getElementById('wager-panel-hint');
@@ -595,25 +665,21 @@
             submitBtn.disabled = false;
             submitBtn.textContent = t('wager.submit');
             submitBtn.onclick = function () {
-                if (_wagerGate.submitted) return;
-                _wagerGate.submitted = true;
+                if (_wagerState.submitted) return;
+                var pct = parseInt(slider.value, 10);
+                _wagerState.submitted = true;
+                _wagerState.pct = pct;
                 submitBtn.disabled = true;
                 if (slider) slider.disabled = true;
                 // Send via the player-core send() function.
                 var send = window.QuizifyPlayer && window.QuizifyPlayer.send;
-                if (send) send('submit_wager', { wager: parseInt(slider.value, 10) });
-                // Unlock answer buttons.
-                var answerButtons = document.getElementById('answer-buttons');
-                if (answerButtons) {
-                    answerButtons.querySelectorAll('.answer-btn').forEach(function (b) {
-                        b.disabled = false;
-                    });
-                }
-                // Collapse the panel into a smaller "wager: 25%" badge so
-                // the player remembers what they bet during the question.
+                if (send) send('submit_wager', { wager: pct });
+                // Collapse into a "wager: 25%" badge. The player now waits for
+                // the rest of the room — the question arrives on its own once
+                // the window closes, so there is nothing else to do here.
                 panel.classList.add('wager-panel--collapsed');
-                if (titleEl) titleEl.textContent = t('wager.locked', { pct: parseInt(slider.value, 10) });
-                if (hintEl) hintEl.textContent = '';
+                if (titleEl) titleEl.textContent = t('wager.locked', { pct: pct });
+                if (hintEl) hintEl.textContent = t('wager.waitingForOthers');
                 if (timeoutNoteEl) timeoutNoteEl.textContent = '';
             };
         }
@@ -1286,6 +1352,7 @@
         isFrozen: isFrozen,
         updateTimer: updateTimer,
         renderQuestion: renderQuestion,
+        renderWagerWindow: renderWagerWindow,
         clearRevealBlur: clearRevealBlur,
         handleAnswerClick: handleAnswerClick,
         lockSubmitted: lockSubmitted,

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -4304,11 +4304,14 @@
      * Render question text and answer buttons
      * @param {Object} data - Question data with text, answers, category
      */
-    // Wager gate (gameplay idea #3). On the final round we block the
-    // answer buttons until the player submits a wager. Without this
-    // gate the player could just tap their answer instantly and never
-    // commit to a bet — which would defeat the Jeopardy-final tension.
-    var _wagerGate = { active: false, submitted: false };
+    // Wager state (gameplay idea #3, reworked by #656). The bet used to be
+    // placed on the question screen, with the answer buttons disabled until it
+    // was in — which meant the answer clock was already draining while the
+    // table argued about the stake, and the question could be read before
+    // betting. Betting is its own phase now (``wager_window``), so nothing
+    // here gates the answer buttons; this only remembers what was locked in,
+    // so the question screen can show it back.
+    var _wagerState = { active: false, submitted: false, pct: 0, round: 0 };
 
     // #434: progressive reveal on the player's banner. The dashboard blurs
     // the picture as the timer drains; the phone has to do the same, or a
@@ -4454,18 +4457,18 @@
         if (_isEstimateRound) {
             if (estimateContainer) estimateContainer.classList.remove('hidden');
             if (answersContainer) answersContainer.classList.add('hidden');
-            _renderWagerPanel(false, 0);
+            _showWagerBadge(false);
             renderEstimateInput(data);
             return;
         }
         if (estimateContainer) estimateContainer.classList.add('hidden');
         if (answersContainer) answersContainer.classList.remove('hidden');
 
-        // Wager round detection — set BEFORE we touch buttons so we can
-        // disable them up-front, then enable once the wager is in.
-        _wagerGate.active = !!data.is_final_round;
-        _wagerGate.submitted = false;
-        _renderWagerPanel(data.is_final_round, data.player_score || 0);
+        // #656: the bet was placed and closed before this message existed, so
+        // the panel is only a reminder here. Deliberately no button gating —
+        // gating on "has wagered" would lock a player who let the window lapse
+        // out of answering at all.
+        _showWagerBadge(!!data.is_final_round);
 
         if (answerButtons) {
             var answers = data.answers || [];
@@ -4492,8 +4495,7 @@
                     btn.disabled = true;
                     btn.classList.remove('is-selected', 'is-correct', 'is-wrong', 'is-eliminated', 'hidden');
                 } else {
-                    // Wager round: keep buttons disabled until wager submitted.
-                    btn.disabled = _wagerGate.active && !_wagerGate.submitted;
+                    btn.disabled = false;
                     btn.classList.remove('is-selected', 'is-correct', 'is-wrong', 'is-eliminated', 'hidden');
                 }
             }
@@ -4602,17 +4604,85 @@
         sendFn('submit_answer', { guess: guess });
     }
 
-    function _renderWagerPanel(isFinal, currentScore) {
+    /**
+     * Render the final round's betting window (#656).
+     *
+     * The screen deliberately has no question on it: category, bank, slider.
+     * Betting on a question you can already read is not betting, and the
+     * countdown here is the *window's*, not the answer clock — that one does
+     * not start until this screen goes away.
+     *
+     * @param {Object} data - wager_window payload (category, player_score,
+     *                        window_duration, round_num)
+     */
+    function renderWagerWindow(data) {
         var panel = document.getElementById('wager-panel');
         if (!panel) return;
 
         var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
+        var round = data.round_num || 0;
 
-        if (!isFinal) {
+        // A reconnect snapshot can arrive right behind the live message.
+        // Re-rendering then would snap the slider back to 25% under the
+        // player's thumb, or re-open a bet they had already locked in.
+        if (_wagerState.active && _wagerState.round === round) return;
+        _wagerState = { active: true, submitted: false, pct: 0, round: round };
+
+        // Clear the question furniture: no text, no image, no answers. The
+        // category is the only clue the bet is placed on.
+        var categoryEl = document.getElementById('question-category');
+        var questionText = document.getElementById('question-text');
+        var media = document.getElementById('question-media');
+        var answersContainer = document.getElementById('answers-container');
+        var estimateContainer = document.getElementById('estimate-container');
+        var tracker = document.getElementById('submission-tracker');
+        var confirmation = document.getElementById('submitted-confirmation');
+        if (categoryEl) categoryEl.textContent = data.category || '';
+        if (questionText) questionText.textContent = t('wager.questionPending');
+        if (media) media.hidden = true;
+        if (answersContainer) answersContainer.classList.add('hidden');
+        if (estimateContainer) estimateContainer.classList.add('hidden');
+        if (tracker) tracker.classList.add('hidden');
+        if (confirmation) confirmation.classList.add('hidden');
+
+        // The window's own countdown. Reuses the round timer element, which is
+        // free: no answer clock is running yet, which is the entire point.
+        var seconds = data.window_duration || 0;
+        if (seconds > 0) startCountdown(Date.now() + seconds * 1000);
+
+        panel.classList.remove('hidden', 'wager-panel--collapsed');
+        _paintWagerPanel(data.player_score || 0);
+    }
+
+    /**
+     * Put the game screen back together after the window closes (#656).
+     * Called from renderQuestion, which then fills in the real question.
+     */
+    function _showWagerBadge(isFinal) {
+        var panel = document.getElementById('wager-panel');
+        var tracker = document.getElementById('submission-tracker');
+        if (tracker) tracker.classList.remove('hidden');
+        _wagerState.active = false;
+        if (!panel) return;
+        // A bet from an earlier game (rematch keeps this module alive) must
+        // not surface as a badge on an ordinary round.
+        if (!isFinal || !_wagerState.submitted) {
+            // No bet placed — nothing to remind anybody of.
             panel.classList.add('hidden');
             return;
         }
+        var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
         panel.classList.remove('hidden');
+        panel.classList.add('wager-panel--collapsed');
+        var titleEl = document.getElementById('wager-panel-title');
+        if (titleEl) titleEl.textContent = t('wager.locked', { pct: _wagerState.pct });
+    }
+
+    function _paintWagerPanel(currentScore) {
+        var panel = document.getElementById('wager-panel');
+        if (!panel) return;
+
+        var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
 
         var titleEl = document.getElementById('wager-panel-title');
         var hintEl = document.getElementById('wager-panel-hint');
@@ -4648,25 +4718,21 @@
             submitBtn.disabled = false;
             submitBtn.textContent = t('wager.submit');
             submitBtn.onclick = function () {
-                if (_wagerGate.submitted) return;
-                _wagerGate.submitted = true;
+                if (_wagerState.submitted) return;
+                var pct = parseInt(slider.value, 10);
+                _wagerState.submitted = true;
+                _wagerState.pct = pct;
                 submitBtn.disabled = true;
                 if (slider) slider.disabled = true;
                 // Send via the player-core send() function.
                 var send = window.QuizifyPlayer && window.QuizifyPlayer.send;
-                if (send) send('submit_wager', { wager: parseInt(slider.value, 10) });
-                // Unlock answer buttons.
-                var answerButtons = document.getElementById('answer-buttons');
-                if (answerButtons) {
-                    answerButtons.querySelectorAll('.answer-btn').forEach(function (b) {
-                        b.disabled = false;
-                    });
-                }
-                // Collapse the panel into a smaller "wager: 25%" badge so
-                // the player remembers what they bet during the question.
+                if (send) send('submit_wager', { wager: pct });
+                // Collapse into a "wager: 25%" badge. The player now waits for
+                // the rest of the room — the question arrives on its own once
+                // the window closes, so there is nothing else to do here.
                 panel.classList.add('wager-panel--collapsed');
-                if (titleEl) titleEl.textContent = t('wager.locked', { pct: parseInt(slider.value, 10) });
-                if (hintEl) hintEl.textContent = '';
+                if (titleEl) titleEl.textContent = t('wager.locked', { pct: pct });
+                if (hintEl) hintEl.textContent = t('wager.waitingForOthers');
                 if (timeoutNoteEl) timeoutNoteEl.textContent = '';
             };
         }
@@ -5339,6 +5405,7 @@
         isFrozen: isFrozen,
         updateTimer: updateTimer,
         renderQuestion: renderQuestion,
+        renderWagerWindow: renderWagerWindow,
         clearRevealBlur: clearRevealBlur,
         handleAnswerClick: handleAnswerClick,
         lockSubmitted: lockSubmitted,
@@ -5559,6 +5626,11 @@
             case 'LOBBY':
                 title = state.playerName ? t('page.titleLobby') : t('page.titleJoin');
                 break;
+            case 'WAGER_ACTIVE':
+                // #656: without this the betting window fell to the default
+                // and the tab said "Join" mid-game.
+                title = t('page.titleWager');
+                break;
             case 'QUESTION_ACTIVE':
             case 'PLAYING':
                 title = t('page.titleQuestion', { current: (msg && msg.round) || 1 });
@@ -5689,6 +5761,13 @@
 
             case 'team_answer':
                 if (team) team.handleTeamAnswer(msg);
+                break;
+
+            case 'wager_window':
+                // #656: the final round's betting window. Arrives BEFORE the
+                // question — that is the whole fix — so there is no flourish
+                // to play here; the 3·2·1 still runs on question_started.
+                handleWagerWindow(msg);
                 break;
 
             case 'question_started':
@@ -5930,6 +6009,27 @@
                 }
                 break;
 
+            case 'WAGER_ACTIVE':
+                // #656: reconnect (or first snapshot) landing in the betting
+                // window. The snapshot carries category and the room's
+                // remaining seconds — never the question text, so a phone that
+                // drops mid-window cannot come back knowing what it is
+                // betting on. The bank comes from the leaderboard, which the
+                // snapshot already carries.
+                if (msg.wager) {
+                    handleWagerWindow({
+                        round_num: msg.round,
+                        total_rounds: msg.total_rounds,
+                        category: msg.wager.category,
+                        difficulty: msg.wager.difficulty,
+                        window_duration: msg.wager.window_remaining,
+                        player_score: _myScore(msg)
+                    });
+                } else {
+                    pu.showView('game-view');
+                }
+                break;
+
             case 'QUESTION_ACTIVE':
             case 'PLAYING':
                 if (msg.question) {
@@ -6115,6 +6215,64 @@
         } catch (e) {
             finish();
         }
+    }
+
+    /**
+     * This player's score out of a game_state snapshot's leaderboard (#656).
+     * The wager slider bets against it, so a reconnect that guessed wrong
+     * would show the player a bank they do not have.
+     */
+    function _myScore(msg) {
+        var board = msg.leaderboard || msg.players || [];
+        for (var i = 0; i < board.length; i++) {
+            if (board[i] && board[i].name === state.playerName) {
+                return board[i].score || 0;
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * The final round's betting window (#656).
+     *
+     * Same view as the question, minus the question: category, bank, slider,
+     * and the window's own countdown. Nothing here starts the answer clock —
+     * that begins with the question_started that follows.
+     */
+    function handleWagerWindow(msg) {
+        state.currentPhase = 'WAGER_ACTIVE';
+        pu.showView('game-view');
+        game.resetSubmissionState();
+        game.stopFrozenOverlay();
+        if (team) team.resetRound();
+
+        var currentRound = document.getElementById('current-round');
+        var totalRounds = document.getElementById('total-rounds');
+        if (currentRound) currentRound.textContent = msg.round_num || 1;
+        if (totalRounds) totalRounds.textContent = msg.total_rounds || 10;
+
+        var banner = document.getElementById('last-round-banner');
+        if (banner) banner.classList.remove('hidden');
+
+        // Admin control bar: End + Skip, no Pause. Pausing a window that has
+        // no timer does nothing (the backend refuses it), and Skip is the one
+        // useful host action here — it closes the window and asks the
+        // question instead of waiting the deadline out.
+        var adminBar = document.getElementById('admin-control-bar');
+        if (adminBar) adminBar.classList.toggle('hidden', !state.isAdmin);
+        var nextRoundAdminBtn = document.getElementById('next-round-admin-btn');
+        var skipBtn = document.getElementById('skip-question-btn');
+        var pauseBtn = document.getElementById('pause-game-btn');
+        var resumeBtn = document.getElementById('resume-game-btn');
+        if (nextRoundAdminBtn) nextRoundAdminBtn.classList.add('hidden');
+        if (skipBtn) skipBtn.classList.toggle('hidden', !state.isAdmin);
+        if (pauseBtn) pauseBtn.classList.add('hidden');
+        if (resumeBtn) resumeBtn.classList.add('hidden');
+
+        var reactionBar = document.getElementById('reaction-bar');
+        if (reactionBar) reactionBar.classList.add('hidden');
+
+        game.renderWagerWindow(msg);
     }
 
     function handleQuestionStarted(msg) {

--- a/tests/test_estimate_wager_353.py
+++ b/tests/test_estimate_wager_353.py
@@ -84,12 +84,19 @@ class _Conn:
     def __init__(self) -> None:
         self.sent: list[dict] = []
         self.errors: list[tuple] = []
+        self.to_hosts: list[dict] = []
 
     async def send(self, ws, message):  # noqa: ANN001
         self.sent.append(message)
 
     async def send_error(self, ws, code, msg):  # noqa: ANN001
         self.errors.append((code, msg))
+
+    async def broadcast_to_admins_and_dashboards(  # noqa: ANN001
+        self, message, dashboard_message=None
+    ):
+        # #656: an accepted wager updates the host/TV lock-in tally.
+        self.to_hosts.append(message)
 
 
 def _final_round_state(
@@ -102,6 +109,12 @@ def _final_round_state(
     state.start_game(language="de", num_rounds=1, timer_duration=30)
     state.start_next_question()
     state._current_question = question
+    # #656: put the state in the phase the real flow would reach for THIS
+    # question. start_next_question ran against the pack's own (MC) question
+    # and opened a betting window; an estimate final never opens one, so arm
+    # the round straight away when we swap an estimate question in.
+    if question.is_estimate:
+        state.arm_round_timers()
     for p in state._player_registry.players.values():
         p.reset_round()
     return state
@@ -112,9 +125,15 @@ def _make_handler():
         QuizifyWebSocketHandler,
     )
 
+    from custom_components.quizify.server.round_message_builder import (  # noqa: PLC0415
+        RoundMessageBuilder,
+    )
+
     handler = QuizifyWebSocketHandler.__new__(QuizifyWebSocketHandler)
     conn = _Conn()
     handler._conn = conn
+    # #656: accepting a wager now also builds the host/TV progress payload.
+    handler._round_messages = RoundMessageBuilder()
     return handler, conn
 
 
@@ -176,7 +195,9 @@ class TestWagerHandler:
         """An MC final wager keeps working exactly as before: ACKed with
         ``wager_accepted`` and stored on the player."""
         state = _final_round_state(tmp_path, _mc_question())
-        assert state.phase is GamePhase.QUESTION_ACTIVE
+        # #656: an MC final sits in the betting window — that is where a
+        # wager is now accepted, and the only place it is.
+        assert state.phase is GamePhase.WAGER_ACTIVE
         assert state.round == state.total_rounds
 
         handler, conn = _make_handler()

--- a/tests/test_game_state.py
+++ b/tests/test_game_state.py
@@ -590,6 +590,7 @@ class TestWagerRound:
         assert state.round == state.total_rounds
         alice = state.get_player("Alice")
         alice.wager = 100  # bet everything — but never submit
+        state.arm_round_timers()  # #656: close the betting window
         # Bob submits so the round can be evaluated without Alice.
         question = state._current_question
         correct_idx = next(i for i, a in enumerate(question.answers) if a.correct)

--- a/tests/test_game_state.py
+++ b/tests/test_game_state.py
@@ -228,6 +228,9 @@ class TestScoring:
 
         for _ in range(3):
             state.start_next_question()
+            # No-op except on the final round, which now opens in the betting
+            # window and needs the clock started before anyone can answer (#656).
+            state.arm_round_timers()
             correct = next(
                 i for i, a in enumerate(state._current_question.answers) if a.correct
             )
@@ -504,6 +507,9 @@ class TestWagerRound:
         # Wager 50% (= 50 points). Correct answer should add 50 → 150.
         alice = state.get_player("Alice")
         alice.wager = 50
+        # #656: the final round opens in the betting window, not on the
+        # question. Arming closes the window — bet locked, clock starts.
+        state.arm_round_timers()
         question = state._current_question
         correct_idx = next(i for i, a in enumerate(question.answers) if a.correct)
         state.submit_answer("Alice", correct_idx)
@@ -518,6 +524,7 @@ class TestWagerRound:
         state.start_next_question()
         alice = state.get_player("Alice")
         alice.wager = 30  # 30 pts at stake
+        state.arm_round_timers()  # #656: close the betting window
         question = state._current_question
         wrong_idx = next(i for i, a in enumerate(question.answers) if not a.correct)
         state.submit_answer("Alice", wrong_idx)
@@ -533,6 +540,7 @@ class TestWagerRound:
         state.start_next_question()
         alice = state.get_player("Alice")
         alice.wager = 100  # 10 pts at stake
+        state.arm_round_timers()  # #656: close the betting window
         question = state._current_question
         wrong_idx = next(i for i, a in enumerate(question.answers) if not a.correct)
         state.submit_answer("Alice", wrong_idx)
@@ -609,6 +617,7 @@ class TestEndGame:
         state.start_game(language="de", num_rounds=2)
         for _ in range(2):
             state.start_next_question()
+            state.arm_round_timers()  # #656: no-op except on the final round
             state.evaluate_round()
         # Next request for a question after round 2 must end the game.
         result = state.start_next_question()

--- a/tests/test_round_lifecycle_255.py
+++ b/tests/test_round_lifecycle_255.py
@@ -249,10 +249,17 @@ class TestWagerAfterAnswerRejected:
     async def test_wager_rejected_when_already_submitted(
         self, tmp_path: Path
     ) -> None:
-        """A wager arriving after the player has locked in their answer is
-        rejected with an error rather than silently mutating the stake."""
+        """A wager arriving after the player has locked in their answer never
+        reaches the stake.
+
+        #255 guarded this with an explicit error, because back then the wager
+        UI lived *inside* the live question. #656 moved betting into its own
+        phase that closes before the question is sent, so the same attempt is
+        now refused one step earlier — by the phase gate, silently. What #255
+        actually protects is unchanged and asserted below: the stake on an
+        already-locked answer cannot be mutated.
+        """
         from custom_components.quizify.server.websocket import (  # noqa: PLC0415
-            ERR_INVALID_ACTION,
             QuizifyWebSocketHandler,
         )
 
@@ -265,6 +272,9 @@ class TestWagerAfterAnswerRejected:
         # Final round (round == total_rounds) so the wager path is reachable.
         gs.start_game(language="de", num_rounds=1)
         gs.start_next_question()
+        # #656: the final round opens in the betting window. Close it so the
+        # question is live and Alice can lock in an answer.
+        assert gs.arm_round_timers() is True
         gs.submit_answer("Alice", 0)
         assert gs.get_player("Alice").submitted is True
         assert gs.phase is GamePhase.QUESTION_ACTIVE
@@ -281,7 +291,7 @@ class TestWagerAfterAnswerRejected:
 
         await handler._handle_submit_wager(ws, {"wager": 50}, gs)
 
-        assert len(sent_errors) == 1
-        assert sent_errors[0][0] == ERR_INVALID_ACTION
-        # The stale wager was not applied.
+        # The stale wager was not applied — the point of #255.
         assert gs.get_player("Alice").wager in (None, 0)
+        # Refused by the closed window, so no error frame is produced.
+        assert sent_errors == []

--- a/tests/test_wager_timeout_653.py
+++ b/tests/test_wager_timeout_653.py
@@ -47,6 +47,10 @@ def _to_final_round(gs: QuizifyGameState, *, rounds: int = 2) -> None:
         gs.start_next_question()
         gs.evaluate_round()
     gs.start_next_question()
+    # #656: the final round now opens with the betting window. These tests set
+    # ``player.wager`` directly — they exercise the settlement, not the window
+    # — so close it here and let the round run.
+    gs.arm_round_timers()
     assert gs.round == gs.total_rounds
 
 

--- a/tests/test_wager_window_656.py
+++ b/tests/test_wager_window_656.py
@@ -1,0 +1,411 @@
+"""Regression tests for #656: the final round's betting window.
+
+Reported by an external player: "the timer to answer the question is already
+running while you're still thinking about how much you want to wager."
+
+Two things were wrong, and only one of them was in the report:
+
+1. ``question_started`` carried the question text AND ``timer_duration`` in one
+   message, and the phone built the wager panel out of that same message — so
+   the answer clock drained while the table argued about the stake.
+2. The question was readable while betting. A player who knew the answer could
+   stake everything at no risk, which is not a bet.
+
+The fix gives betting its own phase, WAGER_ACTIVE: category only, no answer
+timer, closing when every connected player has locked in or the window's own
+deadline passes. Only then is the question sent and the round clock armed.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.questions import (  # noqa: E402
+    QUESTION_TYPE_ESTIMATE,
+    Answer,
+    Question,
+)
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+from custom_components.quizify.server.round_message_builder import (  # noqa: E402
+    RoundMessageBuilder,
+)
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    serialize_wager_window,
+)
+
+_WWW = _REPO_ROOT / "custom_components" / "quizify" / "www"
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _fake_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+def _mc_question() -> Question:
+    return Question(
+        id="mc-final",
+        question="Which planet is closest to the sun?",
+        answers=[
+            Answer(text="Mercury", correct=True),
+            Answer(text="Venus", correct=False),
+            Answer(text="Mars", correct=False),
+        ],
+        category="Science",
+        difficulty="easy",
+    )
+
+
+def _estimate_question() -> Question:
+    return Question(
+        id="est-final",
+        question="How many bones in an adult body?",
+        answers=[],
+        type=QUESTION_TYPE_ESTIMATE,
+        estimate_answer=206,
+        estimate_min=0,
+        estimate_max=500,
+        estimate_unit="bones",
+        estimate_step=1,
+    )
+
+
+def _game(tmp_path: Path, *, rounds: int, players: tuple[str, ...] = ("Anna", "Tom")):
+    state = QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="t")
+    for name in players:
+        state.add_player(name, _fake_ws())
+    state.start_game(language="de", num_rounds=rounds, timer_duration=30)
+    return state
+
+
+class _Conn:
+    """Stub connection recording what went to phones vs. to host/TV."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        self.errors: list[tuple] = []
+        self.to_hosts: list[dict] = []
+        self.broadcasts: list[dict] = []
+
+    async def send(self, ws, message):  # noqa: ANN001
+        self.sent.append(message)
+
+    async def send_error(self, ws, code, msg):  # noqa: ANN001
+        self.errors.append((code, msg))
+
+    async def broadcast_to_admins_and_dashboards(  # noqa: ANN001
+        self, message, dashboard_message=None
+    ):
+        self.to_hosts.append(message)
+
+    async def broadcast(self, message):  # noqa: ANN001
+        self.broadcasts.append(message)
+
+
+def _handler():
+    from custom_components.quizify.server.websocket import (  # noqa: PLC0415
+        QuizifyWebSocketHandler,
+    )
+
+    handler = QuizifyWebSocketHandler.__new__(QuizifyWebSocketHandler)
+    conn = _Conn()
+    handler._conn = conn
+    handler._round_messages = RoundMessageBuilder()
+    handler._wager_window_task = None
+    handler._timer_tick_task = None
+    # Optional collaborators the question fan-out consults; None = not wired,
+    # which is what a standalone dev server looks like.
+    handler._tts_announcer = None
+    handler._event_emitter = None
+    return handler, conn
+
+
+# ---------------------------------------------------------------------------
+# The phase itself
+# ---------------------------------------------------------------------------
+
+
+class TestWindowOpens:
+    def test_mc_final_parks_in_the_window_with_no_clock(self, tmp_path: Path) -> None:
+        """The heart of #656: on the final round nothing is counting down.
+
+        Not "a shorter timer" or "a paused timer" — no timer object exists and
+        no round start has been stamped, so there is no clock that could be
+        draining while the table decides.
+        """
+        state = _game(tmp_path, rounds=1)
+        state.start_next_question()
+
+        assert state.phase is GamePhase.WAGER_ACTIVE
+        assert state._phase_controller.timers == {}
+        assert state._phase_controller.round_start_time is None
+        # The wall-clock fallback must not be able to evaluate a round that
+        # has not started.
+        assert state._phase_controller.round_wall_clock_expired() is False
+        assert state.wager_window_remaining() > 0
+
+    def test_non_final_round_is_untouched(self, tmp_path: Path) -> None:
+        state = _game(tmp_path, rounds=3)
+        state.start_next_question()
+
+        assert state.phase is GamePhase.QUESTION_ACTIVE
+        assert set(state._phase_controller.timers) == {"Anna", "Tom"}
+
+    def test_estimate_final_skips_the_window(self, tmp_path: Path) -> None:
+        """An estimate final scores without ever reading ``player.wager``
+        (#353), so opening a window there would collect bets nothing settles."""
+        state = _game(tmp_path, rounds=1)
+        state.start_next_question()
+        state._current_question = _estimate_question()
+
+        assert state._needs_wager_window(_estimate_question()) is False
+        assert state._needs_wager_window(_mc_question()) is True
+
+
+class TestWindowCloses:
+    def test_arming_starts_the_round(self, tmp_path: Path) -> None:
+        state = _game(tmp_path, rounds=1)
+        state.start_next_question()
+
+        assert state.arm_round_timers() is True
+        assert state.phase is GamePhase.QUESTION_ACTIVE
+        assert set(state._phase_controller.timers) == {"Anna", "Tom"}
+        assert state._phase_controller.round_start_time is not None
+
+    def test_second_arm_is_a_no_op(self, tmp_path: Path) -> None:
+        """The window has two closing triggers — the last bet arriving and the
+        deadline elapsing — and they can land in either order. The loser of
+        that race must do nothing, not restart the round with fresh timers."""
+        state = _game(tmp_path, rounds=1)
+        state.start_next_question()
+        assert state.arm_round_timers() is True
+        first_start = state._phase_controller.round_start_time
+
+        assert state.arm_round_timers() is False
+        assert state._phase_controller.round_start_time == first_start
+
+    def test_missing_wagers_drive_the_early_close(self, tmp_path: Path) -> None:
+        state = _game(tmp_path, rounds=1)
+        state.start_next_question()
+
+        assert sorted(state.players_missing_wager()) == ["Anna", "Tom"]
+        state.get_player("Anna").wager = 50
+        assert state.players_missing_wager() == ["Tom"]
+        state.get_player("Tom").wager = 0
+        assert state.players_missing_wager() == []
+
+    def test_a_disconnected_player_cannot_hold_the_window(
+        self, tmp_path: Path
+    ) -> None:
+        """Waiting on a phone that has left the room would strand everyone
+        else until the deadline."""
+        state = _game(tmp_path, rounds=1)
+        state.start_next_question()
+        state.get_player("Tom").connected = False
+        state.get_player("Anna").wager = 25
+
+        assert state.players_missing_wager() == []
+
+
+# ---------------------------------------------------------------------------
+# What the window is allowed to say
+# ---------------------------------------------------------------------------
+
+
+class TestPayloadWithholdsTheQuestion:
+    def test_wager_window_payload_carries_no_question(self) -> None:
+        payload = serialize_wager_window(
+            question=_mc_question(),
+            round_num=5,
+            total_rounds=5,
+            window_duration=20,
+            player_score=92,
+        )
+
+        assert payload["type"] == "wager_window"
+        assert payload["category"] == "Science"
+        assert payload["player_score"] == 92
+        # The bug in one assertion: nothing in this message may let a player
+        # bet on a question they can already read.
+        assert "question_text" not in payload
+        assert "answers" not in payload
+        assert "Mercury" not in str(payload)
+
+    def test_snapshot_withholds_the_question(self, tmp_path: Path) -> None:
+        """A phone that drops mid-window must not come back knowing what it is
+        betting on — the reconnect path is the obvious way to leak it."""
+        state = _game(tmp_path, rounds=1)
+        state.start_next_question()
+        question_text = state.get_current_question().question
+
+        snapshot = state.get_state_snapshot()
+
+        assert snapshot["phase"] == "WAGER_ACTIVE"
+        assert "question" not in snapshot
+        assert question_text not in str(snapshot)
+        assert snapshot["wager"]["window_remaining"] > 0
+        assert snapshot["wager"]["player_count"] == 2
+
+    def test_host_tally_never_carries_the_amounts(self, tmp_path: Path) -> None:
+        """A bet the TV gives away is not a bet."""
+        state = _game(tmp_path, rounds=1)
+        state.start_next_question()
+        state.get_player("Anna").wager = 77
+
+        payload = RoundMessageBuilder().build_wager_progress(state)
+
+        assert payload["locked_in"] == 1
+        assert payload["player_count"] == 2
+        assert payload["waiting_on"] == ["Tom"]
+        assert "77" not in str(payload)
+
+
+# ---------------------------------------------------------------------------
+# The handler
+# ---------------------------------------------------------------------------
+
+
+class TestHandler:
+    @pytest.mark.asyncio
+    async def test_wager_accepted_inside_the_window(self, tmp_path: Path) -> None:
+        state = _game(tmp_path, rounds=1)
+        state.start_next_question()
+        handler, conn = _handler()
+        anna = state.get_player("Anna")
+
+        await handler._handle_submit_wager(anna.ws, {"wager": 40}, state)
+
+        assert anna.wager == 40
+        assert conn.errors == []
+        assert [m for m in conn.sent if m.get("type") == "wager_accepted"]
+        # Tom has not bet, so the window stays open.
+        assert state.phase is GamePhase.WAGER_ACTIVE
+
+    @pytest.mark.asyncio
+    async def test_wager_refused_once_the_question_is_out(
+        self, tmp_path: Path
+    ) -> None:
+        """The exploit #656 closes: with the question on screen, a player who
+        knows the answer could previously stake everything at no risk."""
+        state = _game(tmp_path, rounds=1)
+        state.start_next_question()
+        state.arm_round_timers()  # window closed, question live
+        handler, conn = _handler()
+        anna = state.get_player("Anna")
+
+        await handler._handle_submit_wager(anna.ws, {"wager": 100}, state)
+
+        assert anna.wager is None
+        assert not [m for m in conn.sent if m.get("type") == "wager_accepted"]
+
+    @pytest.mark.asyncio
+    async def test_last_bet_closes_the_window_and_sends_the_question(
+        self, tmp_path: Path
+    ) -> None:
+        state = _game(tmp_path, rounds=1)
+        state.start_next_question()
+        handler, conn = _handler()
+
+        await handler._handle_submit_wager(
+            state.get_player("Anna").ws, {"wager": 10}, state
+        )
+        assert state.phase is GamePhase.WAGER_ACTIVE
+        await handler._handle_submit_wager(
+            state.get_player("Tom").ws, {"wager": 20}, state
+        )
+
+        # Everyone in → the round starts without waiting out the deadline.
+        assert state.phase is GamePhase.QUESTION_ACTIVE
+        assert set(state._phase_controller.timers) == {"Anna", "Tom"}
+        questions = [m for m in conn.sent if m.get("type") == "question_started"]
+        assert len(questions) == 2  # one per player, own shuffle
+        assert questions[0]["timer_duration"] == 30
+
+    @pytest.mark.asyncio
+    async def test_host_skip_closes_the_window(self, tmp_path: Path) -> None:
+        """Mid-window, skip means "stop waiting for bets" — the question has
+        not been asked yet, so there is nothing to abandon. Without this the
+        host's skip fell through to the advance path, which refuses
+        WAGER_ACTIVE, and the window would have been cancelled with nothing
+        to restart it."""
+        state = _game(tmp_path, rounds=1)
+        state.start_next_question()
+        handler, _conn = _handler()
+
+        await handler._handle_admin_skip(state.get_player("Anna").ws, state)
+
+        assert state.phase is GamePhase.QUESTION_ACTIVE
+
+    @pytest.mark.asyncio
+    async def test_opening_the_window_sends_no_question(
+        self, tmp_path: Path
+    ) -> None:
+        state = _game(tmp_path, rounds=1)
+        question = state.start_next_question()
+        handler, conn = _handler()
+
+        await handler._open_wager_window(state, question)
+        handler._cancel_wager_window()  # don't leave a live deadline in a test
+
+        windows = [m for m in conn.sent if m.get("type") == "wager_window"]
+        assert len(windows) == 2
+        assert not [m for m in conn.sent if m.get("type") == "question_started"]
+        assert question.question not in str(conn.sent)
+        assert conn.to_hosts[0]["type"] == "wager_progress"
+        assert conn.to_hosts[0]["window_duration"] == 20
+
+
+# ---------------------------------------------------------------------------
+# Client: the gate that must NOT come back
+# ---------------------------------------------------------------------------
+
+
+class TestClientSource:
+    """The old client disabled the answer buttons until a wager was in.
+
+    Left in place next to a real betting window, that gate locks a player who
+    let the window lapse out of answering at all — they never submitted a
+    wager, so their buttons would stay dead for the whole final round.
+    """
+
+    def test_answer_buttons_are_not_gated_on_the_wager(self) -> None:
+        src = (_WWW / "js" / "player-game.js").read_text("utf-8")
+
+        assert "_wagerGate" not in src
+        assert not re.search(r"btn\.disabled\s*=\s*_wager", src)
+
+    def test_bundle_carries_the_window_renderer(self) -> None:
+        """player.bundle.js is generated — a stale one ships a phone that
+        cannot render the window at all."""
+        bundle = (_WWW / "js" / "player.bundle.js").read_text("utf-8")
+
+        assert "renderWagerWindow" in bundle
+        assert "wager_window" in bundle
+
+    def test_every_language_carries_the_window_strings(self) -> None:
+        import json  # noqa: PLC0415
+
+        for lang in ("de", "en", "es"):
+            data = json.loads((_WWW / "i18n" / f"{lang}.json").read_text("utf-8"))
+            assert "questionPending" in data["wager"], lang
+            assert "waitingForOthers" in data["wager"], lang
+            assert "hostWindowTitle" in data["wager"], lang
+            assert "hostProgress" in data["wager"], lang
+            assert "titleWager" in data["page"], lang

--- a/tests/test_wager_window_656.py
+++ b/tests/test_wager_window_656.py
@@ -18,6 +18,7 @@ deadline passes. Only then is the question sent and the round clock armed.
 
 from __future__ import annotations
 
+import asyncio
 import re
 import sys
 from pathlib import Path
@@ -337,6 +338,36 @@ class TestHandler:
         questions = [m for m in conn.sent if m.get("type") == "question_started"]
         assert len(questions) == 2  # one per player, own shuffle
         assert questions[0]["timer_duration"] == 30
+
+    @pytest.mark.asyncio
+    async def test_deadline_closes_the_window_and_sends_the_question(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The deadline is the guarantee that a table which never bets still
+        gets its question.
+
+        It caught a real failure on the live server: ``_close_wager_window``
+        clears the deadline first, and the deadline task is one of its two
+        callers — so cancelling blindly killed the coroutine mid-close and the
+        final round sat on the betting screen forever with the countdown at
+        zero. Every unit test passed, because they all closed the window from
+        the *other* trigger.
+        """
+        from custom_components.quizify.server import websocket as ws_mod  # noqa: PLC0415
+
+        monkeypatch.setattr(ws_mod, "WAGER_WINDOW_DURATION", 0.05)
+        state = _game(tmp_path, rounds=1)
+        question = state.start_next_question()
+        handler, conn = _handler()
+
+        await handler._open_wager_window(state, question)
+        assert state.phase is GamePhase.WAGER_ACTIVE
+        await asyncio.sleep(0.3)
+
+        assert state.phase is GamePhase.QUESTION_ACTIVE
+        assert [m for m in conn.sent if m.get("type") == "question_started"]
+        # Nobody bet — that is allowed, and costs nothing.
+        assert state.get_player("Anna").wager is None
 
     @pytest.mark.asyncio
     async def test_host_skip_closes_the_window(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #656.

Reported by an external player: "the timer to answer the question is already running while you're still thinking about how much you want to wager."

Two things were wrong, and only one of them was in the report:

1. `question_started` carried the question text **and** `timer_duration` in one message, and the phone built the wager panel out of that same message — so the answer clock drained while the table argued about the stake.
2. The question was readable while betting. A player who knew the answer could stake everything at no risk, which is not a bet.

## What changed

Betting is its own phase. `WAGER_ACTIVE` holds the loaded question back: category and bank go to the phones, no text, no answers, and no timer object exists yet. The window closes when every connected player has locked in **or** its own 20s deadline passes; only then does `arm_round_timers` stamp the round and send the question.

It is a real phase rather than a flag because everything reading `QUESTION_ACTIVE` would be wrong here: the tick loop's no-timers fallback (#586) would end the round on its first iteration, and the reconnect snapshot would hand out the text the window exists to withhold.

- `_cancel_timer_tick` cancels the window too, so no path can leave a deadline armed over a round that has moved on — one place instead of eight call sites.
- `arm_round_timers` returns `False` when already closed, which is what makes the two closing triggers safe to race.
- The client's old wager gate on the answer buttons is gone. Next to a real window it would lock a player who let the window lapse out of answering at all.
- Host skip mid-window means "stop waiting for bets" — without that branch it fell through to the advance path, which refuses `WAGER_ACTIVE`, and the window would have been cancelled with nothing left to restart it.
- An estimate final never opens a window: it scores without ever reading `player.wager` (#353), so a bet there settles nothing.
- Wagers are refused once the question is out, so #255's explicit rejection is now enforced one step earlier, by the closed window.

## A bug the tests could not see

`_close_wager_window` clears the pending deadline before doing its work, and the deadline task is one of its two callers — so `cancel()` killed the very coroutine that was closing the window. The `CancelledError` landed on the first await inside `_emit_question`, the question never went out, and the final round sat on the betting screen with the countdown reading zero.

Every unit test passed, because they all closed the window from the *other* trigger. It surfaced on a live server. `_cancel_wager_window` now never cancels the calling task, and a test drives the deadline path with a 50ms window.

## Verified

Live game on the standalone server, phone emulated at 390x844:

- Bet placed -> window closes immediately -> question with the full 30s.
- Nothing placed -> deadline -> question with the full 30s, no bet, no penalty.
- The collapsed wager badge is a certainty on every MC final now, and at the old card metrics it pushed the third answer below the fold. Tightened; all three answers are above the fold again, `scrollWidth` 390, no horizontal clipping.
- TV shows "placing bets — n of m", never the amounts.
- An estimate final came up by chance during testing and correctly skipped the window.

Suite 2127, ruff and mypy clean.

## Rebased onto #655

This was cut before #655 (an unanswered wager loses the stake) landed. Rebased on it: the two changes meet in `wager.timeoutNote` (kept #655's wording — the stake is always lost) and in the #653 tests, whose final round now opens in the betting window.

The order turned out to matter. With #655 live, the seconds a player spent on the slider were costing real points: the answer clock was already draining, and running it out now forfeits the stake. This removes that.