### PR TITLE
v1.11.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ That forgiveness was deliberate, so a phone locking mid-question never cost anyo
 
 The line on your phone that used to promise the opposite has been rewritten in all three languages.
 
+### 🎰 Bet on the category, not on the question in front of you
+
+The final round used to show the question and start its thirty-second clock in the same breath as it asked for your wager. Every second spent deciding was a second taken from answering — and with the rule above, running out of time now forfeits the stake as well.
+
+Betting is its own step now. You get the category and your current points; no question text, no answers, no timer. It closes as soon as everyone has locked in, or after twenty seconds, and only then does the question appear with its full time. The television shows how many bets are in, never how large they are.
+
+It also closes something nobody reported: the question used to be readable while you were betting, so a player who knew the answer could stake everything at no risk. The wager is placed on the category alone now, the way a Jeopardy final is.
+
 ## [1.10.0] — 2026-08-23
 
 ### 🇪🇸 Spanish is complete

--- a/docs/release-notes/v1.11.0.md
+++ b/docs/release-notes/v1.11.0.md
@@ -1,0 +1,31 @@
+## v1.11.0 — The Chair Is Auctioned, and the Bet Comes First
+
+This release is about putting points down. A new mode sells the right to answer to whoever risks the most, the finale stops forgiving a wager you never answered, and the finale finally gives you a moment to decide before its clock starts.
+
+### 🪑 The hot seat goes to the highest bidder
+
+Once per game, at a round nobody sees coming, the chair is **sold** rather than handed out ([#616](https://github.com/mholzi/quizify/issues/616)). Everyone bids in secret, the bids are revealed together, and the highest bidder answers one question alone while the rest of the room may stake points on whether they get it.
+
+A bid is a **share of your own points**, not a number of them. Bid in absolute points and the auction always goes to whoever is already ahead, so the chair would belong to the player who needs it least. In percent everyone can commit everything, and the seat is cheapest for whoever is last.
+
+Right wins your stake, wrong loses it, and so does no answer at all. The player in the chair may not bet on themselves, and the whole mode is off in the kids preset.
+
+### 🎲 An unanswered wager loses the stake
+
+The same rule reaches back into the final round ([#653](https://github.com/mholzi/quizify/issues/653)). Letting the clock run out on a wager used to cost nothing — no win, no loss. It now costs the stake, exactly like a wrong answer.
+
+The auction could not inherit the forgiving rule: a stake that buys the right to answer would be free to anyone who simply sat the question out. Two settlement rules in the two places the game asks you to risk something would be harder to play than one.
+
+### 🎰 Bet on the category, not on the question in front of you
+
+The final round used to show the question and start its thirty-second clock in the same breath as it asked for your wager ([#656](https://github.com/mholzi/quizify/issues/656), reported from a live game). Every second spent deciding was a second taken from answering — and, with the rule above, forfeits the stake as well.
+
+Betting is its own step now: the category and your current points, no question and no timer. It closes once everyone has locked in, or after twenty seconds, and only then does the question appear with its full time. The television shows how many bets are in, never how large.
+
+It also closes something nobody reported — the question was readable while you were betting, so a player who knew the answer could stake everything at no risk.
+
+### 🙏 Thank you
+
+Both fixes above started with someone describing an evening rather than filing a defect ([#656](https://github.com/mholzi/quizify/issues/656), [#586](https://github.com/mholzi/quizify/issues/586)), and half of what they uncovered was never in the report.
+
+If a game at your table does something odd — a round that will not move on, a rule that reads unfairly — that report is worth more than another pass over the code.


### PR DESCRIPTION
Player-facing notes for the three commits that have landed since v1.10.0, in `docs/release-notes/v1.11.0.md`, plus the missing CHANGELOG entry for #656. The other two were already under `[Unreleased]`.

**No version stamp, no manifest bump, no tag.** This is the text only.

## Why 1.11.0 and not 1.10.1

Three commits, one of which is a new game mode (#616). A patch number would be mislabelled.

## Why the three read as one release

They are causally linked rather than merely simultaneous:

- The hot seat auction sells the right to answer, so a stake there cannot be free — which is what forces #653 to end the finale's forgiving timeout.
- #653 makes running out of time expensive, which is what made #656 worth fixing now: the wager clock was the answer clock, so deciding cost points.

The notes say that plainly instead of listing three unrelated bullets.

## Format

Matches the existing files in `docs/release-notes/`: title with a half-sentence subtitle, a framing paragraph, emoji sections with issue links, and the 🙏 Thank you close every release since v1.6.1 carries. No "Under the hood" section this time, by request — which also drops the test count those sections carried.