### PR TITLE
v1.12.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to Quizify are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### 🥊 The duel between two regulars
+
+The lobby now names the two people in the room who have played together most often and shows their record: Anna 3 – 2 Ben, last 90 days. The end screen shows it again afterwards, with the game everyone just watched counted in.
+
+A meeting goes to whoever scored higher of those two. A draw counts as a meeting and goes to nobody, and nothing appears until a pair has played twice. Only the shared screens show it; your phone still shows your own standing and nothing else.
+
+### 📺 The lobby fits on the television again
+
+At 1280×720 and 1366×768 the lobby was taller than the picture, and a television does not scroll, so the player names at the bottom were cut off. The new line did not cause this. Short screens now get a smaller join code and tighter spacing; at 1080p nothing changes.
+
 ## [1.11.0] — 2026-08-30
 
 ### 🪑 The hot seat goes to the highest bidder

--- a/docs/release-notes/v1.12.0.md
+++ b/docs/release-notes/v1.12.0.md
@@ -1,0 +1,15 @@
+## v1.12.0 — The Room Keeps Score Between You Two
+
+Quizify has always known who beat whom. It never said so out loud.
+
+### 🥊 The duel between two regulars
+
+The lobby now names the two people in the room who have played together most often and shows their record: Anna 3 – 2 Ben, last 90 days. The end screen shows it again afterwards, with the game everyone just watched counted in.
+
+A meeting goes to whoever scored higher of those two, so Cara topping the table settles nothing between Anna and Ben. A draw counts as a meeting and goes to nobody. Nothing appears until a pair has played twice, because 1–0 after one evening looks like a record and is a coincidence.
+
+Only the shared screens show it. Your phone still shows your own standing and nothing else.
+
+### 📺 The lobby fits on the television again
+
+At 1280×720 and 1366×768 the lobby was taller than the picture, and a television does not scroll, so the player names at the bottom were cut off. The new line did not cause this. The column was already too tall without it. Short screens now get a smaller join code and tighter spacing. At 1080p nothing changes.


### PR DESCRIPTION
Player-facing notes for what has landed since v1.11.0, in `docs/release-notes/v1.12.0.md`, plus the matching `[Unreleased]` block in the CHANGELOG.

**No version stamp, no manifest bump, no tag.** Text only.

## Why 1.12.0 and not 1.11.1

The head-to-head duel (#613) is a new visible feature. A patch number would mislabel it.

## Two sections, not one

The 720p fix has its own heading rather than a footnote to the duel. It was found while measuring where the duel line landed, and it turned out not to be caused by the duel at all: the lobby column was already taller than a 720p screen on `main`, clipping the roster chips. That affected every short-screen television, with or without this feature, so it reads as its own change.

## Shorter, and no "Thank you" section

Cut to 207 words, and the closing thank-you section that v1.6.1 through v1.11.0 carried is dropped here at the maintainer's request.

The draft also lost a fabricated detail on the way: it claimed two players "have played five evenings together". That number came from the seeded test history used for the screenshots, not from the product. An unsourced claim about behaviour is worse in release notes than in most places, because readers check it against what they see.