### PR TITLE
Tear the Hot Seat loop down like Lightning, and keep its toggle across a rematch

### DIFF
--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -638,6 +638,11 @@ class QuizifyGameState:
             "language": self.language,
             "timer_duration": timer_duration,
             "lightning_enabled": lightning_enabled,
+            # #670: hot_seat_enabled belongs here for the same reason
+            # lightning_enabled does. Without it the one-tap rematch falls
+            # back to start_game's default (True) and hands a kids' game the
+            # auction its preset had switched off.
+            "hot_seat_enabled": hot_seat_enabled,
         }
 
         # Load questions. The bank is preloaded off the event loop at

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -1810,6 +1810,13 @@ class QuizifyWebSocketHandler:
         # 2026-05-31: picked Geographie/DE but kept seeing the previous English
         # mixed game. Reset to LOBBY first (keeps connected players) so the
         # fresh settings always take effect. Mirrors _handle_play_again.
+        # #671: unconditional, unlike the block below. A hot-seat loop has no
+        # business surviving into a new game whatever phase we start from, and
+        # "there cannot be one in LOBBY" is the same assumption that let this
+        # task outlive four teardown paths in the first place. Cancelling a
+        # task that isn't there costs nothing.
+        self._cancel_hot_seat_loop()
+
         if game_state.phase != GamePhase.LOBBY:
             self._cancel_timer_tick()
             # #407 (follow-up to #362): cancel the lightning loop and any
@@ -2188,6 +2195,7 @@ class QuizifyWebSocketHandler:
         # game, or a stale pause task pauses round 1 and a lingering lightning
         # loop keeps broadcasting stale frames into the rematch.
         self._cancel_lightning_loop()
+        self._cancel_hot_seat_loop()
         self._cancel_admin_pause()
         # Reset to LOBBY first so start_game's phase guard passes; keeps
         # players (reset_to_lobby leaves connected players in place).
@@ -2234,6 +2242,7 @@ class QuizifyWebSocketHandler:
         """
         self._cancel_timer_tick()
         self._cancel_lightning_loop()
+        self._cancel_hot_seat_loop()
         # Cancel the deferred admin-disconnect pause (#362) so a reset can't
         # be undone by a pause firing right after the fresh lobby is built.
         self._cancel_admin_pause()
@@ -2760,6 +2769,13 @@ class QuizifyWebSocketHandler:
                         break
                     await asyncio.sleep(0.25)
 
+                # #671: the loop above only checks the phase INSIDE the wait.
+                # Leaving it (expired, or everyone bid) and acting without a
+                # re-check lets a reset that landed in the last poll interval
+                # be followed by a ghost round in the fresh lobby.
+                if game_state.phase != GamePhase.HOT_SEAT_AUCTION:
+                    return
+
                 winner = game_state.close_hot_seat_auction()
                 if winner is None:
                     # Nobody wanted the chair. Not a failure — just a round
@@ -2800,6 +2816,12 @@ class QuizifyWebSocketHandler:
                     if hs.answered is not None:
                         break
                     await asyncio.sleep(0.25)
+
+                # #671: same re-check as after the auction wait — a teardown
+                # that lands in the last poll interval must not be followed by
+                # a settlement against a game that no longer exists.
+                if game_state.phase != GamePhase.HOT_SEAT:
+                    return
 
                 # Settle even when nothing was answered: the chair was bought
                 # either way (#653). This is the one place the mode parts ways
@@ -4149,6 +4171,7 @@ class QuizifyWebSocketHandler:
         """Cancel all pending tasks."""
         self._cancel_timer_tick()
         self._cancel_lightning_loop()
+        self._cancel_hot_seat_loop()
         self._cancel_reaction_flush()
         self._cancel_roster_flush()
         self._cancel_progress_flush()

--- a/tests/test_hot_seat_teardown_671.py
+++ b/tests/test_hot_seat_teardown_671.py
@@ -1,0 +1,152 @@
+"""Regression tests for #670 and #671 — the Hot Seat detour must be torn
+down along the same paths Lightning already is, and its toggle must survive
+the one-tap rematch.
+
+Background: the Hot Seat auction (#616) arrived after the Lightning loop had
+been hardened in #362/#407. It inherited none of that work.
+
+  * #670 — ``_last_settings`` snapshotted ``lightning_enabled`` but not
+    ``hot_seat_enabled``, so "Play again — same settings" fell back to
+    ``start_game``'s default (True) and handed a kids' game the auction its
+    preset had switched off.
+  * #671 — ``_cancel_lightning_loop()`` was called from six places,
+    ``_cancel_hot_seat_loop()`` from two. ``start_game``, ``play_again``,
+    ``reset_game`` and ``cleanup_game_tasks`` all left the loop running, and
+    the loop acted on the auction outcome without re-checking the phase it
+    had left, so a reset landing in the last poll interval could be followed
+    by a ghost round in the fresh lobby.
+
+The four teardown tests each assert one path, deliberately: two triggers for
+the same transition need a test per trigger — the lesson from #656/#657.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server.connection import (  # noqa: E402
+    ConnectionManager,
+)
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    ws.close = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+@pytest.fixture
+def handler(game: QuizifyGameState, tmp_path: Path) -> QuizifyWebSocketHandler:
+    h = QuizifyWebSocketHandler(
+        runtime=_FakeRuntime(tmp_path), game_state_provider=lambda: game
+    )
+    h._conn = ConnectionManager(_FakeRuntime(tmp_path), lambda: game)
+    h._conn.broadcast = AsyncMock()
+    return h
+
+
+def _pending_hot_seat_task(handler: QuizifyWebSocketHandler) -> asyncio.Task:
+    """A stand-in for the running auction loop.
+
+    Deliberately not the real loop: this asserts the cancel wiring, and a
+    test that had to arrange a live auction to check a teardown path would
+    stop testing the teardown the first time the auction's own guards moved.
+    """
+
+    async def _sleep_forever() -> None:
+        await asyncio.sleep(3600)
+
+    task = asyncio.ensure_future(_sleep_forever())
+    handler._hot_seat_task = task
+    return task
+
+
+async def _assert_cancelled(handler: QuizifyWebSocketHandler, task) -> None:
+    assert handler._hot_seat_task is None
+    await asyncio.sleep(0)
+    assert task.cancelled()
+
+
+# ---------------------------------------------------------------------------
+# #670 — the toggle survives the rematch
+# ---------------------------------------------------------------------------
+
+
+def test_hot_seat_toggle_persisted_in_last_settings(game: QuizifyGameState) -> None:
+    """A preset that switched the auction off keeps it off on "Play again"."""
+    game.start_game(num_rounds=10, hot_seat_enabled=False)
+    assert game.last_settings["hot_seat_enabled"] is False
+
+
+def test_hot_seat_toggle_defaults_are_carried_too(game: QuizifyGameState) -> None:
+    game.start_game(num_rounds=10)
+    assert game.last_settings["hot_seat_enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# #671 — every teardown path cancels the loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cleanup_game_tasks_cancels_hot_seat_loop(
+    handler: QuizifyWebSocketHandler,
+) -> None:
+    task = _pending_hot_seat_task(handler)
+    await handler.cleanup_game_tasks()
+    await _assert_cancelled(handler, task)
+
+
+@pytest.mark.asyncio
+async def test_reset_game_cancels_hot_seat_loop(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState
+) -> None:
+    task = _pending_hot_seat_task(handler)
+    await handler._handle_reset_game(_ws(), game)
+    await _assert_cancelled(handler, task)
+
+
+@pytest.mark.asyncio
+async def test_start_game_cancels_hot_seat_loop(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState
+) -> None:
+    """A start that lands during a detour must not leave the loop running."""
+    game.add_player("Anna", _ws())
+    task = _pending_hot_seat_task(handler)
+    await handler._handle_start_game(_ws(), {"num_rounds": 3}, game)
+    await _assert_cancelled(handler, task)
+
+
+@pytest.mark.asyncio
+async def test_play_again_cancels_hot_seat_loop(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState
+) -> None:
+    game.add_player("Anna", _ws())
+    game.start_game(num_rounds=3)
+    task = _pending_hot_seat_task(handler)
+    await handler._handle_play_again(_ws(), game)
+    await _assert_cancelled(handler, task)


### PR DESCRIPTION
Fixes the two cheap halves of today's Hot Seat findings. Both come from the same root: the auction (#616) was built after the Lightning loop had been hardened in #362/#407, and it inherited none of that.

## #670 — the toggle did not survive "Play again"

`_last_settings` carried `lightning_enabled` and not `hot_seat_enabled`, so the one-tap rematch fell back to `start_game`'s default of `True`. Run the Kids preset, tap "Play again — same settings", and Lightning stays off while the auction comes back — with a stake forfeited on timeout (#653), in a children's game.

One line, plus the test that was written for the Lightning half and never for this one.

## #671 — four teardown paths left the loop running

`_cancel_lightning_loop()` was called from six places, `_cancel_hot_seat_loop()` from two. `start_game`, `play_again`, `reset_game` and `cleanup_game_tasks` all left `_hot_seat_task` alive.

- on unload the loop kept broadcasting into a torn-down game for up to ~40s
- a `reset_game` landing in the last poll interval of the auction window was followed by a **ghost round in the fresh lobby**: the loop left `while not hs.is_expired()` without re-checking the phase, got `None` from `close_hot_seat_auction`, and called `_continue_normal_question` → `start_next_question()`, which accepts LOBBY because the #298 guard lives only in `_advance_round`

Both wait loops now re-check the phase **after** leaving it, not only inside.

The cancel in `_handle_start_game` is deliberately unconditional rather than tucked into the existing non-LOBBY branch. "There cannot be a loop running in LOBBY" is exactly the assumption that let this task outlive four teardown paths, and cancelling a task that is not there costs nothing.

## Tests

Six new tests in `tests/test_hot_seat_teardown_671.py`: one per teardown path, plus both toggle cases. One test per path on purpose — two triggers for the same transition need a test each, which is what #656/#657 cost us.

The stand-in task is a plain sleeper rather than the real auction loop. A test that had to arrange a live auction to check a teardown path would stop testing the teardown the first time the auction's own guards moved.

## Verification

- full suite: **2,230 passed** (2,224 before), run twice
- `test_perf_wasted_work_304.py::test_repeated_same_reaction_collapses_to_one_broadcast` failed once on the first full run and passed on both re-runs and in isolation; `main` is green and so is this branch on repeat. It is a timing-sensitive coalescing test, not a regression from this change — worth its own look some time
- ruff reports 148 pre-existing errors and would reformat `state.py` and `websocket.py` on `main` as well, so this branch leaves the formatting alone rather than burying a five-line fix in a reformat

Not verified on hardware: no Home Assistant was reachable while this was written.

Closes #670
Closes #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVgwJ4Jb1HE3uvYjfD914M