### PR TITLE
Keep team mode out of the final wager and the Hot Seat auction

### DIFF
--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -2121,6 +2121,17 @@ class QuizifyGameState:
         """
         if self._hot_seat_fired or self._hot_seat_target_round is None:
             return False
+        # #669: never in team mode. Bids are a percentage of the bidder's own
+        # score, which in team mode is the same shadow value #668 is about —
+        # zero for everyone but the round's carrier, and a zero stake is
+        # rejected outright, so most of the room cannot bid at all. Worse, the
+        # settlement writes its deltas to ``player.score`` while the
+        # leaderboard, podium and awards all read ``get_ranked_participants()``
+        # (teams): the detour would stop the game for a minute and put its
+        # result nowhere anyone can see. Lightning got proper team support in
+        # #552; until the auction does too, it stays out.
+        if self.team_mode:
+            return False
         if self.phase not in (GamePhase.LOBBY, GamePhase.ANSWER_REVEAL):
             return False
         return self.round + 1 == self._hot_seat_target_round
@@ -2508,7 +2519,18 @@ class QuizifyGameState:
         through ``_evaluate_estimate_round``, which never reads
         ``player.wager`` (#353) — opening a window there would collect bets
         nothing settles.
+
+        Team mode is excluded for the same reason (#668). There ``player.score``
+        is a by-product: the carrier of a given round — whoever's tap stands at
+        settle — receives the team's points personally and everyone else stays
+        at zero. The window advertised each member "your bank: X" against that
+        meaningless number, and settlement read only the carrier's bet, staked
+        against the carrier's shadow score rather than the team score on the
+        television. A bet nobody can read and most people cannot influence is
+        worse than no bet; a team-level wager is a feature, not a fix.
         """
+        if self.team_mode:
+            return False
         return self.round == self.total_rounds and not question.is_estimate
 
     def arm_round_timers(self) -> bool:

--- a/tests/test_team_mode_gates_668_669.py
+++ b/tests/test_team_mode_gates_668_669.py
@@ -1,0 +1,136 @@
+"""Team mode keeps its hands off the wager window and the Hot Seat (#668, #669).
+
+Both features stake a percentage of ``player.score``. In team mode that number
+is a by-product rather than a score: the carrier of a given round — whoever's
+tap stands at settle — receives the team's points personally, and every other
+member stays at zero. The team's real standing lives on the team.
+
+That mismatch produced two different failures from one cause:
+
+* **#668** — the final-round betting window opened for everyone, showed each
+  member "your bank" against their meaningless personal number, and then
+  settled only the carrier's bet against the carrier's shadow score. A team of
+  two could have one member wager 80%% with no effect at all, while the other's
+  50%% of a hidden 40 decided the finale.
+* **#669** — the auction let bids be a percentage of the same shadow value.
+  Zero-stake bids are rejected, so most of the room could not bid; and the
+  settlement wrote to ``player.score`` while the leaderboard, podium and awards
+  all read teams, so the whole detour's points landed nowhere visible.
+
+Both are gated off until the mechanics themselves learn about teams, the way
+Lightning did in #552. These tests pin the gate *and* pin that solo play is
+untouched — a gate that quietly disables a feature for everyone is the more
+expensive mistake.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.quizify.game.phase_controller import GamePhase
+from custom_components.quizify.game.state import QuizifyGameState
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+class _Runtime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _game(tmp_path: Path, *, teams: bool) -> QuizifyGameState:
+    st = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="test")
+    for name in ("Anna", "Jan", "Mira"):
+        st.add_player(name, _ws())
+    if teams:
+        st.create_team("Sofa", "Anna")
+        st.join_team(st.get_team_of("Anna")["team_id"], "Jan")
+    st.start_game(category="picture-round-en", difficulty="easy",
+                  num_rounds=3, language="en")
+    return st
+
+
+@pytest.fixture
+def solo(tmp_path: Path) -> QuizifyGameState:
+    return _game(tmp_path, teams=False)
+
+
+@pytest.fixture
+def teamed(tmp_path: Path) -> QuizifyGameState:
+    return _game(tmp_path, teams=True)
+
+
+# ---------------------------------------------------------------------------
+# #668 — the final wager
+# ---------------------------------------------------------------------------
+
+
+def test_solo_final_round_still_opens_the_wager_window(
+    solo: QuizifyGameState,
+) -> None:
+    """The gate must not touch the mode the feature was built for."""
+    solo.start_next_question()
+    solo.round = solo.total_rounds
+    question = solo.get_current_question()
+    assert solo._needs_wager_window(question) is True
+
+
+def test_team_final_round_opens_no_wager_window(
+    teamed: QuizifyGameState,
+) -> None:
+    teamed.start_next_question()
+    teamed.round = teamed.total_rounds
+    question = teamed.get_current_question()
+    assert teamed._needs_wager_window(question) is False
+
+
+def test_the_gate_is_team_mode_and_not_the_round(
+    teamed: QuizifyGameState,
+) -> None:
+    """Not an off-by-one: no round of a team game opens a window."""
+    teamed.start_next_question()
+    question = teamed.get_current_question()
+    for r in range(1, teamed.total_rounds + 1):
+        teamed.round = r
+        assert teamed._needs_wager_window(question) is False
+
+
+# ---------------------------------------------------------------------------
+# #669 — the auction
+# ---------------------------------------------------------------------------
+
+
+def test_solo_game_still_arms_the_auction(solo: QuizifyGameState) -> None:
+    solo._hot_seat_target_round = solo.round + 1
+    solo.phase = GamePhase.ANSWER_REVEAL
+    assert solo.should_trigger_hot_seat() is True
+
+
+def test_team_game_never_arms_the_auction(teamed: QuizifyGameState) -> None:
+    teamed._hot_seat_target_round = teamed.round + 1
+    teamed.phase = GamePhase.ANSWER_REVEAL
+    assert teamed.should_trigger_hot_seat() is False
+
+
+def test_the_auction_gate_survives_a_team_being_emptied(
+    teamed: QuizifyGameState,
+) -> None:
+    """``team_mode`` is derived, so a game that loses its teams plays on.
+
+    This is the behaviour the property documents, and it means the gate
+    follows the room rather than a flag set once at kickoff.
+    """
+    team_id = teamed.get_team_of("Anna")["team_id"]
+    teamed.leave_team("Anna")
+    teamed.leave_team("Jan")
+    assert teamed.team_mode is False, team_id
+    teamed._hot_seat_target_round = teamed.round + 1
+    teamed.phase = GamePhase.ANSWER_REVEAL
+    assert teamed.should_trigger_hot_seat() is True


### PR DESCRIPTION
Two failures, one cause: both the final wager and the Hot Seat auction stake a percentage of `player.score`, and in team mode that is not a score.

In a team game the carrier of a round — whoever's tap stands at settle — receives the team's points on their personal score, and everyone else stays at zero. The number on screen, on the television, is the team's.

## #668 — the finale

The window opened for every member and told each of them "your bank: X" against their personal by-product. At settlement only the carrier's bet counted, staked against the carrier's shadow score rather than the team score the room had been watching all evening.

Reproduced by driving the game model: a team of two, A carries, B wagers 80%, A wagers 50% against a hidden bank of 40 → the team earns 20, and B's bet had no effect whatsoever. Where the carrier happens to sit at zero, the wager degrades to plain scoring without saying so.

## #669 — the auction

Bids are a percentage of the same shadow value, and zero-stake bids are rejected — so most of the room physically cannot bid for the chair, while whoever carried an earlier round can. Then `finish_hot_seat` applies its deltas to `player.score`, while the leaderboard, podium and awards are all built from `get_ranked_participants()`, which returns teams. The detour stops the game for up to a minute and puts its outcome nowhere anyone can see.

## Why gate rather than fix

A team-level wager and a team-aware auction are both real features, and both are worth having. What they are not is a patch: making a shadow number look plausible would leave the same mismatch one layer down. Lightning got its team support deliberately in #552, and these two deserve the same treatment rather than a coat of paint. Until then they stay out of team games, which is what the room already assumes when it sees a team score.

## Tests

Six, in `tests/test_team_mode_gates_668_669.py`. Three of them pin that **solo play is untouched** — a gate that quietly disables a feature for everybody is the more expensive mistake, and it would pass a test suite that only checked the team case.

One test pins that the gate follows `team_mode`, which is derived rather than stored: a game whose teams all empty out plays on with the auction armed again. That is the documented behaviour of the property, and it means the gate tracks the room rather than a flag set once at kickoff.

## Verification

Full suite: **2,230 passed**. Not verified on hardware — no Home Assistant was reachable while this was written.

Closes #668
Closes #669

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVgwJ4Jb1HE3uvYjfD914M