### PR TITLE
Put the Hot Seat in the state contract, on the phone and on the television

### DIFF
--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -2843,6 +2843,71 @@ class QuizifyGameState:
         if self.phase == GamePhase.LIGHTNING_RECAP and self._lightning is not None:
             snapshot["lightning_recap"] = self._lightning.build_recap()
 
+        # #664: the Hot Seat detour belongs in the contract like every other
+        # phase. Without this block a reconnecting phone got a snapshot naming
+        # a HOT_SEAT phase and no hot-seat data, fell through the client's
+        # default case onto the lobby, and — if it belonged to the seat holder
+        # — could never get back to the question, which #653 then charges as a
+        # lost stake. The TV had the same hole, with the previous round's
+        # reveal frozen on it for the whole detour.
+        if (
+            self.phase
+            in (
+                GamePhase.HOT_SEAT_AUCTION,
+                GamePhase.HOT_SEAT,
+                GamePhase.HOT_SEAT_REVEAL,
+            )
+            and self._hot_seat is not None
+        ):
+            hs = self._hot_seat
+            if self.phase == GamePhase.HOT_SEAT_AUCTION:
+                stage = "auction"
+            elif self.phase == GamePhase.HOT_SEAT_REVEAL:
+                stage = "result"
+            else:
+                # There is deliberately no separate "the bids are landing"
+                # stage. ``resolve_auction`` starts the answer clock at the
+                # moment the chair is awarded, so the live flow's four-second
+                # bid reveal is already being paid for out of the seat
+                # holder's window. Someone who reconnects during that hold is
+                # better served by the question than by a reveal they are
+                # being charged for — and worse, without a question to look
+                # at they would burn the clock reading a scoreboard.
+                stage = "question"
+            block: dict[str, Any] = {
+                "stage": stage,
+                "time_remaining": round(hs.time_remaining(), 1),
+                "auction_seconds": hs.auction_seconds,
+                "answer_seconds": hs.answer_seconds,
+                # The banks the bids are percentages of — a snapshot taken when
+                # the auction opened, not the live scores.
+                "banks": dict(hs.scores),
+                # Count only. The auction is sealed until it closes, and a
+                # reconnect must not be a way to read it early.
+                "bid_count": len(hs.bids),
+                "bidder_count": len(hs.scores),
+                "winner": hs.winner,
+            }
+            if hs.winner is not None:
+                block["pct"] = hs.winning_pct
+                block["stake"] = hs.winning_stake
+                block["bids"] = hs.reveal()
+            # The question is withheld during the auction on purpose: bidding
+            # is meant to be a bet on yourself, not on a question you have
+            # already read.
+            if stage in ("question", "result") and hs.question is not None:
+                block["question"] = {
+                    "text": hs.question.question,
+                    # Canonical order — admin and TV. The seat holder's own
+                    # shuffle is projected in round_message_builder.
+                    "answers": [a.text for a in hs.question.answers],
+                    "category": hs.question.category,
+                    "image_url": hs.question.image_url,
+                }
+            if stage == "result":
+                block["summary"] = hs.summary()
+            snapshot["hot_seat"] = block
+
         return snapshot
 
     # ------------------------------------------------------------------

--- a/custom_components/quizify/server/round_message_builder.py
+++ b/custom_components/quizify/server/round_message_builder.py
@@ -303,12 +303,15 @@ class RoundMessageBuilder:
                     hs.winner is not None and hs.winner == player.name
                 )
                 if block.get("question") is not None:
-                    question = dict(block["question"])
+                    # Named apart from the ``question`` above on purpose: that
+                    # one is a Question, this one is the wire dict, and mypy
+                    # rightly refuses to let one name mean both.
+                    hs_question = dict(block["question"])
                     if block["you_are_seated"]:
-                        question["answers"] = hs.shuffled_answers()
+                        hs_question["answers"] = hs.shuffled_answers()
                     else:
-                        question.pop("answers", None)
-                    block["question"] = question
+                        hs_question.pop("answers", None)
+                    block["question"] = hs_question
             out["hot_seat"] = block
 
         if phase == GamePhase.ANSWER_REVEAL.value:

--- a/custom_components/quizify/server/round_message_builder.py
+++ b/custom_components/quizify/server/round_message_builder.py
@@ -283,6 +283,34 @@ class RoundMessageBuilder:
                 lightning["question"] = lq
                 out["lightning"] = lightning
 
+        if out.get("hot_seat"):
+            # #664: the canonical block is built for the admin and the TV. A
+            # player must see the question in THEIR shuffle if they hold the
+            # chair, and must not see answer buttons at all if they do not —
+            # spectators stake on the seat holder, they do not answer.
+            hs = game_state.hot_seat
+            block = dict(out["hot_seat"])
+            block["own_bank"] = block.get("banks", {}).get(player.name, 0)
+            block.pop("banks", None)
+            if hs is not None:
+                bid = hs.bids.get(player.name)
+                block["you_bid"] = bid.pct if bid is not None else None
+                bet = hs.bets.get(player.name)
+                block["you_bet"] = (
+                    {"side": bet.side, "pct": bet.pct} if bet is not None else None
+                )
+                block["you_are_seated"] = (
+                    hs.winner is not None and hs.winner == player.name
+                )
+                if block.get("question") is not None:
+                    question = dict(block["question"])
+                    if block["you_are_seated"]:
+                        question["answers"] = hs.shuffled_answers()
+                    else:
+                        question.pop("answers", None)
+                    block["question"] = question
+            out["hot_seat"] = block
+
         if phase == GamePhase.ANSWER_REVEAL.value:
             summary = self.build_round_summary(game_state)
             if summary is not None:

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -1865,6 +1865,32 @@
                 case 'timer_tick':
                     handleTimerTick(msg);
                     break;
+                // #664: the Hot Seat detour (#616) never reached this screen.
+                // The room ran an auction on their phones while the TV kept
+                // the previous round's reveal frozen on it — which does not
+                // read as "something else is happening", it reads as a crash.
+                case 'hot_seat_auction':
+                    // The payload carries seconds + player count, not the
+                    // round numbers — the frame keeps whatever the last round
+                    // put in the indicator.
+                    handleHotSeatAuction({ seconds: msg.seconds });
+                    handleHotSeatBidCount({ count: 0, total: msg.players || 0 });
+                    break;
+                case 'hot_seat_bid_count':
+                    handleHotSeatBidCount(msg);
+                    break;
+                case 'hot_seat_awarded':
+                    handleHotSeatAwarded(msg);
+                    break;
+                case 'hot_seat_question':
+                    handleHotSeatQuestion(msg);
+                    break;
+                case 'hot_seat_no_bids':
+                    handleHotSeatNoBids();
+                    break;
+                case 'hot_seat_tick':
+                    handleTimerTick({ remaining: msg.remaining });
+                    break;
                 case 'round_summary':
                 case 'round_evaluated':
                     handleRoundSummary(msg);
@@ -1997,6 +2023,19 @@
                         renderDashboardEstimateReveal(msg.round_summary.estimate);
                     } else if (msg.round_summary && msg.round_summary.answers) {
                         renderRevealFromSnapshot(msg.round_summary, msg.round, msg.total_rounds);
+                    }
+                    break;
+                case 'HOT_SEAT_AUCTION':
+                case 'HOT_SEAT':
+                case 'HOT_SEAT_REVEAL':
+                    // A TV that (re)connects mid-detour. Same reasoning as
+                    // WAGER_ACTIVE above: the snapshot carries the stage and
+                    // the seconds, and everything else arrives with the next
+                    // message.
+                    if (msg.hot_seat) {
+                        renderHotSeatFromSnapshot(msg.hot_seat, msg.round, msg.total_rounds);
+                    } else {
+                        showView('question');
                     }
                     break;
                 case 'PAUSED':
@@ -2187,6 +2226,118 @@
                 els.timerFill.style.width = '100%';
                 els.timerFill.className = 'dashboard-timer-fill';
             }
+        }
+
+        /* ------------------------------------------------------------
+         * Hot Seat on the television (#664).
+         *
+         * Deliberately rendered into the existing question view rather than
+         * a view of its own, exactly like the betting window: the room is
+         * looking at the same frame, and one auction line replacing the
+         * question text is all the detour needs to stop looking broken.
+         * ---------------------------------------------------------- */
+        function hotSeatT(key, vars, fallback) {
+            return (window.QuizifyI18n && window.QuizifyI18n.t)
+                ? window.QuizifyI18n.t(key, vars)
+                : fallback;
+        }
+
+        function hotSeatFrame(round, total) {
+            showView('question');
+            els.funFact.classList.remove('visible');
+            if (els.roundIndicator && typeof round === 'number') {
+                els.roundIndicator.textContent = hotSeatT(
+                    'dashboard.questionCounter', { current: round, total: total },
+                    'Question ' + round + ' / ' + total
+                );
+            }
+            renderQuestionImage('', '');
+            if (els.answersGrid) els.answersGrid.innerHTML = '';
+            if (els.dashboardEstimate) els.dashboardEstimate.classList.add('hidden');
+        }
+
+        function handleHotSeatAuction(msg) {
+            hotSeatFrame(msg.round_num, msg.total_rounds);
+            els.questionCategory.textContent = '';
+            els.questionText.textContent = hotSeatT(
+                'hotSeat.auctionTitle', null, 'The chair goes to the highest bid'
+            );
+            if (typeof msg.seconds === 'number') {
+                timerDuration = msg.seconds;
+                timerRemaining = timerDuration;
+                els.timerFill.style.width = '100%';
+                els.timerFill.className = 'dashboard-timer-fill';
+            }
+        }
+
+        function handleHotSeatBidCount(msg) {
+            // The count, never the amounts — the auction is sealed, and the
+            // screen everyone can see is the last place to leak it.
+            if (!els.answerProgress) return;
+            els.answerProgress.textContent = hotSeatT(
+                'hotSeat.bidCount', { count: msg.count || 0, total: msg.total || 0 },
+                (msg.count || 0) + ' / ' + (msg.total || 0)
+            );
+            els.answerProgress.classList.remove('hidden');
+        }
+
+        function handleHotSeatAwarded(msg) {
+            hotSeatFrame();
+            els.questionCategory.textContent = '';
+            els.questionText.textContent = hotSeatT(
+                'hotSeat.lost', { name: msg.winner, pct: msg.pct, pts: msg.stake },
+                msg.winner + ' — ' + msg.pct + '%'
+            );
+            if (els.answerProgress) els.answerProgress.classList.add('hidden');
+        }
+
+        function handleHotSeatQuestion(msg) {
+            // ``question`` is the field name on the wire (see
+            // _broadcast_hot_seat_question); the snapshot path passes the
+            // same shape so both routes land here identically.
+            handleQuestionStarted({
+                question_text: msg.question || '',
+                answers: msg.answers || [],
+                timer_duration: msg.seconds,
+                round_num: msg.round_num,
+                total_rounds: msg.total_rounds,
+                category: msg.category || '',
+                image_url: msg.image_url || ''
+            });
+        }
+
+        function handleHotSeatNoBids() {
+            hotSeatFrame();
+            els.questionCategory.textContent = '';
+            els.questionText.textContent = hotSeatT(
+                'hotSeat.noBids', null, 'Nobody bid — carrying on as usual.'
+            );
+            if (els.answerProgress) els.answerProgress.classList.add('hidden');
+        }
+
+        function renderHotSeatFromSnapshot(hs, round, total) {
+            if (hs.stage === 'auction') {
+                handleHotSeatAuction({
+                    round_num: round, total_rounds: total, seconds: hs.time_remaining
+                });
+                handleHotSeatBidCount({ count: hs.bid_count, total: hs.bidder_count });
+                return;
+            }
+            if (hs.stage === 'question' && hs.question) {
+                handleHotSeatQuestion({
+                    question: hs.question.text,
+                    answers: hs.question.answers || [],
+                    seconds: hs.time_remaining,
+                    round_num: round,
+                    total_rounds: total,
+                    category: hs.question.category,
+                    image_url: hs.question.image_url
+                });
+                return;
+            }
+            handleHotSeatAwarded({
+                winner: hs.winner, pct: hs.pct, stake: hs.stake
+            });
         }
 
         function handleQuestionStarted(msg) {

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -681,6 +681,19 @@
                 if (lightning) lightning.handleLightningRecap({ recap: msg.lightning_recap });
                 break;
 
+            case 'HOT_SEAT_AUCTION':
+            case 'HOT_SEAT':
+            case 'HOT_SEAT_REVEAL':
+                // #664: the detour is driven by one-shot events, so a reload
+                // used to fall through to the default case and land on the
+                // lobby with the auction still running. For the seat holder
+                // that was expensive: an unanswered question forfeits the
+                // stake (#653), and they could not answer what they could not
+                // see.
+                pu.showView('game-view');
+                if (hotSeat && msg.hot_seat) hotSeat.restoreFromSnapshot(msg.hot_seat);
+                break;
+
             case 'PAUSED':
                 pu.showView('paused-view');
                 updatePausedView(msg);
@@ -1704,6 +1717,8 @@
             case 'QUESTION_ACTIVE':
             case 'PLAYING':
             case 'LIGHTNING':
+            case 'HOT_SEAT_AUCTION':
+            case 'HOT_SEAT':
             case 'PAUSED':
                 return false;
             default:

--- a/custom_components/quizify/www/js/player-hotseat.js
+++ b/custom_components/quizify/www/js/player-hotseat.js
@@ -293,7 +293,87 @@
         if (fn) fn(msg.remaining);
     }
 
+    /**
+     * Rebuild the panel from a state snapshot (#664).
+     *
+     * The live flow is driven entirely by one-shot events, which a reload
+     * misses for good — they are never re-sent. This maps the snapshot's
+     * hot_seat block onto the same handlers the live events call, so a phone
+     * that reconnects mid-detour lands where it left off instead of on the
+     * lobby. It matters most for the seat holder: they cannot answer a
+     * question they cannot see, and an unanswered question costs the stake.
+     */
+    function restoreFromSnapshot(hs) {
+        if (!hs) return;
+        var stage = hs.stage;
+
+        if (stage === 'auction') {
+            handleAuctionYou({ score: hs.own_bank });
+            handleBidCount({ count: hs.bid_count, total: hs.bidder_count });
+            if (hs.you_bid != null) {
+                // Already bid before the reload. The server rejects a second
+                // bid anyway, so a live-looking slider would only invite a tap
+                // that silently does nothing.
+                lockBidUi(hs.you_bid);
+            }
+            return;
+        }
+
+        if (stage === 'awarded' || stage === 'result') {
+            handleAwarded({
+                winner: hs.winner,
+                pct: hs.pct,
+                stake: hs.stake,
+                bids: hs.bids || []
+            });
+            return;
+        }
+
+        if (stage === 'question') {
+            handleAwarded({
+                winner: hs.winner,
+                pct: hs.pct,
+                stake: hs.stake,
+                bids: hs.bids || []
+            });
+            handleQuestion({
+                you_are_seated: !!hs.you_are_seated,
+                answers: (hs.question && hs.question.answers) || [],
+                winner: hs.winner,
+                score: hs.own_bank
+            });
+            if (hs.you_bet) lockBetUi(hs.you_bet);
+        }
+    }
+
+    function lockBidUi(pct) {
+        _state.bidPlaced = true;
+        var slider = el('hotseat-slider');
+        var btn = el('hotseat-bid-btn');
+        if (slider) slider.disabled = true;
+        if (btn) btn.disabled = true;
+        var hint = el('hotseat-hint');
+        if (hint) {
+            hint.textContent = t('hotSeat.bidPlaced', {
+                pct: pct,
+                pts: Math.floor((_state.score || 0) * pct / 100)
+            });
+        }
+    }
+
+    function lockBetUi(bet) {
+        _state.betPlaced = true;
+        var hint = el('hotseat-hint');
+        if (hint) {
+            hint.textContent = t('hotSeat.betPlaced', {
+                pct: bet.pct,
+                side: bet.side
+            });
+        }
+    }
+
     window.QuizifyPlayerHotSeat = {
+        restoreFromSnapshot: restoreFromSnapshot,
         handleAuctionYou: handleAuctionYou,
         handleBidCount: handleBidCount,
         handleAwarded: handleAwarded,

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -4035,7 +4035,87 @@
         if (fn) fn(msg.remaining);
     }
 
+    /**
+     * Rebuild the panel from a state snapshot (#664).
+     *
+     * The live flow is driven entirely by one-shot events, which a reload
+     * misses for good — they are never re-sent. This maps the snapshot's
+     * hot_seat block onto the same handlers the live events call, so a phone
+     * that reconnects mid-detour lands where it left off instead of on the
+     * lobby. It matters most for the seat holder: they cannot answer a
+     * question they cannot see, and an unanswered question costs the stake.
+     */
+    function restoreFromSnapshot(hs) {
+        if (!hs) return;
+        var stage = hs.stage;
+
+        if (stage === 'auction') {
+            handleAuctionYou({ score: hs.own_bank });
+            handleBidCount({ count: hs.bid_count, total: hs.bidder_count });
+            if (hs.you_bid != null) {
+                // Already bid before the reload. The server rejects a second
+                // bid anyway, so a live-looking slider would only invite a tap
+                // that silently does nothing.
+                lockBidUi(hs.you_bid);
+            }
+            return;
+        }
+
+        if (stage === 'awarded' || stage === 'result') {
+            handleAwarded({
+                winner: hs.winner,
+                pct: hs.pct,
+                stake: hs.stake,
+                bids: hs.bids || []
+            });
+            return;
+        }
+
+        if (stage === 'question') {
+            handleAwarded({
+                winner: hs.winner,
+                pct: hs.pct,
+                stake: hs.stake,
+                bids: hs.bids || []
+            });
+            handleQuestion({
+                you_are_seated: !!hs.you_are_seated,
+                answers: (hs.question && hs.question.answers) || [],
+                winner: hs.winner,
+                score: hs.own_bank
+            });
+            if (hs.you_bet) lockBetUi(hs.you_bet);
+        }
+    }
+
+    function lockBidUi(pct) {
+        _state.bidPlaced = true;
+        var slider = el('hotseat-slider');
+        var btn = el('hotseat-bid-btn');
+        if (slider) slider.disabled = true;
+        if (btn) btn.disabled = true;
+        var hint = el('hotseat-hint');
+        if (hint) {
+            hint.textContent = t('hotSeat.bidPlaced', {
+                pct: pct,
+                pts: Math.floor((_state.score || 0) * pct / 100)
+            });
+        }
+    }
+
+    function lockBetUi(bet) {
+        _state.betPlaced = true;
+        var hint = el('hotseat-hint');
+        if (hint) {
+            hint.textContent = t('hotSeat.betPlaced', {
+                pct: bet.pct,
+                side: bet.side
+            });
+        }
+    }
+
     window.QuizifyPlayerHotSeat = {
+        restoreFromSnapshot: restoreFromSnapshot,
         handleAuctionYou: handleAuctionYou,
         handleBidCount: handleBidCount,
         handleAwarded: handleAwarded,
@@ -6115,6 +6195,19 @@
                 if (lightning) lightning.handleLightningRecap({ recap: msg.lightning_recap });
                 break;
 
+            case 'HOT_SEAT_AUCTION':
+            case 'HOT_SEAT':
+            case 'HOT_SEAT_REVEAL':
+                // #664: the detour is driven by one-shot events, so a reload
+                // used to fall through to the default case and land on the
+                // lobby with the auction still running. For the seat holder
+                // that was expensive: an unanswered question forfeits the
+                // stake (#653), and they could not answer what they could not
+                // see.
+                pu.showView('game-view');
+                if (hotSeat && msg.hot_seat) hotSeat.restoreFromSnapshot(msg.hot_seat);
+                break;
+
             case 'PAUSED':
                 pu.showView('paused-view');
                 updatePausedView(msg);
@@ -7138,6 +7231,8 @@
             case 'QUESTION_ACTIVE':
             case 'PLAYING':
             case 'LIGHTNING':
+            case 'HOT_SEAT_AUCTION':
+            case 'HOT_SEAT':
             case 'PAUSED':
                 return false;
             default:

--- a/tests/test_hot_seat_state_contract_664.py
+++ b/tests/test_hot_seat_state_contract_664.py
@@ -1,0 +1,218 @@
+"""The Hot Seat detour belongs in the state contract (#664).
+
+Everything about the detour (#616) was driven by one-shot events. Those are
+never re-sent, so a reload during the detour fell through to a snapshot that
+named a HOT_SEAT phase and carried no hot-seat data:
+
+* the television kept the previous round's reveal frozen on it for the whole
+  detour, sealed bids and all — the one moment the mode was built to put on
+  the big screen;
+* a phone that reloaded landed on the lobby, because the client's default
+  case is the join view;
+* and if that phone belonged to the seat holder, they could not return to the
+  question. On expiry ``settle()`` charges the stake as a loss (#653), so a
+  page reload cost them their entire bid.
+
+Lightning got this treatment in #221/#296. These tests pin the same three
+things for the Hot Seat, plus the two rules the block must not break: the
+question stays hidden while bidding is open, and the bids stay sealed until
+the auction closes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.quizify.game.phase_controller import GamePhase
+from custom_components.quizify.game.state import QuizifyGameState
+from custom_components.quizify.server.round_message_builder import (
+    RoundMessageBuilder,
+)
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+class _Runtime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    st = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="test")
+    for name in ("Anna", "Ben", "Mira"):
+        st.add_player(name, _ws())
+    st.start_game(category="picture-round-en", difficulty="easy",
+                  num_rounds=5, language="en")
+    for p in st.get_players():
+        p.score = 40
+    st.phase = GamePhase.ANSWER_REVEAL
+    assert st.start_hot_seat_auction()
+    return st
+
+
+def _snapshot(game: QuizifyGameState) -> dict:
+    return game.get_state_snapshot()
+
+
+def _for_player(game: QuizifyGameState, name: str) -> dict:
+    builder = RoundMessageBuilder()
+    return builder.project_snapshot_for_player(
+        game, snapshot=_snapshot(game), player=game.get_player(name)
+    )
+
+
+# ---------------------------------------------------------------------------
+# The block exists at all — the hole this issue is about
+# ---------------------------------------------------------------------------
+
+
+def test_auction_phase_carries_a_hot_seat_block(game: QuizifyGameState) -> None:
+    snap = _snapshot(game)
+    assert snap["phase"] == GamePhase.HOT_SEAT_AUCTION.value
+    assert snap["hot_seat"]["stage"] == "auction"
+    assert snap["hot_seat"]["time_remaining"] > 0
+
+
+def test_the_awarded_chair_reconnects_straight_into_the_question(
+    game: QuizifyGameState,
+) -> None:
+    """No separate "bids are landing" stage, and that is on purpose.
+
+    ``resolve_auction`` starts the answer clock as it awards the chair, so
+    the live flow's four-second bid reveal is already being charged to the
+    seat holder's window. A reconnect during it must land on the question,
+    not on a reveal the player is paying for.
+    """
+    game.hot_seat.record_bid("Anna", 50)
+    game.close_hot_seat_auction()
+    block = _snapshot(game)["hot_seat"]
+    assert block["stage"] == "question"
+    assert block["question"]["text"]
+
+
+def test_settled_detour_carries_its_summary(game: QuizifyGameState) -> None:
+    game.hot_seat.record_bid("Anna", 50)
+    game.close_hot_seat_auction()
+    game.finish_hot_seat()
+    block = _snapshot(game)["hot_seat"]
+    assert block["stage"] == "result"
+    assert block["summary"]
+
+
+# ---------------------------------------------------------------------------
+# What the block must NOT leak
+# ---------------------------------------------------------------------------
+
+
+def test_the_question_is_withheld_while_bidding_is_open(
+    game: QuizifyGameState,
+) -> None:
+    """Bidding is a bet on yourself, not on a question you have read."""
+    assert "question" not in _snapshot(game)["hot_seat"]
+
+
+def test_bids_stay_sealed_until_the_auction_closes(
+    game: QuizifyGameState,
+) -> None:
+    game.hot_seat.record_bid("Anna", 50)
+    game.hot_seat.record_bid("Ben", 20)
+    block = _snapshot(game)["hot_seat"]
+    assert block["bid_count"] == 2
+    assert "bids" not in block, "a reconnect must not be a way to read the auction"
+
+    game.close_hot_seat_auction()
+    assert len(_snapshot(game)["hot_seat"]["bids"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# The player projection
+# ---------------------------------------------------------------------------
+
+
+def test_each_player_gets_their_own_bank_and_not_the_others(
+    game: QuizifyGameState,
+) -> None:
+    game.get_player("Ben").score = 10
+    game.hot_seat.scores["Ben"] = 10
+    block = _for_player(game, "Ben")["hot_seat"]
+    assert block["own_bank"] == 10
+    assert "banks" not in block
+
+
+def test_a_reconnecting_bidder_sees_their_own_bid(game: QuizifyGameState) -> None:
+    game.hot_seat.record_bid("Anna", 50)
+    assert _for_player(game, "Anna")["hot_seat"]["you_bid"] == 50
+    assert _for_player(game, "Ben")["hot_seat"]["you_bid"] is None
+
+
+def test_the_seat_holder_gets_the_question_in_their_own_shuffle(
+    game: QuizifyGameState,
+) -> None:
+    game.hot_seat.record_bid("Anna", 50)
+    game.close_hot_seat_auction()
+    game.hot_seat.start_answer_clock()
+
+    block = _for_player(game, "Anna")["hot_seat"]
+    assert block["you_are_seated"] is True
+    assert block["question"]["answers"] == game.hot_seat.shuffled_answers()
+
+
+def test_spectators_get_the_question_text_but_no_answer_buttons(
+    game: QuizifyGameState,
+) -> None:
+    """They stake on the seat holder; they do not answer."""
+    game.hot_seat.record_bid("Anna", 50)
+    game.close_hot_seat_auction()
+    game.hot_seat.start_answer_clock()
+
+    block = _for_player(game, "Ben")["hot_seat"]
+    assert block["you_are_seated"] is False
+    assert block["question"]["text"]
+    assert "answers" not in block["question"]
+
+
+def test_the_canonical_snapshot_keeps_answers_for_the_television(
+    game: QuizifyGameState,
+) -> None:
+    game.hot_seat.record_bid("Anna", 50)
+    game.close_hot_seat_auction()
+    game.hot_seat.start_answer_clock()
+    q = _snapshot(game)["hot_seat"]["question"]
+    assert q["answers"] == [a.text for a in game.hot_seat.question.answers]
+
+
+# ---------------------------------------------------------------------------
+# The clients
+# ---------------------------------------------------------------------------
+
+
+_WWW = (
+    Path(__file__).resolve().parent.parent
+    / "custom_components" / "quizify" / "www"
+)
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["js/player-core.js", "dashboard.html"],
+    ids=["player", "television"],
+)
+def test_both_clients_handle_every_hot_seat_phase(path: str) -> None:
+    """The server may not name a phase no client can render.
+
+    A grep rather than a render: the point of #664 is that these three phase
+    names existed on the wire and in neither switch, and that absence is
+    exactly what a string search catches.
+    """
+    src = (_WWW / path).read_text(encoding="utf-8")
+    for phase in ("HOT_SEAT_AUCTION", "HOT_SEAT_REVEAL"):
+        assert phase in src, f"{path} has no case for {phase}"
+    assert "'HOT_SEAT'" in src, f"{path} has no case for HOT_SEAT"


### PR DESCRIPTION
The detour (#616) is driven entirely by one-shot events, and those are never re-sent. A snapshot that named a `HOT_SEAT` phase carried no hot-seat data at all, which produced three failures from one gap.

**The television.** `dashboard.html` contained zero occurrences of `hot_seat` while the server sends fifteen distinct `hot_seat_*` messages — one of which explicitly builds a `tv_payload` for dashboards. Neither switch had a `default:`, so for the whole detour the shared screen kept the previous round's reveal on it: old question, correct answer still highlighted, timer stopped. The sealed bids landing together on the big screen is the point of the mode; the code says so in the `HOT_SEAT_REVEAL_HOLD` comment.

**The reconnect.** `get_state_snapshot` had branches for `WAGER_ACTIVE`, `QUESTION_ACTIVE`, `ANSWER_REVEAL`, `FINALE`, `LIGHTNING` and `LIGHTNING_RECAP`, and none for the three Hot Seat phases. A reloading phone got a phase name with nothing behind it and fell through `player-core.js`'s `default:` onto the join view.

**The stake.** If that phone belonged to the seat holder they could not return to the question, and on expiry `settle()` charges the stake as a loss — the strict rule from #653, correct in itself. Combined, a page reload silently cost the winner their entire bid.

## What this adds

Lightning got exactly this in #221/#296: a snapshot block, a player projection, cases in both clients. The Hot Seat now has the same three.

The projection follows the same split the live broadcast already uses: the seat holder gets the answers **in their own shuffle**, spectators get the question text and **no answer buttons at all** (they stake on the seat holder, they do not answer), and each player gets their own bank rather than the whole table's.

Two rules the block must not break, both pinned by tests:

- the question stays **out of the snapshot while bidding is open** — bidding is meant to be a bet on yourself, not on a question you have already read
- the bids stay **sealed until the auction closes** — a reconnect must not become a way to read the room

## One design note worth reading

There is deliberately no separate "the bids are landing" stage. `resolve_auction` starts the answer clock **as it awards the chair**, so the live flow's four-second reveal hold is already being paid for out of the seat holder's 25-second window. Someone reconnecting during that hold is better served by the question than by a reveal they are being charged for.

That the hold eats the answer clock at all is a separate finding and is **not** changed here — the seat holder gets 21 seconds while the countdown says 25. Worth its own issue.

## The television side

Rendered into the existing question view rather than a view of its own, exactly as the betting window is. An auction line replacing the question text is all the detour needs to stop looking like a crash. **No new i18n keys** — the existing `hotSeat.*` strings cover every line, so the three bundles stay at 666 keys and the parity test is untouched.

## Verification

- full suite **2,236 passed** (2,224 on `main`)
- `player.bundle.js` rebuilt; `test_generated_artifacts_in_sync` green
- `node --check` on the two changed player modules and on the dashboard's inline script

Not verified on hardware: the LAN route to the Home Assistant went away again this evening, so nothing here has rendered on a real television. The TV half in particular deserves a look on the actual screen before this ships.

Closes #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVgwJ4Jb1HE3uvYjfD914M