### PR TITLE
Four small UI fixes: step numbering, TV lobby text sizes, German fallbacks, "Wagerunde"

### DIFF
--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -348,7 +348,7 @@
                         <label class="toggle-compact setup-lightning-toggle" for="hot-seat-enabled-toggle">
                             <input type="checkbox" id="hot-seat-enabled-toggle" checked>
                             <span class="toggle-switch-compact" aria-hidden="true"></span>
-                            <span class="toggle-label" data-i18n="setup.eigene.hotSeatHint">Der Stuhl wird versteigert, einer spielt allein</span>
+                            <span class="toggle-label" data-i18n="setup.eigene.hotSeatHint">The chair is auctioned, one player answers alone</span>
                         </label>
                     </div>
 
@@ -363,7 +363,7 @@
                          nested + dimmed/disabled under it. admin.js'
                          _syncTtsChildState toggles the .is-disabled state. -->
                     <div class="vF-step">
-                        <div class="vF-q"><span class="num">7</span><span data-i18n="setup.tts.title">Quizmaster voice?</span></div>
+                        <div class="vF-q"><span class="num">8</span><span data-i18n="setup.tts.title">Quizmaster voice?</span></div>
                         <label class="toggle-compact setup-tts-toggle setup-tts-master" for="tts-enable-toggle">
                             <input type="checkbox" id="tts-enable-toggle">
                             <span class="toggle-switch-compact" aria-hidden="true"></span>
@@ -448,7 +448,7 @@
                          booleans. Empty entity pickers ([] / "") mean "fall back
                          to the config-entry value". -->
                     <div class="vF-step">
-                        <div class="vF-q"><span class="num">8</span><span data-i18n="setup.house.title">Does the house play along?</span></div>
+                        <div class="vF-q"><span class="num">9</span><span data-i18n="setup.house.title">Does the house play along?</span></div>
                         <label class="toggle-compact setup-house-toggle setup-house-master" for="house-enable-toggle">
                             <input type="checkbox" id="house-enable-toggle">
                             <span class="toggle-switch-compact" aria-hidden="true"></span>

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -292,7 +292,12 @@
         .dashboard-loading-text,
         .dashboard-waiting-text {
             font-family: 'JetBrains Mono', ui-monospace, monospace;
-            font-size: 14px;
+            /* #667: 14px is a phone size. This is the primary instruction on
+               the lobby screen ("Scan to join the game"), read from a sofa.
+               Same clamp the couch-legibility pass (#376) gave the rest of
+               this screen; the join-URL fallback (#620) was already sized for
+               three metres and the caption above it was not. */
+            font-size: clamp(16px, 1.6vw, 22px);
             color: var(--dash-text-neon-muted);
             letter-spacing: 0.12em;
             text-transform: uppercase;
@@ -387,11 +392,15 @@
             border: 1px solid var(--dash-border-neon);
             border-radius: 9999px;
             font-family: 'JetBrains Mono', ui-monospace, monospace;
-            font-size: 12px;
+            /* #667: this chip carries a guest's name — the thing they look up
+               at the television to check after scanning. At 12px uppercase it
+               was roughly a third of what #376 deemed readable across a room.
+               The uppercase goes with it: capitals cost legibility at
+               distance and buy nothing here. */
+            font-size: clamp(15px, 1.4vw, 20px);
             color: var(--dash-text-white);
             font-weight: 500;
-            letter-spacing: 0.12em;
-            text-transform: uppercase;
+            letter-spacing: 0.08em;
         }
 
         /* ===================

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -491,7 +491,7 @@
     "chooseCategory": "Kategorie wählen"
   },
   "wager": {
-    "title": "Letzte Runde — Wagerunde",
+    "title": "Letzte Runde — Einsatzrunde",
     "hint": "Du siehst nur die Kategorie. Setze einen Teil deiner Punkte — richtig = gewinnen, falsch = verlieren.",
     "timeoutNote": "Der Einsatz zählt immer — auch wenn du nicht antwortest. Keine Antwort kostet dich den Einsatz genauso wie eine falsche.",
     "bank": "Punktestand",

--- a/custom_components/quizify/www/player.html
+++ b/custom_components/quizify/www/player.html
@@ -348,7 +348,7 @@
                 <section id="wager-panel" class="wager-panel hidden" aria-live="polite">
                     <h2 class="wager-panel-title">
                         <span class="qz-icon qz-icon--sky" data-ui-icon="sparkle" aria-hidden="true">🎰</span>
-                        <span id="wager-panel-title" data-i18n="wager.title">Wagerunde</span>
+                        <span id="wager-panel-title" data-i18n="wager.title">Final round — your stake</span>
                     </h2>
                     <p id="wager-panel-hint" class="wager-panel-hint"></p>
                     <p id="wager-panel-timeout-note" class="wager-panel-hint wager-panel-timeout-note"></p>
@@ -374,7 +374,7 @@
                 <section id="hotseat-panel" class="wager-panel hidden" aria-live="polite">
                     <h2 class="wager-panel-title">
                         <span class="qz-icon qz-icon--sky" data-ui-icon="sparkle" aria-hidden="true">🪑</span>
-                        <span id="hotseat-title" data-i18n="hotSeat.auctionTitle">Der Stuhl wird versteigert</span>
+                        <span id="hotseat-title" data-i18n="hotSeat.auctionTitle">The chair goes to the highest bid</span>
                     </h2>
                     <p id="hotseat-hint" class="wager-panel-hint"></p>
 
@@ -387,7 +387,7 @@
                             <output id="hotseat-value" class="wager-value" for="hotseat-slider">25%</output>
                         </div>
                         <p class="wager-bank-line">
-                            <span data-i18n="wager.bank">Punktestand</span>
+                            <span data-i18n="wager.bank">Current points</span>
                             <span id="hotseat-bank" class="wager-bank">0</span>
                         </p>
                         <button id="hotseat-bid-btn" type="button" class="btn btn-primary btn-block"

--- a/tests/test_small_ui_fixes_667.py
+++ b/tests/test_small_ui_fixes_667.py
@@ -1,0 +1,133 @@
+"""Four small UI fixes from the 2026-09-02 review (#667).
+
+Each is a couple of lines, and each is the kind of thing that survives
+because nothing asserts it. These tests do assert it.
+
+1. The custom-settings questionnaire numbered two different steps "7" — the
+   Hot Seat step (#616) was inserted without renumbering what followed.
+2. The TV lobby rendered a guest's name chip at 12px and "Scan to join the
+   game" at 14px, while the couch-legibility pass (#376) had moved
+   comparable text to a clamp. Those two are the first things a guest looks
+   up at after scanning.
+3. Newer features shipped German literals as the markup fallback on pages
+   that declare ``lang="en"``, so an English or Spanish party saw German
+   until the i18n bundle finished loading.
+4. "Wagerunde" is not a German word.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_WWW = (
+    Path(__file__).resolve().parent.parent
+    / "custom_components" / "quizify" / "www"
+)
+
+
+def _read(name: str) -> str:
+    return (_WWW / name).read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. One number per step
+# ---------------------------------------------------------------------------
+
+
+def test_the_custom_settings_steps_are_numbered_once_each() -> None:
+    nums = re.findall(r'<span class="num">(\d+)</span>', _read("admin.html"))
+    assert nums, "the questionnaire lost its numbers entirely"
+    assert len(nums) == len(set(nums)), f"duplicate step number in {nums}"
+    assert nums == sorted(nums, key=int), f"steps out of order: {nums}"
+
+
+# ---------------------------------------------------------------------------
+# 2. The television is read from a sofa
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "selector",
+    [".dashboard-player-chip", ".dashboard-waiting-text"],
+)
+def test_tv_lobby_text_is_sized_for_the_room(selector: str) -> None:
+    """No fixed pixel font on the two strings a guest looks up to check.
+
+    A clamp is what #376 settled on for this screen. The point is not the
+    exact number, it is that these two stopped being phone-sized.
+    """
+    src = _read("dashboard.html")
+    # Anchor on the rule, not on the first mention: the selector also appears
+    # inside a comment further up, and a test that reads a comment is a test
+    # that stops testing.
+    start = src.index(selector + " {")
+    block = src[start:src.index("}", start)]
+    fixed = re.search(r"font-size:\s*(\d+)px", block)
+    assert fixed is None, (
+        f"{selector} is back to a fixed {fixed.group(1)}px on a screen "
+        "nobody sits close to"
+    )
+    assert "clamp(" in block, f"{selector} has no responsive font-size"
+
+
+def test_the_name_chip_is_not_shouted() -> None:
+    """Capitals cost legibility at distance and buy nothing on a name."""
+    src = _read("dashboard.html")
+    start = src.index(".dashboard-player-chip {")
+    block = src[start:src.index("}", start)]
+    assert "text-transform: uppercase" not in block
+
+
+# ---------------------------------------------------------------------------
+# 3. The markup fallback matches the page's own lang
+# ---------------------------------------------------------------------------
+
+
+_GERMAN_GIVEAWAYS = (
+    "Der Stuhl",
+    "Wagerunde",
+    "Runde",
+    "Spieler",
+    "Punkte",
+    "Frage",
+)
+
+
+@pytest.mark.parametrize("page", ["player.html", "admin.html", "dashboard.html"])
+def test_markup_fallbacks_are_english_like_the_lang_attribute(page: str) -> None:
+    """The fallback is what shows until the bundle lands, and on a slow
+    instance that is a visible flash on every load."""
+    src = _read(page)
+    assert 'lang="en"' in src, f"{page} no longer declares English"
+    for element in re.findall(r"<[^>]*data-i18n=\"[^\"]+\"[^>]*>([^<]+)<", src):
+        text = element.strip()
+        for word in _GERMAN_GIVEAWAYS:
+            assert word not in text, (
+                f"{page}: German fallback {text!r} on a lang=\"en\" page"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 4. German that is actually German
+# ---------------------------------------------------------------------------
+
+
+def test_the_german_bundle_has_no_english_german_hybrid() -> None:
+    de = json.loads((_WWW / "i18n" / "de.json").read_text(encoding="utf-8"))
+
+    def walk(node, path=""):
+        if isinstance(node, dict):
+            for k, v in node.items():
+                yield from walk(v, f"{path}.{k}" if path else k)
+        elif isinstance(node, str):
+            yield path, node
+
+    for path, value in walk(de):
+        assert "Wagerunde" not in value, (
+            f"{path}: 'Wagerunde' is a hybrid of 'wager' and 'Runde'; "
+            "the German word is 'Einsatz' or 'Wette'"
+        )


### PR DESCRIPTION
The four small findings from today's review, each a couple of lines, each of the kind that survives because nothing asserts it. Now something does.

## 1. Two step 7s

The custom-settings questionnaire read 6, **7**, **7**, 8. The Hot Seat step (#616) was inserted with the number 7 and nothing after it was renumbered. The numbers are literals in the markup, so the test asserts they are unique and ascending rather than pinning particular values — the next insertion should fail loudly instead of quietly duplicating.

## 2. The television is read from a sofa

`.dashboard-player-chip` was 12px uppercase and `.dashboard-waiting-text` a fixed 14px. Those are the two strings a guest looks up at immediately after scanning: their own name in the roster, and "Scan to join the game" itself.

The couch-legibility pass (#376) had moved comparable text to `clamp(16px, 1.6vw, 24px)`, and #620 sized the join-URL fallback to read from three metres — the caption above it and the roster below it were not included. Both now clamp. The chip's uppercase goes with it: capitals cost legibility at distance and buy nothing on a name.

## 3. German fallbacks on `lang="en"` pages

`player.html` and `admin.html` shipped German literals as the markup fallback for newer features. That is what shows until the i18n bundle lands — a visible flash on every load on a slower instance, and permanent text if the fetch fails.

**The test found a fourth site the review had missed:** `player.html` uses `wager.bank` in two places, one with the English fallback and one with "Punktestand". Same key, same file, two different languages.

## 4. "Wagerunde"

A hybrid of "wager" and "Runde". Not a German word, and it stood out because the rest of the German bundle is consistent and consistently informal. Now "Einsatzrunde".

## A note on one of the tests

`test_tv_lobby_text_is_sized_for_the_room` anchors on `selector + " {"` rather than the first occurrence of the selector. The first mention is inside a comment, and the first draft of the test happily read that comment and failed. A test that reads a comment is a test that has stopped testing — which is exactly the failure mode #646 turned up in a source-slicing test.

## Verification

Full suite **2,256 passed**, mypy clean. Not verified on hardware: the font sizes are the sort of thing that wants a photograph of the actual television, and no Home Assistant was reachable while this was written.

Closes #667

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVgwJ4Jb1HE3uvYjfD914M