### PR TITLE
Keep the reveal chart out of the layout until it is revealed (#665)

### DIFF
--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -582,6 +582,11 @@
 
         .dashboard-answer {
             display: flex;
+            /* #665: the chart drops to its own line when the answer text needs
+               the first one. Wrapping is also what keeps the tile from forcing
+               its grid track wide: a wrapping flex container's min-content is
+               the widest single item, not the sum of all of them. */
+            flex-wrap: wrap;
             align-items: center;
             gap: clamp(14px, 1.6vw, 20px);
             padding: clamp(16px, 1.8vw, 24px) clamp(18px, 2vw, 28px);
@@ -594,6 +599,18 @@
             color: var(--dash-text-white);
             transition: border-color 120ms ease-out, background 120ms ease-out, box-shadow 320ms ease-out;
             min-height: 80px;
+        }
+
+        /* #665: the answer text takes essentially all of the tile's spare
+           width, and the chart takes the rest of its own line. The lopsided
+           grow factor is the whole mechanism, not a stray number: both items
+           can grow, so on a shared line the 100:1 split leaves the chart at
+           its `min-width` floor and gives the text everything else, while on a
+           wrapped line the chart is alone and fills it. Equal grow factors put
+           a 158 px bar next to a two-line answer at 1920x1080; no grow at all
+           leaves a 10 px stub of a bar on the wrapped line at 1280x720. */
+        .dashboard-answer .answer-text {
+            flex-grow: 100;
         }
 
         .dashboard-answer .answer-label {
@@ -640,23 +657,38 @@
             opacity: 0.45;
         }
 
-        /* Answer-distribution chart (issue #151) — hidden during question,
+        /* Answer-distribution chart (issue #151) — absent during the question,
            fades in + animates the bars at reveal time. TV viewing distance
-           means: thick bars, large percent text, no precision noise. The
-           bar is sized to claim ~30 % of the answer-row width so the
-           answer text still owns the card. */
+           means: thick bars, large percent text, no precision noise.
+
+           #665: `display: none` until `.revealed`, not `opacity: 0`. The bar
+           was sized to claim ~30 % of the answer *row* — true when the answers
+           were one full-width row, wrong since the grid became three columns
+           (`.dashboard-answers`). An invisible 140 px reservation in a ~170 px
+           tile is more than the tile holds: at 1280x720 the grid overflowed its
+           column by 330 px and every answer wrapped to two or three lines
+           beside an empty right half. Hidden means hidden — it must cost no
+           layout while nobody can see it.
+
+           The fade survives the display switch as an animation: a transition
+           cannot run across `display`, `animation` starts when the element
+           appears. `both` holds opacity 0 through the 320 ms delay, so the
+           chart still lands after the correct/wrong colour. */
         .dashboard-answer-distribution {
-            display: flex;
+            display: none;
             align-items: center;
             gap: clamp(10px, 1vw, 14px);
-            margin-left: auto;
-            opacity: 0;
-            transition: opacity 220ms ease-out 320ms;  /* fade in after correct/wrong colour lands */
-            min-width: clamp(140px, 22%, 280px);
+            min-width: clamp(80px, 30%, 200px);
             flex-shrink: 0;
         }
         .dashboard-answer.revealed .dashboard-answer-distribution {
-            opacity: 1;
+            display: flex;
+            flex: 1 1 auto;
+            animation: dashboard-distribution-in 220ms ease-out 320ms both;
+        }
+        @keyframes dashboard-distribution-in {
+            from { opacity: 0; }
+            to   { opacity: 1; }
         }
         .dashboard-answer-bar {
             flex: 1 1 auto;

--- a/tests/test_reveal_chart_layout_665.py
+++ b/tests/test_reveal_chart_layout_665.py
@@ -1,0 +1,116 @@
+"""#665 — the reveal chart must cost no layout while it is invisible.
+
+``dashboard.html`` keeps its CSS inline, so these are text-level guards (same
+shape as ``test_ux_dashboard_w3a.py`` and ``test_reveal_dim_666.py``).
+
+What went wrong: ``.dashboard-answer-distribution`` was ``opacity: 0`` but kept
+its box, and its box had ``min-width: clamp(140px, 22%, 280px)``. That number
+was chosen when the answers were one full-width row; the grid has been three
+columns for a long time. A 140px reservation inside a ~170px tile is more than
+the tile holds, and because grid items cannot shrink below their min-content,
+the whole answers grid overflowed its column — 330px past it at 1280x720, on
+top of the leaderboard — while every answer wrapped to two or three lines
+beside an empty right half.
+
+Measured on the fixed page, question phase: grid width equals grid scrollWidth
+at 1280x720 and 1920x1080, and a 1920x1080 answer went from 100px of text
+across two lines to 250px on one.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DASHBOARD = REPO / "custom_components" / "quizify" / "www" / "dashboard.html"
+
+
+def _css() -> str:
+    """The inline ``<style>`` blocks with CSS comments removed.
+
+    The comments carry commas and braces of their own, so a selector list read
+    straight off the file arrives with half a sentence glued to it.
+    """
+    html = DASHBOARD.read_text(encoding="utf-8")
+    blocks = re.findall(r"<style[^>]*>(.*?)</style>", html, re.DOTALL)
+    assert blocks, "dashboard.html is expected to carry its CSS inline"
+    return re.sub(r"/\*.*?\*/", "", "\n".join(blocks), flags=re.DOTALL)
+
+
+def _rules_for(css: str, selector: str) -> list[str]:
+    """Every declaration block whose selector list contains ``selector``."""
+    out = []
+    for match in re.finditer(r"([^{}]+)\{([^{}]*)\}", css):
+        if selector in [s.strip() for s in match.group(1).split(",")]:
+            out.append(match.group(2))
+    return out
+
+
+def _one(css: str, selector: str) -> str:
+    blocks = _rules_for(css, selector)
+    assert len(blocks) == 1, f"{selector}: expected one rule, found {len(blocks)}"
+    return blocks[0]
+
+
+def test_chart_is_out_of_layout_until_revealed() -> None:
+    """``display: none``, not ``opacity: 0`` — an invisible box still pushes."""
+    base = _one(_css(), ".dashboard-answer-distribution")
+    assert "display: none" in base
+    assert "opacity" not in base
+
+
+def test_chart_reappears_only_on_the_revealed_tile() -> None:
+    revealed = _one(_css(), ".dashboard-answer.revealed .dashboard-answer-distribution")
+    assert "display: flex" in revealed
+
+
+def test_the_fade_is_an_animation_because_a_transition_cannot_cross_display() -> None:
+    """A ``transition`` never runs across a ``display`` change, so the delayed
+    fade-in from #151 has to be a keyframe animation or it silently stops
+    happening — the chart would pop in at the same instant as the colour."""
+    css = _css()
+    revealed = _one(css, ".dashboard-answer.revealed .dashboard-answer-distribution")
+    assert "animation:" in revealed
+    assert "@keyframes dashboard-distribution-in" in css
+    # `both` holds opacity 0 through the delay; without it the chart is visible
+    # during the wait and the sequencing is gone.
+    assert "both" in revealed
+
+
+def test_reservation_floor_is_below_the_old_140px() -> None:
+    base = _one(_css(), ".dashboard-answer-distribution")
+    floor = re.search(r"min-width:\s*clamp\(\s*(\d+)px", base)
+    assert floor, base
+    assert int(floor.group(1)) < 140
+
+
+def test_tile_wraps_so_the_chart_can_take_its_own_line() -> None:
+    """Wrapping is load-bearing twice over: it gives the chart a second line on
+    a narrow tile, and it caps the tile's min-content at its widest single item
+    instead of the sum — which is what stops the grid from overflowing.
+
+    ``.dashboard-answer`` is declared twice (the base rule and the narrow-screen
+    media query), so this reads the base rule rather than asserting there is
+    only one.
+    """
+    base = _rules_for(_css(), ".dashboard-answer")[0]
+    assert "flex-wrap: wrap" in base
+
+
+def test_answer_text_outgrows_the_chart_on_a_shared_line() -> None:
+    """The lopsided grow factor is the mechanism, not a stray number.
+
+    Both items grow, so on a shared line 100:1 leaves the chart at its
+    ``min-width`` floor and hands the text everything else; on a wrapped line
+    the chart is alone and fills it. Equal factors put a 158px bar next to a
+    two-line answer at 1920x1080; no growth at all leaves a 10px stub of a bar
+    on the wrapped line at 1280x720.
+    """
+    css = _css()
+    grow = re.search(r"flex-grow:\s*(\d+)", _one(css, ".dashboard-answer .answer-text"))
+    assert grow, "the answer text needs an explicit grow factor"
+    revealed = _one(css, ".dashboard-answer.revealed .dashboard-answer-distribution")
+    chart = re.search(r"flex:\s*(\d+)", revealed)
+    assert chart, "the chart has to grow too, or a wrapped line leaves a stub"
+    assert int(grow.group(1)) > int(chart.group(1)) * 10

--- a/tests/test_reveal_dim_666.py
+++ b/tests/test_reveal_dim_666.py
@@ -88,11 +88,29 @@ def test_distribution_children_keep_full_contrast() -> None:
         assert "opacity" not in _rule(css, selector), selector
 
 
-def test_distribution_container_opacity_is_only_the_reveal_fade() -> None:
-    """``.dashboard-answer-distribution`` does start at ``opacity: 0`` — that is
-    the fade-in, and ``.revealed`` takes it back to 1. Both halves must stay,
-    or the chart never appears (or never hides)."""
+def _balanced(css: str, header: str) -> str:
+    """Body of an at-rule, read with a brace counter (it nests)."""
+    start = css.index(header)
+    start = css.index("{", start)
+    depth, j = 0, start
+    while True:
+        if css[j] == "{":
+            depth += 1
+        elif css[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return css[start + 1 : j]
+        j += 1
+
+
+def test_the_chart_ends_at_full_opacity_once_it_is_shown() -> None:
+    """#665 replaced the opacity fade with a keyframe animation, because a
+    transition cannot run across the `display` change it introduced. What this
+    issue cares about is unchanged: once the chart is on screen, nothing holds
+    it below full contrast."""
     css = _css()
-    assert "opacity: 0;" in _rule(css, ".dashboard-answer-distribution")
-    revealed = _rule(css, ".dashboard-answer.revealed .dashboard-answer-distribution")
-    assert "opacity: 1;" in revealed
+    frames = _balanced(css, "@keyframes dashboard-distribution-in")
+    assert re.search(r"to\s*\{[^}]*opacity:\s*1", frames), frames
+    # And the tile it sits in must not scale that back down again.
+    for block in _rules_for(css, ".dashboard-answer.wrong"):
+        assert "opacity" not in block


### PR DESCRIPTION
Closes #665.

## The measurement

The issue's arithmetic was right and the failure mode is worse than "no room for the text". `opacity: 0` hides a box without removing it, the box carried `min-width: clamp(140px, 22%, 280px)`, and a grid item cannot shrink below its min-content — so the answers grid pushed straight past its column.

At **1280x720**, question phase: grid `699px` wide, `1029px` of content. The third tile lay across the leaderboard column. Every answer wrapped to two or three lines next to an empty right half.

| | grid vs. content | answer text |
|---|---|---|
| 1280x720 | 699 vs **1029** → 699 vs 699 | 100px / 2–3 lines → **131px** |
| 1920x1080 | 1070 vs 1070 | 100px / 2–3 lines → **250px / 1 line** |

## The change

* `display: none` until `.revealed`. Hidden has to mean hidden.
* The fade becomes a keyframe animation. **A transition cannot run across a `display` change**, so leaving `transition: opacity` in place would have silently dropped the 320ms sequencing from #151 — the chart would pop in *with* the colour instead of after it. `both` holds it at 0 through the delay.
* `flex-wrap: wrap` on the tile plus a 100:1 grow split between the answer text and the chart.

The wrap is load-bearing twice over: it gives the chart its own line on a narrow tile, **and** it caps the tile's min-content at its widest single item rather than the sum — that is what actually stops the overflow. The lopsided grow factor keeps the chart at its `min-width` floor on a shared line and lets it fill a wrapped one; equal factors put a 158px bar next to a two-line answer at 1920x1080, and no growth at all left a 10px stub of a bar at 1280x720.

The floor drops to `clamp(80px, 30%, 200px)`, which the wrap makes affordable.

At reveal the grid stays inside its column at both resolutions: at 1280x720 the chart takes a second line inside the tile, at 1920x1080 it stays beside the answer.

## Tests

Six guards in `tests/test_reveal_chart_layout_665.py`. One test in `test_reveal_dim_666.py` asserted the old opacity mechanism and now checks the same property through the animation — #666's point was that nothing dims the chart, and that still holds.

Suite 2267 (was 2261), mypy clean, ruff clean.

## Noticed, and it is not free

At **1280x720** the left column cannot hold the question view at all: it is `justify-content: center` with no overflow handling, so the content spills *upward* and `#question-category` climbs under the timer bar. That predates this PR — `41.7px` of overlap on `main`, in both the question and the reveal state.

This change moves that number, and not only downward. Measured overlap at 1280x720:

| | main | this PR |
|---|---|---|
| question | 41.7px | **25.2px** |
| reveal | 41.7px | **75.9px** |

The reveal case gets worse: the wrapped charts add roughly 50px per tile row, and the column had no room to give. The trade is deliberate — horizontal overflow put a tile on top of the leaderboard and cut answers to a third of their width, vertical overflow pushes a 12px category label under a bar — but it is a trade, not a clean win, and the vertical half wants its own fix (`justify-content: safe center` on `.dashboard-left` is the one-line candidate, and it needs its own verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhzSvSTebnMqCZYap6eocW
