### PR TITLE
Put the correct tile's star in flow instead of over the chart (#678)

### DIFF
--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -632,17 +632,25 @@
         .dashboard-answer.correct {
             border-color: var(--dash-success);
             background: rgba(127, 168, 151, 0.10);
-            position: relative;
         }
 
+        /* #678: the star is a flex item, not an absolutely positioned corner.
+           Pinned at `right: 16px` it was painted on top of the distribution
+           percentage — 3px into it at 1920x1080, 10.5px at 1024x640, because
+           the star's offset is fixed while the tile's padding is a clamp. In
+           flow it cannot collide with anything, at any width.
+
+           `order: 1` puts it directly after the answer text and before the
+           chart, so it reads as "Konrad Adenauer ★" and stays on the text's
+           line when the chart wraps to its own (#665). As the last item it
+           would instead be stranded on a third line. */
         .dashboard-answer.correct::after {
             content: "★";
-            position: absolute;
-            right: 16px;
-            top: 50%;
-            transform: translateY(-50%);
+            order: 1;
             color: var(--dash-success);
             font-size: 16px;
+            line-height: 1;
+            flex-shrink: 0;
         }
 
         /* #666: dim the wrong answer's *text*, not the tile. Opacity
@@ -683,6 +691,7 @@
         }
         .dashboard-answer.revealed .dashboard-answer-distribution {
             display: flex;
+            order: 2;  /* #678: after the correct tile's star, never before it */
             flex: 1 1 auto;
             animation: dashboard-distribution-in 220ms ease-out 320ms both;
         }

--- a/tests/test_correct_star_in_flow_678.py
+++ b/tests/test_correct_star_in_flow_678.py
@@ -1,0 +1,69 @@
+"""#678 — the correct tile's star must not be painted over anything.
+
+It used to be pinned with `position: absolute; right: 16px`, which put it on
+top of the distribution percentage: measured 3.0px of overlap at 1920x1080,
+5.4px at 1280x720 and 10.5px at 1024x640. The overlap grew as the screen
+shrank, because the star's offset is a fixed 16px while the tile's padding is
+a clamp — two numbers moving at different rates towards each other.
+
+In flow it cannot collide with anything at any width. `order` places it right
+after the answer text and before the chart, so it reads as "Konrad Adenauer ★"
+and stays on the text's line when the chart wraps to its own (#665) instead of
+being stranded on a third line.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DASHBOARD = REPO / "custom_components" / "quizify" / "www" / "dashboard.html"
+
+
+def _css() -> str:
+    html = DASHBOARD.read_text(encoding="utf-8")
+    blocks = re.findall(r"<style[^>]*>(.*?)</style>", html, re.DOTALL)
+    assert blocks, "dashboard.html is expected to carry its CSS inline"
+    return re.sub(r"/\*.*?\*/", "", "\n".join(blocks), flags=re.DOTALL)
+
+
+def _rule(css: str, selector: str) -> str:
+    blocks = [
+        m.group(2)
+        for m in re.finditer(r"([^{}]+)\{([^{}]*)\}", css)
+        if selector in [s.strip() for s in m.group(1).split(",")]
+    ]
+    assert len(blocks) == 1, f"{selector}: expected one rule, found {len(blocks)}"
+    return blocks[0]
+
+
+def test_the_star_is_still_there() -> None:
+    """#521 made the reveal readable without relying on colour. The star is the
+    only non-colour marker on the correct tile, so it may move but not go."""
+    assert '"★"' in _rule(_css(), ".dashboard-answer.correct::after")
+
+
+def test_the_star_is_in_flow_not_pinned_to_the_corner() -> None:
+    star = _rule(_css(), ".dashboard-answer.correct::after")
+    for pinned in ("position:", "right:", "top:", "transform:"):
+        assert pinned not in star, f"{pinned} puts the star back over the chart"
+
+
+def test_the_tile_dropped_the_anchor_the_star_needed() -> None:
+    """`position: relative` on the tile existed only to anchor that star. Left
+    behind it reads as a constraint someone still depends on."""
+    assert "position: relative" not in _rule(_css(), ".dashboard-answer.correct")
+
+
+def test_the_star_comes_before_the_chart() -> None:
+    """Ordering is the difference between the star sharing the answer's line
+    and being stranded alone on a third one once the chart wraps."""
+    css = _css()
+    star = re.search(r"order:\s*(\d+)", _rule(css, ".dashboard-answer.correct::after"))
+    chart = re.search(
+        r"order:\s*(\d+)",
+        _rule(css, ".dashboard-answer.revealed .dashboard-answer-distribution"),
+    )
+    assert star and chart, "both need an explicit order or the source order wins"
+    assert int(star.group(1)) < int(chart.group(1))


### PR DESCRIPTION
Closes #678. **Stacked on #682** (the bar-floor regression) — base branch is `fix/reveal-bar-collapsed-679`, so merge that one first.

`position: absolute; right: 16px` put the star on top of the distribution percentage. The overlap grew as the screen shrank — 3.0px at 1920x1080, 5.4px at 1280x720, 10.5px at 1024x640 — because the star's offset is a fixed 16px while the tile's padding is a clamp. Two numbers moving at different rates towards each other, which is why no single screenshot describes the bug.

## The change

In flow it cannot collide with anything at any width. `order: 1` puts it right after the answer text and before the chart, so it reads as "Eisen ★" and stays on the text's line when the chart wraps to its own (#665); as the last item it would be stranded alone on a third line.

`position: relative` goes with it — it existed only to anchor this star, and a leftover anchor reads as a constraint something still depends on.

## Measured

Overlap of the star's box with the percentage's, in **both** axes — an x-only figure would have flattered the fix, because #665 changed which line each of them sits on:

| | horizontal | vertical | collides |
|---|---|---|---|
| before #665 (`18a6df9`), 1920x1080 | 3.0px | 24px | yes — this is the photographed `18%★` |
| before #665, 1280x720 | 5.4px | 24px | yes |
| current base, 1920x1080 | 3.0px | 2.0px | yes, grazing |
| current base, 1280x720 | 5.4px | 0.9px | yes, grazing |
| **this PR**, both | 0 | 0 | **no** |

Worth being precise about: #665 pushed the chart onto its own line, which pulled the two apart vertically from 24px of overlap down to 1–2px. The collision is still real at the current base, but it is a graze rather than the star sitting in the middle of the digits. Taking the star out of absolute positioning is what removes it at every width instead of at the two that happen to be measured.

Tile heights unchanged, no grid overflow at either resolution.

## Accepted, not hidden

The star costs real width now (16px plus the tile's gap), so on a narrow tile the correct answer's chart can wrap while its neighbours' stay on one line. Reserving the same width on every tile would even that out at a cost of 36px on all four. The correct tile being the odd one out is what the reveal is for.

## Tests

Four guards in `tests/test_correct_star_in_flow_678.py`, three failing before this change. One asserts the star still *exists*: #521 made the reveal readable without relying on colour, and this is the only non-colour marker the correct tile has — it may move, not go.

Suite 2273, mypy clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhzSvSTebnMqCZYap6eocW
