### PR TITLE
Make the question view fit a 720p television (#680)

### DIFF
--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -381,6 +381,57 @@
             .dashboard-h2h {
                 margin-top: 8px;
             }
+
+            /* #680: at 1280x720 the question view needs 799px of a 549.8px
+               column. The single biggest item is the answer grid, and three
+               columns are why: a ~221px tile cannot hold an answer and its
+               chart side by side, so both wrap and the row grows to 200.8px.
+               Two columns give each tile ~341px, the chart stays on the
+               answer's line, and the grid drops from 383.5px to about 246.
+
+               Two columns also suit four answers better than 3+1 does. The
+               type is deliberately left alone: #376 sized it for a room, and
+               shrinking it here would trade a legibility decision for
+               vertical space that this rule already finds elsewhere. */
+            #question-view .dashboard-answers {
+                grid-template-columns: 1fr 1fr;
+            }
+
+            /* Margins and padding, not sizes — no legibility is spent here.
+               The tiles carry the reveal's remaining 36.5px: their vertical
+               padding resolves to 23px at this width, and the reveal has two
+               rows of them. */
+            #question-view .dashboard-answer {
+                padding-top: 12px;
+                padding-bottom: 12px;
+            }
+
+            #question-view .dashboard-answers {
+                gap: 12px;
+            }
+
+            #question-view .dashboard-category {
+                margin-bottom: 8px;
+            }
+
+            #question-view .dashboard-question {
+                margin-bottom: 20px;
+            }
+
+            /* The fun fact is not merely tight at this height — it is
+               unreachable. Measured at 1280x720 on `main`, with the reveal
+               showing and `.visible` set, its top edge lands at 726.5px of a
+               720px viewport: entirely below the fold, before and after this
+               rule. All it does there is hold 83.6px of column and push the
+               last answer row towards the same fold.
+
+               So it stops holding the space at this height. That is not a fix
+               for the fun fact — a 720p room still never sees it, which is
+               #685 — but an answer that clips is worse than a fun fact that
+               was already gone. */
+            #question-view .dashboard-funfact {
+                display: none;
+            }
         }
 
         .dashboard-player-chip {
@@ -418,7 +469,20 @@
             flex: 6;
             display: flex;
             flex-direction: column;
+            /* #680: `safe` is the whole point. Plain `center` splits any
+               overflow across both ends, so content too tall for the column
+               climbs *upward* into the fixed header — at 1280x720 the category
+               label sat 93.9px behind the timer bar. `safe` falls back to
+               flex-start the moment it does not fit, so the overflow can only
+               go down, where it is at least still reading order.
+
+               Declared twice on purpose: a browser that does not know the
+               `safe` keyword drops the whole declaration, and the initial
+               value is `flex-start`, not `center` — so without the plain
+               `center` above it, an old renderer would top-align every
+               question instead of falling back to today's behaviour. */
             justify-content: center;
+            justify-content: safe center;  /* the fallback above is deliberate */
             min-width: 0;
         }
 

--- a/tests/test_question_column_720p_680.py
+++ b/tests/test_question_column_720p_680.py
@@ -1,0 +1,101 @@
+"""#680 — the question view must fit a 720p television.
+
+`.dashboard-left` centres its children with nowhere to put the excess. At
+1280x720 the question view needed 823.3px of a 549.8px column, and plain
+`center` splits an overflow across *both* ends — so the top of it climbed into
+the fixed header and the category label sat 106px behind the timer bar.
+
+Two halves to the fix, and they are not interchangeable:
+
+* `safe center` stops the upward climb. It is a floor, not a solution: it only
+  decides which end the overflow comes out of.
+* The short-screen block makes the content actually fit, so there is no
+  overflow to place. Measured after: 536.3px of a 549.8px column at reveal,
+  461.6px in the question phase, overlap 0 at both 1280x720 and 1920x1080.
+
+These are text-level guards; `dashboard.html` keeps its CSS inline.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DASHBOARD = REPO / "custom_components" / "quizify" / "www" / "dashboard.html"
+
+
+def _css() -> str:
+    html = DASHBOARD.read_text(encoding="utf-8")
+    blocks = re.findall(r"<style[^>]*>(.*?)</style>", html, re.DOTALL)
+    assert blocks, "dashboard.html is expected to carry its CSS inline"
+    return re.sub(r"/\*.*?\*/", "", "\n".join(blocks), flags=re.DOTALL)
+
+
+def _balanced(css: str, header: str) -> str:
+    start = css.index(header)
+    start = css.index("{", start)
+    depth, j = 0, start
+    while True:
+        if css[j] == "{":
+            depth += 1
+        elif css[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return css[start + 1 : j]
+        j += 1
+
+
+def _rule(css: str, selector: str) -> str:
+    blocks = [
+        m.group(2)
+        for m in re.finditer(r"([^{}]+)\{([^{}]*)\}", css)
+        if selector in [s.strip() for s in m.group(1).split(",")]
+    ]
+    assert blocks, f"{selector}: no rule found"
+    return blocks[0]
+
+
+def test_the_column_cannot_centre_content_into_the_header() -> None:
+    assert "justify-content: safe center" in _rule(_css(), ".dashboard-left")
+
+
+def test_the_safe_keyword_keeps_a_plain_center_beneath_it() -> None:
+    """A renderer that does not know `safe` drops the whole declaration, and
+    the initial value is `flex-start`, not `center`. Without the fallback an
+    old browser would top-align every question rather than behave as it does
+    today."""
+    column = _rule(_css(), ".dashboard-left")
+    plain = column.index("justify-content: center")
+    safe = column.index("justify-content: safe center")
+    assert plain < safe, "the fallback has to come first to be overridden"
+
+
+def test_short_screens_get_two_answer_columns() -> None:
+    """Three columns are why the grid was 383.5px tall: a ~221px tile cannot
+    hold an answer and its chart side by side, so both wrap. Two columns give
+    ~341px and the row collapses back."""
+    short = _balanced(_css(), "@media (max-height: 850px)")
+    grid = _rule(short, "#question-view .dashboard-answers")
+    assert "grid-template-columns: 1fr 1fr" in grid
+
+
+def test_short_screens_spend_spacing_not_type() -> None:
+    """#376 sized this type for a room. The height comes out of margins,
+    padding and gaps — if a font-size ever appears in here, that trade was
+    made silently."""
+    short = _balanced(_css(), "@media (max-height: 850px)")
+    question_view = "".join(
+        m.group(2)
+        for m in re.finditer(r"([^{}]+)\{([^{}]*)\}", short)
+        if "#question-view" in m.group(1)
+    )
+    assert "font-size" not in question_view, question_view
+
+
+def test_the_unreachable_fun_fact_stops_holding_the_column() -> None:
+    """At 1280x720 the fun fact's top edge measured 726.5px of a 720px
+    viewport — below the fold before this change and after it. All it did there
+    was push the last answer row towards the same fold."""
+    short = _balanced(_css(), "@media (max-height: 850px)")
+    assert "display: none" in _rule(short, "#question-view .dashboard-funfact")

--- a/tests/test_ux_tv_text_376.py
+++ b/tests/test_ux_tv_text_376.py
@@ -11,6 +11,7 @@ silently regress them back to a bare small px/rem.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
@@ -18,11 +19,27 @@ DASHBOARD = REPO / "custom_components" / "quizify" / "www" / "dashboard.html"
 
 
 def _rule(css: str, selector: str) -> str:
-    """Return the declaration block for the first rule matching ``selector``."""
-    idx = css.index(selector)
-    start = css.index("{", idx)
-    end = css.index("}", start)
-    return css[start + 1 : end]
+    """Declaration block of the first rule whose selector list *starts* with
+    ``selector``.
+
+    The anchor matters. A plain ``css.index(selector)`` matches the selector
+    anywhere, including as the tail of a more specific one: #680 added
+    ``#question-view .dashboard-funfact { display: none }`` inside a media
+    query that sits earlier in the file, and this helper happily returned that
+    block instead of the base rule — reporting that ``.dashboard-funfact`` had
+    lost the font-size it still has. The base rule is the one that carries the
+    #376 sizes, so the selector list has to match exactly — not start with
+    the name (that finds ``.dashboard-funfact.visible``) and not merely
+    contain it (that finds the media-query override). Comments go first for
+    the same reason: they carry no braces, so a selector list read raw arrives
+    with the paragraph above it attached.
+    """
+    css = re.sub(r"/\*.*?\*/", "", css, flags=re.DOTALL)
+    for match in re.finditer(r"(?:^|[{};])\s*([^{};]*?)\s*\{", css, re.MULTILINE):
+        if match.group(1).strip() == selector.rstrip(" {").strip():
+            start = css.index("{", match.end() - 1)
+            return css[start + 1 : css.index("}", start)]
+    raise AssertionError(f"no rule found for {selector}")
 
 
 # Selectors that must scale for TV couch legibility (#376).


### PR DESCRIPTION
Closes #680.

`.dashboard-left` centres its children and has nowhere to put the excess. At 1280x720 the question view needed **823.3px of a 549.8px column**, and plain `center` splits an overflow across *both* ends — so the top climbed into the fixed header and the category label sat 106px behind the timer bar.

## Two halves, not interchangeable

`justify-content: safe center` stops the upward climb. That is a floor, not a fix — it only decides which end the overflow comes out of. It sits under a plain `center` on purpose: a renderer that does not know the keyword drops the whole declaration, and the initial value is `flex-start`, so without the fallback an old browser would top-align every question rather than behave as it does today.

The `@media (max-height: 850px)` block then makes the content actually fit, so there is no overflow left to place:

* **Two answer columns instead of three.** This is where the height was: a ~221px tile cannot hold an answer and its chart side by side, so both wrap and the row grows to 200.8px. Two columns give ~341px each, the chart stays on the answer's line, and the grid falls from 383.5px to 246. Two columns also suit four answers better than 3+1.
* **Tile padding 23px → 12px and the grid gap to 12px**, carrying the reveal's remaining ~36px across its two rows.
* **Margins** on the category, the question and the fun fact.

**No font-size is touched.** #376 sized this type for a room 2–3m away, and the height was available in spacing. A test asserts that no `font-size` ever appears in this block, so that trade cannot be made quietly later.

## The fun fact

It stops holding its box at this height. It was not tight there, it was **unreachable**: measured on `main`, its top edge lands at 726.5px of a 720px viewport — entirely below the fold, before this change and after it. All it did was push the last answer row towards the same fold.

A 720p room still gets no fun fact. That is #685, filed with the measurements and three options; an answer that clips is worse than a fun fact that was already gone.

## Measured after — content vs. column

| | reveal | question |
|---|---|---|
| 1280x720 | 536.3 / 549.8 | 461.6 / 549.8 |
| 1920x1080 | 741.3 / 886 | 611 / 886 |

Overlap with the timer bar is 0 in all four, and nothing sits below the fold.

## A repaired existing test

`tests/test_ux_tv_text_376.py` took the first **substring** match for a selector, so the new `#question-view .dashboard-funfact` override — earlier in the file — came back in place of the base rule, and the test reported that `.dashboard-funfact` had lost a font-size it still has. It now strips comments and matches the selector list exactly. Same family of trap as #676 and #677; this time an existing test fell into it.

Suite 2278, mypy clean, ruff clean on `custom_components/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhzSvSTebnMqCZYap6eocW