### PR TITLE
Move the fun fact to the right column so a 720p room can see it (#685)

### DIFF
--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -418,19 +418,13 @@
                 margin-bottom: 20px;
             }
 
-            /* The fun fact is not merely tight at this height — it is
-               unreachable. Measured at 1280x720 on `main`, with the reveal
-               showing and `.visible` set, its top edge lands at 726.5px of a
-               720px viewport: entirely below the fold, before and after this
-               rule. All it does there is hold 83.6px of column and push the
-               last answer row towards the same fold.
-
-               So it stops holding the space at this height. That is not a fix
-               for the fun fact — a 720p room still never sees it, which is
-               #685 — but an answer that clips is worse than a fun fact that
-               was already gone. */
+            /* #680 hid this at short heights, because under the answers it
+               was unreachable anyway (top edge at 726.5px of a 720px
+               viewport) and only pushed the last answer row towards the fold.
+               #685 moved it to the right column, where it costs the answers
+               nothing — so it is shown again here, just tighter. */
             #question-view .dashboard-funfact {
-                display: none;
+                margin-top: 16px;
             }
         }
 
@@ -799,6 +793,11 @@
         /* Fun fact on reveal */
         .dashboard-funfact {
             margin-top: clamp(24px, 3vw, 36px);
+            /* #685: it shares the right column with a scrolling leaderboard.
+               Without this the flex layout would shrink the fact instead of
+               the list, which is the wrong way round — the list already knows
+               how to give. */
+            flex-shrink: 0;
             padding: 20px 24px;
             background: var(--dash-surface-dark);
             border: 1px solid var(--dash-border-neon);
@@ -1572,15 +1571,23 @@
                         <!-- Estimate reveal number line (#275). Shown only for
                              estimate rounds; hidden for MC. -->
                         <div id="dashboard-estimate" class="dashboard-estimate hidden"></div>
-                        <div id="fun-fact" class="dashboard-funfact">
-                            <div class="fun-fact-label" data-i18n="dashboard.didYouKnow">Did you know?</div>
-                            <div id="fun-fact-text" class="fun-fact-text"></div>
-                        </div>
                     </div>
                 </div>
                 <div class="dashboard-right">
                     <div class="dashboard-leaderboard-title" data-i18n="dashboard.leaderboard">Leaderboard</div>
                     <div id="leaderboard" class="dashboard-leaderboard"></div>
+                    <!-- #685: the fun fact lives here, not under the answers.
+                         Last in the left column it never fit a 720p screen —
+                         its top edge measured 726.5px of a 720px viewport, so
+                         a 720p room had never seen one. This column stands
+                         empty beside the question and has the height. The
+                         leaderboard above it already scrolls (`flex: 1;
+                         overflow-y: auto`), so it yields the space rather than
+                         the fact being pushed off again. -->
+                    <div id="fun-fact" class="dashboard-funfact">
+                        <div class="fun-fact-label" data-i18n="dashboard.didYouKnow">Did you know?</div>
+                        <div id="fun-fact-text" class="fun-fact-text"></div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/tests/test_funfact_right_column_685.py
+++ b/tests/test_funfact_right_column_685.py
@@ -1,0 +1,90 @@
+"""#685 — the fun fact has to live where there is room for it.
+
+Last in the left column it never fit a 720p television: measured with the
+reveal showing and `.visible` set, its top edge landed at 726.5px of a 720px
+viewport. A 720p room had never seen one. #680 stopped it from holding 83.6px
+of an overflowing column, which protected the answers but left it invisible.
+
+The right column stands empty beside the question and has the height. The
+leaderboard above it already scrolls (`flex: 1; overflow-y: auto`), so it is
+the thing that yields. Measured after the move at 1280x720: the fact spans
+565.4px to 681.6px — fully on screen — and the leaderboard gives up 132px and
+scrolls. The answer grid does not move (bottom stays 674.9px).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DASHBOARD = REPO / "custom_components" / "quizify" / "www" / "dashboard.html"
+
+
+def _html() -> str:
+    return DASHBOARD.read_text(encoding="utf-8")
+
+
+def _css() -> str:
+    blocks = re.findall(r"<style[^>]*>(.*?)</style>", _html(), re.DOTALL)
+    assert blocks, "dashboard.html is expected to carry its CSS inline"
+    return re.sub(r"/\*.*?\*/", "", "\n".join(blocks), flags=re.DOTALL)
+
+
+def _rule(css: str, selector: str) -> str:
+    blocks = [
+        m.group(2)
+        for m in re.finditer(r"([^{}]+)\{([^{}]*)\}", css)
+        if selector in [s.strip() for s in m.group(1).split(",")]
+    ]
+    assert blocks, f"{selector}: no rule found"
+    return blocks[0]
+
+
+def _question_view() -> str:
+    """The question view's markup, bounded by the next view's banner comment."""
+    html = _html()
+    start = html.index("<!-- QUESTION VIEW -->")
+    return html[start : html.index("<!-- FINALE VIEW -->", start)]
+
+
+def test_the_fun_fact_sits_in_the_right_column() -> None:
+    """Ordering is the assertion: it has to come after the leaderboard opens
+    and before the right column closes."""
+    view = _question_view()
+    right = view.index('class="dashboard-right"')
+    fact = view.index('id="fun-fact"')
+    body_end = view.index('id="dashboard-estimate"')
+    assert fact > right, "the fun fact is back under the answers"
+    assert fact > body_end
+
+
+def test_the_fun_fact_follows_the_leaderboard() -> None:
+    view = _question_view()
+    assert view.index('id="leaderboard"') < view.index('id="fun-fact"')
+
+
+def test_the_leaderboard_yields_the_space_not_the_fact() -> None:
+    """Both share a flex column. Without this the layout would shrink the fact
+    — the wrong one, since the list already knows how to scroll."""
+    assert "flex-shrink: 0" in _rule(_css(), ".dashboard-funfact")
+    assert "overflow-y: auto" in _rule(_css(), ".dashboard-leaderboard")
+
+
+def test_short_screens_show_it_again() -> None:
+    """#680 hid it at this height because under the answers it was unreachable
+    anyway. Out of that column there is no reason left to hide it."""
+    css = _css()
+    start = css.index("@media (max-height: 850px)")
+    start = css.index("{", start)
+    depth, j = 0, start
+    while True:
+        if css[j] == "{":
+            depth += 1
+        elif css[j] == "}":
+            depth -= 1
+            if depth == 0:
+                break
+        j += 1
+    short = css[start + 1 : j]
+    assert "display: none" not in _rule(short, "#question-view .dashboard-funfact")

--- a/tests/test_question_column_720p_680.py
+++ b/tests/test_question_column_720p_680.py
@@ -93,9 +93,21 @@ def test_short_screens_spend_spacing_not_type() -> None:
     assert "font-size" not in question_view, question_view
 
 
-def test_the_unreachable_fun_fact_stops_holding_the_column() -> None:
+def test_the_fun_fact_does_not_weigh_on_this_column_at_all() -> None:
     """At 1280x720 the fun fact's top edge measured 726.5px of a 720px
-    viewport — below the fold before this change and after it. All it did there
-    was push the last answer row towards the same fold."""
-    short = _balanced(_css(), "@media (max-height: 850px)")
-    assert "display: none" in _rule(short, "#question-view .dashboard-funfact")
+    viewport — below the fold before this change and after it — while still
+    holding 83.6px of column and pushing the last answer row towards the same
+    fold. This issue took the space back by hiding it; #685 then moved it to
+    the right column, which removes the cause instead of the symptom.
+
+    Either way the property that matters here is the same: nothing that the
+    left column cannot show may take height from the answers.
+    """
+    html = DASHBOARD.read_text(encoding="utf-8")
+    start = html.index("<!-- QUESTION VIEW -->")
+    view = html[start : html.index("<!-- FINALE VIEW -->", start)]
+    left = view.index('id="dashboard-left"')
+    right = view.index('class="dashboard-right"')
+    fact = view.index('id="fun-fact"')
+    assert left < right, "the left column is expected to come first"
+    assert fact > right, "the fun fact is back inside the column that overflows"


### PR DESCRIPTION
Closes #685.

Last in the left column the fun fact never fit a 720p television. Measured with the reveal showing and `.visible` set, its top edge landed at **726.5px of a 720px viewport** — entirely below the fold. A 720p room had never seen one.

#680 stopped it from holding 83.6px of an already-overflowing column, which protected the answers but left the fact invisible. This removes the cause instead: the right column stands empty beside the question and has the height.

## Who yields

The leaderboard above it is `flex: 1; overflow-y: auto`, so it is the thing that gives. The fact gets `flex-shrink: 0` so the flex layout shrinks the *list* rather than the paragraph — the list already knows how to scroll, the paragraph does not.

## Measured at 1280x720, reveal

| | before | after |
|---|---|---|
| fun fact | no box at all (`display: none`) | **565.4 → 681.6px, fully on screen** |
| leaderboard | 506.3px | 374.1px, scrolling 497px of rows |
| answer grid bottom | 674.9px | 674.9px — unmoved |
| category/timer overlap | 0 | 0 |

At 1920x1080 the fact is fully visible and the leaderboard is not even constrained (690.3px for 690px of rows).

The short-screen `display: none` from #680 becomes a smaller `margin-top`: it existed because the fact was unreachable *under the answers*, and out of that column the reason is gone.

**No JS change** — the element keeps its ids, and `els.funFact` / `els.funFactText` are looked up by id.

## Tests

Four guards in `tests/test_funfact_right_column_685.py`, three failing on `main`.

One #680 test asserted that `display: none`, which this reverses. Rewritten to the property that issue actually cares about — nothing the left column cannot show may take height from the answers — which the move satisfies more directly than hiding did.

Suite 2282, mypy clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AhzSvSTebnMqCZYap6eocW