### PR TITLE
fix(tv): a long question hid the answers on a 720p television

### DIFF
--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -389,12 +389,23 @@
                Two columns give each tile ~341px, the chart stays on the
                answer's line, and the grid drops from 383.5px to about 246.
 
-               Two columns also suit four answers better than 3+1 does. The
-               type is deliberately left alone: #376 sized it for a room, and
-               shrinking it here would trade a legibility decision for
-               vertical space that this rule already finds elsewhere. */
+               Two columns also suit four answers better than 3+1 does.
+
+               Played on a real 720p television on 03.09.2026: two columns are
+               a step in the right direction that stops one short. A 343px tile
+               still wraps a long answer onto three lines and puts the chart
+               under it — 241.7px per tile, measured live. One column gives the
+               tile the full 699px, the answer sits on two lines, the chart
+               stays on the second, and the tile drops to 125px. Measured
+               against the heaviest question the library actually ships
+               (108 characters, 325 characters of answers, longest 121):
+               519.5px of 573px available, nothing below the fold.
+
+               The four-answer argument above does not apply to this library:
+               all 4.545 multiple-choice questions carry exactly three
+               answers. */
             #question-view .dashboard-answers {
-                grid-template-columns: 1fr 1fr;
+                grid-template-columns: 1fr;
             }
 
             /* Margins and padding, not sizes — no legibility is spent here.
@@ -414,8 +425,27 @@
                 margin-bottom: 8px;
             }
 
+            /* Played on a 720p television on 03.09.2026, and the two rules
+               above were not enough. A 150-character question rendered 6.5
+               lines at 53.8px; the body came to 837.3px of 579.9px available
+               and put 20 elements below the fold — the third answer tile
+               entirely off-screen, percentages included. The same view with a
+               102-character question measures 473.6px and fits, which is why
+               #686 passed: it was measured against one question, not against
+               the longest one. The library runs to 173 characters, p99 137.
+
+               The cause is a mismatch of axes: the type is sized by *width*
+               (4.2vw), and width is the one thing a 1280x720 television has
+               enough of. On a short screen it is sized by the budget that is
+               actually scarce. #376's sizes stay untouched at 1080p and above,
+               and the floor here is 28px — below that the room stops reading
+               it, and clipping the answers would be the better trade. */
             #question-view .dashboard-question {
-                margin-bottom: 20px;
+                font-size: clamp(28px, 4.4vh, 44px);
+                /* 24ch of a smaller type hands the saved lines straight back:
+                   the column is 699px wide, so let the type use it. */
+                max-width: none;
+                margin-bottom: 16px;
             }
 
             /* #680 hid this at short heights, because under the answers it

--- a/tests/test_question_column_720p_680.py
+++ b/tests/test_question_column_720p_680.py
@@ -71,26 +71,64 @@ def test_the_safe_keyword_keeps_a_plain_center_beneath_it() -> None:
     assert plain < safe, "the fallback has to come first to be overridden"
 
 
-def test_short_screens_get_two_answer_columns() -> None:
+def test_short_screens_get_one_answer_column() -> None:
     """Three columns are why the grid was 383.5px tall: a ~221px tile cannot
-    hold an answer and its chart side by side, so both wrap. Two columns give
-    ~341px and the row collapses back."""
+    hold an answer and its chart side by side, so both wrap.
+
+    Two columns (this issue's first answer) were a step in the right direction
+    that stopped one short — measured live on a 720p television, a 343px tile
+    still wrapped a long answer onto three lines and pushed the chart under it,
+    241.7px per tile. One column gives the tile the whole 699px column and it
+    drops to 125px. The four-answer argument for two columns does not apply
+    here: every multiple-choice question in the library carries exactly three
+    answers."""
     short = _balanced(_css(), "@media (max-height: 850px)")
     grid = _rule(short, "#question-view .dashboard-answers")
-    assert "grid-template-columns: 1fr 1fr" in grid
+    cols = [ln for ln in grid.splitlines() if "grid-template-columns" in ln]
+    assert cols, grid
+    assert "1fr 1fr" not in cols[0], "two columns still wrap a long answer"
+    assert "1fr" in cols[0]
 
 
-def test_short_screens_spend_spacing_not_type() -> None:
-    """#376 sized this type for a room. The height comes out of margins,
-    padding and gaps — if a font-size ever appears in here, that trade was
-    made silently."""
-    short = _balanced(_css(), "@media (max-height: 850px)")
-    question_view = "".join(
-        m.group(2)
+def test_the_question_is_sized_by_the_budget_that_is_scarce() -> None:
+    """The trade this file used to forbid, now made openly.
+
+    The old rule was "spacing, not type", so that shrinking #376's sizes could
+    never happen by accident. Playing the game on a 720p television showed what
+    it cost: a 150-character question rendered 6.5 lines at 53.8px, the body
+    came to 837.3px of 579.9px, and the third answer tile was off the screen
+    entirely. Type that cannot be read because it is not on the screen is the
+    worse end of that trade.
+
+    The cause is a mismatch of axes — `4.2vw` sizes the question by *width*,
+    and width is the one thing a 1280x720 television has enough of. So on short
+    screens it is sized by height instead. What still may not happen silently:
+
+    * only inside the short-screen block (1080p keeps #376 exactly),
+    * only the question — the answers keep their size,
+    * and with a floor, so it can never scale to nothing.
+    """
+    css = _css()
+    short = _balanced(css, "@media (max-height: 850px)")
+    rules = {
+        sel.strip(): m.group(2)
         for m in re.finditer(r"([^{}]+)\{([^{}]*)\}", short)
-        if "#question-view" in m.group(1)
-    )
-    assert "font-size" not in question_view, question_view
+        for sel in m.group(1).split(",")
+    }
+
+    question = rules.get("#question-view .dashboard-question", "")
+    assert "vh" in question, "the question has to be sized by the scarce axis"
+    floor = re.search(r"font-size:\s*clamp\(\s*(\d+)px", question)
+    assert floor and int(floor.group(1)) >= 24, question
+
+    for selector, body in rules.items():
+        if selector.startswith("#question-view") and "font-size" in body:
+            assert selector.endswith(".dashboard-question"), (
+                f"{selector} spends type as well — only the question may"
+            )
+
+    base = _rule(css, ".dashboard-question")
+    assert "clamp(32px, 4.2vw, 56px)" in base, "#376's room-sized type stays"
 
 
 def test_the_fun_fact_does_not_weigh_on_this_column_at_all() -> None:
@@ -111,3 +149,27 @@ def test_the_fun_fact_does_not_weigh_on_this_column_at_all() -> None:
     fact = view.index('id="fun-fact"')
     assert left < right, "the left column is expected to come first"
     assert fact > right, "the fun fact is back inside the column that overflows"
+
+
+def test_the_one_column_rule_still_matches_what_the_library_ships() -> None:
+    """The single column was measured against three answers, because that is
+    all this library has: 4.545 multiple-choice questions, every one of them
+    with exactly three. Four long answers do not fit one column at 720p — they
+    do not fit two either, and they do not exist. If a pack ever ships four,
+    the measurement behind the rule above is void and wants redoing rather than
+    trusting."""
+    import json
+
+    questions = REPO / "custom_components" / "quizify" / "questions"
+    counts: set[int] = set()
+    for path in sorted(questions.glob("*.json")):
+        if path.name == "versions.json":
+            continue
+        data = json.loads(path.read_text(encoding="utf-8"))
+        items = data.get("questions") if isinstance(data, dict) else data
+        for item in items or []:
+            answers = item.get("answers") or item.get("options") or []
+            if isinstance(answers, list) and answers:
+                counts.add(len(answers))
+
+    assert counts == {3}, f"answer counts other than three shipped: {sorted(counts)}"


### PR DESCRIPTION
Closes #688.

Found by **playing the game on a real Home Assistant**, not by reading the code — the first live run of this view since the fixes it builds on. Round 1 served a 150-character question and the answers were not on the screen.

## The measurement that started it

At 1280x720 the question body came to **837.3px of the 579.9px** the column has: 20 elements below the fold, the third answer tile and all three percentages outside the picture.

#686 is not wrong, it was measured against **one** question. The same view with a 102-character question comes to 473.6px and fits — that is the 461.6px it recorded. The library ships questions up to 173 characters.

| round | question | tile height | body | below the fold |
|---|---|---|---|---|
| 1 | 150 chars | 241.7px | 837.3px | 20 |
| 2 | 102 chars | 92px | 473.6px | 0 |

## Two rules, both inside the existing short-screen block

**The question is sized by height.** `4.2vw` sizes it by *width*, and width is the one thing a 1280x720 television has enough of; height is what is scarce. On short screens it becomes `clamp(28px, 4.4vh, 44px)` with `max-width: none` — 24ch of a smaller type hands the saved lines straight back, and the column is 699px wide. 1080p keeps #376's sizes exactly.

**One answer column instead of two.** Two columns were a step in the right direction that stopped one short: a 343px tile still wraps a long answer onto three lines and puts the chart underneath — 241.7px per tile, measured live. The full 699px drops the tile to 125px and the chart stays on the answer's line, which is the mechanism #665 built.

**Neither half is enough alone.** One column alone leaves 7 elements below the fold at 720p; the type alone leaves 4.

## Measured after, live on the same television

Worst case the library actually ships (108-character question, 325 characters of answers, longest 121):

| | 1280x720 | 1366x768 | 1920x1080 |
|---|---|---|---|
| body / available | **519.5 / 573** | 526.5 / 598.9 | 670.4 / 826.2 |
| below the fold | 0 | 0 | 0 |

The longest question in the library (173 characters) lands at 554.4px of 588.2px. 1080p is unchanged in every case.

## Tests

The test that forbade a `font-size` in this block is **replaced, not deleted**. Its point was that the trade must never happen silently, so the new test states the trade and bounds it: only inside the short-screen block, only the question (the answers keep their size), with a floor of at least 24px, and #376's base `clamp(32px, 4.2vw, 56px)` asserted untouched.

A second test pins the assumption the single column was measured against: every multiple-choice question in the library carries **exactly three** answers (4.545 of them). Four long answers fit neither one column nor two at 720p — and they do not exist. If a pack ever ships four, that test fails and the measurement wants redoing rather than trusting.

Suite **2283**, mypy clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWNXT3dAydB5NjLmeTnJip