### PR TITLE
docs: the README undersold the library it ships

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ Quizify ships with **4,740 questions across 36 themed packs in 12 themes**, in G
 | 🎯 **Schätzfragen / Estimation / Estimación** | 15 | 15 | 15 |
 | 🖼️ **Bilderrätsel / Picture Round / Ronda de Imágenes** | 17 | 17 | 17 |
 
-Spanish arrived in 1.3.0 and reached every written theme in 1.9.0; the World Cup and Estimation packs are the two it is still missing. The two Estimation packs hold slider questions rather than multiple choice — see [How to Play](#the-experience); every themed pack now carries five slider questions of its own (#566) on top of its written ones.
+Spanish arrived in 1.3.0, reached every written theme in 1.9.0 and was completed in 1.10.0 — every row in the table above ships in all three languages, World Cup, Estimation and Picture Round included. The Estimation packs hold slider questions rather than multiple choice — see [How to Play](#the-experience); every themed pack now carries five slider questions of its own (#566) on top of its written ones.
 
 Pack selection lives on the **first screen**: a featured pack card (e.g. World Cup) up top, with every other pack as a tappable chip right beneath it — tap to select or deselect, mix several, then hit **Start Game**. Game settings (difficulty, rounds, timer) stay one tap away under **Adjust settings**. **Mixed mode** drops you a random question from every selected pack, so you can stir Geography + Pop + Sport together for chaos mode.
 
@@ -385,10 +385,11 @@ Quizify speaks your guests' language.
 
 - **🇩🇪 Deutsch** — Vollständige Unterstützung
 - **🇬🇧 English** — Full support
+- **🇪🇸 Español** — Compatibilidad completa
 
-The UI follows the game language (since v1.1.24) — pick German in the pack-picker and the entire admin / player / dashboard surface switches to German labels, tooltips, error messages, fun-fact labels, and end-game awards. Switch to English and the whole thing flips.
+The UI follows the game language (since v1.1.24) — pick German in the pack-picker and the entire admin / player / dashboard surface switches to German labels, tooltips, error messages, fun-fact labels, and end-game awards. Switch to English or Spanish and the whole thing flips.
 
-390 i18n keys, full parity between locales, validated in CI.
+666 i18n keys, full parity between all three locales, validated in CI.
 
 ---
 

--- a/tests/test_docs_pack_counts.py
+++ b/tests/test_docs_pack_counts.py
@@ -79,3 +79,61 @@ def test_readme_names_every_shipped_theme() -> None:
             f"Theme {theme!r} ships but is missing from the README's list of "
             "valid `theme` values, so a pack author cannot discover it."
         )
+
+
+def test_readme_quotes_the_real_i18n_key_count() -> None:
+    """The README said "390 i18n keys" while the bundles carried 666.
+
+    Nothing failed when keys were added, because the existing tests here count
+    packs and questions. The number is quoted to readers who are deciding
+    whether the integration speaks their language, so it is worth a guard of
+    its own.
+    """
+    i18n = REPO / "custom_components" / "quizify" / "www" / "i18n"
+
+    def leaves(node: object) -> int:
+        if isinstance(node, dict):
+            return sum(leaves(v) for v in node.values())
+        return 1
+
+    counts = {
+        path.stem: leaves(json.loads(path.read_text(encoding="utf-8")))
+        for path in sorted(i18n.glob("*.json"))
+    }
+    assert counts, "no i18n bundles found"
+    assert len(set(counts.values())) == 1, f"bundles are out of parity: {counts}"
+
+    keys = next(iter(counts.values()))
+    readme = README.read_text(encoding="utf-8")
+    assert f"{keys} i18n keys" in readme, (
+        f"README does not quote the real i18n key count ({keys}); "
+        f"bundles: {counts}"
+    )
+
+
+def test_readme_does_not_claim_a_gap_that_has_been_closed() -> None:
+    """Until 1.10.0 the README could truthfully say Spanish was missing two
+    packs. It shipped them and the sentence stayed, so the store text told
+    every reader the library was incomplete for two weeks.
+
+    The mechanical form of that claim: if every shipped language covers the
+    same themes, no language is missing anything, and the README may not say
+    otherwise.
+    """
+    by_language: dict[str, set[str]] = {}
+    for pack in _shipped_packs():
+        language = pack.get("language")
+        theme = pack.get("theme")
+        if language and theme:
+            by_language.setdefault(language, set()).add(theme)
+
+    assert by_language, "no themed packs found"
+    if len({frozenset(themes) for themes in by_language.values()}) != 1:
+        return  # a real gap exists; the README is allowed to describe it
+
+    readme = README.read_text(encoding="utf-8").lower()
+    for claim in ("is still missing", "are still missing", "still missing"):
+        assert claim not in readme, (
+            f"every language now covers the same themes, but the README still "
+            f"says {claim!r}"
+        )


### PR DESCRIPTION
Three claims in the store text had gone stale, all in the same direction — describing a smaller product than the one being distributed.

| Claim | Reality |
|---|---|
| "the World Cup and Estimation packs are the two it is still missing" | `copa-mundial-es` (111) and `estimacion-es` (15) shipped in 1.10.0 — **and the table directly above the sentence already listed them** |
| "390 i18n keys" | 666, in all three locales |
| Multi-Language list: German, English | Spanish has been a first-class UI language since 1.5.0 |

This is the README that HACS shows in the store and that search engines index. In the last 14 days Google (+3 uniques), chatgpt.com (+3), Bing (+1) and DuckDuckGo (+1) all appeared as referrers for the first time — the text is being read by people deciding whether to install.

## Two guards, because none of these is a count

The tests in this file recompute pack and question counts, which is exactly why these three slipped past them.

* **The i18n key count** is recomputed from the bundles and must appear in the README, with a parity check across locales on the way.
* **The "still missing" claim** gets its mechanical form: if every shipped language covers the same themes, then no language is missing anything and the README may not say otherwise. The test steps aside when a real gap exists, so it never blocks an honest sentence.

Both fail against the previous README and pass against this one — checked by stashing the README alone, not by assuming it.

Suite **2285**, ruff clean. Docs and tests only, no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWNXT3dAydB5NjLmeTnJip