### PR TITLE
fix(tv): the end screen hid the leaderboard and the duel on a 720p television

### DIFF
--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -1164,6 +1164,29 @@
             overflow: hidden;
         }
 
+        /* #692: on a 720p television the right column ran 9 elements past the
+           bottom edge — the leaderboard rows and the head-to-head line, which
+           is the whole headline of v1.12.0, were simply not in the picture.
+           Measured: the two award cards came to 337.1px of a 517.8px column,
+           and the leaderboard began at 624px.
+
+           The awards lose their detail line here, and nothing else changes.
+           That line is the footnote ("25 pts in round 6") under a heading that
+           already carries the point ("TOP SCORE · ANNA"), so it is the one
+           thing on this screen that can go without taking a fact with it.
+
+           Capping the awards box instead was measured and rejected: it clips a
+           card halfway, which is the same defect this issue is about, one box
+           further in. Dropping a whole line beats cutting one.
+
+           After: awards 171.9px, every leaderboard row in the picture, nothing
+           below the fold at 1280x720 or 1366x768. 1080p keeps the detail. */
+        @media (max-height: 850px) {
+            .dashboard-finale--split .award-detail {
+                display: none;
+            }
+        }
+
         .dashboard-finale::before {
             /* Single spotlight from above — replaces confetti */
             content: "";

--- a/tests/test_finale_720p_692.py
+++ b/tests/test_finale_720p_692.py
@@ -1,0 +1,87 @@
+"""#692 — the end screen has to fit a 720p television.
+
+Played on a real one: the right column ran nine elements past the bottom edge.
+What a 720p room saw at the end of a game was the podium and two award cards —
+the leaderboard rows and the head-to-head line, the headline of v1.12.0, were
+not in the picture at all.
+
+Nothing here was too tall on its own. The column simply stacked more than the
+screen has room for: two award cards came to 337.1px of a 517.8px column, and
+the leaderboard began at 624px of 720. So this is a content decision, not a
+sizing one, and the decision is recorded in the CSS comment: the awards lose
+their *detail* line on short screens and keep everything else.
+
+That line is the footnote ("25 pts in round 6") under a heading that already
+carries the point ("TOP SCORE · ANNA"). Capping the awards box was measured
+and rejected — it clips a card halfway, which is the same defect one box
+further in. Dropping a whole line beats cutting one.
+
+Measured after, on the television: awards 171.9px, every leaderboard row in
+the picture, the head-to-head line at 608.7–665.6px, nothing below the fold at
+1280x720 or 1366x768. 1080p keeps the detail line.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DASHBOARD = REPO / "custom_components" / "quizify" / "www" / "dashboard.html"
+
+
+def _css() -> str:
+    html = DASHBOARD.read_text(encoding="utf-8")
+    blocks = re.findall(r"<style[^>]*>(.*?)</style>", html, re.DOTALL)
+    assert blocks, "dashboard.html is expected to carry its CSS inline"
+    return re.sub(r"/\*.*?\*/", "", "\n".join(blocks), flags=re.DOTALL)
+
+
+def _short_screen_blocks(css: str) -> list[str]:
+    """Every `@media (max-height: 850px)` block in the file, not just the first."""
+    out = []
+    for match in re.finditer(r"@media \(max-height: 850px\)", css):
+        start = css.index("{", match.start())
+        depth, j = 0, start
+        while True:
+            if css[j] == "{":
+                depth += 1
+            elif css[j] == "}":
+                depth -= 1
+                if depth == 0:
+                    out.append(css[start + 1 : j])
+                    break
+            j += 1
+    return out
+
+
+def test_short_screens_drop_the_award_footnote_and_nothing_else() -> None:
+    short = "\n".join(_short_screen_blocks(_css()))
+    rule = re.search(
+        r"\.dashboard-finale--split \.award-detail\s*\{([^}]*)\}", short
+    )
+    assert rule, "the end screen has no short-screen rule for the award detail"
+    assert "display: none" in rule.group(1), rule.group(1)
+
+
+def test_the_award_footnote_survives_on_a_1080p_television() -> None:
+    """The trade is bought for short screens only. On 1080p the detail is the
+    reason the award is interesting, and there is room for it."""
+    css = _css()
+    outside = css
+    for block in _short_screen_blocks(css):
+        outside = outside.replace(block, "")
+    hidden = re.search(r"\.award-detail\s*\{[^}]*display:\s*none", outside)
+    assert not hidden, (
+        "the award detail is hidden everywhere, not only on short screens"
+    )
+
+
+def test_the_head_to_head_line_is_the_last_block_in_the_column() -> None:
+    """It is the newest block and the one furthest from the fold, so it is the
+    first thing an overflow eats. Keeping it last is what makes the leaderboard
+    — which knows how to give way — the block that shrinks instead."""
+    html = DASHBOARD.read_text(encoding="utf-8")
+    start = html.index('<div class="dashboard-finale-right">')
+    right = html[start : html.index("</div>", html.index('id="end-h2h"'))]
+    assert right.index('class="finale-leaderboard-card"') < right.index('id="end-h2h"')


### PR DESCRIPTION
Closes #692. Sibling of [#693](https://github.com/mholzi/quizify/pull/693), built on `main` rather than stacked on it — the rule sits next to the finale's own CSS instead of in the shared short-screen block, so the two do not collide.

## What a 720p room actually saw

The podium and two award cards. **The leaderboard rows and the head-to-head line were not in the picture** — nine elements past the bottom edge. The duel is the headline of v1.12.0, and on a short television nobody has ever seen it on the end screen.

## Why this one is not #688 or #691

Nothing here is too tall on its own. The column stacks more than the screen has room for:

| | before | after |
|---|---|---|
| awards box | **337.1px** of a 517.8px column | **171.9px** |
| leaderboard top | 624px of 720 | 458.7px |
| head-to-head | not rendered in the picture | **608.7–665.6px** |
| below the fold @720p | **9** | **0** |

So it is a content decision rather than a sizing one, and the decision is written next to the rule: **on short screens the awards lose their detail line, and nothing else changes.** That line is the footnote — "25 pts in round 6" — under a heading that already carries the point, "TOP SCORE · ANNA". It is the one thing on this screen that can go without taking a fact with it.

**Capping the awards box was measured and rejected.** It clips a card halfway, which is the same defect as the one being fixed, one box further in. Dropping a whole line beats cutting one.

1366×768 also lands at zero. **1080p is untouched** and keeps the detail.

## One measurement was not free

The head-to-head line is hidden below two shared games, so the end screen of the test game did not render it. Rather than assume it now fits, it was rendered by hand into the fixed layout and measured: 608.7–665.6px at 720p, 651.6–711px at 768p. The leaderboard gives way to make room, which is what `flex: 1 1 auto; overflow: hidden` on that card was already for.

## Tests

* The short-screen rule exists and hides only the detail.
* The detail is **not** hidden outside a short-screen block — the trade is bought for 720p only.
* The head-to-head line stays the last block in the column, so the leaderboard (which knows how to give way) is the block that shrinks instead of it.

The first fails against the previous `dashboard.html`, checked by stashing that file alone.

Suite **2288**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWNXT3dAydB5NjLmeTnJip