### PR TITLE
fix(tv): the leaderboard outranks the awards on the end screen

### DIFF
--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -1178,7 +1178,32 @@
             min-width: 0;
             width: 100%;
         }
+        /* The leaderboard comes before the awards, decided by Markus on
+           03.09.2026 after a three-player game on a 720p television showed
+           what the old order costs: the card was squeezed to 25.7px, the word
+           "Leaderboard" was cut in half and not one player row was on screen,
+           while both award cards sat above it in full. 1080p failed the same
+           way — this is a player-count problem, not a screen-height one, so
+           the rule is not inside a media query.
+
+           The arithmetic at 1280x720: the right column has 434px and two 16px
+           gaps; the head-to-head line takes 56.9px; a card header is 45.5px
+           and a row 58.6px, so three rows need 221.3px. That leaves ~124px of
+           awards, which is one card — and one award plus a readable ranking
+           beats two awards and no ranking.
+
+           The awards are the block that gives way now. With more players the
+           leaderboard keeps its three rows and scrolls the rest inside its own
+           list, which already carries overflow: auto. */
         .dashboard-finale--split .finale-leaderboard-card {
+            flex: 0 1 auto;
+            /* Header 45.5px, plus the list's own 8px padding, three 58.6px
+               rows and two 4px gaps between them — 245.3px, measured on the
+               television rather than derived from the stylesheet. */
+            min-height: 246px;
+            overflow: hidden;
+        }
+        .dashboard-finale--split .awards-section {
             flex: 1 1 auto;
             min-height: 0;
             overflow: hidden;

--- a/tests/test_finale_720p_692.py
+++ b/tests/test_finale_720p_692.py
@@ -85,3 +85,36 @@ def test_the_head_to_head_line_is_the_last_block_in_the_column() -> None:
     start = html.index('<div class="dashboard-finale-right">')
     right = html[start : html.index("</div>", html.index('id="end-h2h"'))]
     assert right.index('class="finale-leaderboard-card"') < right.index('id="end-h2h"')
+
+
+def test_the_leaderboard_outranks_the_awards() -> None:
+    """Markus, 03.09.2026, after a three-player game on a 720p television.
+
+    #694 freed the space and the awards took it: the leaderboard card was
+    squeezed to 25.7px, "Leaderboard" was cut in half, and not one player row
+    was on screen while both award cards sat above it in full. 1080p failed the
+    same way, so this is a player-count problem and not a screen-height one —
+    which is why the rule is not inside a media query.
+
+    The order is now fixed in CSS: the leaderboard reserves room for a header
+    and three rows, and the awards are the block that gives way.
+    """
+    css = _css()
+
+    def declarations(selector: str) -> str:
+        """Every rule for this selector, joined — CSS cascades, so a single
+        `re.search` would read the first of them and miss the one that wins."""
+        pattern = re.escape(selector) + r"\s*\{([^}]*)\}"
+        found = re.findall(pattern, css)
+        assert found, f"no rule found for {selector}"
+        return "\n".join(found)
+
+    card = declarations(".dashboard-finale--split .finale-leaderboard-card")
+    floor = re.search(r"min-height:\s*(\d+)px", card)
+    assert floor and int(floor.group(1)) >= 200, (
+        f"the leaderboard needs a floor that holds three rows: {card}"
+    )
+
+    awards = declarations(".dashboard-finale--split .awards-section")
+    assert "flex: 1 1 auto" in awards, awards
+    assert "min-height: 0" in awards, awards


### PR DESCRIPTION
Follow-up to [#694](https://github.com/mholzi/quizify/pull/694), and a correction of it.

## What three players showed

[#694](https://github.com/mholzi/quizify/pull/694) freed the space on the end screen and **the awards took it**. Played with three players on a 720p television:

| | before this PR | after |
|---|---|---|
| leaderboard card | **25.7px** | **246px** |
| player rows on screen | **0 of 3** | **3 of 3** |
| award cards | 2, both in full | 1 |
| head-to-head | in the picture | in the picture |
| below the fold | 8 | **0** |

The word "Leaderboard" was cut in half and not a single player row was visible, while both award cards sat above it in full. **1080p failed the same way**, so this is a player-count problem and not a screen-height one — the rule is deliberately not inside a media query.

That was my own regression, three hours old, and it repeats exactly what [#688](https://github.com/mholzi/quizify/issues/688) was about this morning: **measured against one case rather than the worst one.** The test game behind #694 had two players and two rows, and it fitted.

## The order, decided rather than guessed

Markus: *"sie muss Vorrang vor den Awards haben."* So the leaderboard reserves a header and three rows, and the awards are the block that gives way.

The arithmetic at 1280×720, measured on the television rather than derived from the stylesheet: the right column has 434px and two 16px gaps, the head-to-head line takes 56.9px, a card header is 45.5px, and the list needs 8px of its own padding plus three 58.6px rows with two 4px gaps — **245.3px**. One award card fits in what is left.

One award beside a readable ranking beats two awards and no ranking. With more players the leaderboard keeps its three rows and scrolls the rest inside its own list, which already carries `overflow: auto`.

## A measurement note worth keeping

The screenshot decided this, not the element rectangles. A row whose box extends past a clipping card is not the same thing as a row a room cannot see — reading rects alone gave a false "2 of 3" here, twice, until the picture settled it.

Suite **2292**, ruff clean on the touched file. The new test collects *all* rules for a selector rather than the first, because CSS cascades and the first match was the wrong one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWNXT3dAydB5NjLmeTnJip