### PR TITLE
fix(tv): show the Hot Seat's round number and its outcome

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ Quizify speaks your guests' language.
 
 The UI follows the game language (since v1.1.24) — pick German in the pack-picker and the entire admin / player / dashboard surface switches to German labels, tooltips, error messages, fun-fact labels, and end-game awards. Switch to English or Spanish and the whole thing flips.
 
-666 i18n keys, full parity between all three locales, validated in CI.
+669 i18n keys, full parity between all three locales, validated in CI.
 
 ---
 

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -2721,6 +2721,12 @@ class QuizifyWebSocketHandler:
             "type": "hot_seat_auction",
             "seconds": hs.auction_seconds,
             "players": len(hs.scores),
+            # #698: the television's round indicator is interpolated from
+            # these two. Without them the auction kept the previous round's
+            # number and the question that follows printed the literal string
+            # "undefined" for the whole answer window.
+            "round_num": game_state.round,
+            "total_rounds": game_state.total_rounds,
         })
         # Each player needs their own number: a percentage is only meaningful
         # next to the points it costs *them*.
@@ -2829,6 +2835,8 @@ class QuizifyWebSocketHandler:
                 game_state.finish_hot_seat()
                 await self._conn.broadcast({
                     "type": "hot_seat_result",
+                    "round_num": game_state.round,
+                    "total_rounds": game_state.total_rounds,
                     **hs.summary(),
                     "scores": {
                         p.name: p.score for p in game_state.get_players()
@@ -2858,6 +2866,9 @@ class QuizifyWebSocketHandler:
             "type": "hot_seat_question",
             "question": q.question,
             "difficulty": q.difficulty,
+            # #698: see the auction broadcast — the TV interpolates both.
+            "round_num": game_state.round,
+            "total_rounds": game_state.total_rounds,
             "image_url": getattr(q, "image_url", "") or "",
             "seconds": hs.answer_seconds,
             "winner": hs.winner,

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -2549,9 +2549,15 @@
             // which is the only thing everyone was watching for.
             hotSeatFrame(msg.round_num, msg.total_rounds);
             els.questionCategory.textContent = '';
-            var right = msg.answered && msg.answer_index === msg.correct_index;
+            // ``answered`` is tri-state on the server: true = right,
+            // false = wrong, null = never answered. A bare falsy check
+            // collapses the last two, so a wrong answer read "ran out of
+            // time" — the one distinction this screen exists to make, since
+            // #653 made both cost the same points.
+            var noAnswer = msg.answered === null || msg.answered === undefined;
+            var right = msg.answered === true;
             var delta = (msg.deltas && msg.deltas[msg.winner]) || 0;
-            var key = !msg.answered
+            var key = noAnswer
                 ? 'hotSeat.resultTimeout'
                 : (right ? 'hotSeat.resultRight' : 'hotSeat.resultWrong');
             var fallback = msg.winner + (right ? ' +' : ' ') + delta;

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -2121,6 +2121,9 @@
                 case 'hot_seat_no_bids':
                     handleHotSeatNoBids();
                     break;
+                case 'hot_seat_result':
+                    handleHotSeatResult(msg);
+                    break;
                 case 'hot_seat_tick':
                     handleTimerTick({ remaining: msg.remaining });
                     break;
@@ -2537,6 +2540,26 @@
                 category: msg.category || '',
                 image_url: msg.image_url || ''
             });
+        }
+
+        function handleHotSeatResult(msg) {
+            // #698: the settlement had no consumer on any surface. The board
+            // stayed on the question with the bar at zero until the host
+            // advanced, so the room never learned whether the chair paid off —
+            // which is the only thing everyone was watching for.
+            hotSeatFrame(msg.round_num, msg.total_rounds);
+            els.questionCategory.textContent = '';
+            var right = msg.answered && msg.answer_index === msg.correct_index;
+            var delta = (msg.deltas && msg.deltas[msg.winner]) || 0;
+            var key = !msg.answered
+                ? 'hotSeat.resultTimeout'
+                : (right ? 'hotSeat.resultRight' : 'hotSeat.resultWrong');
+            var fallback = msg.winner + (right ? ' +' : ' ') + delta;
+            els.questionText.textContent = hotSeatT(
+                key, { name: msg.winner, pts: Math.abs(delta) }, fallback
+            );
+            if (els.answerProgress) els.answerProgress.classList.add('hidden');
+            if (els.timerFill) els.timerFill.style.width = '0%';
         }
 
         function handleHotSeatNoBids() {

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -794,6 +794,9 @@
     "betOptional": "Mitwetten ist freiwillig.",
     "betPlaced": "Gesetzt: {pct}% auf {side}",
     "noBet": "Der Spieler im Stuhl wettet nicht.",
-    "timeoutNote": "Keine Antwort kostet den Einsatz genauso wie eine falsche."
+    "timeoutNote": "Keine Antwort kostet den Einsatz genauso wie eine falsche.",
+    "resultRight": "{name} hat sie gewusst — +{pts} Punkte",
+    "resultWrong": "{name} lag daneben — −{pts} Punkte",
+    "resultTimeout": "{name} war zu langsam — −{pts} Punkte"
   }
 }

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -794,6 +794,9 @@
     "betOptional": "Betting is optional.",
     "betPlaced": "Staked: {pct}% on {side}",
     "noBet": "The player in the chair does not bet.",
-    "timeoutNote": "No answer costs the stake just like a wrong one."
+    "timeoutNote": "No answer costs the stake just like a wrong one.",
+    "resultRight": "{name} answered it — +{pts} points",
+    "resultWrong": "{name} got it wrong — −{pts} points",
+    "resultTimeout": "{name} ran out of time — −{pts} points"
   }
 }

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -794,6 +794,9 @@
     "betOptional": "Apostar es opcional.",
     "betPlaced": "Apostado: {pct}% a {side}",
     "noBet": "Quien está en la silla no apuesta.",
-    "timeoutNote": "No responder cuesta la apuesta igual que fallar."
+    "timeoutNote": "No responder cuesta la apuesta igual que fallar.",
+    "resultRight": "{name} acertó — +{pts} puntos",
+    "resultWrong": "{name} falló — −{pts} puntos",
+    "resultTimeout": "A {name} se le acabó el tiempo — −{pts} puntos"
   }
 }

--- a/tests/test_hot_seat_television_698.py
+++ b/tests/test_hot_seat_television_698.py
@@ -1,0 +1,89 @@
+"""#698 — the television has to show the Hot Seat, including its outcome.
+
+Two faults, both seen on a real 720p television on 03.09.2026.
+
+The round indicator read "QUESTION UNDEFINED / UNDEFINED" for the whole answer
+window: ``handleHotSeatQuestion`` forwards ``msg.round_num`` and
+``msg.total_rounds`` into the normal question renderer, and the live payload
+carried neither, so ``i18n.js`` interpolated the literal ``undefined``. Only a
+television that *reconnected* showed the right numbers, because the snapshot
+path passes them.
+
+And ``hot_seat_result`` had no consumer anywhere: not on the phone, not on the
+board, not on the admin page. After the seat holder answered, the television
+stayed on the question with the timer at zero until the host advanced — so the
+room never learned whether the chair had paid off, which is the one thing
+everybody was watching for.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+WEBSOCKET = REPO / "custom_components" / "quizify" / "server" / "websocket.py"
+DASHBOARD = REPO / "custom_components" / "quizify" / "www" / "dashboard.html"
+I18N = REPO / "custom_components" / "quizify" / "www" / "i18n"
+
+
+def _payload_block(source: str, message_type: str) -> str:
+    """The dict literal that carries ``"type": "<message_type>"``."""
+    marker = f'"type": "{message_type}"'
+    start = source.index(marker)
+    open_brace = source.rindex("{", 0, start)
+    depth, j = 0, open_brace
+    while True:
+        if source[j] == "{":
+            depth += 1
+        elif source[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[open_brace : j + 1]
+        j += 1
+
+
+def test_every_hot_seat_broadcast_carries_the_round_numbers() -> None:
+    """Written against all three, not just the one that was reported.
+
+    The question broadcast is what printed "undefined"; the auction silently
+    kept the previous round's number, and the result would have inherited
+    whatever the frame had. A television is a single header — if any of the
+    three omits them, the detour lies about where the game is.
+    """
+    source = WEBSOCKET.read_text(encoding="utf-8")
+    for message_type in ("hot_seat_auction", "hot_seat_question", "hot_seat_result"):
+        block = _payload_block(source, message_type)
+        assert '"round_num"' in block, f"{message_type} has no round_num: {block}"
+        assert '"total_rounds"' in block, f"{message_type} has no total_rounds"
+
+
+def test_the_television_renders_the_hot_seat_outcome() -> None:
+    html = DASHBOARD.read_text(encoding="utf-8")
+    assert "case 'hot_seat_result':" in html, (
+        "the settlement still has no case in the dashboard switch"
+    )
+    assert "function handleHotSeatResult(" in html
+
+
+def test_the_outcome_distinguishes_a_wrong_answer_from_a_timeout() -> None:
+    """They cost the same points and mean opposite things about the room.
+
+    #653 made an unanswered chair cost its stake, which is exactly why the
+    board may not report silence as a wrong answer.
+    """
+    html = DASHBOARD.read_text(encoding="utf-8")
+    start = html.index("function handleHotSeatResult(")
+    body = html[start : html.index("\n        }", start)]
+    for key in ("hotSeat.resultRight", "hotSeat.resultWrong", "hotSeat.resultTimeout"):
+        assert key in body, f"{key} is not used in the result renderer"
+
+    for locale in ("de", "en", "es"):
+        strings = json.loads((I18N / f"{locale}.json").read_text(encoding="utf-8"))
+        hot_seat = strings["hotSeat"]
+        for key in ("resultRight", "resultWrong", "resultTimeout"):
+            assert key in hot_seat, f"{locale}.json is missing hotSeat.{key}"
+            assert re.search(r"\{name\}", hot_seat[key]), (
+                f"{locale}.json hotSeat.{key} does not name the player"
+            )

--- a/tests/test_hot_seat_television_698.py
+++ b/tests/test_hot_seat_television_698.py
@@ -20,7 +20,11 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
+import subprocess
 from pathlib import Path
+
+import pytest
 
 REPO = Path(__file__).resolve().parent.parent
 WEBSOCKET = REPO / "custom_components" / "quizify" / "server" / "websocket.py"
@@ -87,3 +91,51 @@ def test_the_outcome_distinguishes_a_wrong_answer_from_a_timeout() -> None:
             assert re.search(r"\{name\}", hot_seat[key]), (
                 f"{locale}.json hotSeat.{key} does not name the player"
             )
+
+
+def _outcome_decision_source() -> str:
+    """The three lines of handleHotSeatResult that choose the outcome string."""
+    html = DASHBOARD.read_text(encoding="utf-8")
+    start = html.index("var noAnswer =", html.index("function handleHotSeatResult("))
+    end = html.index(";", html.index("var key =", start)) + 1
+    return html[start:end]
+
+
+def test_the_timeout_branch_does_not_test_a_bare_falsy_value() -> None:
+    """``answered`` is tri-state — true / false / null.
+
+    The first version keyed the timeout on ``!msg.answered``, and JavaScript
+    treats ``false`` and ``null`` alike, so a wrong answer rendered as "ran
+    out of time" and hotSeat.resultWrong was unreachable. Silence and a wrong
+    guess mean opposite things about the room; this pins the distinction to
+    the only check that can tell them apart.
+    """
+    source = _outcome_decision_source()
+    assert "!msg.answered" not in source, (
+        "a bare falsy check collapses a wrong answer into the timeout branch"
+    )
+    assert "msg.answered === null" in source
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+def test_each_outcome_picks_its_own_string() -> None:
+    """Run the real decision, once per server state."""
+    script = (
+        "function pick(msg) {\n" + _outcome_decision_source() + "\nreturn key; }\n"
+        "console.log(JSON.stringify({"
+        "right: pick({answered: true}),"
+        "wrong: pick({answered: false}),"
+        "silent: pick({answered: null}),"
+        "missing: pick({})"
+        "}));"
+    )
+    out = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, check=True
+    ).stdout
+    assert json.loads(out) == {
+        "right": "hotSeat.resultRight",
+        "wrong": "hotSeat.resultWrong",
+        "silent": "hotSeat.resultTimeout",
+        # A server that omits the field is as silent as an explicit null.
+        "missing": "hotSeat.resultTimeout",
+    }


### PR DESCRIPTION
Closes #698. First of two PRs for the Hot Seat block — this one is the server payload and the television; the phone and the admin page follow in a separate PR that touches disjoint files.

## What the room saw

The auction fired for the first time on 03.09, in a three-player game on a real television. Two things were wrong at once.

**"QUESTION UNDEFINED / UNDEFINED"** in the header for the whole answer window. `handleHotSeatQuestion` (`dashboard.html:2527-2537`) forwards `msg.round_num` / `msg.total_rounds` into the normal renderer, and the live payload carried neither, so `i18n.js:73` interpolated the literal string. Only a television that *reconnected* was right, because the snapshot path passes them.

**No outcome, anywhere.** `hot_seat_result` had no case in the dashboard switch, the phone's handler is a `reset()` that hides the panel, and `admin.js` has no `hot_seat_*` case at all. After the seat holder answered, the board stayed on the question with the bar at zero until the host advanced.

## The fix

All **three** hot-seat broadcasts carry `round_num` and `total_rounds` now, not only the one that was reported: the auction silently kept the previous round's number, and the result would have inherited whatever the frame happened to hold. A television is a single header — one omission and the detour lies about where the game is.

The board now renders the settlement: who sat, and what it cost or paid. It distinguishes a **wrong answer** from a **timeout**, because [#653](https://github.com/mholzi/quizify/issues/653) made those cost the same points while meaning opposite things about the room.

## Tests

Written against the property rather than the reported case: *every* hot-seat broadcast must carry both fields, and the result renderer must use all three outcome strings, present in all three locales and each naming the player. All three fail against the previous tree, checked by stashing only the changed files.

One pleasing side effect: three new i18n keys took the library to 669 and **tripped the README guard added this morning in [#690](https://github.com/mholzi/quizify/pull/690)** — that test existed for exactly this and caught it on the first run.

Suite **2292**, mypy clean, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWNXT3dAydB5NjLmeTnJip