### PR TITLE
fix: give the phone and the host back after the Hot Seat

### DIFF
--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -73,10 +73,21 @@
         switch (currentPhase) {
             case 'QUESTION_ACTIVE':
             case 'LIGHTNING':
+            // #699: a reload during any of these lands on #setup-screen,
+            // which is the default active view and which handleRoundSummary
+            // never leaves. From there the only visible way on is Start —
+            // and Start resets a non-LOBBY game, so a service-worker update
+            // mid-reveal could quietly wipe every score.
+            case 'ANSWER_REVEAL':
+            case 'WAGER_ACTIVE':
+            case 'LIGHTNING_RECAP':
+            case 'HOT_SEAT_AUCTION':
+            case 'HOT_SEAT':
+            case 'HOT_SEAT_REVEAL':
+            case 'PAUSED':
                 return false;
             default:
-                // LOBBY, ANSWER_REVEAL, LIGHTNING_RECAP, FINALE, and any
-                // setup state before a game starts.
+                // LOBBY, FINALE, and any setup state before a game starts.
                 return true;
         }
     };
@@ -1621,6 +1632,20 @@
                 // player.html. The old #admin-reveal-view was removed
                 // in v1.1.16.
                 break;
+            case 'WAGER_ACTIVE':
+            case 'HOT_SEAT_AUCTION':
+            case 'HOT_SEAT':
+            case 'HOT_SEAT_REVEAL':
+                // #699: this switch had no case for any of them, so a host who
+                // started without joining kept looking at the previous
+                // question, "Correct: …" and an enabled Next Question that
+                // answers ERR_INVALID_ACTION for the ~90 seconds the detour
+                // lasts. Show what phase the room is in, and only offer Next
+                // where the server actually accepts it.
+                showView('game');
+                setDetourNotice(msg.phase);
+                if (msg.leaderboard) renderLeaderboard(els.gameLeaderboard, msg.leaderboard);
+                break;
             case 'FINALE':
                 // Land directly on finale view so the admin sees the
                 // result and the "Neues Spiel starten" button without
@@ -1742,6 +1767,37 @@
      * countdown; the refreshes that arrive with each bet leave it out, so the
      * clock keeps running instead of restarting on every tap.
      */
+    /**
+     * Tell the host which detour the room is in (#699).
+     *
+     * The admin tab has no view of its own for the auction, the seat holder's
+     * question or the wager window, and it used to keep showing the previous
+     * round with a live Next Question that the server refuses. This replaces
+     * the stale text and only offers Next where next_round is accepted —
+     * HOT_SEAT_REVEAL, which is the one phase the server leaves on it.
+     */
+    function setDetourNotice(phase) {
+        var keys = {
+            WAGER_ACTIVE: ['wager.hostWindowTitle', 'Final round — players are betting'],
+            HOT_SEAT_AUCTION: ['hotSeat.auctionTitle', 'The chair goes to the highest bid'],
+            HOT_SEAT: ['hotSeat.seatedHint', 'The seat holder is answering'],
+            HOT_SEAT_REVEAL: ['hotSeat.sealed', 'Hot seat settled']
+        };
+        var entry = keys[phase];
+        if (els.adminQuestion && entry) {
+            els.adminQuestion.textContent = _t(entry[0]) || entry[1];
+        }
+        if (els.adminCorrect) {
+            els.adminCorrect.textContent = '';
+            els.adminCorrect.style.display = 'none';
+        }
+        var advanceable = (phase === 'HOT_SEAT_REVEAL');
+        if (els.nextQuestionBtn) {
+            els.nextQuestionBtn.classList.toggle('hidden', !advanceable);
+        }
+        if (els.endGameBtn) els.endGameBtn.classList.remove('hidden');
+    }
+
     function handleWagerProgress(msg) {
         if (_redirecting) return;
         currentPhase = 'WAGER_ACTIVE';

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -692,6 +692,24 @@
                 // see.
                 pu.showView('game-view');
                 if (hotSeat && msg.hot_seat) hotSeat.restoreFromSnapshot(msg.hot_seat);
+                // #697: the detour is entered from ANSWER_REVEAL, which hides
+                // the control bar, and nothing here brought it back. A host
+                // who plays along — the default, since the admin tab redirects
+                // to this page on start — had no Next, no Skip and no End for
+                // the rest of the game: HOT_SEAT_REVEAL is left only by an
+                // explicit next_round. End and Skip stay; Pause does not,
+                // because the detour owns its own clock.
+                var adminBarHS = document.getElementById('admin-control-bar');
+                if (adminBarHS) adminBarHS.classList.toggle('hidden', !state.isAdmin);
+                var nextRoundHS = document.getElementById('next-round-admin-btn');
+                var skipHS = document.getElementById('skip-question-btn');
+                var pauseHS = document.getElementById('pause-game-btn');
+                var resumeHS = document.getElementById('resume-game-btn');
+                var inReveal = msg.phase === 'HOT_SEAT_REVEAL';
+                if (nextRoundHS) nextRoundHS.classList.toggle('hidden', !inReveal);
+                if (skipHS) skipHS.classList.toggle('hidden', inReveal);
+                if (pauseHS) pauseHS.classList.add('hidden');
+                if (resumeHS) resumeHS.classList.add('hidden');
                 break;
 
             case 'PAUSED':
@@ -1537,9 +1555,16 @@
                 var btn = e.target.closest('.answer-btn');
                 if (!btn || btn.disabled) return;
                 var index = parseInt(btn.dataset.index, 10);
-                if (!isNaN(index)) {
-                    game.handleAnswerClick(index, send);
+                if (isNaN(index)) return;
+                // #696: while the seat holder is answering, the same grid
+                // means hot_seat_answer. This used to be an inline onclick on
+                // replacement buttons, which shadowed this handler and left
+                // the grid unusable for every later round.
+                if (hotSeat && hotSeat.handleSeatAnswerClick &&
+                    hotSeat.handleSeatAnswerClick(index)) {
+                    return;
                 }
+                game.handleAnswerClick(index, send);
             });
         }
 

--- a/custom_components/quizify/www/js/player-hotseat.js
+++ b/custom_components/quizify/www/js/player-hotseat.js
@@ -53,6 +53,7 @@
         _state.bidPlaced = false;
         _state.seated = false;
         _state.betPlaced = false;
+        _state.seatAnswering = false;
         _state.winner = null;
         hide();
     }
@@ -187,6 +188,15 @@
         if (!p) return;
         p.classList.remove('hidden');
 
+        // #698: the detour used to play out under the *previous* round's
+        // question and its green/red reveal colouring, because the snapshot
+        // that opens the view clears neither and this handler never rendered
+        // msg.question — which the server sends to every phone, seated or not.
+        var qText = el('question-text');
+        if (qText && msg.question) qText.textContent = msg.question;
+        var qCat = el('question-category');
+        if (qCat) qCat.textContent = '';
+
         if (msg.you_are_seated) {
             // The seat holder answers through the normal answer grid, so the
             // panel steps out of the way and only keeps the reminder that a
@@ -206,23 +216,56 @@
     }
 
     function renderSeatAnswers(answers) {
+        // #696: this used to replace the container's innerHTML with bare
+        // buttons. The markup it destroyed is the markup renderQuestion fills
+        // — that function reuses the existing .answer-btn elements and only
+        // writes their .answer-text child, so once they were gone the seat
+        // winner saw the hot seat's answers under every question for the rest
+        // of the game and could not answer any of them. The grid is filled the
+        // same way here, and left intact.
         var host = el('answer-buttons');
         if (!host) return;
-        host.innerHTML = '';
-        answers.forEach(function (text, i) {
-            var b = document.createElement('button');
-            b.type = 'button';
-            b.className = 'answer-btn';
-            b.textContent = text;
-            b.onclick = function () {
-                host.querySelectorAll('.answer-btn').forEach(function (x) {
-                    x.disabled = true;
-                });
-                b.classList.add('answer-btn--selected');
-                send('hot_seat_answer', { answer: i });
-            };
-            host.appendChild(b);
-        });
+        var buttons = host.querySelectorAll('.answer-btn');
+        for (var i = 0; i < buttons.length; i++) {
+            var btn = buttons[i];
+            var text = answers[i];
+            btn.dataset.index = String(i);
+            btn.disabled = false;
+            btn.classList.remove(
+                'is-selected', 'is-correct', 'is-wrong', 'is-eliminated', 'hidden'
+            );
+            var textEl = btn.querySelector('.answer-text');
+            if (textEl) {
+                textEl.textContent =
+                    ((text && typeof text === 'object') ? text.text : text) || '';
+            }
+            if (i >= answers.length) btn.classList.add('hidden');
+        }
+        _state.seatAnswering = true;
+    }
+
+    /**
+     * Route a tap on the shared answer grid (#696).
+     *
+     * The delegated handler in player-core owns every click on
+     * ``#answer-buttons``. While the seat holder is answering, the tap means
+     * ``hot_seat_answer`` and not ``submit_answer``; an inline onclick used to
+     * do this, and it shadowed the delegated handler badly enough that the
+     * normal path stopped working afterwards.
+     */
+    function handleSeatAnswerClick(index) {
+        if (!_state.seatAnswering) return false;
+        var host = el('answer-buttons');
+        if (host) {
+            var buttons = host.querySelectorAll('.answer-btn');
+            for (var i = 0; i < buttons.length; i++) {
+                buttons[i].disabled = true;
+                if (i === index) buttons[i].classList.add('is-selected');
+            }
+        }
+        _state.seatAnswering = false;
+        send('hot_seat_answer', { answer: index });
+        return true;
     }
 
     function showBetStage(winner) {
@@ -379,6 +422,7 @@
         handleAwarded: handleAwarded,
         handleNoBids: handleNoBids,
         handleQuestion: handleQuestion,
+        handleSeatAnswerClick: handleSeatAnswerClick,
         handleResult: handleResult,
         handleTick: handleTick,
         reset: reset

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -3795,6 +3795,7 @@
         _state.bidPlaced = false;
         _state.seated = false;
         _state.betPlaced = false;
+        _state.seatAnswering = false;
         _state.winner = null;
         hide();
     }
@@ -3929,6 +3930,15 @@
         if (!p) return;
         p.classList.remove('hidden');
 
+        // #698: the detour used to play out under the *previous* round's
+        // question and its green/red reveal colouring, because the snapshot
+        // that opens the view clears neither and this handler never rendered
+        // msg.question — which the server sends to every phone, seated or not.
+        var qText = el('question-text');
+        if (qText && msg.question) qText.textContent = msg.question;
+        var qCat = el('question-category');
+        if (qCat) qCat.textContent = '';
+
         if (msg.you_are_seated) {
             // The seat holder answers through the normal answer grid, so the
             // panel steps out of the way and only keeps the reminder that a
@@ -3948,23 +3958,56 @@
     }
 
     function renderSeatAnswers(answers) {
+        // #696: this used to replace the container's innerHTML with bare
+        // buttons. The markup it destroyed is the markup renderQuestion fills
+        // — that function reuses the existing .answer-btn elements and only
+        // writes their .answer-text child, so once they were gone the seat
+        // winner saw the hot seat's answers under every question for the rest
+        // of the game and could not answer any of them. The grid is filled the
+        // same way here, and left intact.
         var host = el('answer-buttons');
         if (!host) return;
-        host.innerHTML = '';
-        answers.forEach(function (text, i) {
-            var b = document.createElement('button');
-            b.type = 'button';
-            b.className = 'answer-btn';
-            b.textContent = text;
-            b.onclick = function () {
-                host.querySelectorAll('.answer-btn').forEach(function (x) {
-                    x.disabled = true;
-                });
-                b.classList.add('answer-btn--selected');
-                send('hot_seat_answer', { answer: i });
-            };
-            host.appendChild(b);
-        });
+        var buttons = host.querySelectorAll('.answer-btn');
+        for (var i = 0; i < buttons.length; i++) {
+            var btn = buttons[i];
+            var text = answers[i];
+            btn.dataset.index = String(i);
+            btn.disabled = false;
+            btn.classList.remove(
+                'is-selected', 'is-correct', 'is-wrong', 'is-eliminated', 'hidden'
+            );
+            var textEl = btn.querySelector('.answer-text');
+            if (textEl) {
+                textEl.textContent =
+                    ((text && typeof text === 'object') ? text.text : text) || '';
+            }
+            if (i >= answers.length) btn.classList.add('hidden');
+        }
+        _state.seatAnswering = true;
+    }
+
+    /**
+     * Route a tap on the shared answer grid (#696).
+     *
+     * The delegated handler in player-core owns every click on
+     * ``#answer-buttons``. While the seat holder is answering, the tap means
+     * ``hot_seat_answer`` and not ``submit_answer``; an inline onclick used to
+     * do this, and it shadowed the delegated handler badly enough that the
+     * normal path stopped working afterwards.
+     */
+    function handleSeatAnswerClick(index) {
+        if (!_state.seatAnswering) return false;
+        var host = el('answer-buttons');
+        if (host) {
+            var buttons = host.querySelectorAll('.answer-btn');
+            for (var i = 0; i < buttons.length; i++) {
+                buttons[i].disabled = true;
+                if (i === index) buttons[i].classList.add('is-selected');
+            }
+        }
+        _state.seatAnswering = false;
+        send('hot_seat_answer', { answer: index });
+        return true;
     }
 
     function showBetStage(winner) {
@@ -4121,6 +4164,7 @@
         handleAwarded: handleAwarded,
         handleNoBids: handleNoBids,
         handleQuestion: handleQuestion,
+        handleSeatAnswerClick: handleSeatAnswerClick,
         handleResult: handleResult,
         handleTick: handleTick,
         reset: reset
@@ -6206,6 +6250,24 @@
                 // see.
                 pu.showView('game-view');
                 if (hotSeat && msg.hot_seat) hotSeat.restoreFromSnapshot(msg.hot_seat);
+                // #697: the detour is entered from ANSWER_REVEAL, which hides
+                // the control bar, and nothing here brought it back. A host
+                // who plays along — the default, since the admin tab redirects
+                // to this page on start — had no Next, no Skip and no End for
+                // the rest of the game: HOT_SEAT_REVEAL is left only by an
+                // explicit next_round. End and Skip stay; Pause does not,
+                // because the detour owns its own clock.
+                var adminBarHS = document.getElementById('admin-control-bar');
+                if (adminBarHS) adminBarHS.classList.toggle('hidden', !state.isAdmin);
+                var nextRoundHS = document.getElementById('next-round-admin-btn');
+                var skipHS = document.getElementById('skip-question-btn');
+                var pauseHS = document.getElementById('pause-game-btn');
+                var resumeHS = document.getElementById('resume-game-btn');
+                var inReveal = msg.phase === 'HOT_SEAT_REVEAL';
+                if (nextRoundHS) nextRoundHS.classList.toggle('hidden', !inReveal);
+                if (skipHS) skipHS.classList.toggle('hidden', inReveal);
+                if (pauseHS) pauseHS.classList.add('hidden');
+                if (resumeHS) resumeHS.classList.add('hidden');
                 break;
 
             case 'PAUSED':
@@ -7051,9 +7113,16 @@
                 var btn = e.target.closest('.answer-btn');
                 if (!btn || btn.disabled) return;
                 var index = parseInt(btn.dataset.index, 10);
-                if (!isNaN(index)) {
-                    game.handleAnswerClick(index, send);
+                if (isNaN(index)) return;
+                // #696: while the seat holder is answering, the same grid
+                // means hot_seat_answer. This used to be an inline onclick on
+                // replacement buttons, which shadowed this handler and left
+                // the grid unusable for every later round.
+                if (hotSeat && hotSeat.handleSeatAnswerClick &&
+                    hotSeat.handleSeatAnswerClick(index)) {
+                    return;
                 }
+                game.handleAnswerClick(index, send);
             });
         }
 

--- a/tests/test_hot_seat_phone_and_host_696.py
+++ b/tests/test_hot_seat_phone_and_host_696.py
@@ -1,0 +1,107 @@
+"""#696 / #697 / #699 — the Hot Seat has to leave the phone and the host usable.
+
+Three faults with one origin: the detour was built as its own island and never
+handed the surfaces back.
+
+* **#696** ``renderSeatAnswers`` replaced ``#answer-buttons`` innerHTML with
+  bare buttons. That container's markup is what ``renderQuestion`` fills — it
+  reuses the existing ``.answer-btn`` elements and writes only their
+  ``.answer-text`` child — so once it was gone the player who *won* the chair
+  saw the hot seat's answers under every later question and could not answer
+  any of them.
+* **#697** the detour is entered from ANSWER_REVEAL, which hides the admin
+  control bar; nothing brought it back, and HOT_SEAT_REVEAL is left only by an
+  explicit ``next_round``. A host playing along had no way to advance.
+* **#699** the admin tab had no case for the detour phases, and a reload during
+  any of them lands on the setup screen where the only visible control is
+  Start — which resets a non-LOBBY game.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+WWW = REPO / "custom_components" / "quizify" / "www"
+
+
+def _read(name: str) -> str:
+    return (WWW / "js" / name).read_text(encoding="utf-8")
+
+
+def test_the_seat_grid_is_filled_not_replaced() -> None:
+    """The one property that broke every later round.
+
+    Written against the destruction, not the replacement: any future rewrite
+    that clears the container fails here, whatever it puts back.
+    """
+    source = _read("player-hotseat.js")
+    start = source.index("function renderSeatAnswers(")
+    body = source[start : source.index("\n    }", start)]
+    # The comment above the fix names the old mechanism, so read code only.
+    code = re.sub(r"//.*", "", body)
+    assert "innerHTML" not in code, (
+        "renderSeatAnswers destroys the markup renderQuestion depends on"
+    )
+    assert ".answer-text" in code, "the grid is filled the way renderQuestion fills it"
+
+
+def test_the_seat_answer_goes_through_the_delegated_handler() -> None:
+    """An inline onclick shadowed the delegated one and outlived the round."""
+    hotseat = _read("player-hotseat.js")
+    core = _read("player-core.js")
+    assert "b.onclick" not in hotseat, "inline handler is back on the answer grid"
+    assert "handleSeatAnswerClick" in hotseat
+    assert "handleSeatAnswerClick" in core, (
+        "player-core must route the tap while the seat holder is answering"
+    )
+
+
+def test_the_host_can_advance_out_of_the_hot_seat() -> None:
+    """HOT_SEAT_REVEAL ends only on next_round, so the button has to be there."""
+    core = _read("player-core.js")
+    start = core.index("case 'HOT_SEAT_AUCTION':")
+    body = core[start : core.index("case 'PAUSED':", start)]
+    assert "admin-control-bar" in body, (
+        "the control bar is still hidden for the whole detour"
+    )
+    assert "next-round-admin-btn" in body
+
+
+def test_the_admin_tab_knows_the_detour_phases() -> None:
+    admin = _read("admin.js")
+    for phase in ("WAGER_ACTIVE", "HOT_SEAT_AUCTION", "HOT_SEAT", "HOT_SEAT_REVEAL"):
+        assert f"case '{phase}':" in admin, f"admin.js has no case for {phase}"
+    assert "function setDetourNotice(" in admin
+
+
+def test_a_live_round_is_never_idle_enough_to_reload_the_host_out_of_it() -> None:
+    """The reload lands on setup, where Start is the only visible control and
+    Start resets a running game. Every phase that is not the lobby or the
+    finale therefore has to block the service-worker reload."""
+    admin = _read("admin.js")
+    start = admin.index("window.quizifyIsIdleForReload")
+    body = admin[start : admin.index("};", start)]
+    for phase in (
+        "QUESTION_ACTIVE",
+        "LIGHTNING",
+        "ANSWER_REVEAL",
+        "WAGER_ACTIVE",
+        "LIGHTNING_RECAP",
+        "HOT_SEAT_AUCTION",
+        "HOT_SEAT",
+        "HOT_SEAT_REVEAL",
+        "PAUSED",
+    ):
+        assert re.search(rf"case '{phase}':", body), f"{phase} still counts as idle"
+
+
+def test_the_phone_shows_the_hot_seat_question_instead_of_the_last_one() -> None:
+    """The server sends the text to every phone, seated or not; the handler
+    never rendered it, so the room bid under the previous round's question and
+    its green/red reveal colouring."""
+    source = _read("player-hotseat.js")
+    start = source.index("function handleQuestion(")
+    body = source[start : source.index("\n    function renderSeatAnswers", start)]
+    assert "question-text" in body, "the stale question is still on screen"


### PR DESCRIPTION
Closes #696, #697 and #699. Second of two PRs for the Hot Seat block — [#713](https://github.com/mholzi/quizify/pull/713) has the server payload and the television, and touches disjoint files, so the two do not collide.

Three faults with one origin: the detour was built as its own island and never handed the surfaces back.

## #696 — the seat winner could not answer anything afterwards

`renderSeatAnswers` replaced `#answer-buttons` innerHTML with bare buttons. That container's markup is exactly what `renderQuestion` fills: it reuses the existing `.answer-btn` elements and writes only their `.answer-text` child (`player-game.js:420-434`).

So once the markup was gone, **the player who won the chair** saw the hot seat's three answers under every later question — and their taps went nowhere either, because the inline `onclick` disabled the buttons and the delegated handler returns on a disabled button. They scored zero for the rest of the evening unless they reloaded.

The grid is filled the way `renderQuestion` fills it now, and the tap is routed through the one delegated handler that owns that container.

## #697 — the round wedged for a host who plays along

The detour is entered from ANSWER_REVEAL, which hides the admin control bar, and none of the three sites that bring it back (`PAUSED`, the wager window, `question_started`) fires during it. On the server `HOT_SEAT_REVEAL` is left **only** by an explicit `next_round`.

The default flow is the admin tab redirecting to the player page on start — so the host had no Next, no Skip and no End, and the ways out were a Home Assistant service call or the 60-second "host gone" reset. The bar comes back for the detour, with Next offered only in the reveal, where the server accepts it.

## #699 — the admin tab did not know the detour existed

No case for `WAGER_ACTIVE` or the three `HOT_SEAT` phases, so a host who started *without* joining kept looking at the previous question, "Correct: …" and an enabled Next Question that answers `ERR_INVALID_ACTION` for the ~90 seconds the detour lasts.

The second half is worse: those phases counted as idle for the service-worker reload, and a reload lands on `#setup-screen`, where **Start is the only visible control — and Start resets a non-LOBBY game**. Every phase between the lobby and the finale now blocks that reload.

## While the phone was open

The detour also played out under the *previous* round's question and its green/red reveal colouring, because nothing cleared it and `handleQuestion` never rendered `msg.question` — which the server sends to every phone, seated or not. That is the phone half noted in #698; the television half is in #713.

## Tests

Six, each written against the property rather than the line: that the grid is *filled* rather than replaced (any future rewrite that clears the container fails, whatever it puts back), that no inline handler returns to that container, that the control bar and Next exist in the detour branch, that admin.js has a case per phase, that no phase between lobby and finale counts as idle, and that the phone renders the hot seat's own question.

All six fail against the previous tree, checked by stashing `www/js` alone.

Suite **2298**, ruff clean, `player.bundle.js` rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWNXT3dAydB5NjLmeTnJip