### PR TITLE
fix: a malformed community pack no longer takes setup down

### DIFF
--- a/custom_components/quizify/game/questions.py
+++ b/custom_components/quizify/game/questions.py
@@ -396,6 +396,25 @@ def _parse_question(data: dict, category_name: str) -> Question | None:
         )
         return None
 
+    # Every answer must be an object with non-empty ``text`` (#700). Community
+    # packs come off disk unvalidated, so a bare string ("A") or a text-less
+    # object ({"correct": true}) used to raise out of the loader and take
+    # async_setup_entry down with it. Mirrors pack_submission's rules.
+    for a in answers_raw:
+        if not isinstance(a, dict):
+            _LOGGER.warning(
+                "Skipping question '%s': every answer must be an object, got %s",
+                data["id"],
+                type(a).__name__,
+            )
+            return None
+        if not isinstance(a.get("text"), str) or not a["text"].strip():
+            _LOGGER.warning(
+                "Skipping question '%s': every answer needs a non-empty 'text'",
+                data["id"],
+            )
+            return None
+
     correct_count = sum(1 for a in answers_raw if a.get("correct"))
     if correct_count != 1:
         _LOGGER.warning(
@@ -663,7 +682,19 @@ class QuestionBank:
             for entry in questions_data:
                 if not isinstance(entry, dict):
                     continue
-                q = _parse_question(entry, category_name)
+                # Second line of defence (#700): the parser is meant to return
+                # None on bad input, but a future field assumption must not be
+                # able to abort setup over a guest's JSON file.
+                try:
+                    q = _parse_question(entry, category_name)
+                except Exception:  # noqa: BLE001 - untrusted file, never fatal
+                    _LOGGER.warning(
+                        "Community pack '%s': dropping a question that could "
+                        "not be parsed",
+                        file_path.name,
+                        exc_info=True,
+                    )
+                    continue
                 if q is None:
                     continue
                 if q.id in seen_ids:

--- a/custom_components/quizify/questions/community/README.md
+++ b/custom_components/quizify/questions/community/README.md
@@ -67,6 +67,8 @@ a pack is **rejected or trimmed** when:
 - `name` is missing/empty, or `questions` is missing/empty;
 - a question does not have exactly 3 answers with exactly 1 correct answer
   (such questions are skipped individually);
+- an answer is not an object with non-empty `text` — `"answers": ["A", "B", "C"]`
+  and `{"correct": true}` without `text` are both skipped, not fatal;
 - more than **500 questions** are present (the list is truncated);
 - the slug collides with an already-loaded pack.
 

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -330,6 +330,82 @@ class TestCommunityPacks:
         assert loaded_again == {}
         assert qb.get_question_count("community-dupe") == 1
 
+    def test_string_answers_do_not_crash_the_loader(self, tmp_path: Path) -> None:
+        """#700: ``"answers": ["A", "B", "C"]`` used to raise AttributeError.
+
+        The exception escaped load_community_packs into async_setup_entry, so a
+        single guest file turned "Failed to set up" — the whole integration —
+        into the price of a typo.
+        """
+        bad = {"id": "bad", "question": "q", "answers": ["A", "B", "C"]}
+        _write_community_pack(
+            tmp_path / "community", "strings.json", _make_pack(questions=[bad])
+        )
+        qb = QuestionBank(questions_dir=tmp_path)
+        assert qb.load_community_packs() == {}
+
+    def test_answer_without_text_does_not_crash(self, tmp_path: Path) -> None:
+        """#700: ``[{"correct": true}]`` used to raise KeyError on ``a["text"]``."""
+        bad = {
+            "id": "bad",
+            "question": "q",
+            "answers": [{"correct": True}, {"text": "b"}, {"text": "c"}],
+        }
+        _write_community_pack(
+            tmp_path / "community", "notext.json", _make_pack(questions=[bad])
+        )
+        qb = QuestionBank(questions_dir=tmp_path)
+        assert qb.load_community_packs() == {}
+
+    def test_empty_answer_text_is_rejected(self, tmp_path: Path) -> None:
+        """#700: a blank string is as unplayable as a missing one."""
+        bad = {
+            "id": "bad",
+            "question": "q",
+            "answers": [{"text": "  ", "correct": True}, {"text": "b"}, {"text": "c"}],
+        }
+        _write_community_pack(
+            tmp_path / "community", "blank.json", _make_pack(questions=[bad])
+        )
+        qb = QuestionBank(questions_dir=tmp_path)
+        assert qb.load_community_packs() == {}
+
+    def test_malformed_answers_drop_only_that_question(self, tmp_path: Path) -> None:
+        """#700: the README's promise — skipped and logged, not fatal."""
+        good = _make_pack()["questions"][0]
+        bad = {"id": "bad", "question": "q", "answers": ["A", "B", "C"]}
+        _write_community_pack(
+            tmp_path / "community", "mixed700.json", _make_pack(questions=[good, bad])
+        )
+        qb = QuestionBank(questions_dir=tmp_path)
+        loaded = qb.load_community_packs()
+        assert "community-mixed700" in loaded
+        assert qb.get_question_count("community-mixed700") == 1
+
+    def test_parser_exception_is_contained(self, tmp_path: Path, monkeypatch) -> None:
+        """#700: even an unforeseen parser error may not abort the load."""
+        import custom_components.quizify.game.questions as questions_module
+
+        real = questions_module._parse_question
+        calls = {"n": 0}
+
+        def exploding(entry, category_name):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("unforeseen field assumption")
+            return real(entry, category_name)
+
+        monkeypatch.setattr(questions_module, "_parse_question", exploding)
+        q = _make_pack()["questions"][0]
+        second = dict(q, id="cq_002")
+        _write_community_pack(
+            tmp_path / "community", "boom.json", _make_pack(questions=[q, second])
+        )
+        qb = QuestionBank(questions_dir=tmp_path)
+        loaded = qb.load_community_packs()
+        assert "community-boom" in loaded
+        assert qb.get_question_count("community-boom") == 1
+
     def test_shipped_example_pack_loads(self) -> None:
         qb = QuestionBank(questions_dir=QUESTIONS_DIR)
         loaded = qb.load_community_packs()


### PR DESCRIPTION
Closes #700

## What was broken

`questions/community/README.md` promises that "a malformed pack is skipped (and logged) rather than crashing the integration". For two answer shapes it was the opposite.

`_parse_question` validated the *length* of `answers` but never the shape of its entries, then called `a.get("correct")` and `a["text"]` on each one:

* `"answers": ["A", "B", "C"]` → `AttributeError`
* `"answers": [{"correct": true}]` → `KeyError`

`load_community_packs` guarded only the *question* with `isinstance(entry, dict)` and put no `try`/`except` around the parser, and `__init__.py` awaits `load_all_categories` unguarded inside `async_setup_entry`. The result of one typo in a guest-supplied file was "Failed to set up" — every Quizify page and socket gone until somebody found and deleted the file.

## The fix

* `_parse_question` now rejects an answer that is not an object, or that has no non-empty `text`, with a warning and `None` — the bad question is dropped, the rest of the pack still loads. Same rules the submission path (`server/pack_submission.py`) has always applied; the loader was the half that trusted the disk.
* `load_community_packs` wraps the parser in `try`/`except` so a future field assumption cannot take the same route out to setup.
* The community README lists the answer-shape rule with the other documented limits.

## Tests

Five new cases in `tests/test_questions.py::TestCommunityPacks`: both crash shapes, a blank `text`, a pack mixing one good and one bad question (the good one survives), and a parser that raises outright (contained, the rest of the pack loads). All five fail on `main` and pass here; full suite 2297 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE