### PR TITLE
fix: a full room can play over Nabu Casa again

### DIFF
--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import ipaddress
 import logging
 import math
 import random
@@ -26,6 +27,7 @@ from custom_components.quizify.const import (
     ERR_ROUND_EXPIRED,
     ERR_TEAM_CLOSED,
     LOBBY_DISCONNECT_GRACE_PERIOD,
+    MAX_PLAYERS,
     WAGER_WINDOW_DURATION,
 )
 from custom_components.quizify.game.highlights import compute_superlatives
@@ -146,6 +148,17 @@ class QuizifyWebSocketHandler:
     # connections get an HTTP 429 before the WebSocket is upgraded.
     MAX_CONNECTIONS_PER_IP = 15
 
+    # Loopback exception to the cap above (#701). Over Nabu Casa every remote
+    # client reaches HA through snitun on 127.0.0.1, and HA's forwarded-header
+    # middleware deliberately ignores X-Forwarded-For for cloud requests — so
+    # every phone, the television and the admin share one source IP and the
+    # generous-looking 15 became "the room is full at thirteen players". A
+    # loopback address is never a stranger's flood (it is either the cloud
+    # tunnel or something already running on this host), so the cap there only
+    # needs to bound resources: a full room, plus the reload overlap of every
+    # phone at once, plus the television and the admin.
+    MAX_CONNECTIONS_PER_LOOPBACK = MAX_PLAYERS * 2 + 5
+
     # Admin-as-player redirect grace: when the admin clicks "Spiel starten"
     # from /quizify/admin, admin.js navigates the tab to /quizify/player so
     # the admin can answer questions. That navigation closes the admin's
@@ -252,6 +265,14 @@ class QuizifyWebSocketHandler:
         self._join_limiter = SlidingWindowLimiter(
             max_requests=30,  # max join attempts per window, per IP
             window=60.0,  # seconds
+            clock=lambda: asyncio.get_event_loop().time(),
+        )
+        # The same key collapse hits the join guard over Nabu Casa (#701):
+        # 30 attempts a minute is a whole room's worth of joins plus barely
+        # any reconnects. Loopback therefore gets its own, room-sized budget.
+        self._loopback_join_limiter = SlidingWindowLimiter(
+            max_requests=MAX_PLAYERS * 5,
+            window=60.0,
             clock=lambda: asyncio.get_event_loop().time(),
         )
         # Routes named state events (round_evaluated / game_ended) to the
@@ -384,20 +405,47 @@ class QuizifyWebSocketHandler:
             )
         return False
 
+    @staticmethod
+    def _is_loopback(remote: str) -> bool:
+        """True when ``remote`` is a loopback address (#701).
+
+        Nabu Casa hands cloud connections to HA over 127.0.0.1, so this is
+        the shape every remote player arrives in. A hostname or anything
+        unparseable is treated as a normal remote address.
+        """
+        try:
+            return ipaddress.ip_address(remote.split("%", 1)[0]).is_loopback
+        except ValueError:
+            return False
+
+    def _connection_cap(self, remote: str) -> int:
+        """Concurrent-socket cap that applies to ``remote`` (#361, #701)."""
+        if self._is_loopback(remote):
+            return self.MAX_CONNECTIONS_PER_LOOPBACK
+        return self.MAX_CONNECTIONS_PER_IP
+
+    def _join_limiter_for(self, remote: str) -> SlidingWindowLimiter:
+        """Join-flood limiter that applies to ``remote`` (#361, #701)."""
+        if self._is_loopback(remote):
+            return self._loopback_join_limiter
+        return self._join_limiter
+
     async def handle(self, request: web.Request) -> web.StreamResponse:
         """Handle WebSocket connection."""
         remote = request.remote
         # Per-IP connection cap (#361): refuse BEFORE upgrading the socket so
         # a flood of sockets from one host can't exhaust resources. Checked
-        # before prepare() so we answer with a plain HTTP 429.
+        # before prepare() so we answer with a plain HTTP 429. Loopback gets
+        # the room-sized cap instead (#701) — over Nabu Casa it carries every
+        # player at once rather than a single host.
         if (
             remote is not None
-            and self._ip_connections.get(remote, 0) >= self.MAX_CONNECTIONS_PER_IP
+            and self._ip_connections.get(remote, 0) >= self._connection_cap(remote)
         ):
             _LOGGER.warning(
                 "Refusing WebSocket from %s: per-IP connection cap (%d) reached",
                 remote,
-                self.MAX_CONNECTIONS_PER_IP,
+                self._connection_cap(remote),
             )
             return web.Response(
                 status=429, text="Too many connections from this address"
@@ -486,7 +534,7 @@ class QuizifyWebSocketHandler:
                     if (
                         data.get("type") == "join"
                         and remote is not None
-                        and not self._join_limiter.check(remote)
+                        and not self._join_limiter_for(remote).check(remote)
                     ):
                         _LOGGER.warning(
                             "Per-IP join rate limit exceeded for %s", remote

--- a/tests/test_nabu_casa_shared_ip_701.py
+++ b/tests/test_nabu_casa_shared_ip_701.py
@@ -1,0 +1,168 @@
+"""Regression tests for issue #701.
+
+Over Nabu Casa every remote client reaches Home Assistant through snitun on
+127.0.0.1, and HA's forwarded-header middleware ignores ``X-Forwarded-For``
+for cloud requests — so ``request.remote`` is the same string for every phone,
+the television and the admin. With the flat per-IP cap of 15 from #361 the
+room filled up at roughly thirteen remote players: every further handshake got
+an HTTP 429, and the phone sat in "reconnecting…" forever.
+
+Loopback now gets its own, room-sized budget for both the concurrent-socket
+cap and the join-flood guard, while a real remote address keeps the strict
+per-IP limits the security fix put there.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+from aiohttp import WSServerHandshakeError, web
+from aiohttp.test_utils import TestClient, TestServer
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.const import MAX_PLAYERS  # noqa: E402
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server import WS_PATH  # noqa: E402
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    def create_task(self, coro):  # noqa: ANN001, ANN202
+        return asyncio.ensure_future(coro)
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func, *args)
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+@pytest.fixture
+def handler(game: QuizifyGameState) -> QuizifyWebSocketHandler:
+    runtime = _FakeRuntime(game._runtime.data_dir)  # type: ignore[attr-defined]
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    h._conn = ConnectionManager(runtime, lambda: game)
+    return h
+
+
+async def _make_client(handler: QuizifyWebSocketHandler) -> TestClient:
+    app = web.Application()
+    app.router.add_get(WS_PATH, handler.handle)
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    return client
+
+
+class TestLoopbackIsNotOneDevice:
+    def test_loopback_addresses_are_recognised(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        assert handler._is_loopback("127.0.0.1") is True
+        assert handler._is_loopback("127.1.2.3") is True
+        assert handler._is_loopback("::1") is True
+
+    def test_real_addresses_and_junk_are_not_loopback(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        assert handler._is_loopback("192.168.1.42") is False
+        assert handler._is_loopback("2001:db8::1") is False
+        # A hostname or anything unparseable must not be granted the exception.
+        assert handler._is_loopback("some-host.local") is False
+        assert handler._is_loopback("") is False
+
+    def test_loopback_cap_covers_a_full_room(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """A full room, everyone reloading at once, plus TV and admin."""
+        cap = handler._connection_cap("127.0.0.1")
+        assert cap >= MAX_PLAYERS * 2 + 2
+        assert cap == handler.MAX_CONNECTIONS_PER_LOOPBACK
+
+    def test_remote_address_keeps_the_strict_cap(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        assert handler._connection_cap("192.168.1.42") == handler.MAX_CONNECTIONS_PER_IP
+
+    @pytest.mark.asyncio
+    async def test_sixteenth_cloud_connection_is_accepted(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """The bug itself: over Nabu Casa the 16th socket used to get a 429.
+
+        The TestClient connects from 127.0.0.1, which is exactly the shape a
+        cloud connection arrives in.
+        """
+        opened = []
+        client = await _make_client(handler)
+        try:
+            for _ in range(handler.MAX_CONNECTIONS_PER_IP + 1):
+                opened.append(await client.ws_connect(WS_PATH))
+            assert len(opened) == handler.MAX_CONNECTIONS_PER_IP + 1
+        finally:
+            for ws in opened:
+                await ws.close()
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_loopback_cap_still_bites_eventually(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """The exception raises the ceiling, it does not remove it."""
+        handler.MAX_CONNECTIONS_PER_LOOPBACK = 2
+        opened = []
+        client = await _make_client(handler)
+        try:
+            for _ in range(2):
+                opened.append(await client.ws_connect(WS_PATH))
+            for _ in range(50):
+                await asyncio.sleep(0.01)
+                if len(handler._conn.connections) == 2:
+                    break
+            with pytest.raises(WSServerHandshakeError) as exc:
+                await client.ws_connect(WS_PATH)
+            assert exc.value.status == 429
+        finally:
+            for ws in opened:
+                await ws.close()
+            await client.close()
+
+
+class TestLoopbackJoinBudget:
+    def test_loopback_gets_the_room_sized_join_limiter(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        assert handler._join_limiter_for("127.0.0.1") is handler._loopback_join_limiter
+        assert handler._join_limiter_for("192.168.1.42") is handler._join_limiter
+
+    def test_a_full_room_can_join_and_reconnect_over_the_cloud(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """20 players joining, then rejoining twice, must not trip the guard.
+
+        The flat 30-per-minute budget was a whole room plus barely a handful
+        of reconnects — over Nabu Casa that is one shared bucket.
+        """
+        limiter = handler._join_limiter_for("127.0.0.1")
+        for _ in range(MAX_PLAYERS * 3):
+            assert limiter.check("127.0.0.1") is True
+
+    def test_one_real_device_keeps_the_strict_join_budget(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        limiter = handler._join_limiter_for("192.168.1.42")
+        allowed = sum(1 for _ in range(60) if limiter.check("192.168.1.42"))
+        assert allowed == 30

--- a/tests/test_ws_per_ip_cap_361.py
+++ b/tests/test_ws_per_ip_cap_361.py
@@ -80,6 +80,9 @@ class TestPerIpConnectionCap:
         refused with HTTP 429 (before the socket is upgraded); the earlier
         sockets stay open."""
         handler.MAX_CONNECTIONS_PER_IP = 3  # keep the test fast
+        # The TestClient connects from 127.0.0.1, which since #701 gets the
+        # larger loopback cap; lower it too so this still exercises the cap.
+        handler.MAX_CONNECTIONS_PER_LOOPBACK = 3
         client = await _make_client(handler)
         opened = []
         try:


### PR DESCRIPTION
Closes #701

## What was broken

`MAX_CONNECTIONS_PER_IP = 15` (from #361) is keyed on `request.remote`. Over Nabu Casa that key is the same string for everybody: snitun hands cloud connections to HA over loopback, and HA's `http/forwarded.py` skips `X-Forwarded-For` for cloud requests. Every phone, the television and the admin are `127.0.0.1`.

With `MAX_PLAYERS = 20` and a README that advertises playing over Nabu Casa, the room filled at roughly thirteen remote players: every further handshake got an HTTP 429 before the upgrade, and `player-core.js` sat in "reconnecting…" with no hint that a limit was hit.

## The fix

* `MAX_CONNECTIONS_PER_LOOPBACK = MAX_PLAYERS * 2 + 5` — a full room with every phone mid-reload, plus the television and the admin. Applied only when `request.remote` is a loopback address.
* A real remote address keeps the strict 15, so #361's flood guard still covers the case it was written for. Loopback is either the cloud tunnel or something already running on this host, so the cap there only has to bound resources.
* The per-IP join-flood guard collapses to the same key, so it gets a matching loopback-sized budget (`MAX_PLAYERS * 5` per minute instead of 30).
* Address classification goes through `ipaddress`, so a hostname or anything unparseable is treated as remote rather than granted the exception.

## Tests

New `tests/test_nabu_casa_shared_ip_701.py` (9 cases): loopback vs. remote classification including junk input, both caps, the 16th cloud socket that used to be refused, the loopback ceiling still returning 429 when it is genuinely reached, and both join budgets. All nine fail on `main`.

One existing #361 case now also lowers `MAX_CONNECTIONS_PER_LOOPBACK`: its TestClient connects from 127.0.0.1, so it needs the loopback knob to keep exercising the cap. Full suite 2306 passed; ruff and mypy clean.

## Not in scope

The client still shows "reconnecting…" rather than naming a 429. That path is now unreachable for a normal room, but it stays silent if the ceiling is ever genuinely hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE