### PR TITLE
fix: a guest joining during a pause no longer holds the round open

### DIFF
--- a/custom_components/quizify/game/phase_controller.py
+++ b/custom_components/quizify/game/phase_controller.py
@@ -169,21 +169,31 @@ class PhaseController:
             and self.round_start_time is not None
             and name not in self.timers
         ):
-            elapsed = time.monotonic() - self.round_start_time
-            remaining = max(0.5, self.round_duration - elapsed)
-            # Reconstruct the timer against the SHARED round wall-clock rather
-            # than starting a fresh clock at join time (#355). A plain
-            # QuestionTimer(remaining).start() makes get_elapsed() count from
-            # JOIN, so a player joining with 5s left and answering in 2s scores
-            # time_fraction ≈ 0.93 (near-max speed bonus) — beating an on-time
-            # player answering at the same wall-clock instant (≈ 0.17). Seeding
-            # elapsed = now - round_start_time (the exact pause/resume trick)
-            # makes the late joiner's get_elapsed() identical to an on-time
-            # player's, so speed scoring is consistent. The remaining still
-            # carries the 0.5s late-join grace so they can answer the in-flight
-            # question.
-            timer = QuestionTimer.resumed(remaining=remaining, elapsed=elapsed)
-            self.timers[name] = timer
+            timer = self._late_joiner_timer()
+            if timer is not None:
+                self.timers[name] = timer
+
+    def _late_joiner_timer(self) -> QuestionTimer | None:
+        """Build a timer on the round's SHARED wall-clock (#355, #702).
+
+        Used for anyone who was not present when the round began: someone who
+        joins mid-question, and (since #702) someone who joins while the game
+        is paused. Returns None when there is no round to hang a clock on.
+
+        A plain ``QuestionTimer(remaining).start()`` would make get_elapsed()
+        count from JOIN, so a player joining with 5s left and answering in 2s
+        scores time_fraction ≈ 0.93 (near-max speed bonus) — beating an on-time
+        player answering at the same wall-clock instant (≈ 0.17). Seeding
+        elapsed = now - round_start_time (the exact pause/resume trick) makes
+        the late joiner's get_elapsed() identical to an on-time player's, so
+        speed scoring is consistent. The remaining carries a 0.5s floor as the
+        late-join grace, so they can still answer the in-flight question.
+        """
+        if self.round_start_time is None:
+            return None
+        elapsed = time.monotonic() - self.round_start_time
+        remaining = max(0.5, self.round_duration - elapsed)
+        return QuestionTimer.resumed(remaining=remaining, elapsed=elapsed)
 
     def drop_timer(self, name: str) -> None:
         """Drop a single player's timer (player removed)."""
@@ -390,8 +400,9 @@ class PhaseController:
             self.round_start_time += time.monotonic() - self.paused_at
         # Restore timers with the remaining time AND elapsed they had at pause
         # (QuestionTimer.resumed preserves both, so the speed bonus measured
-        # from get_elapsed() isn't inflated — #295/#254). Late-joiners during
-        # PAUSED won't be in the snapshots and get a fresh full-round timer.
+        # from get_elapsed() isn't inflated — #295/#254). Someone who joined
+        # while the game was paused is in no snapshot and gets the round's
+        # shared remaining instead (#702).
         full = self.round_duration
         for name in self._players_fn():
             if name in self.paused_remaining:
@@ -406,8 +417,18 @@ class PhaseController:
                 if frozen_left > 0.0:
                     timer.freeze(frozen_left)
             else:
-                timer = QuestionTimer(full)
-                timer.start()
+                # Joined during the pause (#702). A fresh full clock made the
+                # newcomer outlast everybody else — the tick loop only ends
+                # once every connected timer has expired, and all_submitted()
+                # ignores late joiners, so the whole room sat at 0:00 waiting
+                # for one phone that had up to a full round left. The mid-
+                # question join path already hands out the shared remaining;
+                # this is the same rule for the paused path.
+                late = self._late_joiner_timer()
+                if late is None:  # no round wall-clock to hang it on
+                    late = QuestionTimer(full)
+                    late.start()
+                timer = late
             self.timers[name] = timer
         self.paused_remaining = {}
         self.paused_elapsed = {}

--- a/tests/test_late_joiner_clock_after_pause_702.py
+++ b/tests/test_late_joiner_clock_after_pause_702.py
@@ -1,0 +1,142 @@
+"""Regression tests for issue #702.
+
+``add_late_joiner_timer`` only acts in QUESTION_ACTIVE, so a guest who joined
+while the game was paused was in none of the pause snapshots. ``resume()``
+then gave every such name a fresh ``QuestionTimer(full).start()``: paused with
+14s left, the existing player resumed with 14.0s and the newcomer got 20.0s.
+
+The tick loop ends only once every connected timer has expired and
+``all_submitted()`` ignores late joiners, so the newcomer held the round open —
+every phone and the television sat at 0:00 for up to a full round.
+
+Joining mid-question *without* a pause already handed out the round's shared
+remaining time, so this was an inconsistency between two paths. Both now use
+the same clock.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.phase_controller import (  # noqa: E402
+    GamePhase,
+    PhaseController,
+)
+
+ROUND = 30.0
+
+
+def _paused_mid_round(shift: float, names: list[str]) -> PhaseController:
+    """A controller paused ``shift`` seconds into a round, with ``names`` playing.
+
+    Backdates the shared round wall-clock and every timer so the round looks
+    ``shift`` seconds old without sleeping, then pauses.
+    """
+    pc = PhaseController(players_fn=lambda: list(names))
+    pc.begin_round(ROUND)
+    pc.enter_question_active()
+    pc.round_start_time -= shift  # type: ignore[operator]
+    for timer in pc.timers.values():
+        timer._start_time -= shift  # noqa: SLF001
+    assert pc.pause("admin_disconnected") is True
+    assert pc.phase == GamePhase.PAUSED
+    return pc
+
+
+class TestGuestJoiningDuringPause:
+    def test_newcomer_gets_the_rounds_remaining_not_a_full_clock(self) -> None:
+        names = ["ontime"]
+        pc = _paused_mid_round(16.0, names)  # 14s left on a 30s round
+        names.append("newcomer")  # joins while paused
+
+        assert pc.resume() is True
+
+        ontime_left = pc.timers["ontime"].get_remaining()
+        newcomer_left = pc.timers["newcomer"].get_remaining()
+        assert ontime_left == pytest.approx(14.0, abs=0.2)
+        # The bug: 20.0 here (the full round), 6s past everybody else.
+        assert newcomer_left == pytest.approx(ontime_left, abs=0.2)
+
+    def test_the_round_no_longer_waits_for_the_newcomer(self) -> None:
+        """Every connected timer expires together, so the tick loop can end."""
+        names = ["ontime"]
+        pc = _paused_mid_round(29.6, names)  # 0.4s left
+        names.append("newcomer")
+        assert pc.resume() is True
+
+        # Both clocks are within the same fraction of a second of zero; before
+        # the fix the newcomer still had the full 30s.
+        assert pc.timers["newcomer"].get_remaining() <= 1.0
+
+    def test_newcomer_speed_bonus_matches_an_on_time_player(self) -> None:
+        """elapsed is seeded from the shared wall-clock, not from the join."""
+        names = ["ontime"]
+        pc = _paused_mid_round(20.0, names)
+        names.append("newcomer")
+        assert pc.resume() is True
+
+        assert pc.timers["newcomer"].get_elapsed() == pytest.approx(
+            pc.timers["ontime"].get_elapsed(), abs=0.3
+        )
+
+    def test_newcomer_can_still_answer_the_in_flight_question(self) -> None:
+        """The 0.5s late-join grace applies here too."""
+        names = ["ontime"]
+        pc = _paused_mid_round(29.99, names)
+        names.append("newcomer")
+        assert pc.resume() is True
+
+        assert pc.timers["newcomer"].get_remaining() >= 0.49
+        assert not pc.timers["newcomer"].is_expired()
+
+    def test_players_present_at_pause_still_resume_untouched(self) -> None:
+        """#295/#254 behaviour is unchanged for everyone in the snapshot."""
+        names = ["a", "b"]
+        pc = _paused_mid_round(10.0, names)
+        assert pc.resume() is True
+
+        for name in names:
+            assert pc.timers[name].get_remaining() == pytest.approx(20.0, abs=0.2)
+            assert pc.timers[name].get_elapsed() == pytest.approx(10.0, abs=0.2)
+
+    def test_only_question_active_is_pausable_at_all(self) -> None:
+        """The path this fix touches is the only one resume() can reach.
+
+        pause() is a no-op outside QUESTION_ACTIVE, so ``paused_from`` is
+        always QUESTION_ACTIVE and there is no second phase to special-case.
+        """
+        names = ["ontime"]
+        pc = PhaseController(players_fn=lambda: list(names))
+        pc.begin_round(ROUND)
+        pc.enter_question_active()
+        pc.phase = GamePhase.ANSWER_REVEAL
+        assert pc.pause("admin_disconnected") is False
+
+
+class TestLateJoinerTimerHelper:
+    def test_helper_returns_none_without_a_round(self) -> None:
+        pc = PhaseController(players_fn=list)
+        assert pc._late_joiner_timer() is None
+
+    def test_both_join_paths_use_the_same_clock(self) -> None:
+        """Mid-question join and post-pause join must agree."""
+        names = ["ontime"]
+        pc = PhaseController(players_fn=lambda: list(names))
+        pc.begin_round(ROUND)
+        pc.enter_question_active()
+        pc.round_start_time -= 12.0  # type: ignore[operator]
+        pc.timers["ontime"]._start_time -= 12.0  # noqa: SLF001
+        pc.add_late_joiner_timer("mid_question")
+
+        paused = _paused_mid_round(12.0, ["other"])
+        helper_timer = paused._late_joiner_timer()
+        assert helper_timer is not None
+        assert helper_timer.get_remaining() == pytest.approx(
+            pc.timers["mid_question"].get_remaining(), abs=0.3
+        )


### PR DESCRIPTION
Closes #702

## What was broken

`add_late_joiner_timer` only acts in `QUESTION_ACTIVE`, so a guest who joins while the game is paused appears in none of the pause snapshots. `resume()` then gave every such name a fresh `QuestionTimer(full).start()`.

Measured on a running dev server: paused with 14 s left, the existing player resumed with 14.0 s and the newcomer with 20.0 s. The tick loop ends only when all connected timers have expired and `all_submitted()` excludes late joiners, so the newcomer held the round open — `round_summary` arrived 6.0 s after the first clock hit zero, and up to ~30 s with the default timer paused early. Every phone and the television sit at 0:00 while nothing happens.

Joining mid-question *without* a pause already hands out the shared remaining time, so the two paths simply disagreed.

## The fix

The wall-clock reconstruction moves out of `add_late_joiner_timer` into `_late_joiner_timer()`, and `resume()` uses it for anyone missing from the snapshots:

* remaining = the round's actual remaining time, so every connected timer expires together and the round can end;
* elapsed = seeded from `round_start_time`, not from the join, so the speed bonus stays identical to an on-time player's (#355);
* the 0.5 s floor still lets the newcomer answer the in-flight question.

`pause()` is a no-op outside `QUESTION_ACTIVE`, so there is no second phase to special-case; the full-clock fallback only remains for a missing round wall-clock.

## Tests

New `tests/test_late_joiner_clock_after_pause_702.py` (8 cases): the shared remaining, the round no longer waiting, elapsed parity with an on-time player, the grace window, players present at the pause resuming untouched (#295/#254/#451), pause being a no-op elsewhere, and both join paths agreeing. Five fail on `main`; the other three pin behaviour the fix must not disturb.

Full suite 2305 passed; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE