### PR TITLE
fix: a reconnect during a pause is told why the game stopped

### DIFF
--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -2935,6 +2935,16 @@ class QuizifyGameState:
                 block["summary"] = hs.summary()
             snapshot["hot_seat"] = block
 
+        if self.phase == GamePhase.PAUSED:
+            # #703: the reason used to be attached by the two pause
+            # *broadcasts* only, so any phone that reconnected (or joined, or
+            # asked for state) during a pause got a snapshot without it. The
+            # client derives both the title and the 60s reset affordance from
+            # this field, so a guest who reloaded during a host-gone pause was
+            # told "the host will resume" and lost the only way out (#299) —
+            # on exactly the phones that had just reconnected.
+            snapshot["pause_reason"] = self.get_pause_reason()
+
         return snapshot
 
     # ------------------------------------------------------------------

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -2145,9 +2145,10 @@ class QuizifyWebSocketHandler:
             return False
         # Stop sending tick updates while paused.
         self._cancel_timer_tick()
+        # pause_reason rides along in the snapshot itself since #703, so it
+        # is identical here and on every reconnect.
         state = game_state.get_state_snapshot()
         state["type"] = "game_state"
-        state["pause_reason"] = "admin_paused"
         await self._conn.broadcast(state)
         return True
 
@@ -3582,7 +3583,6 @@ class QuizifyWebSocketHandler:
                 self._cancel_timer_tick()
                 state = gs.get_state_snapshot()
                 state["type"] = "game_state"
-                state["pause_reason"] = "admin_disconnected"
                 await self._conn.broadcast(state)
                 _LOGGER.info(
                     "Paused game after admin %s failed to reconnect within %.1fs",

--- a/tests/test_pause_reason_in_snapshot_703.py
+++ b/tests/test_pause_reason_in_snapshot_703.py
@@ -1,0 +1,103 @@
+"""Regression tests for issue #703.
+
+``pause_reason`` was added by the two pause *broadcasts* and nowhere else:
+``get_state_snapshot`` had no PAUSED branch, so ``_handle_reconnect``,
+``_handle_join`` and ``_handle_get_state`` all sent a snapshot without it.
+
+The client reads exactly that field: ``updatePausedView`` shows "Host
+disconnected" and arms the 60-second reset button (#299) only when
+``data.pause_reason === 'admin_disconnected'``. A guest who reloaded during a
+host-gone pause was therefore told "Paused — the host will resume" and lost the
+only escape hatch from a dead game — on precisely the phones that had just
+reconnected, which in a host-gone pause tends to be all of them.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    ws.close = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+def _paused(game: QuizifyGameState, reason: str) -> None:
+    game.add_player("Alice", _ws())
+    game.add_player("Bob", _ws())
+    game.start_game(language="de", num_rounds=3, difficulty="easy")
+    assert game.start_next_question() is not None
+    assert game.pause(reason=reason) is True
+    assert game.phase == GamePhase.PAUSED
+
+
+class TestSnapshotCarriesThePauseReason:
+    def test_host_gone_pause_is_named_in_the_snapshot(
+        self, game: QuizifyGameState
+    ) -> None:
+        """The bug: a reconnecting phone could not tell why the game stopped."""
+        _paused(game, "admin_disconnected")
+        assert game.get_state_snapshot()["pause_reason"] == "admin_disconnected"
+
+    def test_deliberate_pause_is_named_too(self, game: QuizifyGameState) -> None:
+        _paused(game, "admin_paused")
+        assert game.get_state_snapshot()["pause_reason"] == "admin_paused"
+
+    def test_snapshot_matches_get_pause_reason(self, game: QuizifyGameState) -> None:
+        """One source of truth: the field is read off the phase controller."""
+        _paused(game, "admin_disconnected")
+        snapshot = game.get_state_snapshot()
+        assert snapshot["pause_reason"] == game.get_pause_reason()
+
+    def test_no_pause_reason_outside_a_pause(self, game: QuizifyGameState) -> None:
+        """A running game must not carry a stale reason.
+
+        The client only branches on the value, so a leftover
+        ``admin_disconnected`` would arm a reset button mid-question.
+        """
+        game.add_player("Alice", _ws())
+        game.start_game(language="de", num_rounds=3, difficulty="easy")
+        assert game.start_next_question() is not None
+        assert "pause_reason" not in game.get_state_snapshot()
+
+    def test_reason_is_gone_again_after_resume(self, game: QuizifyGameState) -> None:
+        _paused(game, "admin_disconnected")
+        assert game.resume() is True
+        assert "pause_reason" not in game.get_state_snapshot()
+
+    def test_every_snapshot_consumer_sees_it(self, game: QuizifyGameState) -> None:
+        """join / reconnect / get_state all serialize this same dict.
+
+        They differ only in the per-player answer projection (#253/#286), so
+        one PAUSED branch covers all three paths at once.
+        """
+        _paused(game, "admin_disconnected")
+        first = game.get_state_snapshot()
+        second = game.get_state_snapshot()
+        assert first["pause_reason"] == second["pause_reason"] == "admin_disconnected"
+        assert first["phase"] == GamePhase.PAUSED.value


### PR DESCRIPTION
Closes #703

## What was broken

`pause_reason` was added by the two pause broadcasts (`server/websocket.py`) and nowhere else. `get_state_snapshot` had no PAUSED branch, so `_handle_reconnect`, `_handle_join` and `_handle_get_state` all sent the raw snapshot — verified: a snapshot taken while paused carried no reason.

`updatePausedView` (`www/js/player-core.js`) shows "Host disconnected" and arms `paused-reset-btn` only when `data.pause_reason === 'admin_disconnected'`. So a guest who reloaded during a host-gone pause saw "Paused — the host will resume" and never got the 60-second escape hatch from #299 — on exactly the phones that had reconnected, which in a host-gone pause is likely all of them.

## The fix

`get_state_snapshot` carries `pause_reason` whenever the phase is PAUSED. All three consumer paths serialize that same dict (they differ only in the per-player answer projection from #253/#286), so one branch covers them all.

The two broadcasts drop their manual `state["pause_reason"] = …`: the value came from the same phase controller either way, and a single producer is what stops the reconnect path drifting away from the broadcast path a second time.

## Tests

New `tests/test_pause_reason_in_snapshot_703.py` (6 cases): both reasons present in the snapshot, agreement with `get_pause_reason()`, no stale reason in a running game (a leftover `admin_disconnected` would arm a reset button mid-question), none after resume, and stability across repeated serialization. Four fail on `main`.

Full suite 2303 passed; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE