### PR TITLE
fix(analytics): the page paints in the palette it actually has

### DIFF
--- a/custom_components/quizify/www/analytics.html
+++ b/custom_components/quizify/www/analytics.html
@@ -26,19 +26,19 @@
         .period-btn {
             padding: 8px 16px;
             background: var(--color-bg-surface);
-            border: 1px solid var(--color-border);
+            border: 1px solid var(--color-border-light);
             border-radius: var(--radius-full);
-            font-family: var(--font-main);
+            font-family: var(--font-body);
             font-size: 0.85rem;
-            color: var(--color-text);
+            color: var(--color-text-primary);
             cursor: pointer;
             transition: all var(--transition-fast);
         }
 
         .period-btn.active {
-            background: rgba(108, 92, 231, 0.2);
-            border-color: var(--color-accent);
-            color: var(--color-accent-bright);
+            background: var(--color-accent-brand-bg);
+            border-color: var(--color-accent-primary);
+            color: var(--color-accent-brand-hover);
         }
 
         .stats-grid {
@@ -50,7 +50,7 @@
 
         .stat-card {
             background: var(--color-bg-card);
-            border: 1px solid var(--color-border);
+            border: 1px solid var(--color-border-light);
             border-radius: var(--radius-lg);
             padding: var(--space-lg);
             text-align: center;
@@ -59,7 +59,7 @@
         .stat-value {
             font-size: 1.8rem;
             font-weight: 800;
-            color: var(--color-accent-bright);
+            color: var(--color-accent-brand-hover);
             font-variant-numeric: tabular-nums;
         }
 
@@ -93,7 +93,7 @@
         .games-table td {
             padding: var(--space-sm) var(--space-md);
             text-align: left;
-            border-bottom: 1px solid var(--color-border);
+            border-bottom: 1px solid var(--color-border-light);
             font-size: 0.85rem;
         }
 
@@ -106,12 +106,12 @@
         }
 
         .games-table td {
-            color: var(--color-text);
+            color: var(--color-text-primary);
         }
 
         .chart-container {
             background: var(--color-bg-card);
-            border: 1px solid var(--color-border);
+            border: 1px solid var(--color-border-light);
             border-radius: var(--radius-lg);
             padding: var(--space-lg);
             height: 200px;
@@ -132,7 +132,11 @@
         .chart-bar {
             width: 100%;
             max-width: 40px;
-            background: linear-gradient(180deg, var(--color-accent), var(--color-electric));
+            background: linear-gradient(
+                180deg,
+                var(--color-accent-primary),
+                var(--color-accent-brand-hover)
+            );
             border-radius: 4px 4px 0 0;
             min-height: 2px;
             transition: height var(--transition-normal);
@@ -140,7 +144,7 @@
 
         .chart-label {
             font-size: 0.65rem;
-            color: var(--color-text-dim);
+            color: var(--color-text-muted);
             margin-top: var(--space-xs);
         }
 
@@ -155,7 +159,7 @@
             align-items: center;
             gap: var(--space-md);
             padding: var(--space-md);
-            border-bottom: 1px solid var(--color-border);
+            border-bottom: 1px solid var(--color-border-light);
         }
 
         .top-player-row:last-child {
@@ -181,7 +185,7 @@
         .top-player-rank.rank-3 { background: var(--color-bronze); color: white; }
 
         .top-player-name { flex: 1; font-weight: 500; }
-        .top-player-score { font-weight: 700; color: var(--color-accent-bright); font-variant-numeric: tabular-nums; }
+        .top-player-score { font-weight: 700; color: var(--color-accent-brand-hover); font-variant-numeric: tabular-nums; }
 
         .empty-state {
             text-align: center;
@@ -192,15 +196,15 @@
         .loading-state {
             text-align: center;
             padding: var(--space-2xl);
-            color: var(--color-text-dim);
+            color: var(--color-text-muted);
         }
 
         .back-link {
             display: inline-flex;
             align-items: center;
             gap: var(--space-sm);
-            color: var(--color-accent-bright);
-            text-decoration: none;
+            color: var(--color-accent-brand-hover);
+            text-decoration: underline;
             font-size: 0.85rem;
             margin-bottom: var(--space-lg);
         }

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -38,6 +38,11 @@
             --dash-surface-2: #F3EEDF;               /* cream tint */               /* modals, hover */
             --dash-border-neon: #E5DFCF;             /* warm hairline */             /* hairline */
             --dash-text-neon-muted: #6E6A5C;         /* warm olive-gray */         /* cool blue-gray */
+            /* #705: eight declarations on this page ask for --dash-text-muted,
+               which was never defined — the palette only had the -neon- name.
+               Every one of them was invalidated, so the secondary lines were
+               inheriting full-strength ink instead of the muted olive-gray. */
+            --dash-text-muted: #6E6A5C;              /* warm olive-gray */
             --dash-text-white: #2A2820;              /* dark ink on cream */              /* warm parchment, NOT white */
             --dash-success: #7FA897;                 /* sage for correct */                 /* correct = gold */
             --dash-success-glow: rgba(127, 168, 151, 0.35);

--- a/tests/test_page_tokens_defined_705.py
+++ b/tests/test_page_tokens_defined_705.py
@@ -1,0 +1,61 @@
+"""Every design token a page uses has to exist (#705).
+
+`analytics.html` still referenced seven tokens from the pre-Soft-Parlor
+palette. An undefined `var()` invalidates the whole declaration at
+computed-value time, so each one silently fell back to `initial`: the
+"Games Over Time" bars lost their gradient and rendered transparent, the cards
+lost their borders, the stat values and the "← Back" link lost their colour —
+and the link has no underline, so it read as plain text.
+
+Nothing failed loudly, which is the point of this test: a token that goes away
+during a palette change now breaks a test instead of a page.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_WWW = Path(__file__).resolve().parent.parent / "custom_components/quizify/www"
+_STYLES = _WWW / "css/styles.css"
+
+# ``var(--x)`` with no fallback — those are the ones that fail silently.
+_USE = re.compile(r"var\(\s*(--[\w-]+)\s*\)")
+_DEF = re.compile(r"(--[\w-]+)\s*:")
+
+
+def _pages() -> list[Path]:
+    return sorted(_WWW.glob("*.html"))
+
+
+def test_there_are_pages_to_check() -> None:
+    assert _pages(), "no www/*.html found — the glob is wrong, not the pages"
+
+
+@pytest.mark.parametrize("page", _pages(), ids=lambda p: p.name)
+def test_every_token_a_page_uses_is_defined(page: Path) -> None:
+    html = page.read_text(encoding="utf-8")
+    # A page may define its own tokens inline (dashboard.html does, with its
+    # --dash-* set), so both sources count as a definition.
+    defined = set(_DEF.findall(_STYLES.read_text(encoding="utf-8")))
+    defined |= set(_DEF.findall(html))
+    missing = sorted(t for t in set(_USE.findall(html)) if t not in defined)
+    assert not missing, (
+        f"{page.name} uses undefined tokens: {missing}. "
+        "An undefined var() invalidates the declaration — the rule is dropped, "
+        "not merely mis-coloured."
+    )
+
+
+def test_no_broadcast_living_room_purple_is_left() -> None:
+    """The old palette's purple, hard-coded past the token layer.
+
+    `.period-btn.active` kept `rgba(108, 92, 231, 0.2)` — the only purple on
+    any Soft Parlor surface, and invisible to the token check above because it
+    never went through a token.
+    """
+    for page in _pages():
+        html = page.read_text(encoding="utf-8")
+        assert "108, 92, 231" not in html, f"{page.name} still paints the old purple"


### PR DESCRIPTION
Closes #705

## What was broken

Seven tokens on `analytics.html` come from the pre-Soft-Parlor palette and are defined nowhere under `www/css/`. An undefined `var()` invalidates the whole declaration at computed-value time, so each one silently fell back to `initial`:

* the `.chart-bar` gradient → transparent, so "Games Over Time" showed counts floating over labels with nothing between them;
* `--color-border` (5×) → no card borders, no table rules;
* `--color-accent-bright` (4×) → stat values, top-player scores and the "← Back" link in body ink, and the link has `text-decoration: none`, so it read as plain text;
* `--color-text` (10×) and `--font-main` were undefined too — the period buttons were not even in DM Sans.

`.period-btn.active` also kept `rgba(108, 92, 231, 0.2)`, the last Broadcast Living Room purple on any surface.

## The fix

Each token mapped onto the palette that exists: `--color-border` → `--color-border-light`, `--color-accent` → `--color-accent-primary`, `--color-accent-bright` → `--color-accent-brand-hover` (the darker coral, for contrast on cream), `--color-text-dim` → `--color-text-muted`, `--color-text` → `--color-text-primary`, `--font-main` → `--font-body`. The bar gradient runs coral → deep coral, the active pill uses `--color-accent-brand-bg`, and the back link gets an underline so it reads as a link without relying on colour.

**The television had the same defect.** Eight declarations in `dashboard.html` ask for `--dash-text-muted`; the palette only defines `--dash-text-neon-muted`. All eight were dropped, so the board's secondary lines rendered in full-strength ink instead of the muted olive-gray. The new test found it; the missing definition fixes it.

## Tests

New `tests/test_page_tokens_defined_705.py`: every `var(--token)` without a fallback, on every `www/*.html`, must resolve against `styles.css` or that page's own token block — and no page may carry the old purple. Three cases fail against the previous tree.

## Verified in the browser

Rendered at 390 px against the dev server: cards `rgb(229,223,207)`, stat values and the underlined back link `rgb(217,117,104)`, period buttons in `DM Sans`, bar gradient `linear-gradient(rgb(232,138,127), rgb(217,117,104))`. Full suite 2346 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE