### PR TITLE
fix: five small defects on the host's path

### DIFF
--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -1857,6 +1857,18 @@
         function showView(name) {
             Object.values(views).forEach(function(v) { v.classList.remove('active'); });
             if (views[name]) views[name].classList.add('active');
+            // #706: the tally sits in the header, outside every view, and only
+            // question_started ever took it down. The reveal, the lightning
+            // round, the finale and game_reset all left "3/3" in coral on the
+            // board — through the next lobby, where it hung above the QR code.
+            // Every view change away from the question clears it, so a new
+            // path cannot forget again. The hot-seat frame shows the question
+            // view and sets its own tally afterwards, so it is unaffected.
+            if (name !== 'question' && els.answerProgress) {
+                els.answerProgress.textContent = '';
+                els.answerProgress.classList.add('hidden');
+                els.answerProgress.classList.remove('is-complete');
+            }
         }
 
         // ---- #374: TV lobby join QR + live player roster ----

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -93,20 +93,66 @@
     };
 
     // ---- Simple inline timer ----
-    var adminTimerEl = null;
+    // #706: the seconds used to be written into #admin-timer-bar, which is the
+    // 6px .timer-bar-container — so the text wiped .timer-bar-fill and spilled
+    // out of a strip six pixels tall, while the element built for it
+    // (#admin-timer-bar-text, 1.5rem bold tabular with warning/critical
+    // states) was never written at all. The text goes to the text node, the
+    // bar keeps its fill, and the fill now actually empties: start() has
+    // always been handed the duration and never used it.
+    var adminTimerTextEl = null;
+    var adminTimerFillEl = null;
+    var adminTimerDuration = 0;
     var adminTimerInterval = null;
+
+    function _adminTimerText() {
+        if (!adminTimerTextEl) {
+            adminTimerTextEl = document.getElementById('admin-timer-bar-text');
+        }
+        return adminTimerTextEl;
+    }
+
+    function _adminTimerFill() {
+        if (!adminTimerFillEl) {
+            var bar = document.getElementById('admin-timer-bar');
+            adminTimerFillEl = bar ? bar.querySelector('.timer-bar-fill') : null;
+        }
+        return adminTimerFillEl;
+    }
+
     var adminTimer = {
         start: function(duration) {
-            adminTimerEl = document.getElementById('admin-timer-bar');
+            adminTimerDuration = typeof duration === 'number' && duration > 0
+                ? duration
+                : 0;
             clearInterval(adminTimerInterval);
+            var fill = _adminTimerFill();
+            if (fill) fill.style.width = '100%';
         },
         update: function(remaining) {
-            if (!adminTimerEl) adminTimerEl = document.getElementById('admin-timer-bar');
-            if (adminTimerEl) adminTimerEl.textContent = Math.ceil(remaining) + 's';
+            var left = Math.max(0, remaining);
+            var textEl = _adminTimerText();
+            if (textEl) {
+                textEl.textContent = Math.ceil(left) + 's';
+                // The same thresholds the player's clock uses, so host and
+                // room turn red at the same moment.
+                textEl.classList.toggle('critical', left <= 5);
+                textEl.classList.toggle('warning', left > 5 && left <= 10);
+            }
+            var fill = _adminTimerFill();
+            if (fill && adminTimerDuration > 0) {
+                fill.style.width = (100 * left / adminTimerDuration) + '%';
+            }
         },
         stop: function() {
             clearInterval(adminTimerInterval);
-            if (adminTimerEl) adminTimerEl.textContent = '';
+            var textEl = _adminTimerText();
+            if (textEl) {
+                textEl.textContent = '';
+                textEl.classList.remove('warning', 'critical');
+            }
+            var fill = _adminTimerFill();
+            if (fill) fill.style.width = '0%';
         }
     };
 
@@ -1941,7 +1987,13 @@
         }
         if (countdownEl) {
             countdownEl.classList.toggle('is-ready', isReady);
-            countdownEl.classList.toggle('hidden', isReady);
+            // #706: at LOBBY_MIN_PLAYERS = 1 the only state that shows this
+            // line is the empty lobby, where it reads "Ready at 1 players ·
+            // still need 1 more" — a plural for one and a countdown for a
+            // threshold nobody is waiting on. The marquee already says the
+            // room is waiting. Kept in the markup for a higher threshold.
+            var worthShowing = LOBBY_MIN_PLAYERS > 1 && !isReady;
+            countdownEl.classList.toggle('hidden', !worthShowing);
         }
 
         if (els.startGameplayBtn) {
@@ -2893,7 +2945,6 @@
     on(els.startGameBtn, 'click', function () {
         showView('lobby');
         initJoinUrl();
-        initStatsLink();
     });
 
     // Featured pack spotlight (hero) → SELECT/DESELECT the World Cup pack, the
@@ -3128,9 +3179,18 @@
     }
 
     // ---- Generate join URL ----
+    var _statsLinkBound = false;
+
     function initStatsLink() {
+        // #706: this used to be called from the "Open lobby" handler alone, so
+        // the Stats button on the setup screen did nothing until the host had
+        // opened the lobby once — and every further trip through the lobby
+        // added another listener, so one tap opened one tab per visit. Bound
+        // once, at load, for a button that is visible from the first paint.
+        if (_statsLinkBound) return;
         var btn = document.getElementById('setup-stats-btn');
         if (!btn) return;
+        _statsLinkBound = true;
         btn.addEventListener('click', function () {
             // Deliberately NO ?token= (#359, #608): analytics.html reads the
             // admin token from localStorage via QuizifyUtils.readAdminToken()
@@ -3284,6 +3344,10 @@
         updateSettingsSummary();
         updateCategorySummary();
     }
+
+    // #706: the Stats button sits on the setup screen, so it is bound here
+    // rather than on the way into the lobby.
+    initStatsLink();
 
     connect();
     updateConnectionStatus('reconnecting');

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -897,6 +897,17 @@
         if (currentRound) currentRound.textContent = msg.round_num || 1;
         if (totalRounds) totalRounds.textContent = msg.total_rounds || 10;
 
+        // #706: the wager window raises the "Final Round!" pill and the only
+        // line that lowered it again lives in updateGameView, which nothing
+        // has called since #619. Play again keeps the phones on this page, so
+        // round 1 of game 2 — and every round after it — wore the pill until
+        // somebody reloaded. Taken down here for any round that is not the
+        // last; raising it stays with the wager window, as before.
+        if (!isFinalRound(msg)) {
+            var lastRoundBanner = document.getElementById('last-round-banner');
+            if (lastRoundBanner) lastRoundBanner.classList.add('hidden');
+        }
+
         // Timer
         if (msg.timer_duration) {
             var deadline = Date.now() + (msg.timer_duration * 1000);

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -6455,6 +6455,17 @@
         if (currentRound) currentRound.textContent = msg.round_num || 1;
         if (totalRounds) totalRounds.textContent = msg.total_rounds || 10;
 
+        // #706: the wager window raises the "Final Round!" pill and the only
+        // line that lowered it again lives in updateGameView, which nothing
+        // has called since #619. Play again keeps the phones on this page, so
+        // round 1 of game 2 — and every round after it — wore the pill until
+        // somebody reloaded. Taken down here for any round that is not the
+        // last; raising it stays with the wager window, as before.
+        if (!isFinalRound(msg)) {
+            var lastRoundBanner = document.getElementById('last-round-banner');
+            if (lastRoundBanner) lastRoundBanner.classList.add('hidden');
+        }
+
         // Timer
         if (msg.timer_duration) {
             var deadline = Date.now() + (msg.timer_duration * 1000);

--- a/tests/test_host_path_defects_706.py
+++ b/tests/test_host_path_defects_706.py
@@ -1,0 +1,159 @@
+"""#706 — five small defects on the host's path.
+
+Each was verified on its own; they are grouped the way #667 grouped its four,
+because every one of them is a couple of lines and all of them sit between the
+host and a running game.
+
+1. **Stats was dead until the lobby had been opened**, then opened one tab per
+   visit — ``initStatsLink`` was called from the "Open lobby" handler alone,
+   so the button on the setup screen had no listener until then and collected
+   another one on every trip through the lobby.
+2. **The timer was written into the 6 px bar container**, wiping
+   ``.timer-bar-fill``; the element built for it — 1.5 rem bold tabular with
+   warning and critical states — was never written.
+3. **"Final Round!" never came down again.** The only line that hid it lives
+   in ``updateGameView``, which nothing has called since #619, and Play again
+   keeps the phones on the same page.
+4. **The television kept the previous question's answer tally**, through the
+   reveal, the lightning round, the finale and into the next lobby, where it
+   sat above the QR code.
+5. **An empty lobby read "Ready at 1 players · still need 1 more"** — a plural
+   for one and a countdown for a threshold nobody waits on.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+WWW = REPO / "custom_components" / "quizify" / "www"
+
+
+def _js(name: str) -> str:
+    return (WWW / "js" / name).read_text(encoding="utf-8")
+
+
+def _html(name: str) -> str:
+    return (WWW / name).read_text(encoding="utf-8")
+
+
+def _strip_comments(text: str) -> str:
+    """Comments quote the old behaviour, so assertions read code only."""
+    return re.sub(r"//.*", "", text)
+
+
+def _function_body(source: str, signature: str, end: str = "\n    }") -> str:
+    start = source.index(signature)
+    return source[start : source.index(end, start)]
+
+
+# --- 1. the Stats link -----------------------------------------------------
+
+
+def test_the_stats_link_is_bound_at_load_not_on_the_way_to_the_lobby() -> None:
+    source = _js("admin.js")
+    lobby_handler = _function_body(
+        source, "on(els.startGameBtn, 'click'", end="\n    });"
+    )
+    assert "initStatsLink" not in _strip_comments(lobby_handler), (
+        "binding from the lobby handler leaves the setup-screen button dead "
+        "until the host has been to the lobby"
+    )
+    # Called from the module body, next to connect().
+    assert re.search(r"^    initStatsLink\(\);", source, re.MULTILINE)
+
+
+def test_binding_the_stats_link_twice_adds_one_listener() -> None:
+    """Otherwise one tap opens one tab per visit."""
+    body = _strip_comments(_function_body(_js("admin.js"), "function initStatsLink("))
+    assert "_statsLinkBound" in body, "no guard against a second listener"
+    assert body.index("_statsLinkBound") < body.index("addEventListener"), (
+        "the guard has to run before the listener is attached"
+    )
+
+
+# --- 2. the in-game timer --------------------------------------------------
+
+
+def test_the_timer_writes_to_the_text_element_not_the_bar() -> None:
+    """#admin-timer-bar is the 6 px .timer-bar-container and holds the fill."""
+    source = _js("admin.js")
+    start = source.index("var adminTimer = {")
+    timer = _strip_comments(source[start : source.index("\n    };", start)])
+    assert "admin-timer-bar-text" in _strip_comments(source), (
+        "the styled element is still never written"
+    )
+    assert not re.search(
+        r"getElementById\(\s*'admin-timer-bar'\s*\)\.textContent", timer
+    )
+    for line in timer.splitlines():
+        if "textContent" in line:
+            assert "Fill" not in line and "adminTimerFillEl" not in line, (
+                f"text is being written into the bar again: {line.strip()}"
+            )
+
+
+def test_the_timer_uses_the_warning_and_critical_states() -> None:
+    """They exist in styles.css for this element and were unreachable."""
+    source = _js("admin.js")
+    start = source.index("var adminTimer = {")
+    timer = _strip_comments(source[start : source.index("\n    };", start)])
+    assert "'critical'" in timer and "'warning'" in timer
+    css = (WWW / "css" / "styles.css").read_text(encoding="utf-8")
+    assert ".timer-text.warning" in css and ".timer-text.critical" in css
+
+
+# --- 3. the final-round banner ---------------------------------------------
+
+
+def test_the_final_round_banner_comes_down_on_a_normal_round() -> None:
+    body = _strip_comments(
+        _function_body(_js("player-core.js"), "function handleQuestionStarted(")
+    )
+    assert "last-round-banner" in body, (
+        "nothing takes the pill down, so it survives into the next game"
+    )
+    assert "isFinalRound(msg)" in body, "it may only come down when it is not the final"
+
+
+# --- 4. the television's answer tally --------------------------------------
+
+
+def test_leaving_the_question_view_clears_the_answer_tally() -> None:
+    """One funnel, so a future path cannot forget it again."""
+    body = _strip_comments(
+        _function_body(
+            _html("dashboard.html"), "function showView(name)", end="\n        }"
+        )
+    )
+    assert "answerProgress" in body, "showView still leaves the tally on the board"
+    assert "!== 'question'" in body, "the question view sets its own tally"
+
+
+def test_the_tally_lives_outside_every_view() -> None:
+    """Which is why hiding a view was never enough.
+
+    If it is ever moved inside #question-view this test should be deleted
+    along with the guard above.
+    """
+    html = _html("dashboard.html")
+    tally = html.index('id="answer-progress"')
+    header = html.index('class="dashboard-header"')
+    first_view = html.index('id="question-view"')
+    assert header < tally < first_view
+
+
+# --- 5. the empty lobby's countdown ----------------------------------------
+
+
+def test_the_countdown_line_is_hidden_at_a_threshold_of_one() -> None:
+    source = _js("admin.js")
+    body = _strip_comments(_function_body(source, "function renderLobbyPlayers("))
+    assert "LOBBY_MIN_PLAYERS > 1" in body, (
+        'at a threshold of 1 the line can only ever read "Ready at 1 players · '
+        'still need 1 more"'
+    )
+    assert re.search(r"LOBBY_MIN_PLAYERS\s*=\s*1", source), (
+        "if the threshold rises, this test should be re-read rather than deleted"
+    )


### PR DESCRIPTION
Closes #706

Five defects, each verified on its own, grouped the way #667 grouped its four.

## 1. Stats was dead until the lobby had been opened, then opened a tab per visit

`initStatsLink` was called from the "Open lobby" handler alone. Fresh page → tap Stats → nothing; every further round-trip through the lobby added another listener, so one tap fired `window.open` once per visit. Now bound once at load, with a guard that makes a second call a no-op.

## 2. The in-game timer was written into the 6 px bar

`adminTimer.update` set `textContent` on `#admin-timer-bar` — the `.timer-bar-container` — which wiped `.timer-bar-fill`. The element built for the number, `#admin-timer-bar-text` (1.5 rem bold tabular, with `.warning` and `.critical` in `styles.css`), was never written.

The text now goes to the text node, the warning/critical states are applied at the same thresholds the phone uses, and the fill actually empties: `start()` has always been handed the duration and never used it.

## 3. "Final Round!" was never hidden again

The wager window raises `#last-round-banner`; the only `classList.add('hidden')` for it sits in `updateGameView`, which nothing has called since #619. Play again keeps the phones on `/quizify/player`, so round 1 of game 2 and every round after it wore the coral pill until someone reloaded. `handleQuestionStarted` takes it down on any round that is not the last — raising it stays with the wager window, so nothing new appears where it did not before.

## 4. The television kept the previous question's answer tally

`#answer-progress` lives in the header, outside every view, and only `question_started` hid it. The reveal, the lightning phases, the finale and `game_reset` did not, so "3/3" in coral survived into the next lobby, above the QR code. `showView` now clears it on every change away from the question view — one funnel instead of five call sites. The hot-seat frame shows the question view and sets its own tally afterwards, so it is unaffected.

## 5. An empty lobby read "Ready at 1 players · still need 1 more"

With `LOBBY_MIN_PLAYERS = 1` that line can only ever show at zero players: a plural for one, and a countdown for a threshold nobody waits on. The marquee already says the room is waiting. Hidden below a threshold of two; the markup stays for a higher one.

## Tests

New `tests/test_host_path_defects_706.py`, eight cases, written against the property: the lobby handler may not bind the link and the module body must, a second bind may not add a listener, no `textContent` may go to the bar element, the warning/critical classes must be used and must exist in the CSS, the banner must come down for a non-final round, `showView` must clear the tally, the tally must still live outside the views, and the countdown must be gated on a threshold above one. Seven fail on `main`.

## Verified in the browser

Against the dev server: the Stats button opens `/quizify/analytics` on the first tap from the setup screen and still opens exactly one URL on a second tap; the empty lobby shows no countdown line. Full suite 2347 passed, `player.bundle.js` rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE