### PR TITLE
fix(tv): the four strings the room reads are sized for a room

### DIFF
--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -99,7 +99,10 @@
 
         .dashboard-round {
             font-family: 'JetBrains Mono', ui-monospace, monospace;
-            font-size: 12px;
+            /* #707: 12px was a phone label. It carries "Question 4 / 10" —
+               where the room is in the game — so it scales with the rest of
+               the board (#376). */
+            font-size: clamp(14px, 1.2vw, 20px);
             color: var(--dash-accent-primary);
             font-weight: 500;
             letter-spacing: 0.2em;
@@ -256,7 +259,9 @@
             background: rgba(214, 106, 106, 0.15);
             border: 1px solid var(--dash-error);
             font-family: 'JetBrains Mono', ui-monospace, monospace;
-            font-size: 14px;
+            /* #707: the one signal that the board has gone dead — it has to be
+               readable from wherever the room noticed the freeze. */
+            font-size: clamp(15px, 1.2vw, 20px);
             color: var(--dash-error);
             letter-spacing: 0.12em;
             text-transform: uppercase;
@@ -1083,7 +1088,11 @@
             background: var(--dash-surface-dark);
             border: 1px solid var(--dash-border-neon);
             font-family: 'DM Sans', sans-serif;
-            font-size: 0.95rem;
+            /* #707: the recap is the only moment the room ever sees the
+               lightning answers — the phone says so explicitly ("answers
+               revealed at the end"). Sized like the leaderboard rows it sits
+               among, not like the phone it was copied from. */
+            font-size: clamp(16px, 1.6vw, 24px);
             color: var(--dash-text-white);
         }
         .dashboard-lightning-recap-row .lr-qnum {
@@ -1373,10 +1382,15 @@
 
         .podium-name {
             font-family: 'DM Sans', sans-serif;
-            font-size: 1.1rem;
+            /* #707: the winner's name was 17.6px while the leaderboard rows
+               beside it are clamp(16px, 1.6vw, 24px) — the name of the person
+               who won read smaller than the list of everyone else. Scaled with
+               the score under it, and the truncation width scales too: 160px
+               cut ordinary names off at the finale. */
+            font-size: clamp(18px, 1.8vw, 28px);
             font-weight: 600;
             color: var(--dash-text-white);
-            max-width: 160px;
+            max-width: clamp(160px, 16vw, 300px);
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;

--- a/tests/test_television_type_scale_707.py
+++ b/tests/test_television_type_scale_707.py
@@ -1,0 +1,98 @@
+"""#707 — television type that the room has to read is sized for a room.
+
+#376 sized the board for a sofa and #667 fixed the lobby chips and "Scan to
+join". Four strings that carry *content* were in neither pass and kept their
+phone sizes, measured at the 16 px root:
+
+* `.dashboard-lightning-recap-row` at 0.95rem — **15.2 px** — although the
+  recap is the only moment the room ever sees the lightning answers;
+* `.podium-name` at 1.1rem — **17.6 px** — the winner's name, smaller than the
+  `clamp(16px, 1.6vw, 24px)` leaderboard rows beside it, and truncated at
+  160 px;
+* `.dashboard-round` at **12 px**, which carries "Question 4 / 10";
+* `.dashboard-reconnect-pill` at **14 px**, the one signal that the board has
+  gone dead.
+
+The eyebrow labels ("LEADERBOARD", "FUN FACT", the award captions) stay small
+on purpose — they name a block, they are not the block. This pins the four
+that are read, not everything with a font-size.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+DASHBOARD = (
+    Path(__file__).resolve().parent.parent
+    / "custom_components/quizify/www/dashboard.html"
+)
+
+# selector → the smallest acceptable upper end of its clamp, in px
+CONTENT_RULES = {
+    ".dashboard-lightning-recap-row": 24,
+    ".podium-name": 26,
+    ".dashboard-round": 20,
+    ".dashboard-reconnect-pill": 20,
+}
+
+
+def _rule_body(selector: str) -> str:
+    css = DASHBOARD.read_text(encoding="utf-8")
+    start = css.index(selector + " {")
+    return css[start : css.index("}", start)]
+
+
+@pytest.mark.parametrize("selector", sorted(CONTENT_RULES))
+def test_content_type_scales_with_the_screen(selector: str) -> None:
+    """A fixed font-size here is a phone size on a television."""
+    body = _rule_body(selector)
+    match = re.search(r"font-size:\s*([^;]+);", body)
+    assert match, f"{selector} lost its font-size"
+    value = match.group(1).strip()
+    assert value.startswith("clamp("), (
+        f"{selector} is back to a fixed {value} — the board is metres away"
+    )
+
+
+@pytest.mark.parametrize("selector,ceiling", sorted(CONTENT_RULES.items()))
+def test_the_upper_end_is_big_enough_for_a_room(selector: str, ceiling: int) -> None:
+    """clamp() alone is not enough: the top of the range is what a 4K TV gets."""
+    body = _rule_body(selector)
+    value = re.search(r"font-size:\s*clamp\(([^)]*)\);", body).group(1)
+    largest = value.split(",")[-1].strip()
+    assert largest.endswith("px"), f"{selector} caps in {largest}, expected px"
+    assert float(largest[:-2]) >= ceiling, (
+        f"{selector} tops out at {largest}, below the {ceiling}px this carries"
+    )
+
+
+def test_the_winners_name_is_not_truncated_at_a_phone_width() -> None:
+    """160 px cut ordinary names off at the moment they are being celebrated."""
+    body = _rule_body(".podium-name")
+    match = re.search(r"max-width:\s*([^;]+);", body)
+    assert match, ".podium-name lost its max-width"
+    value = match.group(1).strip()
+    assert value.startswith("clamp("), f"max-width is a fixed {value} again"
+
+
+def test_the_podium_name_is_not_smaller_than_the_rows_beside_it() -> None:
+    """The winner's name reading smaller than the also-rans was the tell."""
+    name = re.search(
+        r"font-size:\s*clamp\(([^)]*)\);", _rule_body(".podium-name")
+    ).group(1)
+    row = re.search(
+        r"font-size:\s*clamp\(([^)]*)\);",
+        _rule_body(".dashboard-leaderboard .leaderboard-row"),
+    ).group(1)
+
+    def top(clamp_args: str) -> float:
+        return float(clamp_args.split(",")[-1].strip().rstrip("px"))
+
+    def bottom(clamp_args: str) -> float:
+        return float(clamp_args.split(",")[0].strip().rstrip("px"))
+
+    assert bottom(name) >= bottom(row)
+    assert top(name) >= top(row)


### PR DESCRIPTION
Closes #707

## What was wrong

#376 sized the television for a room and #667 fixed the lobby chips and "Scan to join". Three places that carry *content* were in neither pass, measured at the 16 px root:

* `.dashboard-lightning-recap-row` at `0.95rem` — **15.2 px**. The recap is the only moment the room ever sees the lightning answers; the phone says so explicitly ("answers revealed at the end").
* `.podium-name` at `1.1rem` — **17.6 px** — for the winner's name, while the leaderboard rows beside it are `clamp(16px, 1.6vw, 24px)`. It was also truncated at 160 px.
* `.dashboard-round` at **12 px** ("Question 4 / 10") and `.dashboard-reconnect-pill` at **14 px**, the one signal that the board has gone dead.

## The fix

All four scale with the screen, on the house scale #376 established. The podium name's truncation width scales too.

Measured in the browser at a 1920 px viewport, before → after:

| | before | after |
|---|---|---|
| lightning recap row | 15.2 px | 24 px |
| podium name | 17.6 px | 28 px (max-width 160 → 300 px) |
| round indicator | 12 px | 20 px |
| reconnect pill | 14 px | 20 px |

The eyebrow labels — "LEADERBOARD", "FUN FACT", the award captions — stay small deliberately: they name a block rather than being one, so this does not touch them.

## Tests

New `tests/test_television_type_scale_707.py` (10 cases): each of the four rules must be `clamp()`-sized with an upper end big enough for what it carries, the winner's name may not be truncated at a fixed phone width, and it may not be smaller than the leaderboard rows beside it at either end of its range. All ten fail on `main`.

Full suite 2349 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE