### PR TITLE
Require WS-level admin for house/TTS config and check entity domains

### DIFF
--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -106,9 +106,53 @@ MSG_RESUME_GAME = "resume_game"
 MSG_KICK_PLAYER = "kick_player"
 MSG_CONFIGURE_TTS = "configure_tts"
 MSG_CONFIGURE_HOUSE = "configure_house"
+
+# Admin messages that require WS-level admin (a real ?role=admin tab) rather
+# than the admin-as-player relaxation ``_is_authorized_admin`` allows. These
+# two reach Home Assistant service calls with host-supplied entity ids (#724).
+_WS_ADMIN_ONLY = frozenset({MSG_CONFIGURE_TTS, MSG_CONFIGURE_HOUSE})
 MSG_CREATE_TEAM = "create_team"
 MSG_JOIN_TEAM = "join_team"
 MSG_LEAVE_TEAM = "leave_team"
+
+
+def _in_domain(entity_id: str, domain: str) -> bool:
+    """True when ``entity_id`` names an entity of ``domain``.
+
+    The house config arrives as untyped client JSON and its ids are handed
+    straight to ``light.turn_on`` / ``scene.turn_on`` / ``media_player.play_media``.
+    A domain check is the cheap half of #724: even an authorized host should not
+    be able to aim the party lights at ``lock.front_door`` by editing the frame.
+    """
+    return entity_id.startswith(f"{domain}.")
+
+
+def _entities_in_domain(entity_ids: list[str], domain: str, field: str) -> list[str]:
+    """Keep only the ids of ``domain``, logging what was dropped (#724)."""
+    kept = [e for e in entity_ids if _in_domain(e, domain)]
+    dropped = [e for e in entity_ids if not _in_domain(e, domain)]
+    if dropped:
+        _LOGGER.warning(
+            "House config: ignored %d %s entry/entries outside the %s domain: %s",
+            len(dropped),
+            field,
+            domain,
+            ", ".join(dropped),
+        )
+    return kept
+
+
+def _entity_in_domain(entity_id: str, domain: str, field: str) -> str:
+    """Keep ``entity_id`` only if it is of ``domain``, else "" (#724)."""
+    if not entity_id or _in_domain(entity_id, domain):
+        return entity_id
+    _LOGGER.warning(
+        "House config: ignored %s %r - not a %s entity",
+        field,
+        entity_id,
+        domain,
+    )
+    return ""
 
 
 def _coerce_toggle(value: Any, *, default: bool) -> bool:
@@ -631,6 +675,40 @@ class QuizifyWebSocketHandler:
             return
 
         handler, admin_required = entry
+
+        # #724: two admin messages need WS-level admin, not the
+        # admin-as-player relaxation. ``configure_house`` and ``configure_tts``
+        # forward host-supplied entity ids into light.turn_on, scene.turn_on,
+        # media_player.play_media and tts.speak - Home Assistant service calls
+        # against the whole house. The ``is_admin: true`` join claim (#208) was
+        # accepted as "claim the single admin slot of the quiz"; it was never
+        # meant to reach HA services, and a host who runs the game from the
+        # ?role=admin tab leaves that player slot free all evening for any
+        # guest to take. Same bar as ``admin_connect`` above.
+        # Same bar, same reason, different carrier: the ``tts`` and ``house``
+        # blocks ride the start payload straight into ``_apply_tts_config`` /
+        # ``_apply_house_config``. A player-admin may still start the game (that
+        # IS the #208 flow) — the room's lights, speakers and scenes just stay on
+        # whatever the host configured. Stripped here rather than in the handler
+        # so the authoritative ``is_admin`` decides, not a second lookup.
+        if msg_type == MSG_START_GAME and not is_admin:
+            if data.get("tts") or data.get("house"):
+                _LOGGER.warning(
+                    "Dropped the tts/house blocks of start_game from a "
+                    "connection without the WS admin role (#724)"
+                )
+            data = {k: v for k, v in data.items() if k not in ("tts", "house")}
+
+        if msg_type in _WS_ADMIN_ONLY and not is_admin:
+            _LOGGER.warning(
+                "Refused %s from a connection without the WS admin role (#724)",
+                msg_type,
+            )
+            await self._conn.send_error(
+                ws, ERR_ADMIN_REQUIRED, "This connection is not the host"
+            )
+            return
+
         if admin_required and not self._is_authorized_admin(ws, is_admin, game_state):
             # Centralized admin guard — same error code/message as the legacy
             # per-type checks. ``_is_authorized_admin`` accepts either WS-level
@@ -3810,8 +3888,16 @@ class QuizifyWebSocketHandler:
                 # Per-game entity overrides from the admin dropdowns (#281).
                 # Empty/missing → the announcer falls back to the config-entry
                 # default entities.
-                tts_entity=tts.get("tts_entity"),
-                media_player=tts.get("media_player"),
+                tts_entity=_entity_in_domain(
+                    str(tts.get("tts_entity") or "").strip(), "tts", "tts_entity"
+                )
+                or None,
+                media_player=_entity_in_domain(
+                    str(tts.get("media_player") or "").strip(),
+                    "media_player",
+                    "media_player",
+                )
+                or None,
             )
         except Exception:  # noqa: BLE001
             _LOGGER.exception("TTS configure raised")
@@ -3899,6 +3985,17 @@ class QuizifyWebSocketHandler:
         )
         media_player = str(house.get("media_player") or "").strip()
         winner_scene_entity = str(house.get("winner_scene_entity") or "").strip()
+
+        # Domain allowlist (#724). Each override is forwarded to exactly one
+        # service - light.turn_on, scene.turn_on, media_player.play_media - so
+        # an id from any other domain is never a legitimate value here. Dropped
+        # rather than rejected: one bad picker entry must not disarm the whole
+        # house block, which is the same defensive stance as the guards below.
+        light_entities = _entities_in_domain(light_entities, "light", "light_entities")
+        media_player = _entity_in_domain(media_player, "media_player", "media_player")
+        winner_scene_entity = _entity_in_domain(
+            winner_scene_entity, "scene", "winner_scene_entity"
+        )
 
         lights = self._party_lights
         if lights is not None:

--- a/tests/test_house_admin_bar_724.py
+++ b/tests/test_house_admin_bar_724.py
@@ -1,0 +1,240 @@
+"""The house and TTS config need WS-level admin, and their ids need a domain (#724).
+
+Two separate holes, one payload:
+
+  1. ``_is_authorized_admin`` accepts ``player.is_admin`` — the ``is_admin: true``
+     join claim accepted in #208 as "claim the single admin slot of the quiz".
+     A host who runs the evening from the ``?role=admin`` tab is a WS-admin and
+     never takes that player slot, so it stays free for any guest all evening.
+     Through ``configure_house`` / ``configure_tts`` (and the ``house``/``tts``
+     blocks of ``start_game``) that slot reaches ``light.turn_on``,
+     ``scene.turn_on``, ``media_player.play_media`` and ``tts.speak``.
+  2. Even for a legitimate host the ids were only stripped and deduped
+     (``lights._clean_entity_ids``) — no domain check anywhere on the path.
+
+So the fix has two halves and this file pins both: the WS-admin bar on the way
+in, and the domain allowlist on the way out.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    def create_task(self, coro):  # noqa: ANN001, ANN202
+        return asyncio.ensure_future(coro)
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    ws.close = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+@pytest.fixture
+def handler(game: QuizifyGameState, tmp_path: Path, monkeypatch):
+    runtime = _FakeRuntime(tmp_path)
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    h._conn = ConnectionManager(runtime, lambda: game)
+    h._get_game_state = lambda: game  # type: ignore[assignment]
+    h.START_REDIRECT_GRACE = 0
+
+    errors: dict[int, list[dict]] = {}
+
+    async def _send_error(ws, code, message) -> None:
+        errors.setdefault(id(ws), []).append({"code": code, "message": message})
+
+    async def _noop(*args, **kwargs) -> None:
+        return None
+
+    h._conn.broadcast = _noop  # type: ignore[assignment]
+    h._conn.send_error = _send_error  # type: ignore[assignment]
+    h._conn._safe_send = _noop  # type: ignore[assignment]
+    h._conn.broadcast_to_admins_and_dashboards = _noop  # type: ignore[assignment]
+    monkeypatch.setattr(h, "_start_timer_tick", lambda *a, **k: None)
+
+    h.set_party_lights(MagicMock())
+    h.set_sound_effects(MagicMock())
+    h.set_event_emitter(MagicMock())
+    h.set_tts_announcer(MagicMock())
+
+    h._errors = errors  # type: ignore[attr-defined]
+    return h
+
+
+def _player_admin_ws(h: QuizifyWebSocketHandler, game: QuizifyGameState) -> MagicMock:
+    """A guest who claimed the free player-admin slot: ``player.is_admin`` is
+    True while the connection itself was never opened with ``?role=admin``.
+
+    This is exactly the state a host leaves behind by running the game from the
+    admin tab — the player slot nobody occupies.
+    """
+    ws = _ws()
+    h._conn.add_connection(ws, is_admin=False, is_dashboard=False)
+    game.add_player("Guest", ws)
+    game.get_player("Guest").is_admin = True
+    return ws
+
+
+_HOUSE = {
+    "enabled": True,
+    "light_entities": ["light.living_room"],
+    "media_player": "media_player.kitchen",
+    "winner_scene_entity": "scene.party",
+}
+
+
+# ---------------------------------------------------------------------------
+# 1. The WS-admin bar
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("msg_type", ["configure_house", "configure_tts"])
+async def test_player_admin_cannot_configure_the_house(
+    msg_type: str, handler, game: QuizifyGameState
+) -> None:
+    """A player-admin is refused, and no consumer is reconfigured."""
+    ws = _player_admin_ws(handler, game)
+
+    await handler._handle_message(ws, {"type": msg_type, **_HOUSE}, is_admin=False)
+
+    errs = handler._errors.get(id(ws), [])
+    assert errs and errs[-1]["code"] == "ADMIN_REQUIRED", (
+        f"{msg_type} from a player-admin was not refused: {errs}"
+    )
+    handler._party_lights.configure.assert_not_called()
+    handler._sound_effects.configure.assert_not_called()
+    handler._tts_announcer.configure.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("msg_type", ["configure_house", "configure_tts"])
+async def test_ws_admin_still_configures_the_house(
+    msg_type: str, handler, game: QuizifyGameState
+) -> None:
+    """The real ``?role=admin`` tab keeps working — the bar must not lock the host
+    out of the panel it exists for."""
+    ws = _ws()
+    handler._conn.add_connection(ws, is_admin=True, is_dashboard=False)
+
+    await handler._handle_message(ws, {"type": msg_type, **_HOUSE}, is_admin=True)
+
+    errs = handler._errors.get(id(ws), [])
+    assert all(e["code"] != "ADMIN_REQUIRED" for e in errs), errs
+    if msg_type == "configure_house":
+        handler._party_lights.configure.assert_called_once()
+    else:
+        handler._tts_announcer.configure.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_player_admin_starts_the_game_without_touching_the_room(
+    handler, game: QuizifyGameState
+) -> None:
+    """A player-admin may still start the game (that is the #208 flow), but the
+    ``house`` / ``tts`` blocks of the payload are dropped: the lights, speakers
+    and scenes stay on whatever the host configured."""
+    ws = _player_admin_ws(handler, game)
+
+    await handler._handle_message(
+        ws,
+        {
+            "type": "start_game",
+            "num_rounds": 1,
+            "house": _HOUSE,
+            "tts": {"enabled": True, "tts_entity": "tts.google"},
+        },
+        is_admin=False,
+    )
+
+    assert game.phase != GamePhase.LOBBY, "the #208 admin-as-player start broke"
+    handler._party_lights.configure.assert_not_called()
+    handler._sound_effects.configure.assert_not_called()
+    # TTS is applied unconditionally on start (an empty dict disarms it), so the
+    # assertion is on the payload, not on the call count.
+    if handler._tts_announcer.configure.called:
+        kwargs = handler._tts_announcer.configure.call_args.kwargs
+        assert kwargs["enabled"] is False
+        assert not kwargs["tts_entity"]
+
+
+# ---------------------------------------------------------------------------
+# 2. The domain allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_light_entities_outside_the_light_domain_are_dropped(handler) -> None:
+    handler._apply_house_config(
+        {**_HOUSE, "light_entities": ["light.living_room", "lock.front_door"]}
+    )
+    kwargs = handler._party_lights.configure.call_args.kwargs
+    assert kwargs["light_entities"] == ["light.living_room"]
+
+
+def test_media_player_and_scene_overrides_are_domain_checked(handler) -> None:
+    handler._apply_house_config(
+        {
+            **_HOUSE,
+            "media_player": "switch.garage_door",
+            "winner_scene_entity": "script.disarm_alarm",
+        }
+    )
+    assert handler._sound_effects.configure.call_args.kwargs["media_player"] == ""
+    assert (
+        handler._party_lights.configure.call_args.kwargs["winner_scene_entity"] == ""
+    )
+
+
+def test_tts_entity_overrides_are_domain_checked(handler) -> None:
+    handler._apply_tts_config(
+        {
+            "enabled": True,
+            "tts_entity": "notify.everyone",
+            "media_player": "lock.front_door",
+        }
+    )
+    kwargs = handler._tts_announcer.configure.call_args.kwargs
+    assert kwargs["tts_entity"] is None
+    assert kwargs["media_player"] is None
+
+
+def test_valid_overrides_still_reach_their_consumers(handler) -> None:
+    """The allowlist must not eat the legitimate case — this is the regression
+    the domain check itself could cause."""
+    handler._apply_house_config(_HOUSE)
+    lights_kw = handler._party_lights.configure.call_args.kwargs
+    assert lights_kw["light_entities"] == ["light.living_room"]
+    assert lights_kw["winner_scene_entity"] == "scene.party"
+    assert (
+        handler._sound_effects.configure.call_args.kwargs["media_player"]
+        == "media_player.kitchen"
+    )

--- a/tests/test_house_config_ws_494.py
+++ b/tests/test_house_config_ws_494.py
@@ -291,7 +291,11 @@ def test_malformed_types_are_coerced_not_raised(handler) -> None:
     # A non-list light_entities is dropped rather than smuggled into a light
     # service call (where a bare string would iterate into characters).
     assert lights_kw["light_entities"] == []
-    assert lights_kw["winner_scene_entity"] == "42"
+    # ``42`` used to be coerced to the string "42" and forwarded to scene.turn_on.
+    # Since #724 the overrides are domain-checked, so a value that names no scene
+    # is dropped to "" — the consumer falls back to the config-entry default.
+    # Still coerced, still not raised: only the destination changed.
+    assert lights_kw["winner_scene_entity"] == ""
     assert handler._sound_effects.configure.call_args.kwargs["media_player"] == ""
 
 


### PR DESCRIPTION
### The hole

`_is_authorized_admin` accepts `player.is_admin` — the `is_admin: true` join claim accepted in #208 as "claim the single admin slot of the quiz". A host who runs the evening from the `?role=admin` tab is a WS-admin and never takes that player slot, so it stays free for any guest all game long.

Through `configure_house`, `configure_tts` and the `house`/`tts` blocks of `start_game`, that free slot reached `light.turn_on`, `scene.turn_on`, `media_player.play_media` and `tts.speak` — service calls against the host's whole house, with no Home Assistant credential. `_clean_entity_ids` only stripped and deduped: no domain check anywhere on the path.

### The fix, in two halves

**The bar on the way in.** `configure_house` and `configure_tts` now require WS-level admin — the same bar `admin_connect` already sets. The `tts`/`house` blocks of `start_game` are stripped for any non-WS-admin connection, so the #208 admin-as-player flow still starts the game; the room simply stays on whatever the host configured.

**The allowlist on the way out.** Every override is domain-checked before it can reach a service call: `light_entities` → `light.*`, `media_player` → `media_player.*`, `winner_scene_entity` → `scene.*`, and the TTS overrides → `tts.*` / `media_player.*`. Out-of-domain ids are dropped with a warning rather than raising — one bad picker entry must not disarm the whole house block.

### Tests

`tests/test_house_admin_bar_724.py`, nine tests: the refusal for both configure messages, the host still getting through, the player-admin start that leaves the room alone, and the four domain cases. Six of the nine fail without the change; the other three are the must-not-break guards.

One existing assertion moved: `test_malformed_types_are_coerced_not_raised` pinned `winner_scene_entity == "42"` and now pins `""`. The value is still coerced and still never raises — only its destination changed.

Closes #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE