### PR TITLE
fix(security): keep the persisted admin token when the admin grace period expires

### DIFF
--- a/custom_components/quizify/server/connection.py
+++ b/custom_components/quizify/server/connection.py
@@ -225,30 +225,36 @@ class ConnectionManager:
             self._admin_disconnect_task = None
 
     def schedule_admin_timeout(self) -> None:
-        """Start the admin-session grace period; clears the token on expiry."""
+        """Start the admin-session grace period after the last admin socket left.
+
+        The task is the "no admin socket is attached right now" marker that
+        :meth:`has_pending_admin_disconnect` reports and that a returning admin
+        cancels (``_handle_admin_connect`` / ``_handle_join`` /
+        ``_handle_reconnect``). Expiry keeps the game alive; it no longer
+        touches the credential.
+
+        #725: expiry used to null the token and delete ``admin_token.json``.
+        That handed the *next* ``?role=admin`` connection from any LAN address
+        a free bootstrap into full admin — the very takeover the persisted
+        token (#140/#168) exists to prevent, and the gate behind every
+        host-only HTTP endpoint (analytics, all-time leaderboard, flags with
+        player names and free text, question stats, presets, TTS/house entity
+        lists — see ``views._is_admin_authenticated``). A host closing the tab
+        for two minutes is not a reason to drop the credential. Recovery has a
+        deliberate, HA-authenticated path instead: the
+        ``quizify.reset_admin_session`` service.
+
+        The #351 admin-as-player guard is gone with the wipe it guarded: there
+        is nothing left to guard against.
+        """
 
         async def admin_timeout() -> None:
             await asyncio.sleep(self.ADMIN_SESSION_GRACE)
-            # Guard (#351): the admin tab redirecting from /quizify/admin to
-            # /quizify/player at game start closes the last admin WS and
-            # schedules this timeout — but the host is still present as an
-            # admin *player*. Clearing the token here would delete the
-            # persisted credential ~120s into every admin-as-player game and
-            # re-open the LAN bootstrap-takeover window that the persisted
-            # token (#140/#168) exists to close. If a connected player still
-            # holds the crown, keep the token.
-            game_state = self._get_game_state()
-            if game_state is not None and any(
-                p.is_admin and p.connected for p in game_state.get_players()
-            ):
-                _LOGGER.debug(
-                    "Admin grace expired but an admin player is connected; "
-                    "keeping session token"
-                )
-                return
-            _LOGGER.info("Admin session grace period expired, clearing token")
-            self._admin_session_token = None
-            await self._async_save_admin_token()
+            _LOGGER.info(
+                "Admin session grace period expired; keeping the persisted "
+                "token (call the quizify.reset_admin_session service to clear "
+                "it deliberately)"
+            )
 
         self._admin_disconnect_task = asyncio.ensure_future(admin_timeout())
         self._admin_disconnect_task.add_done_callback(_log_task_exception)

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -931,10 +931,10 @@ class QuizifyWebSocketHandler:
             # redirect from /quizify/admin to /quizify/player took the
             # fresh-join path (no session token) instead of the
             # reconnect path. Same desired outcome — game keeps running.
-            # Also cancel the admin-session-token timeout (#351): the closed
-            # admin WS scheduled it, but the host is right here as a player —
-            # letting it fire would wipe the persisted token mid-game and
-            # re-open the LAN admin-takeover window.
+            # Also clear the admin-disconnect grace armed by the closed admin
+            # WS: the host is right here as a player, so nothing is "away".
+            # (It no longer wipes the token on expiry — #725 — but leaving it
+            # armed would keep has_pending_admin_disconnect() lying.)
             if player_obj and player_obj.is_admin:
                 self._cancel_admin_pause()
                 self._conn.cancel_admin_disconnect()
@@ -1027,8 +1027,9 @@ class QuizifyWebSocketHandler:
         # Without this, the pause would fire ~4s after the redirect
         # completes — the user would see the question briefly, then
         # the paused-view, defeating the whole grace-period fix.
-        # Also cancel the admin-session-token timeout (#351) so the host
-        # returning as a player never lets the persisted token get wiped.
+        # Also clear the admin-disconnect grace (#351) so the returning host
+        # isn't still counted as away. Since #725 the grace no longer wipes
+        # the persisted token, only reports "no admin socket attached".
         if player.is_admin:
             self._cancel_admin_pause()
             self._conn.cancel_admin_disconnect()

--- a/tests/test_admin_token_survives_grace_725.py
+++ b/tests/test_admin_token_survives_grace_725.py
@@ -1,0 +1,181 @@
+"""Regression tests for issue #725 (security).
+
+The persisted admin token is the only credential behind
+``views._is_admin_authenticated`` — the gate in front of analytics, the
+all-time leaderboard, flags (player names plus free text), question stats,
+presets and the TTS/house entity lists. ``__init__.py`` loads it at setup
+precisely so no LAN client can seize admin after a restart.
+
+The admin-disconnect grace timer used to undo that between sessions: when the
+last ``?role=admin`` socket closed, ``_handle_disconnect`` armed
+``schedule_admin_timeout()``, and 120 s later the token was set to ``None`` and
+``admin_token.json`` deleted. From then on ``_grant_admin`` bootstrapped the
+*first* ``?role=admin`` connection from any address and handed it the session
+token — the exact takeover the persisted token (#140/#168) exists to close.
+
+The fix: grace expiry no longer touches the credential. Clearing it is a
+deliberate, HA-authenticated act via the ``quizify.reset_admin_session``
+service.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+
+class _FakePlayer:
+    def __init__(self, *, is_admin: bool, connected: bool) -> None:
+        self.is_admin = is_admin
+        self.connected = connected
+
+
+class _FakeGameState:
+    def __init__(self, players: list[_FakePlayer]) -> None:
+        self._players = players
+
+    def get_players(self) -> list[_FakePlayer]:
+        return self._players
+
+
+def _request(remote: str = "192.168.1.66") -> MagicMock:
+    """A minimal stand-in for the aiohttp request ``_grant_admin`` logs."""
+    request = MagicMock()
+    request.remote = remote
+    return request
+
+
+async def _expire_grace(conn: ConnectionManager) -> None:
+    """Arm the admin grace with a zero wait and let it run to completion."""
+    conn.ADMIN_SESSION_GRACE = 0
+    conn.schedule_admin_timeout()
+    await asyncio.gather(conn._admin_disconnect_task, return_exceptions=True)
+
+
+class TestGraceExpiryKeepsTheCredential:
+    @pytest.mark.asyncio
+    async def test_token_survives_when_the_host_is_gone(self, tmp_path: Path) -> None:
+        """Nobody is left in the room — the token must still not be dropped."""
+        conn = ConnectionManager(_FakeRuntime(tmp_path), lambda: None)
+        await conn.try_bootstrap_admin()
+        token = conn._admin_session_token
+        assert token is not None
+
+        await _expire_grace(conn)
+
+        assert conn._admin_session_token == token
+
+    @pytest.mark.asyncio
+    async def test_token_survives_when_the_admin_player_disconnected(
+        self, tmp_path: Path
+    ) -> None:
+        """The host closed the tab mid-game; that is not a reason to de-auth."""
+        gs = _FakeGameState([_FakePlayer(is_admin=True, connected=False)])
+        conn = ConnectionManager(_FakeRuntime(tmp_path), lambda: gs)
+        await conn.try_bootstrap_admin()
+        token = conn._admin_session_token
+
+        await _expire_grace(conn)
+
+        assert conn._admin_session_token == token
+
+    @pytest.mark.asyncio
+    async def test_token_file_stays_on_disk(self, tmp_path: Path) -> None:
+        """The file must survive too, or the next HA restart bootstraps fresh."""
+        conn = ConnectionManager(_FakeRuntime(tmp_path), lambda: None)
+        await conn.try_bootstrap_admin()
+        token_file = tmp_path / "admin_token.json"
+        assert token_file.exists()
+
+        await _expire_grace(conn)
+
+        assert token_file.exists(), (
+            "admin_token.json was deleted on grace expiry — a restart would "
+            "hand admin to the first LAN client that asks (#725)"
+        )
+
+        # And a fresh manager (i.e. the next HA start) loads the same token.
+        reloaded = ConnectionManager(_FakeRuntime(tmp_path), lambda: None)
+        await reloaded.async_load_admin_token()
+        assert reloaded._admin_session_token == conn._admin_session_token
+
+
+class TestNoBootstrapWindowAfterGrace:
+    @pytest.mark.asyncio
+    async def test_lan_client_cannot_seize_admin_after_the_grace(
+        self, tmp_path: Path
+    ) -> None:
+        """The security property itself: no free bootstrap once the host left.
+
+        A stranger on the LAN opens ``/quizify/admin`` (no token) two minutes
+        after the host closed their tab. Before the fix ``_grant_admin``
+        returned True for them and ``_handle_admin_connect`` handed over the
+        session token.
+        """
+        runtime = _FakeRuntime(tmp_path)
+        handler = QuizifyWebSocketHandler(
+            runtime=runtime, game_state_provider=lambda: None
+        )
+        handler._conn = ConnectionManager(runtime, lambda: None)
+        handler._conn.broadcast = AsyncMock()
+        handler._conn.send = AsyncMock()
+
+        # The host bootstrapped admin at some earlier point.
+        await handler._conn.try_bootstrap_admin()
+        host_token = handler._conn._admin_session_token
+        assert host_token is not None
+
+        # The host's last admin socket closed and the grace ran out.
+        await _expire_grace(handler._conn)
+
+        # A different LAN address asks for admin without presenting a token.
+        granted = await handler._grant_admin("admin", None, _request("192.168.1.99"))
+        assert granted is False, (
+            "the grace period re-opened the admin bootstrap window for any "
+            "LAN client (#725)"
+        )
+
+        # The host's own tab still authenticates with the token it kept.
+        assert (
+            await handler._grant_admin("admin", host_token, _request()) is True
+        )
+
+    @pytest.mark.asyncio
+    async def test_reset_service_is_still_the_way_out(self, tmp_path: Path) -> None:
+        """Clearing the credential stays possible — deliberately, via HA.
+
+        ``quizify.reset_admin_session`` (registered in ``__init__.py``) calls
+        exactly this; it is the documented recovery for a host who lost their
+        browser copy of the token.
+        """
+        conn = ConnectionManager(_FakeRuntime(tmp_path), lambda: None)
+        await conn.try_bootstrap_admin()
+        token_file = tmp_path / "admin_token.json"
+        assert token_file.exists()
+
+        await conn.async_clear_admin_token()
+
+        assert conn._admin_session_token is None
+        assert not token_file.exists()
+        # …and the next admin connection may bootstrap again.
+        assert await conn.try_bootstrap_admin() is True

--- a/tests/test_admin_token_wipe_351.py
+++ b/tests/test_admin_token_wipe_351.py
@@ -17,6 +17,14 @@ Two-layer fix:
      timeout when the (re)connecting player holds the crown.
   2. ``admin_timeout()`` refuses to clear the token while a *connected* admin
      player still holds the crown (belt-and-suspenders).
+
+Superseded in part by #725: layer 2 is gone because the wipe it guarded is
+gone — grace expiry no longer touches the credential at all, for any player
+constellation. The cases below that used to assert "cleared" now assert the
+token survives; see ``test_admin_token_survives_grace_725.py`` for the reasoning
+and for the LAN-takeover property itself. Layer 1 still matters: cancelling the
+timer keeps ``has_pending_admin_disconnect()`` honest and stops the deferred
+admin pause.
 """
 
 from __future__ import annotations
@@ -78,7 +86,7 @@ async def _run_admin_timeout(conn: ConnectionManager) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Layer 2 — admin_timeout() guard
+# Layer 2 — admin_timeout() no longer wipes the token at all (#725)
 # ---------------------------------------------------------------------------
 
 
@@ -100,32 +108,35 @@ class TestAdminTimeoutGuard:
         assert conn._admin_session_token == token
 
     @pytest.mark.asyncio
-    async def test_clears_token_when_no_admin_player(self, tmp_path: Path) -> None:
-        # Host truly left (no admin among the players) → original behaviour:
-        # the token is cleared so a fresh bootstrap can happen.
+    async def test_keeps_token_when_no_admin_player(self, tmp_path: Path) -> None:
+        # Host truly left (no admin among the players). This used to clear the
+        # token "so a fresh bootstrap can happen" — which is precisely the LAN
+        # takeover of #725. It is kept now; the reset is the HA service.
         gs = _FakeGameState([_FakePlayer(is_admin=False, connected=True)])
         conn = ConnectionManager(_FakeRuntime(tmp_path), lambda: gs)
         await conn.try_bootstrap_admin()
-        assert conn._admin_session_token is not None
+        token = conn._admin_session_token
+        assert token is not None
 
         await _run_admin_timeout(conn)
 
-        assert conn._admin_session_token is None
+        assert conn._admin_session_token == token
 
     @pytest.mark.asyncio
-    async def test_clears_token_when_admin_player_disconnected(
+    async def test_keeps_token_when_admin_player_disconnected(
         self, tmp_path: Path
     ) -> None:
         # The admin player exists but is no longer connected (host closed the
-        # tab and never came back) → clear, matching the prior semantics.
+        # tab and never came back) → still kept (#725).
         gs = _FakeGameState([_FakePlayer(is_admin=True, connected=False)])
         conn = ConnectionManager(_FakeRuntime(tmp_path), lambda: gs)
         await conn.try_bootstrap_admin()
-        assert conn._admin_session_token is not None
+        token = conn._admin_session_token
+        assert token is not None
 
         await _run_admin_timeout(conn)
 
-        assert conn._admin_session_token is None
+        assert conn._admin_session_token == token
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #725

## The hole

When the last `?role=admin` socket closed, `_handle_disconnect` armed `schedule_admin_timeout()`. 120 s later `admin_timeout()` set `_admin_session_token = None` and `_async_save_admin_token()` deleted `admin_token.json`. From that moment on the install looked fresh to `_grant_admin`: `try_bootstrap_admin()` succeeded for the **first** `?role=admin` connection from **any** address, and `_handle_admin_connect` handed that connection the session token.

That token is the only credential behind `views._is_admin_authenticated` — the gate in front of analytics, the all-time leaderboard, flags (player names plus free text), question stats, presets and the TTS/house entity lists. `__init__.py` loads the persisted token at setup precisely so no LAN client can seize admin after a restart. The grace timer undid exactly that, between sessions, two minutes after the host closed their tab.

## The fix

`admin_timeout()` no longer touches the credential. It logs the expiry and points at the reset service.

The timer itself stays armed, because it is not only a token-wipe scheduler: `has_pending_admin_disconnect()` is the "no admin socket is attached right now" marker read by `_handle_admin_connect`, and `cancel_admin_disconnect()` is what `_handle_join` / `_handle_reconnect` call when the host comes back as a player. Those paths are unchanged.

## Two corrections to the issue text

1. **The issue says "keep the timer for the pause logic". The pause is not this timer.** The host-disconnect pause is a separate mechanism — `_schedule_admin_pause()` / `_cancel_admin_pause()` with its own `ADMIN_REDIRECT_GRACE`, armed further down in `_handle_disconnect`. `schedule_admin_timeout()`'s body did nothing *but* clear the token. The timer is kept anyway, for the connection-state reasons above; the pause behaviour is untouched either way.

2. **The #351 guard goes with it.** `admin_timeout()` carried a check that refused to clear the token while a connected admin *player* still held the crown. That guard only existed to stop the wipe; with no wipe there is nothing to guard, so it is removed rather than left as dead branching. The #351 layer-1 fix (cancel the grace on the crown-holder's join/reconnect) stays and still matters.

## Recovery path — verified

`quizify.reset_admin_session` exists: registered in `custom_components/quizify/__init__.py` (it calls `conn.async_clear_admin_token()` and logs the reset) and documented in `custom_components/quizify/services.yaml:1-8` — "Wipe the persisted admin session token. Use this if you can't access the admin panel because the saved token is out of sync… Only callable by HA admins." That is the deliberate, HA-authenticated way out for a host who lost their browser copy, and it is now the only way the credential is dropped. A new test asserts it still clears both the in-memory token and the file, and that a bootstrap can follow.

## Tests

New `tests/test_admin_token_survives_grace_725.py`:

- the token survives grace expiry with nobody in the room, and with a disconnected admin player;
- `admin_token.json` survives, and a fresh `ConnectionManager` (i.e. the next HA start) loads the same token;
- the security property itself: after the grace expires, `_grant_admin("admin", None, request)` from a different LAN address returns `False`, while the host's own token still authenticates;
- `async_clear_admin_token()` (the service path) still wipes both and re-opens bootstrap.

Verified failing without the fix: `git stash push custom_components/quizify/server/connection.py` → 4 of the 5 fail (the reset-service test is expected to pass both ways, it documents the recovery path) → `git stash pop`.

Two cases in `tests/test_admin_token_wipe_351.py` asserted the old "cleared" behaviour and now assert the token survives; the file's docstring records why.

## Gates

`pytest -q` 2369 passed · `ruff check custom_components/` clean · `mypy custom_components/` clean. No `www/js/` changes, so no bundle rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE