### PR TITLE
fix: a player who joins between rounds is no longer scored as a timeout

### DIFF
--- a/custom_components/quizify/game/phase_controller.py
+++ b/custom_components/quizify/game/phase_controller.py
@@ -102,6 +102,36 @@ class GamePhase(str, Enum):  # noqa: UP042 — StrEnum changes str()/serializati
     PAUSED = "PAUSED"
 
 
+# Phases in which a main-round question is genuinely in flight, i.e. the answer
+# clock for the current round is running (or frozen mid-run). Someone joining
+# during one of these cannot possibly answer that question in time, so they are
+# flagged ``joined_late`` and excluded from ``all_submitted()`` until the round
+# they walked into has been evaluated.
+#
+# This is deliberately an allowlist rather than "everything except LOBBY"
+# (#727): every phase NOT named here is a between-rounds phase where the next
+# question has not started yet, and a joiner there gets a full timer from
+# ``begin_round`` like everybody else.
+#
+#   * ANSWER_REVEAL — the previous round is already scored.
+#   * WAGER_ACTIVE (#656) — the final round's betting window. No timer runs;
+#     ``begin_round`` builds one for every player present when the window
+#     closes, this joiner included.
+#   * LIGHTNING / LIGHTNING_RECAP (#42) and HOT_SEAT_AUCTION / HOT_SEAT /
+#     HOT_SEAT_REVEAL (#616) — self-contained detours with their own rosters
+#     and scoring. Neither reads ``joined_late``, and the main round they hand
+#     back to has not begun.
+#   * FINALE — the game is over. The flag would only survive into a
+#     "play again" round.
+#
+# PAUSED belongs here because ``PhaseController.pause`` only ever enters it
+# from QUESTION_ACTIVE: a paused game is a live question with its clocks
+# frozen, and ``resume`` hands the joiner the round's shared remaining (#702).
+MID_QUESTION_PHASES: frozenset[str] = frozenset(
+    {GamePhase.QUESTION_ACTIVE.value, GamePhase.PAUSED.value}
+)
+
+
 class PhaseController:
     """Owns the game phase + per-question timer mechanics.
 

--- a/custom_components/quizify/game/player.py
+++ b/custom_components/quizify/game/player.py
@@ -48,6 +48,10 @@ class PlayerSession:
     connected: bool = True
     is_admin: bool = False
     color: str = ""  # assigned on join from PLAYER_COLORS palette
+    # True only while a question this player walked in on is still
+    # unevaluated (join during QUESTION_ACTIVE / PAUSED — see
+    # MID_QUESTION_PHASES). NOT "joined after the lobby": a join between
+    # rounds leaves this False so the next round waits for them (#727).
     joined_late: bool = False
     joined_at: float = field(default_factory=time.time)
     submitted: bool = False

--- a/custom_components/quizify/game/player_registry.py
+++ b/custom_components/quizify/game/player_registry.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
     from aiohttp import web
 
+from .phase_controller import MID_QUESTION_PHASES
 from .player import PLAYER_COLORS, PlayerSession
 
 _LOGGER = logging.getLogger(__name__)
@@ -140,9 +141,26 @@ class PlayerRegistry:
         if len(self.players) >= MAX_PLAYERS:
             return False, ERR_GAME_FULL
 
-        # Determine if late joiner
-        joined_late = phase_value != "LOBBY"
-        initial_score = average_score_fn() if joined_late else 0
+        # Two different questions hide behind the word "late", and #727 was
+        # them sharing a single flag:
+        #
+        #   * Did this player miss rounds that are already on the board? Anyone
+        #     joining after the LOBBY did, and they are seeded with the room's
+        #     average so they do not start stranded at zero.
+        #   * Is a question in flight *right now* that they cannot answer in
+        #     time? Only then may ``all_submitted()`` skip them and
+        #     ``_do_evaluate_round`` record them as a timeout.
+        #
+        # Answering the second question with "any phase but LOBBY" meant a
+        # player who joined during ANSWER_REVEAL (or the wager window, or a
+        # Lightning/Hot Seat detour) stayed flagged into the NEXT round: they
+        # saw the question and their own running clock, the other players'
+        # answers closed the round without waiting for them, and they were
+        # scored as a timeout — a later tap getting ERR_ROUND_EXPIRED. See
+        # ``MID_QUESTION_PHASES`` for which phases count and why.
+        joined_after_lobby = phase_value != "LOBBY"
+        joined_late = phase_value in MID_QUESTION_PHASES
+        initial_score = average_score_fn() if joined_after_lobby else 0
 
         # Assign a unique color from the palette (cycle if more than palette size)
         used_colors = {p.color for p in self.players.values()}
@@ -166,9 +184,10 @@ class PlayerRegistry:
         self._sessions[player.session_id] = name
 
         _LOGGER.info(
-            "Player joined: %s (total: %d, late: %s)",
+            "Player joined: %s (total: %d, phase: %s, mid-question: %s)",
             name,
             len(self.players),
+            phase_value,
             joined_late,
         )
         return True, None
@@ -227,10 +246,13 @@ class PlayerRegistry:
         _handle_disconnect hasn't fired yet) can't block early reveal for
         the whole room.
 
-        Late-joiners (who entered the game mid-round) are excluded \u2014
+        Late-joiners (who entered the game mid-question) are excluded:
         otherwise a new player arriving after most answers are in would
         force the round to run the full timer duration even though all the
-        actual participants are done.
+        actual participants are done. Only a join into a question that is
+        already running counts (see ``MID_QUESTION_PHASES``); somebody who
+        joined between two rounds is a full participant in the next one
+        and must be waited for (#727).
         """
         participants = [
             p for p in self.players.values()

--- a/tests/test_late_join_between_rounds_727.py
+++ b/tests/test_late_join_between_rounds_727.py
@@ -1,0 +1,207 @@
+"""Regression tests for #727 — a between-rounds join is not a late join.
+
+``add_player`` used to set ``joined_late = phase_value != "LOBBY"``, so joining
+during ANSWER_REVEAL (or the wager window, or a Lightning / Hot Seat detour)
+was flagged exactly like joining in the middle of a live question. The flag is
+only cleared at the end of ``_do_evaluate_round``, so it survived into the
+NEXT round: ``all_submitted()`` skipped the player, the round closed on the
+other answers, and the newcomer was recorded as a ``"timeout"`` with 0 points
+while their phone still showed a running clock.
+
+Covered here:
+- the phase split itself (``MID_QUESTION_PHASES``),
+- the average-score seeding, which must still key off "joined after the
+  lobby" and not off the narrowed mid-question flag,
+- the end-to-end failure scenario from the issue.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.phase_controller import (  # noqa: E402
+    MID_QUESTION_PHASES,
+    GamePhase,
+)
+from custom_components.quizify.game.player_registry import (  # noqa: E402
+    PlayerRegistry,
+)
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+
+
+def _fake_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+class _Runtime:
+    """Minimal runtime: runs scheduled coroutines on the live loop."""
+
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+    def create_task(self, coro):  # noqa: ANN001
+        return asyncio.ensure_future(coro)
+
+
+# ---------- which phases count as "a question is in flight" ----------
+
+
+class TestMidQuestionPhaseSplit:
+    @pytest.mark.parametrize(
+        "phase",
+        [GamePhase.QUESTION_ACTIVE, GamePhase.PAUSED],
+    )
+    def test_join_during_live_question_is_late(self, phase: GamePhase) -> None:
+        """A join while the answer clock runs (or is frozen mid-run) must stay
+        flagged — that player genuinely cannot answer in time and must not
+        hold up all_submitted()."""
+        reg = PlayerRegistry()
+        reg.add_player("Alice", _fake_ws(), "LOBBY", reg.get_average_score)
+        ok, err = reg.add_player(
+            "Newcomer", _fake_ws(), phase.value, reg.get_average_score
+        )
+        assert (ok, err) == (True, None)
+        assert reg.players["Newcomer"].joined_late is True
+
+    @pytest.mark.parametrize(
+        "phase",
+        [
+            GamePhase.ANSWER_REVEAL,
+            GamePhase.WAGER_ACTIVE,
+            GamePhase.LIGHTNING,
+            GamePhase.LIGHTNING_RECAP,
+            GamePhase.HOT_SEAT_AUCTION,
+            GamePhase.HOT_SEAT,
+            GamePhase.HOT_SEAT_REVEAL,
+            GamePhase.FINALE,
+        ],
+    )
+    def test_join_between_rounds_is_not_late(self, phase: GamePhase) -> None:
+        """No question is running in any of these phases: the joiner gets a
+        full timer from begin_round like everybody else, so they must count
+        toward all_submitted() from the very next round on (#727)."""
+        reg = PlayerRegistry()
+        reg.add_player("Alice", _fake_ws(), "LOBBY", reg.get_average_score)
+        ok, err = reg.add_player(
+            "Newcomer", _fake_ws(), phase.value, reg.get_average_score
+        )
+        assert (ok, err) == (True, None)
+        assert reg.players["Newcomer"].joined_late is False
+
+    def test_phase_set_is_an_allowlist(self) -> None:
+        """Guard against a future phase silently inheriting the flag."""
+        assert set(MID_QUESTION_PHASES) == {"QUESTION_ACTIVE", "PAUSED"}
+
+    def test_between_rounds_joiner_is_not_blocking_yet_but_counts_next(
+        self,
+    ) -> None:
+        """all_submitted() must wait for a player who joined at the reveal."""
+        reg = PlayerRegistry()
+        reg.add_player("Alice", _fake_ws(), "LOBBY", reg.get_average_score)
+        reg.add_player("Dana", _fake_ws(), "ANSWER_REVEAL", reg.get_average_score)
+        reg.players["Alice"].submitted = True
+        assert reg.all_submitted() is False
+        reg.players["Dana"].submitted = True
+        assert reg.all_submitted() is True
+
+
+# ---------- seeding still keys off "joined after the lobby" ----------
+
+
+class TestAverageScoreSeedingUnchanged:
+    @pytest.mark.parametrize(
+        "phase_value",
+        ["ANSWER_REVEAL", "WAGER_ACTIVE", "QUESTION_ACTIVE", "FINALE"],
+    )
+    def test_any_post_lobby_join_is_seeded_with_the_average(
+        self, phase_value: str
+    ) -> None:
+        """Narrowing ``joined_late`` must not un-seed the newcomer's score:
+        somebody joining at the reveal still missed every scored round."""
+        reg = PlayerRegistry()
+        ok, _ = reg.add_player("Dana", _fake_ws(), phase_value, lambda: 42)
+        assert ok is True
+        assert reg.players["Dana"].score == 42
+
+    def test_lobby_join_still_starts_at_zero(self) -> None:
+        reg = PlayerRegistry()
+        ok, _ = reg.add_player("Dana", _fake_ws(), "LOBBY", lambda: 42)
+        assert ok is True
+        assert reg.players["Dana"].score == 0
+        assert reg.players["Dana"].joined_late is False
+
+
+# ---------- the scenario from the issue, end to end ----------
+
+
+class TestJoinAtRevealPlaysTheNextRound:
+    def test_reveal_joiner_is_not_scored_as_a_timeout(
+        self, tmp_path: Path
+    ) -> None:
+        """A, B play; C joins during the reveal. The next round must not close
+        on A+B alone, and C must not be recorded as a timeout while their own
+        clock is still running."""
+        gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+        gs.add_player("Alice", _fake_ws())
+        gs.add_player("Bob", _fake_ws())
+        gs.start_game(language="de", num_rounds=5)
+        gs.start_next_question()
+
+        gs.submit_answer("Alice", 0)
+        gs.submit_answer("Bob", 0)
+        assert gs.phase is GamePhase.ANSWER_REVEAL
+
+        # Carol joins between the two rounds.
+        gs.add_player("Carol", _fake_ws())
+        carol = gs.get_player("Carol")
+        assert carol is not None
+        assert carol.joined_late is False
+
+        # Round 2: Alice + Bob answering must NOT close the round.
+        gs.start_next_question()
+        assert gs.phase is GamePhase.QUESTION_ACTIVE
+        gs.submit_answer("Alice", 0)
+        gs.submit_answer("Bob", 0)
+        assert gs._player_registry.all_submitted() is False
+        assert gs.phase is GamePhase.QUESTION_ACTIVE
+
+        # Carol's tap is accepted (no ERR_ROUND_EXPIRED) and closes the round.
+        result = gs.submit_answer("Carol", 0)
+        assert not isinstance(result, str), f"got error: {result!r}"
+        assert gs.phase is GamePhase.ANSWER_REVEAL
+
+        # And she was never booked as a timeout for the round she played.
+        assert "timeout" not in carol.round_history
+
+    def test_mid_question_joiner_still_does_not_block(
+        self, tmp_path: Path
+    ) -> None:
+        """The reason the flag exists is unchanged: a genuine mid-question
+        join must still let the round close on the other players."""
+        gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+        gs.add_player("Alice", _fake_ws())
+        gs.add_player("Bob", _fake_ws())
+        gs.start_game(language="de", num_rounds=5)
+        gs.start_next_question()
+
+        gs.add_player("Carol", _fake_ws())
+        carol = gs.get_player("Carol")
+        assert carol is not None
+        assert carol.joined_late is True
+
+        gs.submit_answer("Alice", 0)
+        gs.submit_answer("Bob", 0)
+        assert gs.phase is GamePhase.ANSWER_REVEAL


### PR DESCRIPTION
Closes #727

## The bug

`add_player` decided lateness with `joined_late = phase_value != "LOBBY"`, so joining during ANSWER_REVEAL — or the wager window, or a Lightning / Hot Seat detour — was flagged exactly like joining in the middle of a live question. The flag is only cleared at the end of `_do_evaluate_round`, so a join *between* two rounds survived into the next one.

A, B and C are playing; D joins during the round-3 reveal. In round 4 `begin_round` gives D a full timer and their phone shows the question. A, B and C answer within 8 s, `all_submitted()` — which skips `joined_late` players — returns True, the round evaluates, and D is recorded as a `"timeout"` with streak 0 and 0 points with 22 seconds still on their screen. A later tap gets `ERR_ROUND_EXPIRED`. On the final round the phantom timeout additionally settles as a lost wager.

## The fix

The flag exists for a real reason — a player who joins mid-question genuinely cannot answer it in time and must not hold up `all_submitted()` — so it is narrowed, not removed. A new `MID_QUESTION_PHASES` allowlist sits next to the `GamePhase` enum, which owns the answer.

**In flight, stays flagged:**

- `QUESTION_ACTIVE` — the live question.
- `PAUSED` — the same question with its timers frozen. `PhaseController.pause` only ever enters PAUSED from QUESTION_ACTIVE, so a join here is still a join into a running round, and `resume` hands it the round's shared remaining (#702).

**Between rounds, no longer flagged.** In each of these the joiner gets a full timer from `begin_round` like everybody else:

- `ANSWER_REVEAL` — the previous round is already scored.
- `WAGER_ACTIVE` (#656) — the final round's betting window. No timer runs yet; `begin_round` builds one for every player present when the window closes, this joiner included. They miss the chance to place a bet, but they can answer the question, and being silently scored 0 is strictly worse than betting nothing.
- `LIGHTNING` / `LIGHTNING_RECAP` (#42) and `HOT_SEAT_AUCTION` / `HOT_SEAT` / `HOT_SEAT_REVEAL` (#616) — self-contained detours with their own rosters and scoring. Neither reads `joined_late`, and the main round they hand back to has not started, so flagging a joiner here only sabotages the round *after* the detour.
- `FINALE` — the game is over. The flag would only survive into a "play again" round.

It is an allowlist rather than "everything except LOBBY" so a phase added later defaults to *not* a late joiner instead of silently inheriting this bug.

## Score seeding is deliberately left alone

`initial_score = average_score_fn() if joined_late else 0` rode on the same flag, but it answers a different question: *did this player miss rounds that are already on the board?* Anyone joining after the LOBBY did. Narrowing one flag for both would have stopped seeding the most common late join (at the reveal) and stranded them at zero. `add_player` now computes `joined_after_lobby` for the seed and `joined_late` for the round mechanics — collapsing the two onto a single flag is what produced the bug in the first place.

## Tests

New `tests/test_late_join_between_rounds_727.py` (19 cases):

- every non-LOBBY phase, parametrized, asserting which side of the split it lands on;
- `all_submitted()` waits for a reveal joiner but still ignores a mid-question one;
- average-score seeding for every post-lobby phase, and zero for LOBBY;
- the end-to-end scenario from the issue: Carol joins at the reveal, round 2 does *not* close on Alice + Bob, her tap is accepted rather than `ERR_ROUND_EXPIRED`, and `"timeout"` never lands in her `round_history`;
- the reason the flag exists is still guarded: a genuine mid-question join still lets the round close on the others.

Verified failing without the fix: with `custom_components/quizify/game/player_registry.py` stashed, 10 of the 19 fail (including the end-to-end scenario); the 9 that pass are the unchanged-behaviour guards. Restored, all 19 pass.

Full suite 2396 passed; `ruff check custom_components/` clean; `mypy custom_components/` clean. No JS touched, so no bundle rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE
