### PR TITLE
fix: one score floor for a team, whatever the question type

### DIFF
--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -1151,6 +1151,77 @@ class QuizifyGameState:
         # dark would punish the wrong thing.
         return next((p for p in candidates if p.connected), candidates[0])
 
+    def _record_team_timeout(self, team: Team) -> None:
+        """Book a round the team never answered (#748).
+
+        The shape a missed round takes everywhere else: streak broken, a
+        ``timeout`` history entry, a zero in the round-score history, and the
+        round still counted as played so the per-round averages divide by the
+        right number. Shared by both settlement paths so a fourth copy cannot
+        drift the way the scoring blocks did.
+        """
+        team.streak = 0
+        team.round_history.append("timeout")
+        team.round_scores.append(0)
+        team.rounds_played += 1
+
+    def _credit_team_round(
+        self,
+        team: Team,
+        points: int,
+        correct: bool,
+        elapsed: float,
+        breakdown: dict[str, Any],
+    ) -> None:
+        """Book one scored round onto a team — the only place that does (#748).
+
+        Multiple choice and estimate used to keep a copy of this each, the
+        second documented as "the mirror of" the first. They drifted anyway:
+        the estimate copy floored the running total at zero and the
+        multiple-choice copy did not, so whether a team could end a round below
+        zero depended on the question type. One function now, so the next
+        divergence has to be written on purpose.
+
+        **The floor is the right side of that disagreement.** Every individual
+        score in this file is floored at zero — a submitted answer
+        (``submit_answer``), an estimate result, a final-round timeout, a
+        STEAL, a Hot Seat settlement — and ``ScoringEngine`` bounds the wager
+        loss itself at ``-min(wager_pts, bank)`` so a bet cannot price a player
+        out of an existing rematch flow. Teams are not a separate ranking:
+        ``get_ranked_participants`` returns teams and solo players in one list,
+        which the dashboard, the reveal and the finale draw with the same code
+        that has never been handed a negative number (``player-end.js`` sizes
+        every bar as ``score / topScore``). A table where the team reads -30
+        and the guest who stayed solo reads 0 for the same lost bet is the bug;
+        the floor is not.
+
+        The streak rule is shared for the same reason — it was already
+        identical on both sides. ``submit_answer`` advances the carrier's lent
+        streak on a correct answer and zeroes it otherwise, and the estimate
+        path spells out the same rule against ``exact`` (#408).
+        """
+        team.score += points
+        if team.score < 0:
+            team.score = 0
+        team.streak = team.streak + 1 if correct else 0
+        if team.streak > team.max_streak:
+            team.max_streak = team.streak
+        team.last_answer_correct = correct
+        team.last_elapsed = elapsed
+        team.round_score = points
+        team.round_score_breakdown = dict(breakdown)
+        # Award tallies, kept in the same shape a player keeps them so the
+        # awards can be computed by the same code (#365).
+        team.round_history.append("correct" if correct else "wrong")
+        team.round_scores.append(points)
+        team.rounds_played += 1
+        if correct:
+            team.answer_times.append(elapsed)
+            if (question := self._current_question) is not None and (
+                question.difficulty == Difficulty.HARD.value
+            ):
+                team.hard_score += points
+
     def _settle_team_answers(self) -> None:
         """Score each team's standing answer once, through the player path.
 
@@ -1166,17 +1237,11 @@ class QuizifyGameState:
         round_started = self._round_start_time or 0.0
         for team in self._team_registry.all_teams():
             if team.current_answer is None or team.answer_by is None:
-                team.streak = 0
-                team.round_history.append("timeout")
-                team.round_scores.append(0)
-                team.rounds_played += 1
+                self._record_team_timeout(team)
                 continue
             player = self._pick_team_carrier(team, team.answer_by)
             if player is None:
-                team.streak = 0
-                team.round_history.append("timeout")
-                team.round_scores.append(0)
-                team.rounds_played += 1
+                self._record_team_timeout(team)
                 continue
 
             elapsed = max(0.0, (team.answered_at or round_started) - round_started)
@@ -1191,25 +1256,13 @@ class QuizifyGameState:
                 _settling_team=True,
             )
             if isinstance(result, AnswerResult):
-                team.score += result.points_earned
-                team.streak = result.new_streak
-                team.last_answer_correct = result.correct
-                team.last_elapsed = elapsed
-                team.round_score = result.points_earned
-                team.round_score_breakdown = dict(player.round_score_breakdown)
-                team.round_history.append("correct" if result.correct else "wrong")
-                # Award tallies, kept in the same shape a player keeps them so
-                # the awards can be computed by the same code (#365).
-                team.round_scores.append(result.points_earned)
-                team.rounds_played += 1
-                if result.correct:
-                    team.answer_times.append(elapsed)
-                    if (question := self._current_question) is not None and (
-                        question.difficulty == Difficulty.HARD.value
-                    ):
-                        team.hard_score += result.points_earned
-                if team.streak > team.max_streak:
-                    team.max_streak = team.streak
+                self._credit_team_round(
+                    team,
+                    result.points_earned,
+                    result.correct,
+                    elapsed,
+                    player.round_score_breakdown,
+                )
 
     def _settle_team_guesses(self) -> dict[str, str]:
         """Hand each team's standing guess to the member who set it (#602).
@@ -1247,11 +1300,12 @@ class QuizifyGameState:
     ) -> None:
         """Copy each carrier's estimate result onto their team (#602).
 
-        The mirror of the bookkeeping block in ``_settle_team_answers``: the
-        team takes the points, the streak, the history entry and the award
-        tallies, in the same shape a player keeps them, so the awards can be
-        computed by the same code. A team that never guessed records a
-        timeout, which is what a missed round looks like everywhere else.
+        Which member carried the guess is this method's only concern; the
+        bookkeeping itself belongs to ``_credit_team_round``, shared with
+        ``_settle_team_answers`` (#748). This used to be a hand-kept "mirror"
+        of that block, and it had already drifted — only this copy floored the
+        team total at zero. A team that never guessed records a timeout, which
+        is what a missed round looks like everywhere else.
         """
         for team in self._team_registry.all_teams():
             carrier_name = carriers.get(team.team_id)
@@ -1262,36 +1316,19 @@ class QuizifyGameState:
             )
             entry = scores.get(carrier_name) if carrier_name else None
             if player is None or entry is None:
-                team.streak = 0
-                team.round_history.append("timeout")
-                team.round_scores.append(0)
-                team.rounds_played += 1
+                self._record_team_timeout(team)
                 continue
 
-            points = player.round_score
-            exact = bool(entry["exact"])
-            team.score += points
-            if team.score < 0:
-                team.score = 0
-            # Streak only advances on an exact hit, matching the per-player
-            # rule (#408) — a near miss is recorded as "wrong", and growing a
-            # streak on it would step past a milestone that was never paid.
-            team.streak = team.streak + 1 if exact else 0
-            if team.streak > team.max_streak:
-                team.max_streak = team.streak
-            team.last_answer_correct = exact
-            team.last_elapsed = player.last_elapsed
-            team.round_score = points
-            team.round_score_breakdown = dict(player.round_score_breakdown)
-            team.round_history.append("correct" if exact else "wrong")
-            team.round_scores.append(points)
-            team.rounds_played += 1
-            if exact:
-                team.answer_times.append(player.last_elapsed)
-                if (question := self._current_question) is not None and (
-                    question.difficulty == Difficulty.HARD.value
-                ):
-                    team.hard_score += points
+            # "Correct" on an estimate round means an EXACT hit — a near miss
+            # is recorded as "wrong", so the shared streak rule cannot grow a
+            # streak past a milestone that was never paid (#408).
+            self._credit_team_round(
+                team,
+                player.round_score,
+                bool(entry["exact"]),
+                player.last_elapsed,
+                player.round_score_breakdown,
+            )
 
     def _collect_team_powerup_stats(self) -> None:
         """Roll each team's members' power-up usage up to the team (#365).

--- a/tests/test_team_score_floor_748.py
+++ b/tests/test_team_score_floor_748.py
@@ -1,0 +1,225 @@
+"""One floor under a team's score, whatever the question type (#748).
+
+``_apply_estimate_results_to_teams`` called itself "the mirror of the
+bookkeeping block in ``_settle_team_answers``" and then stopped being one: it
+floored ``team.score`` at zero and the multiple-choice block did not. So the
+answer to "can a team end a round below zero?" was decided by the question
+type — an estimate final said no, a multiple-choice final said yes.
+
+The floor is the side that survives. Every individual score in ``state.py`` is
+floored at zero (``submit_answer``, the estimate result, the final-round
+timeout, STEAL, the Hot Seat settlement), ``ScoringEngine`` bounds the wager
+loss at ``-min(wager_pts, bank)`` on purpose, and
+``get_ranked_participants`` puts teams and solo players in ONE ranked list that
+the dashboard, the reveal and the finale render with one code path. A -30 next
+to a 0 for the same lost bet is a rendering nobody designed.
+
+Note on reachability: team mode does not open a betting window today (#668),
+so ``player.wager`` is normally ``None`` when settlement runs. These tests set
+it directly because settlement reads it unconditionally — the invariant under
+test is the settlement contract, which has to hold before a team-level wager
+can be built on top of it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from custom_components.quizify.game.state import QuizifyGameState
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+class _Runtime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+    def create_task(self, coro):  # noqa: ANN001
+        import asyncio
+
+        return asyncio.ensure_future(coro)
+
+
+def _game(tmp_path: Path, category: str, rounds: int = 1) -> QuizifyGameState:
+    """A team of two plus one solo player, parked on round 1 of ``rounds``."""
+    st = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="test")
+    for name in ("Anna", "Jan", "Mira"):
+        st.add_player(name, _ws())
+    st.create_team("Sofa", "Anna")
+    st.join_team(st.get_team_of("Anna")["team_id"], "Jan")
+    st.start_game(
+        category=category, difficulty="easy", num_rounds=rounds, language="en"
+    )
+    st.start_next_question()
+    return st
+
+
+def _team(game: QuizifyGameState):  # noqa: ANN202
+    return game.team_registry.all_teams()[0]
+
+
+def _wrong_index(game: QuizifyGameState) -> int:
+    q = game.get_current_question()
+    return next(i for i, a in enumerate(q.answers) if not a.correct)
+
+
+# --------------------------------------------------------------------------
+# The defect: the floor was question-type dependent
+# --------------------------------------------------------------------------
+
+
+def test_a_lost_wager_cannot_push_a_team_below_zero(tmp_path: Path) -> None:
+    """The multiple-choice path had no floor, so the team ended at -140.
+
+    ``_settle_team_answers`` lends the carrier the team's *streak* but not its
+    *score*, so the engine bounds the loss by the carrier's own shadow bank
+    while the subtraction lands on the team's. Give the carrier a bank the team
+    does not have and the team goes negative — which is exactly what the
+    estimate path had already refused to do.
+    """
+    game = _game(tmp_path, "picture-round-en")
+    team = _team(game)
+    carrier = game.get_player("Anna")
+
+    team.score = 60
+    carrier.score = 200  # bigger shadow bank than the team's real one
+    carrier.wager = 100  # bet the lot on the final round
+
+    game.submit_answer("Anna", _wrong_index(game))
+    game.evaluate_round()
+
+    assert team.score == 0, f"team ended the round at {team.score}"
+
+
+def test_the_estimate_path_keeps_the_same_floor(tmp_path: Path) -> None:
+    """The side that was already right stays right after the refactor."""
+    game = _game(tmp_path, "estimation-en")
+    team = _team(game)
+    team.score = 40
+
+    carrier = game.get_player("Anna")
+    carrier.round_score = -500  # a loss bigger than the team's bank
+    game._apply_estimate_results_to_teams(  # noqa: SLF001
+        {team.team_id: "Anna"},
+        {"Anna": {"exact": False, "points": -500, "distance": 1.0, "rank": 2}},
+    )
+
+    assert team.score == 0
+
+
+def test_both_paths_book_a_round_through_the_same_function(
+    tmp_path: Path,
+) -> None:
+    """The structural half of the fix: no second copy left to drift.
+
+    Two blocks documented as mirrors drifted anyway, so "they agree today" is
+    not the property worth pinning — "there is only one of them" is.
+    """
+    calls: list[tuple[int, bool]] = []
+    original = QuizifyGameState._credit_team_round  # noqa: SLF001
+
+    def _spy(self, team, points, correct, elapsed, breakdown):  # noqa: ANN001
+        calls.append((points, correct))
+        return original(self, team, points, correct, elapsed, breakdown)
+
+    for category in ("picture-round-en", "estimation-en"):
+        game = _game(tmp_path, category)
+        game._credit_team_round = _spy.__get__(game)  # noqa: SLF001
+        before = len(calls)
+
+        if category == "estimation-en":
+            answer = game.get_current_question().estimate_answer
+            game.submit_guess("Anna", answer)
+            game.submit_guess("Mira", answer * 0.5)
+        else:
+            game.submit_answer("Anna", _wrong_index(game))
+        game.evaluate_round()
+
+        assert len(calls) == before + 1, f"{category} did not use the helper"
+
+
+# --------------------------------------------------------------------------
+# The bookkeeping the two copies used to keep separately
+# --------------------------------------------------------------------------
+
+
+def test_a_scored_round_is_booked_identically_on_both_paths(
+    tmp_path: Path,
+) -> None:
+    """Same points, same correctness → same team row, whatever the question."""
+    rows = []
+    for category in ("picture-round-en", "estimation-en"):
+        game = _game(tmp_path, category)
+        team = _team(game)
+        game._credit_team_round(  # noqa: SLF001
+            team, 150, True, 2.5, {"speed_bonus": 10}
+        )
+        rows.append(
+            (
+                team.score,
+                team.streak,
+                team.max_streak,
+                team.last_answer_correct,
+                team.last_elapsed,
+                team.round_score,
+                team.round_history,
+                team.round_scores,
+                team.rounds_played,
+                team.answer_times,
+            )
+        )
+
+    assert rows[0] == rows[1]
+
+
+def test_a_missed_round_is_booked_identically_on_both_paths(
+    tmp_path: Path,
+) -> None:
+    """A team that never responded looks the same in MC and in estimate."""
+    game_mc = _game(tmp_path, "picture-round-en")
+    game_est = _game(tmp_path, "estimation-en")
+
+    game_mc.submit_answer("Mira", 0)
+    game_mc.evaluate_round()
+    game_est.submit_guess(
+        "Mira", game_est.get_current_question().estimate_answer
+    )
+    game_est.evaluate_round()
+
+    def _row(team):  # noqa: ANN001, ANN202
+        return (
+            team.score,
+            team.streak,
+            team.round_history,
+            team.round_scores,
+            team.rounds_played,
+        )
+
+    assert _row(_team(game_mc)) == _row(_team(game_est))
+
+
+def test_the_shared_streak_rule_matches_the_engine(tmp_path: Path) -> None:
+    """The helper owns the streak, so it must reproduce what it replaced.
+
+    ``_settle_team_answers`` used to take ``result.new_streak`` straight from
+    the engine. The engine's rule is "+1 on a correct answer, 0 otherwise"
+    against the streak the carrier was lent — the same rule the estimate path
+    spelled out by hand against ``exact`` (#408).
+    """
+    game = _game(tmp_path, "picture-round-en", rounds=3)
+    team = _team(game)
+    team.streak = 4
+
+    game._credit_team_round(team, 100, True, 1.0, {})  # noqa: SLF001
+    assert (team.streak, team.max_streak) == (5, 5)
+
+    game._credit_team_round(team, 0, False, 1.0, {})  # noqa: SLF001
+    assert (team.streak, team.max_streak) == (0, 5)


### PR DESCRIPTION
Closes #748

## The defect

`_apply_estimate_results_to_teams` called itself "the mirror of the bookkeeping block in `_settle_team_answers`" and then stopped being one. The estimate copy did `team.score += points; if team.score < 0: team.score = 0`; the multiple-choice copy at `state.py:1194` had no clamp at all. Whether a team could end a round below zero was decided by the question type — an estimate final said no, a multiple-choice final said yes.

## Which side is right: the floor

I did not pick the clamp because it was there. Three things say the floor is the rule this codebase already has:

**1. Every individual score in `state.py` is floored at zero.** Five sites, no exceptions: `submit_answer` (`:1005`), the estimate result (`:1545`), the final-round timeout via `max(0, player.score - loss)` (`:1365`), STEAL on both ends (`:2430`, `:2434`), and the Hot Seat settlement (`:2238`). There is no negative-score branch anywhere in the game model.

**2. `ScoringEngine` bounds the loss on purpose.** `points = -min(wager_pts, bank)` (`scoring_engine.py:190`) carries the comment "never go below zero so a player can't be priced out of an existing rematch flow". The engine is already trying to hold this invariant; the multiple-choice team path was quietly undoing it, because `_settle_team_answers` lends the carrier only the team's **streak** and not its **score** — so the engine bounded the loss by the *carrier's* shadow bank while the subtraction landed on the *team's*.

**3. Teams and solo players share one leaderboard and one renderer.** `get_ranked_participants()` returns `teams + solo` as a single list, and its docstring is explicit that this is why "the dashboard, reveal and finale need no team-specific rendering path". That renderer has never been handed a negative number: `player-end.js:305-311` seeds `topScore = 0` and sizes every bar as `Math.max(4, (entry.score / topScore) * 100)`, so a negative score draws a stub bar with a minus sign next to it, and `quizify-host-card.js:354` prints `p.score` raw on the television. A team on **-140** sitting next to a solo guest on **0** after the same lost bet is the defect. The floor is not.

## The honest fix, not the smaller one

Two blocks documented as mirrors drifted anyway, so agreeing them by hand would only reset the clock on the next divergence. Both paths now book a scored round through one `_credit_team_round(team, points, correct, elapsed, breakdown)`, and all three copies of the timeout block go through one `_record_team_timeout(team)`.

The streak rule moved into the helper too, because it was **already** identical on both sides and only looked different: `submit_answer` advances the carrier's lent streak on a correct answer and zeroes it otherwise, so `result.new_streak` is exactly `team.streak + 1 if correct else 0` — which is what the estimate path spelled out by hand against `exact` (#408). Net: 60 lines of duplicated bookkeeping become one function. No behaviour changes except the floor.

## Reachability, stated plainly

Team mode opens no betting window today (`_needs_wager_window` returns `False` for `team_mode`, #668), so `player.wager` is normally `None` when settlement runs, and the negative total is latent rather than shipped — which is what the `code-quality` label says. Settlement reads `player.wager` unconditionally, and #668's own docstring calls a team-level wager "a feature, not a fix", so the invariant has to hold before that feature can be built on top of it. The tests set the wager directly for this reason and say so.

## Tests

`tests/test_team_score_floor_748.py`, six tests. Verified they fail without the fix (`git stash push custom_components/quizify/game/state.py`): 4 of 6 fail, the behavioural one with

```
AssertionError: team ended the round at -140
```

- `test_a_lost_wager_cannot_push_a_team_below_zero` — the defect itself, driven through `submit_answer` + `evaluate_round`.
- `test_the_estimate_path_keeps_the_same_floor` — the side that was already right stays right.
- `test_both_paths_book_a_round_through_the_same_function` — the structural half: "they agree today" is not the property worth pinning, "there is only one of them" is.
- `test_a_scored_round_is_booked_identically_on_both_paths` / `test_a_missed_round_is_booked_identically_on_both_paths` — full field-by-field equality.
- `test_the_shared_streak_rule_matches_the_engine` — the helper reproduces what it replaced.

## Gates

- `pytest -q` — 2383 passed
- `ruff check custom_components/` — all checks passed
- `mypy custom_components/` — no issues in 48 source files

No `www/js/` change, so no bundle rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE
