### PR TITLE
fix: end_game leaves the lightning loop running (#746)

### DIFF
--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -245,6 +245,45 @@ class QuizifyWebSocketHandler:
     # answering, which is the whole moment the auction buys.
     HOT_SEAT_REVEAL_HOLD = 4.0
 
+    # ------------------------------------------------------------------
+    # Task ownership registry (#746)
+    # ------------------------------------------------------------------
+    # Five round-scoped tasks used to be cancelled by hand at ~20 call sites,
+    # and the resulting matrix was asymmetric: reset/play_again/start_game/
+    # cleanup cancelled four, _advance_round two, and end_game exactly one —
+    # so a lightning question was still scored after the finale had been
+    # broadcast. That was the fifth repeat of one shape (#362, #407, #656,
+    # #671): a new task is added, and one teardown path is forgotten.
+    #
+    # These two tuples are the single source of truth for "who owns what".
+    # ``_cancel_round_tasks()`` walks the first, ``cleanup_game_tasks()``
+    # walks both, and every teardown path goes through one of those two
+    # instead of listing cancellers itself. A task added to __init__ but to
+    # neither tuple fails ``tests/test_round_task_teardown_746.py`` — the
+    # registry is checked against the annotated ``asyncio.Task | None``
+    # attributes, so "forgot a call site" is no longer expressible.
+    #
+    # Round-scoped: anything that drives, times, or interrupts THE CURRENT
+    # ROUND. It must not survive a round ending, a game ending, or a reset.
+    _ROUND_SCOPED_TASKS: tuple[tuple[str, str], ...] = (
+        ("_timer_tick_task", "_cancel_timer_tick"),
+        ("_wager_window_task", "_cancel_wager_window"),
+        ("_lightning_task", "_cancel_lightning_loop"),
+        ("_hot_seat_task", "_cancel_hot_seat_loop"),
+        ("_admin_pause_task", "_cancel_admin_pause"),
+    )
+
+    # Deliberately NOT round-scoped: broadcast coalescers. They batch frames
+    # over a few hundred milliseconds and are keyed to nothing in the round,
+    # so a round boundary is not a reason to drop a pending flush. Only the
+    # full ``cleanup_game_tasks()`` (integration unload / dev-server shutdown)
+    # stops them.
+    _CONNECTION_SCOPED_TASKS: tuple[tuple[str, str], ...] = (
+        ("_reaction_flush_task", "_cancel_reaction_flush"),
+        ("_roster_flush_task", "_cancel_roster_flush"),
+        ("_progress_flush_task", "_cancel_progress_flush"),
+    )
+
     def __init__(
         self,
         runtime: Runtime,
@@ -1936,22 +1975,16 @@ class QuizifyWebSocketHandler:
         # 2026-05-31: picked Geographie/DE but kept seeing the previous English
         # mixed game. Reset to LOBBY first (keeps connected players) so the
         # fresh settings always take effect. Mirrors _handle_play_again.
-        # #671: unconditional, unlike the block below. A hot-seat loop has no
-        # business surviving into a new game whatever phase we start from, and
-        # "there cannot be one in LOBBY" is the same assumption that let this
-        # task outlive four teardown paths in the first place. Cancelling a
-        # task that isn't there costs nothing.
-        self._cancel_hot_seat_loop()
+        # #671, generalized in #746: unconditional, and the whole set. No
+        # round-scoped task has any business surviving into a new game
+        # whatever phase we start from, and "there cannot be one in LOBBY" is
+        # the same assumption that let the hot-seat task outlive four teardown
+        # paths in the first place. Cancelling a task that isn't there costs
+        # nothing; the reset_to_lobby below stays phase-gated because it
+        # touches state, not tasks.
+        self._cancel_round_tasks()
 
         if game_state.phase != GamePhase.LOBBY:
-            self._cancel_timer_tick()
-            # #407 (follow-up to #362): cancel the lightning loop and any
-            # deferred admin-disconnect pause too, exactly like
-            # ``_handle_reset_game``. Otherwise a stale admin-pause task can
-            # pause round 1 of the NEW game, and a start during a LIGHTNING
-            # detour leaves ``_lightning_task`` broadcasting stale frames.
-            self._cancel_lightning_loop()
-            self._cancel_admin_pause()
             game_state.reset_to_lobby()
 
         raw_category = data.get("category")
@@ -2153,6 +2186,10 @@ class QuizifyWebSocketHandler:
         # round counter, so the start_next_question below lands on the
         # originally-scheduled round.
         if game_state.phase == GamePhase.LIGHTNING_RECAP:
+            # DELIBERATE SUBSET (#746): not ``_cancel_round_tasks()``. The
+            # game is not ending here — the host is settling one detour and
+            # resuming the round it interrupted. Killing the admin-pause task
+            # would swallow a genuine host disconnect that is still pending.
             self._cancel_lightning_loop()
             if game_state.resume_after_lightning():
                 await self._start_next_question(game_state)
@@ -2161,6 +2198,8 @@ class QuizifyWebSocketHandler:
         # Hot Seat reveal (#616): the host's advance settles the detour and
         # returns to the round the auction interrupted.
         if game_state.phase == GamePhase.HOT_SEAT_REVEAL:
+            # DELIBERATE SUBSET (#746), same reasoning as the branch above:
+            # one detour settles, the game carries on.
             self._cancel_hot_seat_loop()
             if game_state.resume_after_hot_seat():
                 await self._start_next_question(game_state)
@@ -2218,6 +2257,8 @@ class QuizifyWebSocketHandler:
             # Stop the countdown and evaluate now. evaluate_round()'s
             # state-machine event (_fire_broadcast("round_evaluated")) drives
             # the summary broadcast, same as the timer-expiry auto-evaluate.
+            # DELIBERATE SUBSET (#746): a skip cuts the QUESTION short, it
+            # does not end the round or the game. Only the clock stops.
             self._cancel_timer_tick()
             game_state.evaluate_round()
             return
@@ -2239,7 +2280,14 @@ class QuizifyWebSocketHandler:
         Shared by the admin ``end_game`` WS handler and the ``quizify.end_game``
         HA service.
         """
-        self._cancel_timer_tick()
+        # #746: this used to cancel the tick and nothing else. ``end_game()``
+        # has no phase guard, so the admin can end the game mid-detour — and a
+        # surviving lightning loop then ran ``lr.advance()`` after the finale
+        # had already been broadcast and the analytics recorded, changing the
+        # scoreboard after the end screen was up. The hot-seat loop and the
+        # deferred admin pause were free to outlive the finale for the same
+        # reason. The game is over: every round-scoped task goes.
+        self._cancel_round_tasks()
         # end_game() fires the ``game_ended`` state event, which the
         # BroadcastDispatcher routes to _broadcast_finale — that's the single
         # finale broadcast source. Calling _broadcast_finale here too would
@@ -2270,6 +2318,8 @@ class QuizifyWebSocketHandler:
         if not game_state.pause(reason="admin_paused"):
             return False
         # Stop sending tick updates while paused.
+        # DELIBERATE SUBSET (#746): a pause freezes the clock and nothing
+        # else — the round is still live and resume() restarts it.
         self._cancel_timer_tick()
         # pause_reason rides along in the snapshot itself since #703, so it
         # is identical here and on every reconnect.
@@ -2316,14 +2366,11 @@ class QuizifyWebSocketHandler:
             await self._handle_reset_game(ws, game_state)
             return
         settings = game_state.last_settings
-        self._cancel_timer_tick()
-        # #407 (follow-up to #362): mirror ``_handle_reset_game`` — cancel the
-        # lightning loop and any deferred admin-disconnect pause before the new
-        # game, or a stale pause task pauses round 1 and a lingering lightning
-        # loop keeps broadcasting stale frames into the rematch.
-        self._cancel_lightning_loop()
-        self._cancel_hot_seat_loop()
-        self._cancel_admin_pause()
+        # #407 (follow-up to #362), via the #746 registry: nothing from the
+        # finished game may run into the rematch — a stale pause task would
+        # pause round 1, a lingering lightning loop would broadcast stale
+        # frames over it.
+        self._cancel_round_tasks()
         # Reset to LOBBY first so start_game's phase guard passes; keeps
         # players (reset_to_lobby leaves connected players in place).
         game_state.reset_to_lobby()
@@ -2367,12 +2414,10 @@ class QuizifyWebSocketHandler:
           3. Wipe per-player session tokens so the reconnect path can't
              resurrect a cleared player under their old slot.
         """
-        self._cancel_timer_tick()
-        self._cancel_lightning_loop()
-        self._cancel_hot_seat_loop()
-        # Cancel the deferred admin-disconnect pause (#362) so a reset can't
-        # be undone by a pause firing right after the fresh lobby is built.
-        self._cancel_admin_pause()
+        # #362 + #746: every round-scoped task, in one call. A deferred
+        # admin-disconnect pause surviving this would undo the reset the
+        # moment it fires into the fresh lobby.
+        self._cancel_round_tasks()
         # Cancel any pending admin-disconnect timer and stale player-removal
         # tasks from the finished game.
         await self._conn.cleanup()
@@ -2685,6 +2730,14 @@ class QuizifyWebSocketHandler:
                         waited += step
                         if game_state.phase != GamePhase.LIGHTNING:
                             return
+                    # #746, the re-check the hot-seat loop got in #671 and
+                    # this one did not: the wait above only tests the phase
+                    # AFTER a sleep, so the all-answered ``break`` leaves it
+                    # untested. An end_game landing in that gap was still
+                    # followed by ``lr.advance()`` — a lightning question
+                    # scored, and a recap frame broadcast, after the finale.
+                    if game_state.phase != GamePhase.LIGHTNING:
+                        return
                     # No reveal — score silently and arm the next question.
                     has_more = lr.advance()
                     if not has_more:
@@ -3515,6 +3568,34 @@ class QuizifyWebSocketHandler:
             self._timer_tick_task = None
         self._cancel_wager_window()
 
+    def _cancel_task_group(self, group: tuple[tuple[str, str], ...]) -> None:
+        """Run every canceller in one of the registries above (#746).
+
+        Cancellers are idempotent and safe on a task that was never started,
+        so a group can always be run whole. That is the point: the caller
+        says *which scope* it is tearing down, never *which tasks*.
+        """
+        for _attr, canceller in group:
+            cancel: Callable[[], None] = getattr(self, canceller)
+            cancel()
+
+    def _cancel_round_tasks(self) -> None:
+        """Tear down EVERY round-scoped task (#746).
+
+        The one place that owns "the round is over": end game, reset,
+        play again, start game, and the full cleanup all route through here
+        rather than listing cancellers themselves. A sixth task added to
+        ``_ROUND_SCOPED_TASKS`` is therefore stopped by all of them at once.
+
+        Paths that deliberately stop only PART of a round — ``_advance_round``
+        settling one detour, ``admin_action_pause`` freezing the clock while
+        the round stays alive, ``_handle_admin_skip`` cutting a question short
+        — keep calling the individual cancellers, with a comment saying why.
+        A deliberate subset should read as one; only a *complete* teardown
+        belongs here.
+        """
+        self._cancel_task_group(self._ROUND_SCOPED_TASKS)
+
     @staticmethod
     def _log_task_exception(task: asyncio.Task) -> None:
         """Done-callback that surfaces a fire-and-forget task's exception (#307).
@@ -4332,17 +4413,14 @@ class QuizifyWebSocketHandler:
             await self._conn.broadcast(state)
 
     async def cleanup_game_tasks(self) -> None:
-        """Cancel all pending tasks."""
-        self._cancel_timer_tick()
-        self._cancel_lightning_loop()
-        self._cancel_hot_seat_loop()
-        self._cancel_reaction_flush()
-        self._cancel_roster_flush()
-        self._cancel_progress_flush()
-        # Also cancel the deferred admin-disconnect pause (#362): a game
-        # teardown/reset that leaves it pending would fire a spurious pause
-        # (or hold a reference) after the game is already gone.
-        self._cancel_admin_pause()
+        """Cancel all pending tasks — both registries (#746).
+
+        The widest teardown there is (integration unload, dev-server
+        shutdown), so it takes the round-scoped tasks *and* the broadcast
+        coalescers that a round boundary deliberately leaves alone.
+        """
+        self._cancel_round_tasks()
+        self._cancel_task_group(self._CONNECTION_SCOPED_TASKS)
         await self._conn.cleanup()
         _LOGGER.debug("Cleaned up all pending game tasks")
 

--- a/tests/test_round_task_teardown_746.py
+++ b/tests/test_round_task_teardown_746.py
@@ -1,0 +1,407 @@
+"""Regression tests for #746 — one owner for round-scoped task teardown.
+
+Five round-scoped asyncio tasks lived as handler attributes and were
+cancelled by hand at roughly twenty call sites. The resulting matrix was
+asymmetric, and the asymmetry was the bug: ``_handle_reset_game``,
+``_handle_play_again``, ``_handle_start_game`` and ``cleanup_game_tasks``
+cancelled four of them, ``_advance_round`` two, and ``admin_action_end_game``
+exactly one — the tick.
+
+So the lightning loop outlived the finale. ``end_game()`` has no phase guard,
+the loop's wait re-checked the phase only *after* a sleep (the all-answered
+``break`` skipped the check), and ``lr.advance()`` then scored a question
+after the podium had been broadcast and the analytics recorded. The
+scoreboard moved after the end screen was up.
+
+That is the same shape as #362, #407, #656 and #671 — four earlier rounds of
+"a task was added, one path was forgotten". These tests therefore guard two
+different things:
+
+  * the teardown paths themselves, one test per path per task, because two
+    triggers for the same transition need a test each (the lesson from
+    #656/#657); and
+  * the *registry*, so a sixth task cannot be forgotten at a twenty-first
+    call site. ``test_every_handler_task_is_classified`` reads the handler's
+    own source and fails if an ``asyncio.Task | None`` attribute appears in
+    ``__init__`` without landing in one of the two scope tuples.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import inspect
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+from custom_components.quizify.server.connection import (  # noqa: E402
+    ConnectionManager,
+)
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    def create_task(self, coro):
+        return asyncio.ensure_future(coro)
+
+    async def run_in_executor(self, func, *args):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func, *args)
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    ws.close = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+@pytest.fixture
+def handler(game: QuizifyGameState, tmp_path: Path) -> QuizifyWebSocketHandler:
+    h = QuizifyWebSocketHandler(
+        runtime=_FakeRuntime(tmp_path), game_state_provider=lambda: game
+    )
+    h._conn = ConnectionManager(_FakeRuntime(tmp_path), lambda: game)
+    h._conn.broadcast = AsyncMock()
+    h._conn.broadcast_to_admins_and_dashboards = AsyncMock()
+    h._conn.send = AsyncMock()
+    return h
+
+
+def _park(handler: QuizifyWebSocketHandler, attr: str) -> asyncio.Task:
+    """Park a stand-in task on ``attr``.
+
+    Deliberately not the real loop: these assert the cancel *wiring*, and a
+    test that had to arrange a live lightning round to check a teardown path
+    would stop testing the teardown the first time the round's own guards
+    moved. The behavioural half lives in the end_game test further down.
+    """
+
+    async def _sleep_forever() -> None:
+        await asyncio.sleep(3600)
+
+    task = asyncio.ensure_future(_sleep_forever())
+    setattr(handler, attr, task)
+    return task
+
+
+async def _assert_cancelled(
+    handler: QuizifyWebSocketHandler, attr: str, task: asyncio.Task
+) -> None:
+    assert getattr(handler, attr) is None
+    await asyncio.sleep(0)
+    assert task.cancelled()
+
+
+async def _assert_cancelled_even_if_replaced(
+    handler: QuizifyWebSocketHandler, attr: str, task: asyncio.Task
+) -> None:
+    """For paths that tear down and then start a fresh game in one call.
+
+    ``start_game`` and ``play_again`` run on into round 1, which arms a new
+    timer tick — so the attribute is legitimately non-None afterwards. What
+    must hold is that the OLD task died and did not survive as the live one.
+    """
+    await asyncio.sleep(0)
+    assert task.cancelled()
+    assert getattr(handler, attr) is not task
+
+
+# Every round-scoped task, by the attribute the handler parks it on. Used to
+# parametrize the teardown paths so a task added to the registry is asserted
+# against every path at once, rather than only the one whose bug prompted it.
+#
+# Spelled out rather than read from ``_ROUND_SCOPED_TASKS`` on purpose: the
+# behavioural tests below have to run — and fail — against a handler that has
+# no registry yet, which is the whole point of a regression test.
+# ``test_registry_matches_the_round_scoped_tasks`` ties the two together.
+_ROUND_TASK_ATTRS = [
+    "_timer_tick_task",
+    "_wager_window_task",
+    "_lightning_task",
+    "_hot_seat_task",
+    "_admin_pause_task",
+]
+
+
+# ---------------------------------------------------------------------------
+# The bug: end_game left the lightning loop running
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("attr", _ROUND_TASK_ATTRS)
+async def test_end_game_cancels_every_round_scoped_task(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState, attr: str
+) -> None:
+    """The finale ends the round, so nothing round-scoped may survive it.
+
+    Before #746 this passed only for ``_timer_tick_task`` (and the wager
+    window it drags along); the lightning loop, the hot-seat loop and the
+    deferred admin pause were all free to outlive the podium.
+    """
+    task = _park(handler, attr)
+    await handler.admin_action_end_game(game)
+    await _assert_cancelled(handler, attr, task)
+
+
+@pytest.mark.asyncio
+async def test_ws_end_game_handler_cancels_the_lightning_loop(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState
+) -> None:
+    """The admin's WS ``end_game`` reaches the same teardown as the service."""
+    task = _park(handler, "_lightning_task")
+    await handler._handle_end_game(_ws(), game)
+    await _assert_cancelled(handler, "_lightning_task", task)
+
+
+@pytest.mark.asyncio
+async def test_lightning_question_is_not_scored_after_end_game(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState
+) -> None:
+    """The behavioural half: the real loop, ended mid-question.
+
+    Reproduces the exact gap. The wait loop re-checks the phase only after
+    ``asyncio.sleep(step)``, so the all-answered ``break`` reached
+    ``lr.advance()`` with no check at all — and there is no await between the
+    two, so cancelling the task alone does not stop it either. The end_game
+    here lands inside the tick broadcast, which is precisely where the host's
+    tap lands on a live server.
+    """
+    game.add_player("A", _ws())
+    assert game.start_lightning_round() is True
+    lr = game.lightning
+    lr.seconds_per_question = 30.0  # long: only all-answered ends the wait
+    # One connected player who has "answered" — the short-circuit the loop
+    # takes when the room is quicker than the clock.
+    lr.all_connected_answered = lambda _connected: True
+    lr.advance = MagicMock(return_value=True)
+
+    handler.LIGHTNING_SPLASH_GRACE = 0.0  # keep the test sub-second
+
+    ended: list[bool] = []
+
+    async def _tick_then_end(*_args, **_kwargs) -> None:
+        if not ended:
+            ended.append(True)
+            await handler.admin_action_end_game(game)
+
+    handler._broadcast_lightning_tick = _tick_then_end
+
+    handler._start_lightning_loop(game)
+    for _ in range(20):
+        await asyncio.sleep(0.02)
+        if ended:
+            break
+    await asyncio.sleep(0.05)
+
+    assert game.phase == GamePhase.FINALE
+    assert lr.advance.called is False, (
+        "a lightning question was scored after the finale — #746"
+    )
+    # And no recap frame after the podium.
+    sent_types = [
+        c.args[0].get("type")
+        for c in handler._conn.broadcast.call_args_list
+        if c.args and isinstance(c.args[0], dict)
+    ]
+    assert "lightning_recap" not in sent_types
+
+
+# ---------------------------------------------------------------------------
+# The other complete-teardown paths keep cancelling everything
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("attr", _ROUND_TASK_ATTRS)
+async def test_reset_game_cancels_every_round_scoped_task(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState, attr: str
+) -> None:
+    task = _park(handler, attr)
+    await handler._handle_reset_game(_ws(), game)
+    await _assert_cancelled(handler, attr, task)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("attr", _ROUND_TASK_ATTRS)
+async def test_cleanup_game_tasks_cancels_every_round_scoped_task(
+    handler: QuizifyWebSocketHandler, attr: str
+) -> None:
+    task = _park(handler, attr)
+    await handler.cleanup_game_tasks()
+    await _assert_cancelled(handler, attr, task)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("attr", _ROUND_TASK_ATTRS)
+async def test_start_game_cancels_every_round_scoped_task(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState, attr: str
+) -> None:
+    """Unconditional since #746 — a fresh start owes the new game a clean slate
+    whatever phase it starts from, LOBBY included."""
+    game.add_player("Anna", _ws())
+    handler.START_REDIRECT_GRACE = 0.0
+    task = _park(handler, attr)
+    await handler._handle_start_game(_ws(), {"num_rounds": 3}, game)
+    await _assert_cancelled_even_if_replaced(handler, attr, task)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("attr", _ROUND_TASK_ATTRS)
+async def test_play_again_cancels_every_round_scoped_task(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState, attr: str
+) -> None:
+    game.add_player("Anna", _ws())
+    game.start_game(num_rounds=3)
+    handler.START_REDIRECT_GRACE = 0.0
+    task = _park(handler, attr)
+    await handler._handle_play_again(_ws(), game)
+    await _assert_cancelled_even_if_replaced(handler, attr, task)
+
+
+# ---------------------------------------------------------------------------
+# The deliberate subsets stay subsets
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pause_freezes_the_clock_and_nothing_else(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState
+) -> None:
+    """A pause is not a teardown: the round is still live, so the deferred
+    admin-disconnect pause and the detour loops must survive it."""
+    game.add_player("Anna", _ws())
+    game.start_game(num_rounds=3)
+    game.start_next_question()
+    tick = _park(handler, "_timer_tick_task")
+    pending = _park(handler, "_admin_pause_task")
+
+    assert await handler.admin_action_pause(game) is True
+
+    await asyncio.sleep(0)
+    assert tick.cancelled()
+    assert handler._admin_pause_task is pending
+    assert not pending.cancelled()
+    pending.cancel()
+
+
+@pytest.mark.asyncio
+async def test_advance_out_of_lightning_recap_keeps_the_admin_pause(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState
+) -> None:
+    """``_advance_round`` settles ONE detour. Cancelling the whole round here
+    would swallow a genuine host disconnect that is still counting down."""
+    game.add_player("Anna", _ws())
+    game.start_game(num_rounds=3)
+    assert game.start_lightning_round(auto=True) is True
+    game.finish_lightning_round()
+    assert game.phase == GamePhase.LIGHTNING_RECAP
+
+    loop_task = _park(handler, "_lightning_task")
+    pending = _park(handler, "_admin_pause_task")
+
+    assert await handler._advance_round(game) is None
+
+    await asyncio.sleep(0)
+    assert loop_task.cancelled()
+    assert handler._admin_pause_task is pending
+    assert not pending.cancelled()
+    pending.cancel()
+    handler._cancel_timer_tick()
+
+
+# ---------------------------------------------------------------------------
+# The registry itself — the guard that makes a sixth omission unwritable
+# ---------------------------------------------------------------------------
+
+
+def _task_attributes_declared_in_init() -> set[str]:
+    """Every ``self._x: asyncio.Task | None`` assigned in the handler's init."""
+    source_file = inspect.getsourcefile(QuizifyWebSocketHandler)
+    assert source_file is not None
+    tree = ast.parse(Path(source_file).read_text(encoding="utf-8"))
+
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef) or node.name != "QuizifyWebSocketHandler":
+            continue
+        for item in node.body:
+            if not isinstance(item, ast.FunctionDef) or item.name != "__init__":
+                continue
+            for stmt in ast.walk(item):
+                if not isinstance(stmt, ast.AnnAssign):
+                    continue
+                target = stmt.target
+                if (
+                    isinstance(target, ast.Attribute)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "self"
+                    and ast.unparse(stmt.annotation) == "asyncio.Task | None"
+                ):
+                    found.add(target.attr)
+    return found
+
+
+def test_every_handler_task_is_classified() -> None:
+    """A new background task must declare its scope, not just a call site.
+
+    This is the test that retires the #362/#407/#656/#671/#746 pattern. Adding
+    ``self._foo_task: asyncio.Task | None = None`` and wiring one cancel call
+    by hand now fails here, with the two tuples as the only place to put it —
+    and both are walked by teardown code, so classifying it is also enough to
+    tear it down everywhere.
+    """
+    declared = _task_attributes_declared_in_init()
+    classified = {a for a, _ in QuizifyWebSocketHandler._ROUND_SCOPED_TASKS} | {
+        a for a, _ in QuizifyWebSocketHandler._CONNECTION_SCOPED_TASKS
+    }
+
+    assert declared, "the AST walk found no task attributes — it has gone stale"
+    assert declared == classified, (
+        "unclassified handler task(s): "
+        f"{sorted(declared - classified)}; stale registry entries: "
+        f"{sorted(classified - declared)}. Add each task to "
+        "_ROUND_SCOPED_TASKS (dies with the round) or "
+        "_CONNECTION_SCOPED_TASKS (survives it)."
+    )
+
+
+def test_registry_matches_the_round_scoped_tasks() -> None:
+    """Ties the hand-written list above back to the registry it stands in for."""
+    assert [
+        attr for attr, _c in QuizifyWebSocketHandler._ROUND_SCOPED_TASKS
+    ] == _ROUND_TASK_ATTRS
+
+
+def test_every_registered_canceller_exists_and_is_callable() -> None:
+    """The registries are strings; this is what keeps them honest."""
+    for attr, canceller in (
+        *QuizifyWebSocketHandler._ROUND_SCOPED_TASKS,
+        *QuizifyWebSocketHandler._CONNECTION_SCOPED_TASKS,
+    ):
+        fn = getattr(QuizifyWebSocketHandler, canceller, None)
+        assert callable(fn), f"{canceller} (for {attr}) is not a handler method"
+        params = list(inspect.signature(fn).parameters)
+        assert params == ["self"], f"{canceller} must take no arguments but self"


### PR DESCRIPTION
The host ends the game. The finale broadcasts, the podium goes up — and a lightning question is still scored behind it. The scoreboard changes after the end screen.

`admin_action_end_game` cancelled the timer tick and nothing else. `end_game()` has no phase guard, so it is reachable mid-detour, and the lightning loop re-checked the phase only *after* `asyncio.sleep(step)` — the all-answered `break` skipped straight to `lr.advance()`. There is no await between the two, so cancelling the task alone would not have been enough either.

## One owner instead of twenty call sites

The missing line is the smaller half. Five round-scoped tasks lived as handler attributes and were cancelled by hand at roughly twenty sites, and the matrix was asymmetric in three places, not one. That is the fifth repeat of the same shape (#362, #407, #656, #671): a task is added, one path is forgotten.

Two tuples now name every background task the handler holds:

- `_ROUND_SCOPED_TASKS` — drives, times or interrupts the current round; must not survive a round ending, a game ending, or a reset.
- `_CONNECTION_SCOPED_TASKS` — broadcast coalescers, deliberately unaffected by a round boundary.

`_cancel_round_tasks()` walks the first, `cleanup_game_tasks()` walks both. `end_game`, `reset_game`, `play_again` and `start_game` now state **which scope** they are tearing down rather than listing cancellers, so a sixth task cannot be forgotten at a twenty-first call site.

Paths that stop only part of a round on purpose keep their individual calls and are labelled `DELIBERATE SUBSET` with the reason: `_advance_round` settles one detour and the game carries on (cancelling the pending admin-pause there would swallow a real host disconnect), `admin_action_pause` only freezes the clock, `_handle_admin_skip` only cuts a question short. A deliberate subset should read as one.

## Two further omissions, found by writing the registry down

Named as asked, both fixed here:

1. `end_game` also left the **hot-seat loop** and the **deferred admin pause** running — the same bug as the lightning task, on the same path.
2. `start_game` from LOBBY cancelled only the hot-seat loop. #671's own comment argued the hot-seat cancel had to be unconditional because "there cannot be one in LOBBY" was the assumption that caused the bug; the lightning loop and admin-pause task were left with exactly that assumption. The teardown is now unconditional and whole. `reset_to_lobby` stays phase-gated — it touches state, not tasks.

The lightning loop also gets the post-wait phase re-check the hot-seat loop was given in #671.

## Tests

`tests/test_round_task_teardown_746.py` (32 tests, all new). Every complete-teardown path is parametrized over every round-scoped task, so a task added to the registry is asserted against every path at once. `test_lightning_question_is_not_scored_after_end_game` drives the real loop and lands the `end_game` inside the tick broadcast — the exact gap, where the host's tap lands on a live server. Two tests hold the deliberate subsets to being subsets.

`test_every_handler_task_is_classified` is the guard that retires the pattern: it parses the handler's own `__init__` and fails if an `asyncio.Task | None` attribute is not in one of the two tuples. Adding a task and wiring one cancel call by hand no longer type-checks past CI, and classifying it is also enough to tear it down everywhere.

**Fails without the fix:** with `custom_components/quizify/server/websocket.py` stashed, 10 of the 32 fail — including the behavioural `test_lightning_question_is_not_scored_after_end_game` (`a lightning question was scored after the finale`), the three `end_game` teardown cases, and both `start_game`-from-LOBBY cases. With the fix: 32 passed.

**Gates:** `pytest -q` 2409 passed · `ruff check custom_components/` clean · `mypy custom_components/` clean. No `www/js/` changes, so no bundle rebuild.

Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE
