### PR TITLE
fix(lightning): two teams of the same name are two teams (#728)

### DIFF
--- a/custom_components/quizify/game/lightning.py
+++ b/custom_components/quizify/game/lightning.py
@@ -76,9 +76,9 @@ class LightningQuestionRecap:
     question_id: str
     question_text: str
     correct_answer: str
-    #: player_name -> "correct" | "wrong" | "miss"
+    #: entrant key (player name, or team id) -> "correct" | "wrong" | "miss"
     results: dict[str, str] = field(default_factory=dict)
-    #: player_name -> the answer text they picked (only kept when wrong, so
+    #: entrant key -> the answer text they picked (only kept when wrong, so
     #: the recap can show "You said X" beside the correct answer).
     chosen: dict[str, str] = field(default_factory=dict)
 
@@ -135,21 +135,34 @@ class LightningRound:
         #
         # `teams` is a snapshot of `TeamRegistry.to_list()`; taking a snapshot
         # rather than the registry keeps this module free of the game state.
+        #
+        # The key is the TEAM ID, not the team name (#728). Nothing stops two
+        # teams from carrying the same name — ``TeamRegistry.create`` takes the
+        # name as typed, and its empty-name fallback hands out the same
+        # suggestion again once a team has dissolved. Keyed by name, two
+        # "Sofa"s collapsed into one entrant: one team's tap overwrote the
+        # other's answer, and a single correct answer paid 20 instead of 10,
+        # because ``_entrants`` held the key twice while ``scores`` held it
+        # once. The name lives beside the key in ``_entrant_names`` — it is
+        # what the phones and the TV render, so no id ever reaches a screen.
         self._entrant_of: dict[str, str] = {}
         self._entrants: list[str] = []
+        self._entrant_names: dict[str, str] = {}
         for team in teams or []:
-            key = team.get("name") or team.get("team_id") or ""
-            if not key:
+            key = team.get("team_id") or team.get("name") or ""
+            if not key or key in self._entrant_names:
                 continue
             self._entrants.append(key)
+            self._entrant_names[key] = team.get("name") or key
             for member in team.get("members", []):
                 self._entrant_of[member] = key
         self.team_mode = bool(self._entrants)
         for name in self._players:
-            if name not in self._entrant_of:
+            if name not in self._entrant_of and name not in self._entrant_names:
                 self._entrants.append(name)
+                self._entrant_names[name] = name
 
-        # scores keyed by ENTRANT (player name, or team name in team mode);
+        # scores keyed by ENTRANT (player name, or team id in team mode);
         # recap rows in question order.
         self.scores: dict[str, int] = dict.fromkeys(self._entrants, 0)
         self._recaps: list[LightningQuestionRecap] = []
@@ -279,8 +292,21 @@ class LightningRound:
         return True
 
     def entrant_for(self, name: str) -> str:
-        """Who this player scores as: their team, or themselves."""
+        """Who this player scores as: their team's id, or their own name."""
         return self._entrant_of.get(name, name)
+
+    def display_name(self, entrant: str) -> str:
+        """The name the room reads for an entrant key (#728).
+
+        Entrants are keyed by team id so two teams called the same thing stay
+        two entrants. Every frame a phone or the TV renders resolves the key
+        through here, so what people see is still the team's name.
+        """
+        return self._entrant_names.get(entrant, entrant)
+
+    def display_name_for_player(self, name: str) -> str:
+        """The name this player scores under: their team's, or their own."""
+        return self.display_name(self.entrant_for(name))
 
     def score_for(self, name: str) -> int:
         """This player's standing — their team's, in team mode."""
@@ -308,6 +334,7 @@ class LightningRound:
             self.scores[name] = 0
         if name not in self._entrants:
             self._entrants.append(name)
+        self._entrant_names.setdefault(name, name)
         if name not in self._players:
             self._players.append(name)
         # Give them a shuffle for the in-flight question so they can answer
@@ -496,20 +523,22 @@ class LightningRound:
             question_text=q.question,
             correct_answer=correct_answer,
         )
-        for name in self._entrants:
-            ans = bucket.get(name)
+        for entrant in self._entrants:
+            ans = bucket.get(entrant)
             if ans is None or ans.correct is None:
-                recap.results[name] = "miss"
+                recap.results[entrant] = "miss"
             elif ans.correct:
-                recap.results[name] = "correct"
-                self.scores[name] = self.scores.get(name, 0) + self.points_per_correct
+                recap.results[entrant] = "correct"
+                self.scores[entrant] = (
+                    self.scores.get(entrant, 0) + self.points_per_correct
+                )
             else:
-                recap.results[name] = "wrong"
+                recap.results[entrant] = "wrong"
                 if (
                     ans.answer_index is not None
                     and 0 <= ans.answer_index < len(q.answers)
                 ):
-                    recap.chosen[name] = q.answers[ans.answer_index].text
+                    recap.chosen[entrant] = q.answers[ans.answer_index].text
         self._recaps.append(recap)
 
     # ------------------------------------------------------------------
@@ -517,13 +546,23 @@ class LightningRound:
     # ------------------------------------------------------------------
 
     def leaderboard(self) -> list[dict[str, Any]]:
-        """Lightning-only leaderboard, sorted high→low."""
+        """Lightning-only leaderboard, sorted high→low.
+
+        ``entrant_id`` is the key the recap grid is indexed by; ``name`` is
+        what the row prints. Two teams sharing a name are two rows (#728) —
+        which is the point: they are two teams.
+        """
         ranked = sorted(
             self.scores.items(), key=lambda kv: kv[1], reverse=True
         )
         return [
-            {"rank": i + 1, "name": name, "score": score}
-            for i, (name, score) in enumerate(ranked)
+            {
+                "rank": i + 1,
+                "entrant_id": entrant,
+                "name": self.display_name(entrant),
+                "score": score,
+            }
+            for i, (entrant, score) in enumerate(ranked)
         ]
 
     def build_recap(self) -> dict[str, Any]:
@@ -543,6 +582,10 @@ class LightningRound:
             "num_questions": self.num_questions,
             "points_per_correct": self.points_per_correct,
             "leaderboard": self.leaderboard(),
+            # entrant key -> the name to print for it (#728). ``results`` and
+            # ``chosen`` are keyed by entrant, and a team's key is its id;
+            # without this map the host screen would chip out raw ids.
+            "names": {e: self.display_name(e) for e in self._entrants},
             "questions": [
                 {
                     "question_id": r.question_id,

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -1778,12 +1778,16 @@
         }
         if (els.adminLightningRecapGrid) {
             var questions = recap.questions || [];
+            // The results are keyed by entrant — a team's key is its id since
+            // #728, so the chip label comes from the names map. Falling back
+            // to the key keeps solo players (whose key IS their name) right.
+            var names = recap.names || {};
             els.adminLightningRecapGrid.innerHTML = questions.map(function (q, qi) {
-                var chips = Object.keys(q.results || {}).map(function (name) {
-                    var r = q.results[name];
+                var chips = Object.keys(q.results || {}).map(function (entrant) {
+                    var r = q.results[entrant];
                     var mark = r === 'correct' ? '✓' : (r === 'wrong' ? '✗' : '–');
                     return '<span class="lr-admin-chip lr-admin-chip--' + r + '">' +
-                        escapeHtmlAdmin(name) + ' ' + mark + '</span>';
+                        escapeHtmlAdmin(names[entrant] || entrant) + ' ' + mark + '</span>';
                 }).join('');
                 return '<div class="lr-admin-row">' +
                     '<div class="lr-admin-q"><span class="lr-admin-qnum">' + (qi + 1) +

--- a/custom_components/quizify/www/js/player-lightning.js
+++ b/custom_components/quizify/www/js/player-lightning.js
@@ -223,14 +223,19 @@
     /**
      * Whose row is "mine" in the recap (#552).
      *
-     * In team mode the round scored the TEAM, so the recap is keyed by team
-     * name — looking myself up by player name finds nothing and every
+     * In team mode the round scored the TEAM, so the recap is keyed by the
+     * team — looking myself up by player name finds nothing and every
      * question silently renders as a miss, no matter how the team did.
+     *
+     * The key is the team ID since #728: two teams may carry the same name,
+     * and by name they shared one recap row and one score. The name is still
+     * what gets drawn — it arrives in `recap.names` and in each leaderboard
+     * row — but it is no longer what anything is looked up by.
      */
     function myEntrant() {
         var team = window.QuizifyPlayerTeam;
         var mine = team && team.myTeam();
-        return (mine && mine.name) || state.playerName;
+        return (mine && (mine.team_id || mine.name)) || state.playerName;
     }
 
     function renderRecap(recap) {
@@ -239,12 +244,16 @@
         if (lbEl) {
             var youLabel = (t('lobby.you') && t('lobby.you') !== 'lobby.you')
                 ? t('lobby.you') : 'Du';
+            var meRow = myEntrant();
             var rows = lb.map(function (p) {
                 return {
                     rank: p.rank,
                     name: p.name,
                     score: p.score,
-                    isYou: p.name === myEntrant()
+                    // Match on the entrant key, not the printed name — two
+                    // teams may share a name (#728), and only one of them
+                    // is mine.
+                    isYou: (p.entrant_id || p.name) === meRow
                 };
             });
             pu.renderMedalStandings(lbEl, rows, { youLabel: youLabel });

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -3628,14 +3628,19 @@
     /**
      * Whose row is "mine" in the recap (#552).
      *
-     * In team mode the round scored the TEAM, so the recap is keyed by team
-     * name — looking myself up by player name finds nothing and every
+     * In team mode the round scored the TEAM, so the recap is keyed by the
+     * team — looking myself up by player name finds nothing and every
      * question silently renders as a miss, no matter how the team did.
+     *
+     * The key is the team ID since #728: two teams may carry the same name,
+     * and by name they shared one recap row and one score. The name is still
+     * what gets drawn — it arrives in `recap.names` and in each leaderboard
+     * row — but it is no longer what anything is looked up by.
      */
     function myEntrant() {
         var team = window.QuizifyPlayerTeam;
         var mine = team && team.myTeam();
-        return (mine && mine.name) || state.playerName;
+        return (mine && (mine.team_id || mine.name)) || state.playerName;
     }
 
     function renderRecap(recap) {
@@ -3644,12 +3649,16 @@
         if (lbEl) {
             var youLabel = (t('lobby.you') && t('lobby.you') !== 'lobby.you')
                 ? t('lobby.you') : 'Du';
+            var meRow = myEntrant();
             var rows = lb.map(function (p) {
                 return {
                     rank: p.rank,
                     name: p.name,
                     score: p.score,
-                    isYou: p.name === myEntrant()
+                    // Match on the entrant key, not the printed name — two
+                    // teams may share a name (#728), and only one of them
+                    // is mine.
+                    isYou: (p.entrant_id || p.name) === meRow
                 };
             });
             pu.renderMedalStandings(lbEl, rows, { youLabel: youLabel });

--- a/tests/test_lightning_duplicate_team_names_728.py
+++ b/tests/test_lightning_duplicate_team_names_728.py
@@ -1,0 +1,239 @@
+"""Two teams with the same name are two teams (#728).
+
+Nothing in Quizify makes a team name unique: ``TeamRegistry.create`` takes the
+name the phone typed, and its empty-name fallback hands the same suggestion out
+again as soon as an earlier team has dissolved. Two rooms full of friends
+naming themselves "Sofa" is therefore not an edge case, it is a Tuesday.
+
+The Lightning Round used to key its entrants by that name. Both Sofas mapped
+onto one entrant, which cost the round three separate things:
+
+* one team's tap landed on the other's standing answer;
+* a single correct answer was paid twice, because ``_entrants`` carried the key
+  once per team while ``scores`` — built with ``dict.fromkeys`` — carried it
+  once;
+* the recap and the standings showed one row where two teams had played.
+
+The fix keys entrants by team id. What the room *sees* must not change: the
+phones and the TV still read the team's name, which now travels beside the key
+instead of being the key.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from custom_components.quizify.game.lightning import LightningRound
+from custom_components.quizify.game.questions import QuestionBank
+from custom_components.quizify.game.team import ANSWER_CHANGE_LOCK_SECONDS
+
+#: Two different teams, same name — the whole point of this file.
+_TWO_SOFAS = [
+    {"team_id": "t1", "name": "Sofa", "members": ["Anna", "Ben"]},
+    {"team_id": "t2", "name": "Sofa", "members": ["Cara", "Dan"]},
+]
+
+
+_WWW_JS = (
+    Path(__file__).resolve().parent.parent
+    / "custom_components"
+    / "quizify"
+    / "www"
+    / "js"
+)
+
+
+@pytest.fixture
+def bank() -> QuestionBank:
+    root = Path(__file__).resolve().parent.parent / "custom_components" / "quizify"
+    return QuestionBank(root / "questions")
+
+
+def _round(bank: QuestionBank) -> LightningRound:
+    lr = LightningRound(
+        bank,
+        ["Anna", "Ben", "Cara", "Dan"],
+        language="en",
+        category="picture-round-en",
+        teams=_TWO_SOFAS,
+    )
+    assert lr.start(), "the picture pack must yield lightning questions"
+    return lr
+
+
+def _correct_button(lr: LightningRound, name: str) -> int:
+    """The position of the correct answer on THIS player's phone."""
+    q = lr.current_question
+    assert q is not None
+    correct = next(i for i, a in enumerate(q.answers) if a.correct)
+    return lr.ensure_shuffle(name).index(correct)
+
+
+def _wrong_button(lr: LightningRound, name: str) -> int:
+    q = lr.current_question
+    assert q is not None
+    wrong = next(i for i, a in enumerate(q.answers) if not a.correct)
+    return lr.ensure_shuffle(name).index(wrong)
+
+
+# ----------------------------------------------------------------------
+# The money
+# ----------------------------------------------------------------------
+
+
+def test_one_correct_answer_pays_one_team_once(bank: QuestionBank) -> None:
+    """The reported symptom: 20 points for a 10-point answer."""
+    lr = _round(bank)
+
+    assert lr.record_answer("Anna", _correct_button(lr, "Anna"), now=100.0) is True
+    lr.advance()
+
+    assert lr.scores["t1"] == lr.points_per_correct
+    assert lr.scores["t2"] == 0, "the other Sofa answered nothing"
+    assert sum(lr.scores.values()) == lr.points_per_correct
+
+
+def test_both_sofas_keep_their_own_total(bank: QuestionBank) -> None:
+    lr = _round(bank)
+
+    lr.record_answer("Anna", _correct_button(lr, "Anna"), now=100.0)
+    lr.record_answer("Cara", _wrong_button(lr, "Cara"), now=100.0)
+    lr.advance()
+
+    assert lr.score_for("Anna") == lr.score_for("Ben") == lr.points_per_correct
+    assert lr.score_for("Cara") == lr.score_for("Dan") == 0
+
+
+# ----------------------------------------------------------------------
+# The answer
+# ----------------------------------------------------------------------
+
+
+def test_one_sofa_cannot_overwrite_the_other_sofas_answer(bank: QuestionBank) -> None:
+    """Cara is not Anna's teammate; her tap is her own team's answer.
+
+    Under the name-keyed version Cara's tap either overwrote Anna's or — taps
+    landing in the same second, as they do in a 15s round — was refused by the
+    re-decision lock that only teammates should feel.
+    """
+    lr = _round(bank)
+
+    assert lr.record_answer("Anna", _correct_button(lr, "Anna"), now=100.0) is True
+    assert lr.record_answer("Cara", _wrong_button(lr, "Cara"), now=100.0) is False
+
+    anna = lr.standing_answer("Anna")
+    cara = lr.standing_answer("Cara")
+    assert anna is not None and cara is not None
+    assert anna.set_by == "Anna"
+    assert cara.set_by == "Cara"
+    assert anna.correct is True and cara.correct is False
+
+
+def test_the_lock_stays_inside_one_team(bank: QuestionBank) -> None:
+    """The brake exists so two members cannot flip their team's answer back
+    and forth — it has no business reaching across to a different team."""
+    lr = _round(bank)
+
+    lr.record_answer("Anna", _wrong_button(lr, "Anna"), now=100.0)
+    # A teammate is held back...
+    assert lr.record_answer("Ben", _correct_button(lr, "Ben"), now=100.2) is None
+    # ...the other Sofa is not.
+    assert lr.record_answer("Dan", _correct_button(lr, "Dan"), now=100.2) is True
+
+    later = 100.0 + ANSWER_CHANGE_LOCK_SECONDS
+    assert lr.record_answer("Ben", _correct_button(lr, "Ben"), now=later) is True
+    lr.advance()
+
+    assert lr.scores["t1"] == lr.points_per_correct
+    assert lr.scores["t2"] == lr.points_per_correct
+
+
+def test_members_do_not_bleed_between_two_teams_of_a_name(
+    bank: QuestionBank,
+) -> None:
+    lr = _round(bank)
+
+    assert sorted(lr.members_of("Anna")) == ["Anna", "Ben"]
+    assert sorted(lr.members_of("Cara")) == ["Cara", "Dan"]
+    assert lr.entrant_for("Anna") == "t1"
+    assert lr.entrant_for("Dan") == "t2"
+
+
+# ----------------------------------------------------------------------
+# What the room sees
+# ----------------------------------------------------------------------
+
+
+def test_the_standings_show_both_sofas_by_name(bank: QuestionBank) -> None:
+    """Two rows, both saying "Sofa" — never an id on a screen."""
+    lr = _round(bank)
+    lr.record_answer("Anna", _correct_button(lr, "Anna"), now=100.0)
+    while lr.advance():
+        pass
+
+    board = lr.build_recap()["leaderboard"]
+    assert [row["name"] for row in board] == ["Sofa", "Sofa"]
+    assert {row["entrant_id"] for row in board} == {"t1", "t2"}
+    top = next(row for row in board if row["entrant_id"] == "t1")
+    assert top["rank"] == 1 and top["score"] == lr.points_per_correct
+
+
+def test_the_recap_grid_tells_the_two_sofas_apart(bank: QuestionBank) -> None:
+    """The per-question grid is keyed by entrant, and ``names`` turns each key
+    back into the label the host screen prints on its chips."""
+    lr = _round(bank)
+    lr.record_answer("Anna", _correct_button(lr, "Anna"), now=100.0)
+    lr.record_answer("Cara", _wrong_button(lr, "Cara"), now=100.0)
+    while lr.advance():
+        pass
+
+    recap = lr.build_recap()
+    first = recap["questions"][0]["results"]
+    assert first["t1"] == "correct"
+    assert first["t2"] == "wrong"
+    assert recap["names"] == {"t1": "Sofa", "t2": "Sofa"}
+    assert "Sofa" not in first, "the name is a label, not a key"
+
+
+def test_a_wrong_pick_belongs_to_the_team_that_made_it(bank: QuestionBank) -> None:
+    lr = _round(bank)
+    lr.record_answer("Cara", _wrong_button(lr, "Cara"), now=100.0)
+    lr.record_answer("Anna", _correct_button(lr, "Anna"), now=100.0)
+    lr.advance()
+
+    chosen = lr.build_recap()["questions"][0]["chosen"]
+    assert "t2" in chosen, "the Sofa that guessed wrong sees its own pick"
+    assert "t1" not in chosen, "the Sofa that got it right has nothing to show"
+
+
+# ----------------------------------------------------------------------
+# The clients that read those keys
+# ----------------------------------------------------------------------
+
+
+def test_the_phone_looks_itself_up_by_team_id() -> None:
+    """A phone that still looked itself up by name would find the wrong
+    Sofa's row — or its own, half the time, which is worse."""
+    src = (_WWW_JS / "player-lightning.js").read_text("utf-8")
+
+    assert "mine.team_id" in src
+    assert "p.entrant_id || p.name" in src
+
+
+def test_the_host_screen_prints_the_name_not_the_key() -> None:
+    """The recap chips are the one place an entrant key could leak onto a
+    screen: their label used to BE the key. It now goes through the map."""
+    src = (_WWW_JS / "admin.js").read_text("utf-8")
+
+    assert "recap.names" in src
+    assert "names[entrant] || entrant" in src
+
+
+def test_the_shipped_bundle_carries_the_fix() -> None:
+    """The player page loads the bundle, not the modules — without a rebuild
+    the phones keep the name-keyed lookup (#728)."""
+    bundle = (_WWW_JS / "player.bundle.js").read_text("utf-8")
+
+    assert "mine.team_id" in bundle

--- a/tests/test_lightning_team_552.py
+++ b/tests/test_lightning_team_552.py
@@ -66,7 +66,10 @@ def test_a_team_scores_once_not_once_per_member(bank: QuestionBank) -> None:
     assert lr.record_answer("Anna", _correct_button(lr, "Anna"), now=100.0) is True
     lr.advance()
 
-    assert lr.scores["Sofa"] == lr.points_per_correct
+    # Keyed by team id since #728 — the name is what the room reads, not
+    # what the bookkeeping is indexed by.
+    assert lr.scores["t1"] == lr.points_per_correct
+    assert lr.display_name("t1") == "Sofa"
     assert "Anna" not in lr.scores and "Jan" not in lr.scores, (
         "members are represented by their team, not next to it"
     )
@@ -90,7 +93,7 @@ def test_a_teammate_can_change_the_answer(bank: QuestionBank) -> None:
     assert lr.record_answer("Jan", _correct_button(lr, "Jan"), now=later) is True
     lr.advance()
 
-    assert lr.scores["Sofa"] == lr.points_per_correct, "the last tap counts"
+    assert lr.scores["t1"] == lr.points_per_correct, "the last tap counts"
 
 
 def test_the_lock_refuses_an_instant_second_change(bank: QuestionBank) -> None:
@@ -101,7 +104,7 @@ def test_the_lock_refuses_an_instant_second_change(bank: QuestionBank) -> None:
     assert lr.record_answer("Jan", _correct_button(lr, "Jan"), now=100.5) is None
     lr.advance()
 
-    assert lr.scores["Sofa"] == 0, "the locked-out change must not apply"
+    assert lr.scores["t1"] == 0, "the locked-out change must not apply"
 
 
 def test_a_solo_players_answer_is_still_final(bank: QuestionBank) -> None:
@@ -153,9 +156,12 @@ def test_the_recap_and_standings_name_the_team(bank: QuestionBank) -> None:
 
     recap = lr.build_recap()
     names = {row["name"] for row in recap["leaderboard"]}
-    assert names == {"Sofa", "Mira"}
+    assert names == {"Sofa", "Mira"}, "the standings print the team's NAME"
     first = recap["questions"][0]["results"]
-    assert first["Sofa"] == "correct"
+    # ...while the grid is keyed by entrant (#728), with the map that turns
+    # a key back into the name the host screen chips out.
+    assert first["t1"] == "correct"
+    assert recap["names"]["t1"] == "Sofa"
     assert first["Mira"] == "wrong"
     assert "Anna" not in first and "Jan" not in first
 

--- a/tests/test_team_screens_365.py
+++ b/tests/test_team_screens_365.py
@@ -265,10 +265,14 @@ team.handleTeamJoined({ team: { team_id: 't1', name: 'Sofa', color: 'sage', memb
 const out = { threw: null };
 try {
   lightning.handleLightningRecap({ recap: {
-    leaderboard: [{ rank: 1, name: 'Sofa', score: 10 }, { rank: 2, name: 'Mira', score: 0 }],
+    leaderboard: [
+      { rank: 1, entrant_id: 't1', name: 'Sofa', score: 10 },
+      { rank: 2, entrant_id: 'Mira', name: 'Mira', score: 0 },
+    ],
+    names: { t1: 'Sofa', Mira: 'Mira' },
     questions: [{
       question_id: 'q1', question_text: 'Why does a ball bounce?',
-      correct_answer: 'Compressed air', results: { Sofa: 'correct', Mira: 'wrong' }, chosen: {},
+      correct_answer: 'Compressed air', results: { t1: 'correct', Mira: 'wrong' }, chosen: {},
     }],
   }});
   const html = get('lightning-recap-grid').innerHTML;
@@ -421,6 +425,11 @@ def test_the_lightning_recap_reads_the_teams_row(tmp_path: Path) -> None:
     Found by playing it: the round scored "Sofa", the client looked itself up
     as "Anna", found nothing, and drew every question as a miss while the
     standings above it showed the team's 10 points.
+
+    Since #728 the key is the team ID rather than its name — two teams may be
+    called the same thing — so the payload here carries ids and the ``names``
+    map beside them. What the row *shows* is unchanged, and that is what the
+    assertions below still check.
     """
     _require_node()
     harness = tmp_path / "recap-harness.js"


### PR DESCRIPTION
Two teams called "Sofa" were one entrant in the Lightning Round, because the round keyed its entrants by team name. Nothing makes a name unique: `TeamRegistry.create` takes the text the phone typed, and the empty-name fallback hands the same suggestion out again once an earlier team has dissolved. So this is not an exotic case — it is a room where two groups pick the same joke.

Three things went wrong from that one key:

* **the answer** — one team's tap landed on the other team's standing answer, and the re-decision lock (there so two *members* cannot flip their own team's answer back and forth) reached across into a different team, refusing taps that were nobody's business but their own;
* **the money** — a single correct answer paid 20 instead of 10, because `_entrants` carried the key once per team while `scores`, built with `dict.fromkeys`, carried it once, so `_score_current` walked the same key twice;
* **the screens** — the recap grid and the standings showed one row where two teams had played.

## The fix

Entrants are keyed by `team_id`. The display name travels *beside* the key instead of being the key, so nothing the room reads changes:

* `LightningRound._entrant_names` maps entrant key → name; `display_name()` resolves it.
* `leaderboard()` rows carry `entrant_id` **and** `name` — two teams sharing a name are two rows, both printing "Sofa".
* `build_recap()` gains a `names` map beside `results` / `chosen`, which stay keyed by entrant.
* The phone (`player-lightning.js`) looks its own row up by `team_id`, and matches the leaderboard on `entrant_id`.
* The host screen (`admin.js`) — the one place a key could have leaked onto a screen, since its recap chips *were* labelled with the key — resolves each chip label through `names`. No id reaches a screen.

Solo players are unaffected: their entrant key is their own name, exactly as before. The TV (`dashboard.html`) reads only the leaderboard and the question text, so it needed no change.

## Tests

`tests/test_lightning_duplicate_team_names_728.py` — two teams named "Sofa", four players. It pins the score (10, not 20, and the other Sofa on 0), that neither team can overwrite or lock out the other, that both rows still print "Sofa", and that the recap grid tells them apart while the `names` map hands the host the label. Three checks cover the clients: the phone's `team_id` lookup, the host's `names` lookup, and the rebuilt bundle carrying both.

Verified failing first: with `custom_components/quizify/game/lightning.py` and the three JS files stashed, all 11 fail; with them restored, all 11 pass.

Two existing files were updated to the new keying rather than the old: `test_lightning_team_552.py` (asserts `scores["t1"]` and the `names` map) and the node recap harness in `test_team_screens_365.py` (its fixture payload now carries ids + `names`; the assertions — what the row *shows* — are unchanged).

Gates: `pytest -q` 2372 passed · `ruff check custom_components/` clean · `mypy custom_components/` clean · `scripts/build_bundle.py` re-run and the bundle committed.

## Considered and left out: rejecting a duplicate name in `create_team`

I'd leave the name alone. It is free text on purpose, the empty-name fallback would need its own de-duplication loop to stop handing out a suggestion twice, and rejecting a name mid-lobby costs an error path, an i18n string and client wiring — for a case that is now correctly scored anyway. Two friends' groups may reasonably want the same name.

One thing it does leave, outside this PR's scope: in the **normal** round, `serialize_leaderboard` identifies rows by name only, so two same-named teams give the room two identical-looking rows and a phone highlighting "you" by name would light up both. That is a display ambiguity, not a scoring one — the normal round scores `Team` objects and pays each of them correctly. Worth its own issue if it ever shows up on a television.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE
