### PR TITLE
feat(tts): narrate a Spanish game in Spanish, and localize the streak shout (#745)

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ Quizify speaks your guests' language.
 
 The UI follows the game language (since v1.1.24) — pick German in the pack-picker and the entire admin / player / dashboard surface switches to German labels, tooltips, error messages, fun-fact labels, and end-game awards. Switch to English or Spanish and the whole thing flips.
 
-669 i18n keys, full parity between all three locales, validated in CI.
+670 i18n keys, full parity between all three locales, validated in CI.
 
 ---
 

--- a/custom_components/quizify/game/tts_phrases.py
+++ b/custom_components/quizify/game/tts_phrases.py
@@ -1,32 +1,43 @@
 """Localized TTS announcement phrases for Quizify (issue #281).
 
 Spoken announcements are composed here and rendered per language. Quizify's
-default game language is German, so the German strings are complete; English is
-the *authoritative* fallback — any missing language or key falls back to
-English, and a translated template that fails to format also falls back to
-English so a malformed string can never break a live game.
+default game language is German; German, English and Spanish are all complete,
+and English is the *authoritative* fallback — any missing language or key falls
+back to English, and a translated template that fails to format also falls back
+to English so a malformed string can never break a live game.
+
+Spanish was added in #745: the integration already shipped twelve Spanish
+question packs and a full Spanish UI, so a Spanish evening showed Spanish on
+every screen and was narrated in English. The three sets are held to the same
+bar — a host talking in the room, not a translated string table.
 
 Templates are ``str.format`` strings; placeholders like ``{name}`` are filled
 by the caller. ``{names}`` may hold a single name or several joined by
 ``join_names`` (the language's "and" word).
 
 Keys: question-start, answer-options readout, reveal answer, who-got-it,
-standings/leader-change, player-joined, and the time-running-out countdown.
+standings/leader-change, player-joined, the time-running-out countdown, the
+game lifecycle lines (start / final round / game over + winner) and the
+streak-milestone shout.
 """
 
 from __future__ import annotations
 
 DEFAULT_LANGUAGE = "en"
 
-# Languages we ship spoken phrases for. Quizify games run de/en (and some
-# packs es), but only de+en are translated here; everything else falls back to
-# English via ``normalize_language``.
-SUPPORTED_LANGUAGES = ("de", "en")
+# Languages we ship spoken phrases for. These mirror the languages the UI and
+# the question packs ship in (de/en/es) so a game is narrated in the language
+# it is played in; everything else falls back to English via
+# ``normalize_language``.
+SUPPORTED_LANGUAGES = ("de", "en", "es")
 
-# Word joining names in a spoken list ("Marco and Anna" / "Marco und Anna").
+# Word joining names in a spoken list ("Marco and Anna" / "Marco und Anna" /
+# "Marco y Anna"). Spanish swaps "y" for "e" before an i- sound — see
+# ``join_names``.
 _AND: dict[str, str] = {
     "en": "and",
     "de": "und",
+    "es": "y",
 }
 
 # str.format templates per language. Keys must be identical across languages;
@@ -43,6 +54,14 @@ _PHRASES: dict[str, dict[str, str]] = {
         "tie_at_top": "It's a tie at the top.",
         "player_joined": "{name} joined the game.",
         "countdown": "{seconds} seconds left!",
+        "game_start": "Quizify starting. Good luck!",
+        "final_round": "Final round!",
+        "game_over": "Game over.",
+        "game_over_winner": (
+            "Game over. The winner is {name} with {score} points!"
+        ),
+        "milestone_streak": "{name} hit a {streak}-streak!",
+        "milestone_fire": "{name} is on fire — {streak} in a row!",
     },
     "de": {
         "question": "Frage {round} von {total}: {text}",
@@ -55,6 +74,34 @@ _PHRASES: dict[str, dict[str, str]] = {
         "tie_at_top": "Gleichstand an der Spitze.",
         "player_joined": "{name} ist dabei!",
         "countdown": "Noch {seconds} Sekunden!",
+        "game_start": "Quizify geht los. Viel Glück!",
+        "final_round": "Letzte Runde!",
+        "game_over": "Das Spiel ist vorbei.",
+        "game_over_winner": (
+            "Das Spiel ist vorbei. Gewonnen hat {name} mit {score} Punkten!"
+        ),
+        "milestone_streak": "{name} hat {streak} in Folge richtig!",
+        "milestone_fire": "{name} ist nicht zu stoppen — {streak} in Folge!",
+    },
+    "es": {
+        "question": "Pregunta {round} de {total}: {text}",
+        "options": "Las opciones son: {options}.",
+        "answer": "La respuesta correcta es {answer}.",
+        "got_it_single": "{names} lo ha acertado.",
+        "got_it_multi": "{names} lo han acertado.",
+        "nobody": "Esta ronda no la ha acertado nadie.",
+        "leader_change": "¡{name} se pone en cabeza!",
+        "tie_at_top": "Empate en cabeza.",
+        "player_joined": "¡{name} se une a la partida!",
+        "countdown": "¡Quedan {seconds} segundos!",
+        "game_start": "¡Empieza Quizify! ¡Mucha suerte!",
+        "final_round": "¡Última ronda!",
+        "game_over": "Se acabó el juego.",
+        "game_over_winner": (
+            "¡Se acabó el juego! Gana {name} con {score} puntos."
+        ),
+        "milestone_streak": "¡{name} lleva {streak} seguidas!",
+        "milestone_fire": "¡{name} está imparable: {streak} seguidas!",
     },
 }
 
@@ -83,9 +130,32 @@ def phrase(language: str | None, key: str, **kwargs: object) -> str:
         return _PHRASES[DEFAULT_LANGUAGE][key].format(**kwargs)
 
 
+def _spanish_and(next_name: str) -> str:
+    """Spanish "y", or "e" when the following name starts with an i- sound.
+
+    "Marco e Inés", not "Marco y Inés". The exception to the exception is a
+    "hie-" start ("hierro"), which keeps "y" because it is pronounced /je/.
+    """
+    word = next_name.strip().lower()
+    if word.startswith("hie"):
+        return "y"
+    if word.startswith(("i", "hi")):
+        return "e"
+    return "y"
+
+
 def join_names(language: str | None, names: list[str]) -> str:
     """Join names for speech ("Marco and Anna" / "Marco und Anna")."""
     lang = normalize_language(language)
+    if lang == "es":
+        # The conjunction depends on the word that follows it, so Spanish is
+        # joined pairwise instead of with a single separator.
+        if not names:
+            return ""
+        joined = names[0]
+        for name in names[1:]:
+            joined = f"{joined} {_spanish_and(name)} {name}"
+        return joined
     and_word = _AND.get(lang, _AND[DEFAULT_LANGUAGE])
     return f" {and_word} ".join(names)
 

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -3807,6 +3807,7 @@ class QuizifyWebSocketHandler:
                 announce_standings=bool(tts.get("announce_standings", True)),
                 announce_join=bool(tts.get("announce_join", True)),
                 announce_countdown=bool(tts.get("announce_countdown", True)),
+                announce_milestone=bool(tts.get("announce_milestone", True)),
                 # Per-game entity overrides from the admin dropdowns (#281).
                 # Empty/missing → the announcer falls back to the config-entry
                 # default entities.

--- a/custom_components/quizify/tts.py
+++ b/custom_components/quizify/tts.py
@@ -41,6 +41,24 @@ TTS_MIN_INTERVAL = 5.0
 # narration that follows a few seconds later when the round ends.
 COUNTDOWN_THRESHOLD_SECONDS = 10
 
+# Key under which HA stores the ``tts`` entity component in ``hass.data``
+# (``homeassistant.components.tts.const.DATA_COMPONENT`` is ``HassKey("tts")``,
+# a plain ``str`` subclass). Read by entity id rather than imported so this
+# module keeps its "no runtime HA import" shape (#745).
+_TTS_ENTITY_COMPONENT_KEY = "tts"
+
+# Regional tag preferred when an engine advertises only regional variants of a
+# language we speak ("de" → "de-DE"). Engines differ: google_translate lists
+# bare ``de``, HA Cloud lists ``de-DE``, and ``tts.speak`` matches by strict
+# membership — so a blind ``language: "de"`` would raise on Cloud and the room
+# would hear nothing. Anything not listed here falls back to the
+# alphabetically first matching tag, so the pick is always deterministic.
+_PREFERRED_REGIONAL_TAG = {
+    "de": "de-DE",
+    "en": "en-US",
+    "es": "es-ES",
+}
+
 
 class QuizifyTTSAnnouncer:
     """Speaks game events via HA TTS. Configured per-entry; no-op when
@@ -82,6 +100,7 @@ class QuizifyTTSAnnouncer:
         self._announce_standings: bool = True
         self._announce_join: bool = True
         self._announce_countdown: bool = True
+        self._announce_milestone: bool = True
         # One-shot guard so the spoken countdown warning fires at most once per
         # round. Reset at every question start (see ``announce_question``).
         self._countdown_announced: bool = False
@@ -110,6 +129,7 @@ class QuizifyTTSAnnouncer:
         announce_options: bool = True,
         announce_join: bool = True,
         announce_countdown: bool = True,
+        announce_milestone: bool = True,
         tts_entity: str | None = None,
         media_player: str | None = None,
     ) -> None:
@@ -131,6 +151,7 @@ class QuizifyTTSAnnouncer:
         self._announce_standings = bool(announce_standings)
         self._announce_join = bool(announce_join)
         self._announce_countdown = bool(announce_countdown)
+        self._announce_milestone = bool(announce_milestone)
         self._tts_entity_override = (tts_entity or "").strip() or None
         self._media_player_override = (media_player or "").strip() or None
         self._previous_leader = None
@@ -152,6 +173,7 @@ class QuizifyTTSAnnouncer:
             "announce_standings": self._announce_standings,
             "announce_join": self._announce_join,
             "announce_countdown": self._announce_countdown,
+            "announce_milestone": self._announce_milestone,
             "tts_entity_override": self._tts_entity_override,
             "media_player_override": self._media_player_override,
         }
@@ -183,6 +205,9 @@ class QuizifyTTSAnnouncer:
         )
         self._announce_countdown = bool(
             snapshot.get("announce_countdown", self._announce_countdown)
+        )
+        self._announce_milestone = bool(
+            snapshot.get("announce_milestone", self._announce_milestone)
         )
         self._tts_entity_override = (
             snapshot.get("tts_entity_override", self._tts_entity_override)
@@ -221,6 +246,65 @@ class QuizifyTTSAnnouncer:
     def _lang(self) -> str:
         """Normalized language for spoken phrases, from the live game."""
         return tts_phrases.normalize_language(self._game.language)
+
+    def _engine_supported_languages(self) -> list[str] | None:
+        """Language tags the active TTS entity advertises, or ``None``.
+
+        ``supported_languages`` lives on the entity object (HA keeps TTS
+        entities in an ``EntityComponent`` under ``hass.data["tts"]``); it is
+        deliberately not published in the entity's state attributes, so there
+        is no cheaper way to read it. ``None`` means "could not find out" —
+        the standalone dev server, a legacy non-entity provider, or a future
+        HA that moves the component — and the caller then omits the language
+        rather than guessing.
+        """
+        hass = self._hass
+        entity_id = self._active_tts_entity
+        if hass is None or not entity_id:
+            return None
+        try:
+            component = hass.data[_TTS_ENTITY_COMPONENT_KEY]
+            entity = component.get_entity(entity_id)
+            languages = list(entity.supported_languages)
+        except Exception:  # noqa: BLE001
+            return None
+        return [str(tag) for tag in languages] or None
+
+    def _speech_language(self) -> str | None:
+        """The tag to hand ``tts.speak``, or ``None`` to let the engine pick.
+
+        Without this the engine always spoke in its own default language, so a
+        Spanish game read Spanish sentences with a German voice (#745). The
+        tag is resolved against what the engine actually supports: an exact
+        match wins, then the preferred regional variant, then the first
+        regional variant in alphabetical order. When the engine speaks none of
+        it — or we could not read its list at all — the language is left out
+        and the engine keeps its default, exactly as before.
+        """
+        lang = self._lang()
+        supported = self._engine_supported_languages()
+        if not supported:
+            return None
+        for tag in supported:
+            if tag.lower() == lang:
+                return tag
+        regional = sorted(
+            tag
+            for tag in supported
+            if tag.lower().replace("_", "-").split("-")[0] == lang
+        )
+        if not regional:
+            _LOGGER.debug(
+                "TTS entity %s does not speak %s — using its default language",
+                self._active_tts_entity,
+                lang,
+            )
+            return None
+        preferred = _PREFERRED_REGIONAL_TAG.get(lang)
+        for tag in regional:
+            if preferred and tag.lower() == preferred.lower():
+                return tag
+        return regional[0]
 
     # ------------------------------------------------------------------
     # Narration hooks (#281) — driven from the WS handler
@@ -406,18 +490,24 @@ class QuizifyTTSAnnouncer:
     def announce_milestone(self, player_name: str, streak: int) -> None:
         """Trigger a milestone announcement. Called from the WS handler
         when it broadcasts ``streak_milestone`` so the announcement is
-        tied to the actual award, not to a state-snapshot reading."""
-        if not self._enabled:
+        tied to the actual award, not to a state-snapshot reading.
+
+        Localized and toggleable since #745: the line used to be a hardcoded
+        English f-string spoken into German games, and it was the one
+        announcement without a per-event switch of its own.
+        """
+        if not (self._enabled and self._announce_milestone):
             return
         key = (player_name, streak)
         if key in self._announced_milestones:
             return
         self._announced_milestones.add(key)
-        if streak >= 10:
-            phrase = f"{player_name} is on fire — {streak} in a row!"
-        else:
-            phrase = f"{player_name} hit a {streak}-streak!"
-        self._speak(phrase)
+        phrase_key = "milestone_fire" if streak >= 10 else "milestone_streak"
+        self._speak(
+            tts_phrases.phrase(
+                self._lang(), phrase_key, name=player_name, streak=streak
+            )
+        )
 
     # ------------------------------------------------------------------
     # State change handler
@@ -441,7 +531,7 @@ class QuizifyTTSAnnouncer:
             and self._game.round == 1
         ):
             self._announced_milestones.clear()
-            self._speak("Quizify starting. Good luck!")
+            self._speak(tts_phrases.phrase(self._lang(), "game_start"))
             return
 
         # ANSWER_REVEAL on the last round transitions through FINALE.
@@ -449,11 +539,15 @@ class QuizifyTTSAnnouncer:
             leader = self._game.leader
             if leader is not None:
                 self._speak(
-                    f"Game over. The winner is {leader.name} "
-                    f"with {leader.score} points!"
+                    tts_phrases.phrase(
+                        self._lang(),
+                        "game_over_winner",
+                        name=leader.name,
+                        score=leader.score,
+                    )
                 )
             else:
-                self._speak("Game over.")
+                self._speak(tts_phrases.phrase(self._lang(), "game_over"))
             return
 
         # "Final round!" announcement when entering the last round.
@@ -462,7 +556,7 @@ class QuizifyTTSAnnouncer:
             and self._game.round == self._game.total_rounds
             and self._game.total_rounds > 1
         ):
-            self._speak("Final round!")
+            self._speak(tts_phrases.phrase(self._lang(), "final_round"))
 
     # ------------------------------------------------------------------
     # Internal
@@ -488,15 +582,22 @@ class QuizifyTTSAnnouncer:
 
         tts_entity = self._active_tts_entity
         media_player = self._active_media_player
+        data: dict[str, object] = {
+            "entity_id": tts_entity,
+            "media_player_entity_id": media_player,
+            "message": message,
+        }
+        # Speak the game's language, not the engine's default (#745). Omitted
+        # when the engine does not advertise it — ``tts.speak`` raises on an
+        # unsupported tag, and silence is worse than the wrong accent.
+        language = self._speech_language()
+        if language:
+            data["language"] = language
         fire_and_forget_service(
             self._hass,
             "tts",
             "speak",
-            {
-                "entity_id": tts_entity,
-                "media_player_entity_id": media_player,
-                "message": message,
-            },
+            data,
             f"TTS announcement (tts={tts_entity}, "
-            f"media_player={media_player})",
+            f"media_player={media_player}, language={language})",
         )

--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -402,6 +402,11 @@
                                 <span class="toggle-switch-compact" aria-hidden="true"></span>
                                 <span class="toggle-label" data-i18n="setup.tts.countdown">Call out the final countdown</span>
                             </label>
+                            <label class="toggle-compact setup-tts-toggle" for="tts-announce-milestone">
+                                <input type="checkbox" id="tts-announce-milestone" checked>
+                                <span class="toggle-switch-compact" aria-hidden="true"></span>
+                                <span class="toggle-label" data-i18n="setup.tts.milestone">Shout out answer streaks</span>
+                            </label>
                         </div>
                         <!-- Per-game entity pickers (#281). The host can choose the
                              TTS engine + media_player right here; populated from

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -426,6 +426,7 @@
       "standings": "Neue Führung ausrufen",
       "join": "Neue Spieler begrüßen",
       "countdown": "Countdown ansagen",
+      "milestone": "Antwortserien ausrufen",
       "engine": "TTS-Stimme",
       "usedefault": "Standard verwenden",
       "noentities": "Keine gefunden – in HA einrichten"

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -426,6 +426,7 @@
       "standings": "Call out the new leader",
       "join": "Welcome players as they join",
       "countdown": "Call out the final countdown",
+      "milestone": "Shout out answer streaks",
       "engine": "TTS engine",
       "usedefault": "Use default",
       "noentities": "None found — configure in HA"

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -426,6 +426,7 @@
       "standings": "Anunciar el nuevo líder",
       "join": "Dar la bienvenida a los jugadores",
       "countdown": "Anunciar la cuenta atrás final",
+      "milestone": "Anunciar las rachas de aciertos",
       "engine": "Motor de TTS",
       "usedefault": "Usar predeterminado",
       "noentities": "Ninguno encontrado: configúralo en HA"

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -1270,6 +1270,7 @@
         announce_standings: true,
         announce_join: true,
         announce_countdown: true,
+        announce_milestone: true,
         // Per-game entity overrides (#281). Empty string → fall back to the
         // integration-options default entities on the server.
         tts_entity: '',
@@ -2217,6 +2218,7 @@
             announce_standings: TTS_DEFAULTS.announce_standings,
             announce_join: TTS_DEFAULTS.announce_join,
             announce_countdown: TTS_DEFAULTS.announce_countdown,
+            announce_milestone: TTS_DEFAULTS.announce_milestone,
             tts_entity: TTS_DEFAULTS.tts_entity,
             media_player: TTS_DEFAULTS.media_player,
         };
@@ -2232,6 +2234,7 @@
                     if (typeof saved.announce_standings === 'boolean') cfg.announce_standings = saved.announce_standings;
                     if (typeof saved.announce_join === 'boolean') cfg.announce_join = saved.announce_join;
                     if (typeof saved.announce_countdown === 'boolean') cfg.announce_countdown = saved.announce_countdown;
+                    if (typeof saved.announce_milestone === 'boolean') cfg.announce_milestone = saved.announce_milestone;
                     if (typeof saved.tts_entity === 'string') cfg.tts_entity = saved.tts_entity;
                     if (typeof saved.media_player === 'string') cfg.media_player = saved.media_player;
                 }
@@ -2277,6 +2280,7 @@
             announce_standings: _ttsEls.standings ? !!_ttsEls.standings.checked : TTS_DEFAULTS.announce_standings,
             announce_join: _ttsEls.join ? !!_ttsEls.join.checked : TTS_DEFAULTS.announce_join,
             announce_countdown: _ttsEls.countdown ? !!_ttsEls.countdown.checked : TTS_DEFAULTS.announce_countdown,
+            announce_milestone: _ttsEls.milestone ? !!_ttsEls.milestone.checked : TTS_DEFAULTS.announce_milestone,
             tts_entity: _ttsEls.engine ? _ttsEls.engine.value : TTS_DEFAULTS.tts_entity,
             media_player: _ttsEls.speaker ? _ttsEls.speaker.value : TTS_DEFAULTS.media_player,
         };
@@ -2357,6 +2361,7 @@
             standings: document.getElementById('tts-announce-standings'),
             join: document.getElementById('tts-announce-join'),
             countdown: document.getElementById('tts-announce-countdown'),
+            milestone: document.getElementById('tts-announce-milestone'),
             engine: document.getElementById('tts-engine-select'),
             // #525: one speaker for the whole game. The control moved out of
             // #tts-children (that container goes pointer-events:none when
@@ -2373,7 +2378,8 @@
         if (_ttsEls.standings) _ttsEls.standings.checked = cfg.announce_standings;
         if (_ttsEls.join) _ttsEls.join.checked = cfg.announce_join;
         if (_ttsEls.countdown) _ttsEls.countdown.checked = cfg.announce_countdown;
-        ['enable', 'question', 'options', 'reveal', 'standings', 'join', 'countdown', 'engine', 'speaker'].forEach(function (k) {
+        if (_ttsEls.milestone) _ttsEls.milestone.checked = cfg.announce_milestone;
+        ['enable', 'question', 'options', 'reveal', 'standings', 'join', 'countdown', 'milestone', 'engine', 'speaker'].forEach(function (k) {
             if (_ttsEls[k]) on(_ttsEls[k], 'change', _saveTtsConfig);
         });
         // Reflect the master→child enabled/dimmed state (Variant B, #281).

--- a/tests/test_phase3.py
+++ b/tests/test_phase3.py
@@ -183,7 +183,9 @@ class TestTTSMilestoneAnnounce:
         domain, service, data = hass.calls[0]
         assert (domain, service) == ("tts", "speak")
         assert "Alice" in data["message"]
-        assert "5-streak" in data["message"]
+        # The game defaults to German, so the streak line is German too — it
+        # used to be a hardcoded English f-string spoken into every game (#745).
+        assert data["message"] == "Alice hat 5 in Folge richtig!"
         assert data["entity_id"] == "tts.cloud"
         assert data["media_player_entity_id"] == "media_player.kitchen"
 
@@ -258,7 +260,8 @@ class TestTTSPhaseAnnouncements:
         game._notify_state_callbacks()
         await asyncio.sleep(0)
         assert len(hass.calls) == 1
-        assert "starting" in hass.calls[0][2]["message"].lower()
+        # German game → German opener (#745).
+        assert hass.calls[0][2]["message"] == "Quizify geht los. Viel Glück!"
 
     @pytest.mark.asyncio
     async def test_finale_announces_winner(self, game) -> None:

--- a/tests/test_spanish_narration_745.py
+++ b/tests/test_spanish_narration_745.py
@@ -1,0 +1,432 @@
+"""Spanish narration + the localized, toggleable streak shout (#745).
+
+Quizify shipped twelve Spanish question packs and a full Spanish UI, but
+``tts_phrases`` only knew ``de``/``en`` — a Spanish evening showed Spanish on
+every screen and was narrated in English. Two more holes sat next to it: the
+streak line was a hardcoded English f-string spoken into German games with no
+per-event toggle of its own, and ``tts.speak`` was never told which language to
+speak, so the phrase was handed to whatever voice the engine defaults to.
+
+The suite covers all three: the phrase table, the announcer, and the admin
+panel that has to expose the new toggle for it to be reachable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game import tts_phrases  # noqa: E402
+from custom_components.quizify.game.questions import Answer, Question  # noqa: E402
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+from custom_components.quizify.tts import QuizifyTTSAnnouncer  # noqa: E402
+
+_WWW = _REPO_ROOT / "custom_components" / "quizify" / "www"
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeTTSEntity:
+    def __init__(self, supported: list[str]) -> None:
+        self.supported_languages = supported
+
+
+class _FakeEntityComponent:
+    def __init__(self, entities: dict[str, _FakeTTSEntity]) -> None:
+        self._entities = entities
+
+    def get_entity(self, entity_id: str):  # noqa: ANN201
+        return self._entities.get(entity_id)
+
+
+class _FakeHass:
+    """Records tts.speak calls, and can advertise engine languages like HA."""
+
+    def __init__(self, supported: list[str] | None = None) -> None:
+        self.calls: list[tuple[str, str, dict]] = []
+        self.states = MagicMock()
+        self.states.get = lambda eid: MagicMock(state="on")
+        self.services = MagicMock()
+        self.data: dict = {}
+        if supported is not None:
+            self.data["tts"] = _FakeEntityComponent(
+                {"tts.cloud": _FakeTTSEntity(supported)}
+            )
+
+        async def _async_call(domain, service, data, blocking=False):  # noqa: ANN001
+            self.calls.append((domain, service, dict(data)))
+
+        self.services.async_call = _async_call
+
+    def async_create_task(self, coro):  # noqa: ANN001
+        return asyncio.ensure_future(coro)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+@pytest.fixture
+def game(tmp_path):
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="t")
+
+
+def _announcer(hass, game) -> QuizifyTTSAnnouncer:
+    return QuizifyTTSAnnouncer(
+        hass=hass,
+        tts_entity_id="tts.cloud",
+        media_player_entity_id="media_player.kitchen",
+        game_state=game,
+    )
+
+
+def _configure(t: QuizifyTTSAnnouncer, **overrides) -> None:
+    cfg = {
+        "enabled": True,
+        "announce_question": True,
+        "announce_options": True,
+        "announce_reveal": True,
+        "announce_standings": True,
+        "announce_join": True,
+        "announce_countdown": True,
+        "announce_milestone": True,
+    }
+    cfg.update(overrides)
+    t.configure(**cfg)
+
+
+def _last_call(hass) -> dict:
+    assert hass.calls, "expected a tts.speak call"
+    domain, service, data = hass.calls[-1]
+    assert (domain, service) == ("tts", "speak")
+    return data
+
+
+def _last_message(hass) -> str:
+    return _last_call(hass)["message"]
+
+
+# ---------------------------------------------------------------------------
+# The phrase table
+# ---------------------------------------------------------------------------
+
+
+class TestSpanishPhraseTable:
+    def test_spanish_is_a_narration_language(self) -> None:
+        assert "es" in tts_phrases.SUPPORTED_LANGUAGES
+        assert tts_phrases.normalize_language("es") == "es"
+
+    def test_all_three_languages_carry_the_same_keys(self) -> None:
+        keys = {
+            lang: set(table)
+            for lang, table in tts_phrases._PHRASES.items()
+        }
+        assert set(keys) == {"de", "en", "es"}
+        assert keys["es"] == keys["en"] == keys["de"]
+
+    @pytest.mark.parametrize(
+        ("key", "kwargs", "expected"),
+        [
+            (
+                "question",
+                {"round": 3, "total": 10, "text": "¿Capital?"},
+                "Pregunta 3 de 10: ¿Capital?",
+            ),
+            ("answer", {"answer": "Madrid"}, "La respuesta correcta es Madrid."),
+            ("countdown", {"seconds": 5}, "¡Quedan 5 segundos!"),
+        ],
+    )
+    def test_spanish_renders_in_spanish(self, key, kwargs, expected) -> None:
+        assert tts_phrases.phrase("es", key, **kwargs) == expected
+
+    def test_no_spanish_phrase_leaks_english(self) -> None:
+        """Every Spanish template must differ from the English fallback."""
+        english = tts_phrases._PHRASES["en"]
+        spanish = tts_phrases._PHRASES["es"]
+        shared = [k for k in english if english[k] == spanish[k]]
+        assert shared == [], f"still English in the es table: {shared}"
+
+    def test_spanish_joins_names_with_y(self) -> None:
+        assert tts_phrases.join_names("es", ["Marco", "Ana"]) == "Marco y Ana"
+
+    def test_spanish_swaps_y_for_e_before_an_i_sound(self) -> None:
+        """"Marco e Inés", not "Marco y Inés"."""
+        assert tts_phrases.join_names("es", ["Marco", "Inés"]) == "Marco e Inés"
+        # "hie-" is pronounced /je/ and keeps "y".
+        assert tts_phrases.join_names("es", ["Ana", "Hierro"]) == "Ana y Hierro"
+
+    def test_unknown_language_still_falls_back_to_english(self) -> None:
+        assert tts_phrases.phrase("fr", "final_round") == "Final round!"
+
+
+# ---------------------------------------------------------------------------
+# The announcer speaks the game's language
+# ---------------------------------------------------------------------------
+
+
+class TestAnnouncerSpeaksSpanish:
+    @pytest.mark.asyncio
+    async def test_question_is_narrated_in_spanish(self, game) -> None:
+        game.language = "es"
+        hass = _FakeHass()
+        t = _announcer(hass, game)
+        _configure(t)
+        question = Question(
+            id="q1",
+            question="¿Capital de España?",
+            answers=[Answer(text="Madrid", correct=True)],
+        )
+        t.announce_question(question, 3, 10, ["Madrid", "Roma", "París"])
+        await asyncio.sleep(0)
+        msg = _last_message(hass)
+        assert "Pregunta 3 de 10: ¿Capital de España?" in msg
+        assert "Las opciones son:" in msg
+        assert "Question" not in msg
+
+    @pytest.mark.asyncio
+    async def test_join_is_narrated_in_spanish(self, game) -> None:
+        game.language = "es"
+        hass = _FakeHass()
+        t = _announcer(hass, game)
+        _configure(t)
+        t.announce_join("Lucía")
+        await asyncio.sleep(0)
+        assert _last_message(hass) == "¡Lucía se une a la partida!"
+
+
+# ---------------------------------------------------------------------------
+# The lifecycle lines that used to be hardcoded English
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycleLinesAreLocalized:
+    @pytest.mark.asyncio
+    async def test_game_start_speaks_the_game_language(self, game) -> None:
+        game.language = "es"
+        hass = _FakeHass()
+        t = _announcer(hass, game)
+        _configure(t)
+        game.phase = GamePhase.QUESTION_ACTIVE
+        game.round = 1
+        t._on_state_changed()
+        await asyncio.sleep(0)
+        assert _last_message(hass) == "¡Empieza Quizify! ¡Mucha suerte!"
+
+    @pytest.mark.asyncio
+    async def test_final_round_speaks_german_in_a_german_game(self, game) -> None:
+        game.language = "de"
+        hass = _FakeHass()
+        t = _announcer(hass, game)
+        _configure(t)
+        t._last_phase = GamePhase.ANSWER_REVEAL
+        game.phase = GamePhase.QUESTION_ACTIVE
+        game.round = 5
+        game.total_rounds = 5
+        t._on_state_changed()
+        await asyncio.sleep(0)
+        assert _last_message(hass) == "Letzte Runde!"
+
+    @pytest.mark.asyncio
+    async def test_winner_line_speaks_the_game_language(self, game) -> None:
+        game.language = "es"
+        hass = _FakeHass()
+        t = _announcer(hass, game)
+        _configure(t)
+        t._last_phase = GamePhase.ANSWER_REVEAL
+        game.phase = GamePhase.FINALE
+        game.add_player("Lucía", MagicMock())
+        game.get_player("Lucía").score = 420
+        t._on_state_changed()
+        await asyncio.sleep(0)
+        msg = _last_message(hass)
+        assert msg == "¡Se acabó el juego! Gana Lucía con 420 puntos."
+        assert "winner" not in msg
+
+
+# ---------------------------------------------------------------------------
+# The streak shout: localized, and toggleable like its six siblings
+# ---------------------------------------------------------------------------
+
+
+class TestMilestoneIsLocalizedAndToggleable:
+    @pytest.mark.asyncio
+    async def test_streak_is_not_english_in_a_german_game(self, game) -> None:
+        game.language = "de"
+        hass = _FakeHass()
+        t = _announcer(hass, game)
+        _configure(t)
+        t.announce_milestone("Anna", 3)
+        await asyncio.sleep(0)
+        msg = _last_message(hass)
+        assert msg == "Anna hat 3 in Folge richtig!"
+        assert "streak" not in msg
+
+    @pytest.mark.asyncio
+    async def test_streak_is_spanish_in_a_spanish_game(self, game) -> None:
+        game.language = "es"
+        hass = _FakeHass()
+        t = _announcer(hass, game)
+        _configure(t)
+        t.announce_milestone("Lucía", 3)
+        await asyncio.sleep(0)
+        assert _last_message(hass) == "¡Lucía lleva 3 seguidas!"
+
+    @pytest.mark.asyncio
+    async def test_the_on_fire_variant_is_localized_too(self, game) -> None:
+        game.language = "es"
+        hass = _FakeHass()
+        t = _announcer(hass, game)
+        _configure(t)
+        t.announce_milestone("Lucía", 12)
+        await asyncio.sleep(0)
+        assert _last_message(hass) == "¡Lucía está imparable: 12 seguidas!"
+
+    @pytest.mark.asyncio
+    async def test_its_own_toggle_silences_it(self, game) -> None:
+        hass = _FakeHass()
+        t = _announcer(hass, game)
+        _configure(t, announce_milestone=False)
+        t.announce_milestone("Anna", 3)
+        await asyncio.sleep(0)
+        assert hass.calls == []
+
+    @pytest.mark.asyncio
+    async def test_the_other_toggles_do_not_silence_it(self, game) -> None:
+        """The streak switch is independent — it is not the reveal switch."""
+        hass = _FakeHass()
+        t = _announcer(hass, game)
+        _configure(t, announce_reveal=False, announce_standings=False)
+        t.announce_milestone("Anna", 3)
+        await asyncio.sleep(0)
+        assert len(hass.calls) == 1
+
+    def test_the_toggle_survives_an_options_reload(self, game) -> None:
+        """Same export/restore round-trip the six siblings get (#411)."""
+        hass = _FakeHass()
+        t = _announcer(hass, game)
+        _configure(t, announce_milestone=False)
+        snapshot = t.export_runtime_config()
+        assert snapshot["announce_milestone"] is False
+        fresh = _announcer(hass, game)
+        fresh.restore_runtime_config(snapshot)
+        assert fresh._announce_milestone is False
+
+
+# ---------------------------------------------------------------------------
+# The engine has to be told which language to speak
+# ---------------------------------------------------------------------------
+
+
+class TestSpeakCarriesTheLanguage:
+    @pytest.mark.asyncio
+    async def test_language_rides_the_speak_call(self, game) -> None:
+        game.language = "es"
+        hass = _FakeHass(supported=["de", "en", "es"])
+        t = _announcer(hass, game)
+        _configure(t)
+        t.announce_join("Lucía")
+        await asyncio.sleep(0)
+        assert _last_call(hass)["language"] == "es"
+
+    @pytest.mark.asyncio
+    async def test_a_regional_engine_gets_its_own_tag(self, game) -> None:
+        """HA matches by strict membership, so "es" must become "es-ES"."""
+        game.language = "es"
+        hass = _FakeHass(supported=["de-DE", "en-US", "es-ES", "es-MX"])
+        t = _announcer(hass, game)
+        _configure(t)
+        t.announce_join("Lucía")
+        await asyncio.sleep(0)
+        assert _last_call(hass)["language"] == "es-ES"
+
+    @pytest.mark.asyncio
+    async def test_regional_pick_is_deterministic_without_a_preference(
+        self, game
+    ) -> None:
+        game.language = "es"
+        hass = _FakeHass(supported=["es-MX", "es-AR"])
+        t = _announcer(hass, game)
+        _configure(t)
+        t.announce_join("Lucía")
+        await asyncio.sleep(0)
+        assert _last_call(hass)["language"] == "es-AR"
+
+    @pytest.mark.asyncio
+    async def test_language_is_omitted_when_the_engine_cannot_speak_it(
+        self, game
+    ) -> None:
+        """Silence is worse than the wrong accent — tts.speak raises on an
+        unsupported tag, so we let the engine keep its default."""
+        game.language = "es"
+        hass = _FakeHass(supported=["de-DE", "en-US"])
+        t = _announcer(hass, game)
+        _configure(t)
+        t.announce_join("Lucía")
+        await asyncio.sleep(0)
+        assert "language" not in _last_call(hass)
+
+    @pytest.mark.asyncio
+    async def test_language_is_omitted_when_the_engine_is_unknown(
+        self, game
+    ) -> None:
+        game.language = "es"
+        hass = _FakeHass()  # no tts entity component at all
+        t = _announcer(hass, game)
+        _configure(t)
+        t.announce_join("Lucía")
+        await asyncio.sleep(0)
+        assert "language" not in _last_call(hass)
+
+
+# ---------------------------------------------------------------------------
+# The admin panel has to expose the new toggle
+# ---------------------------------------------------------------------------
+
+
+class TestAdminPanelExposesTheToggle:
+    def test_the_checkbox_is_in_the_setup_step(self) -> None:
+        html = (_WWW / "admin.html").read_text("utf-8")
+        assert 'id="tts-announce-milestone"' in html
+        assert 'data-i18n="setup.tts.milestone"' in html
+        # Nested under the master switch with its six siblings.
+        children = html.split('id="tts-children"', 1)[1]
+        assert 'id="tts-announce-milestone"' in children.split("</div>", 1)[0]
+
+    def test_admin_js_reads_persists_and_pushes_it(self) -> None:
+        js = (_WWW / "js" / "admin.js").read_text("utf-8")
+        assert "announce_milestone: true" in js
+        assert "tts-announce-milestone" in js
+        assert "saved.announce_milestone" in js
+        assert "_ttsEls.milestone" in js
+
+    def test_every_bundle_has_the_label(self) -> None:
+        for lang in ("en", "de", "es"):
+            bundle = json.loads(
+                (_WWW / "i18n" / f"{lang}.json").read_text("utf-8")
+            )
+            assert bundle["setup"]["tts"]["milestone"], lang
+
+    def test_the_server_forwards_the_toggle(self) -> None:
+        ws = (
+            _REPO_ROOT
+            / "custom_components"
+            / "quizify"
+            / "server"
+            / "websocket.py"
+        ).read_text("utf-8")
+        assert 'announce_milestone=bool(tts.get("announce_milestone", True))' in ws

--- a/tests/test_tts_phrases_281.py
+++ b/tests/test_tts_phrases_281.py
@@ -74,9 +74,10 @@ class TestPhraseRendering:
 
 class TestFallbacks:
     def test_unknown_language_falls_back_to_english(self) -> None:
-        # Spanish is not translated here → English template.
+        # French is not translated here → English template. (Spanish was an
+        # untranslated language until #745; it is a first-class one now.)
         assert tts_phrases.phrase(
-            "es", "nobody"
+            "fr", "nobody"
         ) == "Nobody got it this round."
 
     def test_unknown_key_within_known_language_uses_english(self) -> None:
@@ -118,9 +119,11 @@ class TestNormalizeLanguage:
     def test_known_languages_pass_through(self) -> None:
         assert tts_phrases.normalize_language("de") == "de"
         assert tts_phrases.normalize_language("en") == "en"
+        # Spanish joined the shipped set in #745.
+        assert tts_phrases.normalize_language("es") == "es"
 
     def test_unknown_and_none_default_to_english(self) -> None:
-        assert tts_phrases.normalize_language("es") == "en"
+        assert tts_phrases.normalize_language("fr") == "en"
         assert tts_phrases.normalize_language(None) == "en"
         assert tts_phrases.normalize_language("") == "en"
 


### PR DESCRIPTION
Closes #745

## What the room heard before

The integration ships twelve Spanish question packs and a complete Spanish UI, but `game/tts_phrases.py` set `SUPPORTED_LANGUAGES = ("de", "en")` and fell back to English for everything else. A Spanish evening showed "Pregunta 3 de 10" on every screen and said "Question 3 of 10" out of the speaker. On top of that a German game could be interrupted by "Anna hit a 3-streak!", because four narration lines were still hardcoded English f-strings.

## Spanish

`es` is now a first-class narration language, written at the same level of care as the German set — a host in the room, not a translated string table:

| | |
|---|---|
| question | `Pregunta {round} de {total}: {text}` |
| leader change | `¡{name} se pone en cabeza!` |
| nobody | `Esta ronda no la ha acertado nadie.` |
| countdown | `¡Quedan {seconds} segundos!` |
| join | `¡{name} se une a la partida!` |

Names are joined with the conjunction Spanish actually uses: `join_names` swaps "y" for "e" before an i- sound, so the speaker says "Marco e Inés", not "Marco y Inés" — with the "hie-" exception ("Ana y Hierro") that keeps "y". Every Spanish template is asserted to differ from its English counterpart, so a key added later cannot quietly ship the English string.

## The hardcoded lines

Four lines were English f-strings spoken into every game regardless of language: the opener, the final-round call, the winner line, and the streak shout. All four are phrase-table keys now, in all three languages.

The streak shout also gets the per-event toggle its six siblings already had:

- `tts-announce-milestone` checkbox in the setup step, nested with the other six under the master switch (so it dims with them);
- `setup.tts.milestone` label in all three i18n bundles;
- `announce_milestone` in `TTS_DEFAULTS`, loaded from and saved to the `quizify_tts` localStorage object, and pushed over `configure_tts` like its siblings;
- forwarded by `_apply_tts_config`, and carried through `export_runtime_config` / `restore_runtime_config` so an options save mid-game does not silently flip narration settings back to their defaults (#411).

## The language actually reaching the engine

Traced from `QuizifyGameState.language` through `_lang()` to the `tts.speak` call — and it stopped at `_lang()`. The service call carried `entity_id`, `media_player_entity_id` and `message` only, so the Spanish sentence was handed to whatever voice the entity defaults to.

`tts.speak` now carries a `language`, resolved against what the entity advertises rather than guessed. HA matches that field by **strict membership** and raises `HomeAssistantError` on anything else — google_translate lists bare `de`, HA Cloud lists `de-DE` — so a blind `language: "de"` would have turned a working narration into silence on Cloud. The resolution reads `supported_languages` off the entity object (HA keeps TTS entities in an `EntityComponent` under `hass.data["tts"]`; the field is deliberately not in the state attributes) and picks, in order: the exact tag, the preferred regional variant (`es` → `es-ES`), then the first match alphabetically. When the engine speaks none of it — or the list cannot be read at all, as on the standalone dev server — the language is left out and the engine keeps its default, exactly as before. Silence is worse than the wrong accent.

## Tests

New: `tests/test_spanish_narration_745.py`, 29 tests over the phrase table, the announcer, the language resolution, and the admin panel wiring. **All 29 fail on `origin/main`** (verified by stashing the eight changed source files and re-running the file).

Two existing tests pinned the old behaviour — `test_phase3.py` asserted `"5-streak" in message` and `"starting" in message.lower()` for a game whose language is German — and now pin the localized German lines instead. `test_tts_phrases_281.py` used `es` as its example of an untranslated language and now uses `fr`.

Gates: `pytest -q` 2393 passed · `ruff check custom_components/` clean · `mypy custom_components/` clean. `scripts/build_bundle.py` re-run; `admin.js` is not part of the player bundle, so the bundle is byte-identical and not in the diff. The README's i18n key count went 669 → 670 for the new toggle label (there is a test that guards it).

## Notes

- Nothing in the Spanish set was shipped stilted; every phrase above reads as natural spoken Spanish. If a reviewer prefers a more neutral Latin-American register over the peninsular default (`es-ES` preferred tag, "¡Lucía lleva 3 seguidas!"), that is a one-line change in `_PREFERRED_REGIONAL_TAG` plus the phrase table.
- The issue's third point — that `_dispatch_game_ended` fires no narration — is **not** a gap: `end_game()` calls `_fire_broadcast("game_ended")`, which calls `_notify_state_callbacks()` first, so the announcer's `_on_state_changed` does see `FINALE` and does speak the winner. It was speaking it in English, which this PR fixes. There is a separate, real issue there worth its own ticket: that winner line arrives within `TTS_MIN_INTERVAL` (5 s) of the last round's reveal narration and is therefore usually throttled away. Left alone here rather than widened into a throttle redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE
