### PR TITLE
fix(tv): the estimate reveal is sized like the rest of the board (#735)

### DIFF
--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -586,7 +586,11 @@
             display: flex;
             align-items: center;
             gap: 10px;
-            font-size: 22px;
+            /* #735: the estimate reveal was not in the #707 pass and kept its
+               phone sizes. This carries the range the room is guessing inside
+               ("Schätzfrage zwischen 10 und 500"), so it takes the step #707
+               gave the podium name — the largest of the four it settled. */
+            font-size: clamp(18px, 1.8vw, 28px);
             font-weight: 600;
             color: var(--color-text-muted, #6E6A5C);
             margin-top: 16px;
@@ -597,7 +601,10 @@
         }
         .dnl-truth { text-align: center; margin: 8px 0 12px; }
         .dnl-truth-label {
-            font-size: 16px; text-transform: uppercase; letter-spacing: 0.1em;
+            /* #735: an eyebrow naming the block below it ("RICHTIGE ANTWORT"),
+               so it takes the same step as the round indicator in #707. */
+            font-size: clamp(14px, 1.2vw, 20px);
+            text-transform: uppercase; letter-spacing: 0.1em;
             color: var(--color-text-muted, #6E6A5C); font-weight: 600;
         }
         .dnl-truth-value {
@@ -622,12 +629,20 @@
         }
         .dnl-lbl {
             position: absolute; left: 50%; transform: translateX(-50%);
-            white-space: nowrap; font-size: 17px; font-weight: 600;
+            white-space: nowrap;
+            /* #735: who guessed what is the thing the room leans forward for,
+               and it was 17px on a 1920px screen. It is a name plus a number
+               in a row, exactly what the leaderboard and the lightning recap
+               carry, so it takes their step (#376/#707). */
+            font-size: clamp(16px, 1.6vw, 24px);
+            font-weight: 600;
             color: var(--color-text-muted, #6E6A5C); font-family: var(--font-mono, monospace);
         }
         .dnl-lbl.is-winner { color: var(--color-accent-secondary, #7FA897); }
-        .dnl-lbl--above { bottom: 24px; }
-        .dnl-lbl--below { top: 24px; }
+        /* #735: in em, so the clearance from the dot grows with the label
+           instead of the type creeping towards the axis as it scales. */
+        .dnl-lbl--above { bottom: 1.4em; }
+        .dnl-lbl--below { top: 1.4em; }
         .dnl-truth-line {
             position: absolute; top: -40px; bottom: -18px; width: 3px;
             background: var(--color-accent-primary, #E88A7F); transform: translateX(-50%);
@@ -635,12 +650,21 @@
         .dnl-truth-flag {
             position: absolute; top: -62px; transform: translateX(-50%);
             background: var(--color-accent-primary, #E88A7F); color: #fff;
-            font-family: var(--font-mono, monospace); font-weight: 700; font-size: 18px;
+            font-family: var(--font-mono, monospace); font-weight: 700;
+            /* #735: the true value sitting on the line, next to the guesses it
+               is being compared against — the same step as the guesses. */
+            font-size: clamp(16px, 1.6vw, 24px);
             padding: 4px 12px; border-radius: 9999px; white-space: nowrap;
         }
         .dnl-scale-ends {
-            display: flex; justify-content: space-between; margin-top: 16px;
-            font-family: var(--font-mono, monospace); font-size: 18px;
+            display: flex; justify-content: space-between;
+            /* #735: the below-labels hang out of the axis box into this band,
+               and at 16px they already grazed the endpoints. In em the gap
+               grows with the labels instead of being overrun by them. */
+            margin-top: 2.4em;
+            font-family: var(--font-mono, monospace);
+            /* #735: the two numbers that tell the room what the line spans. */
+            font-size: clamp(16px, 1.6vw, 24px);
             color: var(--color-text-light, #8F8A78);
         }
 

--- a/tests/test_estimate_reveal_type_scale_735.py
+++ b/tests/test_estimate_reveal_type_scale_735.py
@@ -1,0 +1,128 @@
+"""#735 — the estimate reveal is sized like the rest of the television.
+
+#707 sized the lightning recap row, the podium name, the round indicator and
+the reconnect pill for a sofa. The estimate reveal was not in that pass and
+kept its phone sizes: the guesses along the number line were 17px on a 1920px
+screen, while the multiple-choice reveal beside them scales and the true value
+itself is 56px. Who guessed what is the thing the room leans forward for.
+
+The point of this entry is *consistency*, not new sizes. Every rule here takes
+a step #707/#376 already settled, by role:
+
+* `.dnl-lbl`, `.dnl-truth-flag`, `.dnl-scale-ends` — a name plus a number in a
+  row, so the leaderboard/recap step `clamp(16px, 1.6vw, 24px)`;
+* `.dnl-truth-label` — an eyebrow naming the block, so the round-indicator step
+  `clamp(14px, 1.2vw, 20px)`;
+* `.dashboard-estimate-hint` — the range the room is guessing inside, so the
+  podium-name step `clamp(18px, 1.8vw, 28px)`.
+
+The label offsets move to `em` so the clearance from the dots grows with the
+type instead of the type creeping towards the axis as it scales.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+DASHBOARD = (
+    Path(__file__).resolve().parent.parent
+    / "custom_components/quizify/www/dashboard.html"
+)
+
+# The steps #707 settled, quoted verbatim. Nothing here invents a size.
+ROW_STEP = "clamp(16px, 1.6vw, 24px)"
+EYEBROW_STEP = "clamp(14px, 1.2vw, 20px)"
+HEADLINE_STEP = "clamp(18px, 1.8vw, 28px)"
+
+# selector → the #707 step its role earns
+ESTIMATE_RULES = {
+    ".dnl-lbl": ROW_STEP,
+    ".dnl-truth-flag": ROW_STEP,
+    ".dnl-scale-ends": ROW_STEP,
+    ".dnl-truth-label": EYEBROW_STEP,
+    ".dashboard-estimate-hint": HEADLINE_STEP,
+}
+
+
+def _rule_body(selector: str) -> str:
+    css = DASHBOARD.read_text(encoding="utf-8")
+    start = css.index(selector + " {")
+    return css[start : css.index("}", start)]
+
+
+def _font_size(selector: str) -> str:
+    match = re.search(r"font-size:\s*([^;]+);", _rule_body(selector))
+    assert match, f"{selector} lost its font-size"
+    return match.group(1).strip()
+
+
+@pytest.mark.parametrize("selector", sorted(ESTIMATE_RULES))
+def test_the_estimate_reveal_scales_with_the_screen(selector: str) -> None:
+    """A fixed font-size here is a phone size on a television."""
+    value = _font_size(selector)
+    assert value.startswith("clamp("), (
+        f"{selector} is a fixed {value} — the estimate reveal is read from a sofa"
+    )
+
+
+@pytest.mark.parametrize("selector,step", sorted(ESTIMATE_RULES.items()))
+def test_it_reuses_a_step_707_already_settled(selector: str, step: str) -> None:
+    """#735 is a consistency entry: no new sizes, only #707's."""
+    value = _font_size(selector)
+    assert value == step, (
+        f"{selector} is {value}; #707 settled {step} for what it carries. "
+        "A new size here re-opens a decision that was already made."
+    )
+
+
+@pytest.mark.parametrize("selector", sorted(ESTIMATE_RULES))
+def test_the_upper_end_is_big_enough_for_a_room(selector: str) -> None:
+    """The top of the range is what a 1920px television actually gets."""
+    largest = _font_size(selector).rstrip(")").split(",")[-1].strip()
+    assert largest.endswith("px"), f"{selector} caps in {largest}, expected px"
+    assert float(largest[:-2]) >= 20, (
+        f"{selector} tops out at {largest} — still a phone size on a television"
+    )
+
+
+def test_the_guesses_are_not_smaller_than_the_leaderboard_rows() -> None:
+    """17px next to clamp(16px, 1.6vw, 24px) rows was the tell."""
+
+    def ends(value: str) -> tuple[float, float]:
+        args = value[len("clamp(") : -1].split(",")
+        return (
+            float(args[0].strip().rstrip("px")),
+            float(args[-1].strip().rstrip("px")),
+        )
+
+    low, high = ends(_font_size(".dnl-lbl"))
+    row_low, row_high = ends(_font_size(".dashboard-leaderboard .leaderboard-row"))
+    assert low >= row_low
+    assert high >= row_high
+
+
+def test_the_axis_endpoints_clear_the_labels_hanging_below_the_line() -> None:
+    """A fixed 16px band is overrun by the labels that hang into it."""
+    match = re.search(r"margin-top:\s*([^;]+);", _rule_body(".dnl-scale-ends"))
+    assert match, ".dnl-scale-ends lost its margin-top"
+    value = match.group(1).strip()
+    assert value.endswith("em"), (
+        f".dnl-scale-ends keeps a fixed {value} below the axis — the guesses "
+        "hanging under the line land on top of the range endpoints"
+    )
+
+
+@pytest.mark.parametrize("selector", [".dnl-lbl--above", ".dnl-lbl--below"])
+def test_the_label_offsets_scale_with_the_label(selector: str) -> None:
+    """A fixed 24px offset shrinks, in effect, as the type around it grows."""
+    body = _rule_body(selector)
+    match = re.search(r"(?:top|bottom):\s*([^;]+);", body)
+    assert match, f"{selector} lost its offset"
+    value = match.group(1).strip()
+    assert value.endswith("em"), (
+        f"{selector} offsets by a fixed {value} — it no longer keeps its "
+        "clearance from the dot once the label scales"
+    )


### PR DESCRIPTION
#707 sized the lightning recap row, the podium name, the round indicator and the reconnect pill for a sofa. The estimate reveal was not in that pass and kept its phone sizes, so on a 1920px screen the multiple-choice reveal beside it scaled to 56px while who guessed what — the thing the room leans forward for — stayed at 17px.

This entry is about consistency, not new sizes. Every rule takes a step #707/#376 already settled, chosen by what the rule carries:

| Selector | Before | After | The step it borrows |
|---|---|---|---|
| `.dnl-lbl` | 17px | `clamp(16px, 1.6vw, 24px)` | leaderboard row / lightning recap row |
| `.dnl-truth-flag` | 18px | `clamp(16px, 1.6vw, 24px)` | same — it sits on the line among the guesses |
| `.dnl-scale-ends` | 18px | `clamp(16px, 1.6vw, 24px)` | same |
| `.dnl-truth-label` | 16px | `clamp(14px, 1.2vw, 20px)` | `.dashboard-round`, the other eyebrow |
| `.dashboard-estimate-hint` | 22px | `clamp(18px, 1.8vw, 28px)` | `.podium-name` |

On a 1920px television those measure 24, 24, 24, 20 and 28px, against 17, 18, 18, 16 and 22 before.

## What changes visually

Rendered from the real `<style>` block at 1920x1080, before and after:

- Every player's name and guess along the number line grows by seven points and now matches the leaderboard rows on the right of the same screen — previously the guesses were the smallest content on the board while being its focus.
- The pill on the line carrying the true value, and the two range endpoints under it, grow with them.
- "RICHTIGE ANTWORT" over the 56px answer grows a little; it stays deliberately smaller, because it names the block rather than being it.
- "Schätzfrage zwischen 10 und 500" on the question screen goes from 22 to 28px.

## Two offsets move to em

`.dnl-lbl--above` / `.dnl-lbl--below` kept a fixed 24px of clearance from the dots, which the type would have crept towards as it grew; they are now `1.4em`, the same ratio they had at 17px.

`.dnl-scale-ends` sat 16px under the axis. The labels that hang *below* the line overflow into that band — at 17px they already grazed the endpoints, and at 24px they overran them (visible in the first render I took). It is now `2.4em`, so the gap grows with the labels. With that, the card holds everything at 1920x1080 with nothing clipped.

## Tests

`tests/test_estimate_reveal_type_scale_735.py`, 19 tests: each of the five rules must be `clamp()`-sized, must be the *exact* #707 step its role earns rather than a size of its own, and must top out above a phone size; the guesses may not read smaller than the leaderboard rows beside them at either end of the range; and the three offsets must be `em`.

18 of the 19 fail against the previous tree (`git stash push custom_components/quizify/www/dashboard.html` → `18 failed, 1 passed`; the one pass is the "big enough" assertion on the hint, which was already 22px).

Full suite 2396 passed, `ruff check custom_components/` clean, `mypy custom_components/` clean. `dashboard.html` is not bundled, so no bundle rebuild is involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE