### PR TITLE
feat(#743): community packs move out of the folder HACS replaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,9 @@ All packs follow an "Unnützes Wissen" editorial line — surprising, counter-in
 
 ### Custom Question Packs
 
-Pack files live in `custom_components/quizify/questions/`. Drop a JSON file in there, restart Home Assistant, and it appears in the picker on the next game start.
+Your own packs go in your **Home Assistant config directory**, at `<config>/quizify/packs/` — the same `<config>` that holds `configuration.yaml` (`/config/quizify/packs/` on Home Assistant OS). Quizify creates the folder on startup. Drop a JSON file in there and call the `quizify.reload_packs` action (Developer Tools → Actions → "Quizify: Reload question packs"), then reload the admin page — the pack appears in the picker. No restart needed; a restart works too.
+
+> **Why not `custom_components/quizify/questions/`?** HACS replaces that whole directory on every update, so a pack kept in there is deleted the next time Quizify updates. If you already have packs in `custom_components/quizify/questions/community/`, Quizify **moves them to `<config>/quizify/packs/` on the next start** so they survive from now on.
 
 ```json
 {
@@ -373,7 +375,7 @@ Pack files live in `custom_components/quizify/questions/`. Drop a JSON file in t
 - Exactly **1 correct** answer
 - Per-question fields the loader reads: `id` (required), `question` (required), `answers` (required), `difficulty` (default `medium`), `fun_fact` (optional), `category` (optional, falls back to pack name), `image_url` (optional — an `https://` URL, or a path under `/quizify/static/` for an image shipped with the pack; anything else is ignored)
 - Pack-level fields: `name`, `language` (`de` / `en` / `es` — only those are wired into the language chip; other ISO codes load but won't be selectable from the UI), `theme` (one of `geography`, `nature`, `popculture`, `sport`, `music`, `science`, `history`, `food`, `tech`, `worldcup`, `trivia` — drives the theme-tab filter and pack-card icon), `version`
-- File goes in the `questions/` directory — picked up automatically on next game start
+- File goes in `<config>/quizify/packs/` — picked up on the next `quizify.reload_packs` call, or the next restart
 
 ---
 

--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -397,12 +397,41 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
         await handler.admin_action_end_game(game)
 
+    async def reload_packs_service(call: ServiceCall) -> None:  # noqa: ARG001
+        """Re-read the question packs from disk (#743).
+
+        The host-owned drop-in folder is ``<config>/quizify/packs``; a pack
+        added there used to need a full Home Assistant restart, because
+        ``reload_categories`` had no caller and no service. Reloading is
+        refused outside the lobby: the running game's queue was built from the
+        packs as they were, and swapping the bank underneath it would leave
+        the round the players are answering pointing at questions that are no
+        longer loaded.
+        """
+        _handler, game = _require_runtime()
+        if game.phase != GamePhase.LOBBY:
+            raise ServiceValidationError(
+                "Packs can only be reloaded from the lobby. End the running "
+                "game first, then reload."
+            )
+        # Blocking disk I/O (glob + JSON parse of every pack) — off the loop.
+        categories = await runtime.run_in_executor(
+            game.question_bank.reload_categories
+        )
+        _LOGGER.info(
+            "Quizify packs reloaded via service: %d packs available",
+            len(categories),
+        )
+
     hass.services.async_register(DOMAIN, "start_game", start_game_service)
     hass.services.async_register(DOMAIN, "next_round", next_round_service)
     hass.services.async_register(DOMAIN, "pause", pause_service)
     hass.services.async_register(DOMAIN, "resume", resume_service)
     hass.services.async_register(DOMAIN, "end_game", end_game_service)
     _LOGGER.debug("Quizify game-control services registered (#367)")
+
+    hass.services.async_register(DOMAIN, "reload_packs", reload_packs_service)
+    _LOGGER.debug("Quizify reload_packs service registered (#743)")
 
     # Forward to sensor/binary_sensor platforms so HA exposes Quizify game
     # state as entities (sensor.quizify_current_round, etc.).

--- a/custom_components/quizify/game/questions.py
+++ b/custom_components/quizify/game/questions.py
@@ -6,6 +6,7 @@ import json
 import logging
 import math
 import random
+import shutil
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -25,7 +26,26 @@ QUESTIONS_DIR = Path(__file__).resolve().parent.parent / "questions"
 # kept apart from the built-in, reviewed packs. The non-recursive ``*.json``
 # glob used for built-in discovery never reaches into this subfolder, so the
 # two namespaces stay cleanly separated.
+#
+# NOTE (#743): this folder is *inside* the integration directory, which HACS
+# replaces wholesale on every update. It is where the shipped example pack
+# lives and where hosts used to drop their own packs — and where those packs
+# were silently deleted by the next update. The host-owned drop-in location is
+# now ``<config>/quizify/packs`` (see ``COMMUNITY_PACKS_DIRNAME``); this folder
+# remains a read-only scan root for the shipped example and for any pack a
+# migration could not move.
 COMMUNITY_SUBDIR = "community"
+
+# Host-owned drop-in folder, relative to the runtime data dir
+# (``<config>/quizify`` under Home Assistant). Outside ``custom_components``,
+# so a HACS update cannot touch it (#743).
+COMMUNITY_PACKS_DIRNAME = "packs"
+
+# Files shipped inside ``questions/community`` by the integration itself. They
+# are part of the release artefact, not host data, so the #743 migration leaves
+# them where they are — moving them would copy repo content into the host's
+# config directory and re-create it on every update.
+SHIPPED_COMMUNITY_PACKS = frozenset({"example-pack.json"})
 
 # Slugs of community packs are prefixed so they can never collide with (or
 # silently shadow) a built-in pack slug.
@@ -448,9 +468,24 @@ def _parse_question(data: dict, category_name: str) -> Question | None:
 class QuestionBank:
     """Manages loading and serving questions from JSON files."""
 
-    def __init__(self, questions_dir: Path | None = None) -> None:
-        """Initialize the question bank."""
+    def __init__(
+        self,
+        questions_dir: Path | None = None,
+        community_dir: Path | None = None,
+    ) -> None:
+        """Initialize the question bank.
+
+        *questions_dir* holds the built-in packs shipped with the integration.
+        *community_dir* is the host-owned drop-in folder outside the
+        integration directory (``<config>/quizify/packs`` under Home
+        Assistant, #743). When it is ``None`` — bare unit tests, or any caller
+        without a runtime — only the in-integration community folder is
+        scanned and no migration is attempted.
+        """
         self._questions_dir = questions_dir or QUESTIONS_DIR
+        self._community_dir = (
+            Path(community_dir) if community_dir is not None else None
+        )
         self._categories: dict[str, list[Question]] = {}
         self._pack_versions: dict[str, dict] = {}
         self._queue: list[Question] = []
@@ -481,6 +516,25 @@ class QuestionBank:
     def questions_dir(self) -> Path:
         """Directory the question-pack JSON files are loaded from."""
         return self._questions_dir
+
+    @property
+    def community_dir(self) -> Path | None:
+        """Host-owned drop-in folder for community packs, if one is bound.
+
+        Lives outside the integration directory so a HACS update cannot delete
+        what the host put there (#743). ``None`` when the bank was created
+        without a runtime.
+        """
+        return self._community_dir
+
+    @property
+    def legacy_community_dir(self) -> Path:
+        """The pre-#743 community folder inside the integration directory.
+
+        Still scanned (it carries the shipped example pack), but no longer the
+        place hosts are told to drop their own files.
+        """
+        return self._questions_dir / COMMUNITY_SUBDIR
 
     @property
     def is_loaded(self) -> bool:
@@ -545,14 +599,21 @@ class QuestionBank:
         )
         return questions
 
-    def load_all_categories(self) -> dict[str, list[Question]]:
+    def load_all_categories(self, force: bool = False) -> dict[str, list[Question]]:
         """Discover and load all category JSON files.
 
         Subsequent calls return the cached result without re-reading from disk.
-        Call reload_categories() to force a fresh load.
+        Pass ``force=True`` (or call :meth:`reload_categories`) to re-read from
+        disk regardless of the cache. The ``force`` flag exists so the reload
+        path cannot be defeated by the ``_loaded`` short-circuit — the flag is
+        checked here, not by the caller, so a concurrent load that re-sets
+        ``_loaded`` in between cannot turn a requested reload into a no-op.
         """
-        if self._loaded:
+        if self._loaded and not force:
             return dict(self._categories)
+
+        if force:
+            self._reset_loaded_state()
 
         if not self._questions_dir.is_dir():
             _LOGGER.warning("Questions directory not found: %s", self._questions_dir)
@@ -578,14 +639,135 @@ class QuestionBank:
         self._loaded = True
         return dict(self._categories)
 
-    def reload_categories(self) -> dict[str, list[Question]]:
-        """Clear the cache and reload all categories from disk."""
+    def _reset_loaded_state(self) -> None:
+        """Drop every cached artefact of a previous load.
+
+        ``_pack_versions`` matters as much as ``_categories``: the admin
+        category chips and the ``/api/quizify/packs`` endpoint are rendered
+        from it, so a reload that only cleared the questions would keep
+        showing a chip for a pack the host had just deleted. The queue is
+        dropped too — it holds ``Question`` objects from the previous load.
+        """
         self._loaded = False
         self._categories = {}
-        return self.load_all_categories()
+        self._pack_versions = {}
+        self._queue = []
+        self._queue_index = 0
+
+    def reload_categories(self) -> dict[str, list[Question]]:
+        """Clear the cache and reload all categories from disk.
+
+        Blocking disk I/O — call it from an executor, never on the event loop.
+        Exposed to hosts as the ``quizify.reload_packs`` service (#743) so a
+        newly dropped pack can be picked up without restarting Home Assistant.
+        """
+        return self.load_all_categories(force=True)
+
+    def _community_scan_roots(self) -> list[Path]:
+        """Directories scanned for community packs, in precedence order.
+
+        The host-owned folder outside the integration comes first so that when
+        the same filename exists in both places the host's copy wins — the
+        in-integration copy is then skipped by the slug-collision check.
+        """
+        roots: list[Path] = []
+        if self._community_dir is not None:
+            roots.append(self._community_dir)
+        legacy = self.legacy_community_dir
+        if legacy not in roots:
+            roots.append(legacy)
+        return roots
+
+    def _ensure_community_dir(self) -> None:
+        """Create the host-owned drop-in folder so it is there to be found.
+
+        The README tells hosts to drop packs into ``<config>/quizify/packs``;
+        a folder that only appears once somebody guesses the path right is a
+        worse instruction than one that is simply there. Best-effort: a
+        read-only config dir logs and moves on, and every scan root is
+        ``is_dir()``-guarded anyway.
+        """
+        if self._community_dir is None:
+            return
+        try:
+            self._community_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            _LOGGER.debug(
+                "Could not create community pack directory %s: %s",
+                self._community_dir,
+                exc,
+            )
+
+    def _migrate_legacy_community_packs(self) -> None:
+        """Move host-dropped packs out of the doomed in-integration folder.
+
+        Before #743 the only documented drop-in location was
+        ``custom_components/quizify/questions/community`` — inside the
+        directory HACS replaces wholesale on every update, so each update
+        deleted the host's own packs without a word. On every load we move any
+        leftover ``*.json`` there into the host-owned folder, so a host who
+        already had packs in the old place keeps them instead of losing them
+        at the next update.
+
+        Deliberately conservative: files shipped by the integration itself
+        (:data:`SHIPPED_COMMUNITY_PACKS`) are left alone, an existing file of
+        the same name in the target is never overwritten, and any OS error is
+        logged and swallowed — a pack that could not be moved is still loaded
+        from the legacy folder by :meth:`load_community_packs`, so a failed
+        migration degrades to the old behaviour rather than losing a pack.
+        """
+        if self._community_dir is None:
+            return
+
+        legacy = self.legacy_community_dir
+        if not legacy.is_dir() or legacy == self._community_dir:
+            return
+
+        for file_path in sorted(legacy.glob("*.json")):
+            if file_path.name in SHIPPED_COMMUNITY_PACKS:
+                continue
+
+            target = self._community_dir / file_path.name
+            if target.exists():
+                _LOGGER.warning(
+                    "Community pack '%s' also exists in %s — leaving the old "
+                    "copy in place; the file in %s is the one that loads",
+                    file_path.name,
+                    self._community_dir,
+                    self._community_dir,
+                )
+                continue
+
+            try:
+                self._community_dir.mkdir(parents=True, exist_ok=True)
+                shutil.move(str(file_path), str(target))
+            except OSError as exc:
+                _LOGGER.warning(
+                    "Could not move community pack '%s' to %s: %s. It is still "
+                    "loaded from %s, but a HACS update will delete it — move "
+                    "it by hand.",
+                    file_path.name,
+                    self._community_dir,
+                    exc,
+                    legacy,
+                )
+                continue
+
+            _LOGGER.warning(
+                "Moved community pack '%s' from %s to %s so a HACS update "
+                "cannot delete it (#743)",
+                file_path.name,
+                legacy,
+                self._community_dir,
+            )
 
     def load_community_packs(self) -> dict[str, list[Question]]:
-        """Discover and load user-contributed packs from the community subfolder.
+        """Discover and load user-contributed packs from every scan root.
+
+        Two roots are scanned (#743): the host-owned drop-in folder outside
+        the integration directory first, then the in-integration
+        ``questions/community`` folder that ships the example pack. Leftover
+        host packs in the second are migrated into the first before scanning.
 
         Community packs are untrusted input, so loading is deliberately
         defensive: every failure mode (missing folder, unreadable file,
@@ -598,7 +780,16 @@ class QuestionBank:
         (``community-<filename>``) so it can never shadow a built-in category.
         Returns the mapping of the community packs that were loaded.
         """
-        community_dir = self._questions_dir / COMMUNITY_SUBDIR
+        self._ensure_community_dir()
+        self._migrate_legacy_community_packs()
+
+        loaded: dict[str, list[Question]] = {}
+        for root in self._community_scan_roots():
+            loaded.update(self._load_community_dir(root))
+        return loaded
+
+    def _load_community_dir(self, community_dir: Path) -> dict[str, list[Question]]:
+        """Load every community pack found in a single scan root."""
         loaded: dict[str, list[Question]] = {}
 
         if not community_dir.is_dir():
@@ -610,8 +801,10 @@ class QuestionBank:
 
             if slug in self._categories:
                 _LOGGER.warning(
-                    "Skipping community pack '%s': slug '%s' already loaded",
+                    "Skipping community pack '%s' in %s: slug '%s' already "
+                    "loaded",
                     file_path.name,
+                    community_dir,
                     slug,
                 )
                 continue
@@ -722,10 +915,12 @@ class QuestionBank:
                 "language": pack_language,
                 "question_count": len(questions),
                 "community": True,
-                # Theme stored at load time (#309) — community packs live at
-                # questions/community/<stem>.json under a ``community-`` slug, so
-                # the old views.py path read (questions_dir / f"{slug}.json")
-                # never found them and they always fell back to the 🎲 icon.
+                # Theme stored at load time (#309) — community packs live in a
+                # separate folder under a ``community-`` slug, so the old
+                # views.py path read (questions_dir / f"{slug}.json") never
+                # found them and they always fell back to the 🎲 icon. Since
+                # #743 they may live outside the integration entirely, which
+                # makes reconstructing a path from the slug wronger still.
                 "theme": (
                     raw.get("theme", "")
                     if isinstance(raw.get("theme"), str)

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -40,7 +40,12 @@ from .powerups import (
     PowerUpManager,
     PowerUpType,
 )
-from .questions import Answer, Question, QuestionBank
+from .questions import (
+    COMMUNITY_PACKS_DIRNAME,
+    Answer,
+    Question,
+    QuestionBank,
+)
 from .scoring import (
     calculate_estimate_scores,
     calculate_podium,
@@ -160,7 +165,18 @@ class QuizifyGameState:
         # Teams (#365). Empty unless somebody forms one in the lobby — the mode
         # is opt-in per game and costs nothing while unused.
         self._team_registry = TeamRegistry()
-        self._question_bank = QuestionBank()
+        # Community packs the host drops in live outside the integration
+        # directory (#743), under the runtime data dir — HACS replaces
+        # ``custom_components/quizify`` wholesale on every update, so anything
+        # kept inside it is deleted without a word. Without a runtime (bare
+        # unit tests) the bank falls back to the in-integration folder only.
+        self._question_bank = QuestionBank(
+            community_dir=(
+                runtime.data_dir / COMMUNITY_PACKS_DIRNAME
+                if runtime is not None
+                else None
+            )
+        )
         self._powerup_manager = PowerUpManager()
         # Stateless scoring engine — owns the pure points/breakdown/wager/
         # milestone arithmetic that submit_answer applies (issue #184).

--- a/custom_components/quizify/questions/community/README.md
+++ b/custom_components/quizify/questions/community/README.md
@@ -1,9 +1,41 @@
 # Community Question Packs
 
-This folder holds **user-contributed** question packs. Any `*.json` file you
-drop in here is discovered automatically the next time Quizify loads its
-question bank (a Home Assistant restart, or an in-app pack reload). They appear
-in the category picker alongside the built-in packs.
+> **⚠️ Do not drop your own packs in this folder.** It lives inside
+> `custom_components/quizify/`, which HACS **replaces wholesale on every
+> update** — anything you put here is deleted the next time Quizify updates.
+> This folder now only carries `example-pack.json`, shipped with the
+> integration as a reference.
+
+## Where your packs go
+
+Put your own packs in your **Home Assistant config directory**:
+
+```
+<config>/quizify/packs/my-pack.json
+```
+
+(the same `<config>` that holds `configuration.yaml`; on Home Assistant OS that
+is `/config`, so `/config/quizify/packs/`). Quizify creates the folder on
+startup. It is outside `custom_components/`, so updates never touch it.
+
+**If you already had packs in this folder**, you do not have to do anything:
+on the next start Quizify **moves** every `*.json` it finds here (except the
+shipped `example-pack.json`) into `<config>/quizify/packs/` and logs the move.
+If a file of the same name is already there, your copy in `<config>` wins and
+the old file is left alone rather than overwritten.
+
+## Loading a pack without restarting
+
+After adding, editing or removing a pack, call the
+
+```
+quizify.reload_packs
+```
+
+service (Developer Tools → Actions → "Quizify: Reload question packs"), then
+reload the admin page. The pack shows up in the category picker alongside the
+built-in ones. The service only works from the lobby — a running game keeps the
+packs it started with. A Home Assistant restart works too, of course.
 
 Community packs are kept separate from the built-in, hand-reviewed packs so
 that user content is clearly namespaced and can be validated independently.
@@ -80,3 +112,10 @@ shadow a built-in pack.
 To share a pack with the wider community, open a pull request adding your
 `*.json` file to this folder. Keep it focused (one theme per pack) and run the
 question bank tests before submitting.
+
+**Maintainer note:** a pack merged into this folder ships with the release, so
+add its filename to `SHIPPED_COMMUNITY_PACKS` in
+`custom_components/quizify/game/questions.py`. Otherwise the first-run
+migration treats it as host data and moves it into every user's
+`<config>/quizify/packs/`, where the next update would re-create it here and
+the two copies would fight over the same slug.

--- a/custom_components/quizify/services.yaml
+++ b/custom_components/quizify/services.yaml
@@ -49,3 +49,13 @@ end_game:
     it to a remote button, dashboard button or Assist sentence ("Hey Nabu, end
     the quiz"). Only works while a game is running.
   fields: {}
+
+reload_packs:
+  name: Reload question packs
+  description: >-
+    Re-read every question pack from disk, including the community packs you
+    dropped into the "quizify/packs" folder of your Home Assistant config
+    directory. Use it after adding, editing or removing a pack so it shows up
+    in the picker without restarting Home Assistant. Only works from the
+    lobby — a running game keeps the packs it started with.
+  fields: {}

--- a/custom_components/quizify/translations/de.json
+++ b/custom_components/quizify/translations/de.json
@@ -75,6 +75,10 @@
         "end_game": {
             "name": "Spiel beenden",
             "description": "Beendet das aktuelle Spiel sofort und springt zur End-Rangliste. Verknüpfe es mit einem Fernbedienungs-Button, Dashboard-Button oder Assist-Satz. Funktioniert nur, während ein Spiel läuft."
+        },
+        "reload_packs": {
+            "name": "Fragenpakete neu laden",
+            "description": "Liest alle Fragenpakete neu von der Festplatte, inklusive der Community-Pakete im Ordner quizify/packs deines Home-Assistant-Konfigurationsverzeichnisses. Nutze es, nachdem du ein Paket hinzugefügt, geändert oder gelöscht hast, damit es ohne Neustart von Home Assistant in der Auswahl auftaucht. Funktioniert nur in der Lobby."
         }
     }
 }

--- a/custom_components/quizify/translations/en.json
+++ b/custom_components/quizify/translations/en.json
@@ -75,6 +75,10 @@
         "end_game": {
             "name": "End game",
             "description": "End the current game immediately and jump to the final leaderboard. Wire it to a remote button, dashboard button or Assist sentence. Only works while a game is running."
+        },
+        "reload_packs": {
+            "name": "Reload question packs",
+            "description": "Re-read every question pack from disk, including the community packs in the quizify/packs folder of your Home Assistant config directory. Use it after adding, editing or removing a pack so it shows up in the picker without restarting Home Assistant. Only works from the lobby."
         }
     }
 }

--- a/custom_components/quizify/translations/es.json
+++ b/custom_components/quizify/translations/es.json
@@ -75,6 +75,10 @@
         "end_game": {
             "name": "Terminar juego",
             "description": "Termina la partida actual de inmediato y salta a la clasificación final. Vincúlalo a un botón de mando, un botón del panel o una frase de Assist. Solo funciona mientras hay una partida en curso."
+        },
+        "reload_packs": {
+            "name": "Recargar paquetes de preguntas",
+            "description": "Vuelve a leer del disco todos los paquetes de preguntas, incluidos los paquetes de la comunidad que están en la carpeta quizify/packs de tu directorio de configuración de Home Assistant. Úsalo después de añadir, editar o borrar un paquete para que aparezca en el selector sin reiniciar Home Assistant. Solo funciona desde la sala de espera."
         }
     }
 }

--- a/custom_components/quizify/translations/fr.json
+++ b/custom_components/quizify/translations/fr.json
@@ -75,6 +75,10 @@
         "end_game": {
             "name": "Terminer la partie",
             "description": "Termine immédiatement la partie en cours et affiche le classement final. Associez-le à un bouton de télécommande, un bouton de tableau de bord ou une phrase Assist. Ne fonctionne que pendant une partie en cours."
+        },
+        "reload_packs": {
+            "name": "Recharger les paquets de questions",
+            "description": "Relit tous les paquets de questions depuis le disque, y compris les paquets communautaires du dossier quizify/packs de votre répertoire de configuration Home Assistant. À utiliser après avoir ajouté, modifié ou supprimé un paquet pour qu'il apparaisse dans le sélecteur sans redémarrer Home Assistant. Ne fonctionne que depuis le salon."
         }
     }
 }

--- a/custom_components/quizify/translations/nl.json
+++ b/custom_components/quizify/translations/nl.json
@@ -75,6 +75,10 @@
         "end_game": {
             "name": "Spel beëindigen",
             "description": "Beëindigt het huidige spel direct en gaat naar het eindklassement. Koppel het aan een afstandsbedieningsknop, dashboardknop of Assist-zin. Werkt alleen terwijl er een spel loopt."
+        },
+        "reload_packs": {
+            "name": "Vragenpakketten herladen",
+            "description": "Leest alle vragenpakketten opnieuw van schijf, inclusief de community-pakketten in de map quizify/packs van je Home Assistant-configuratiemap. Gebruik het nadat je een pakket hebt toegevoegd, gewijzigd of verwijderd, zodat het in de kiezer verschijnt zonder Home Assistant te herstarten. Werkt alleen vanuit de lobby."
         }
     }
 }

--- a/tests/test_community_pack_location_743.py
+++ b/tests/test_community_pack_location_743.py
@@ -1,0 +1,503 @@
+"""Community packs survive a HACS update, and can be reloaded (issue #743).
+
+Two defects, one story:
+
+* ``QUESTIONS_DIR`` lives inside the integration, so ``questions/community``
+  — the only folder the docs ever named — is inside the directory HACS
+  replaces wholesale on every update. Every pack the host dropped there was
+  deleted, without a word, by the next update.
+* ``reload_categories()`` existed but had no caller and no service, so the
+  "in-app pack reload" the README promised did not exist either: the only way
+  to pick up a new pack was a full Home Assistant restart.
+
+The fix moves the host-owned drop-in folder to ``<config>/quizify/packs``
+(outside ``custom_components``), migrates whatever is still sitting in the old
+folder into it, keeps scanning the old folder for the shipped example pack and
+for anything a migration could not move, and wires ``reload_categories`` to a
+``quizify.reload_packs`` service.
+
+Unit level covers the loader + migration; integration level (real ``hass``
+fixture, like ``test_game_control_services_367``) covers the service.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.const import DOMAIN  # noqa: E402
+from custom_components.quizify.game.questions import (  # noqa: E402
+    COMMUNITY_PACKS_DIRNAME,
+    COMMUNITY_SUBDIR,
+    SHIPPED_COMMUNITY_PACKS,
+    QuestionBank,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _pack(name: str, *, prefix: str = "q", count: int = 3) -> dict:
+    """A minimal, valid community pack payload."""
+    return {
+        "name": name,
+        "language": "en",
+        "version": "1.0",
+        "questions": [
+            {
+                "id": f"{prefix}_{i}",
+                "question": f"Question {i}?",
+                "answers": [
+                    {"text": "Right", "correct": True},
+                    {"text": "Wrong", "correct": False},
+                    {"text": "Also wrong", "correct": False},
+                ],
+                "difficulty": "easy",
+            }
+            for i in range(count)
+        ],
+    }
+
+
+def _write(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _make_dirs(tmp_path: Path) -> tuple[Path, Path]:
+    """(questions_dir, community_dir) — the shipped tree and the host's tree.
+
+    ``questions_dir`` stands in for ``custom_components/quizify/questions``
+    (replaced by every HACS update); ``community_dir`` for
+    ``<config>/quizify/packs`` (the host's own, untouched by updates).
+    """
+    questions_dir = tmp_path / "custom_components" / "quizify" / "questions"
+    questions_dir.mkdir(parents=True)
+    community_dir = tmp_path / "config" / "quizify" / COMMUNITY_PACKS_DIRNAME
+    return questions_dir, community_dir
+
+
+# ---------------------------------------------------------------------------
+# Unit level: the drop-in folder lives outside the integration
+# ---------------------------------------------------------------------------
+
+
+def test_pack_in_config_dir_is_loaded(tmp_path: Path) -> None:
+    """A pack dropped into <config>/quizify/packs is discovered — the folder
+    HACS cannot touch is a real scan root, not just documentation."""
+    questions_dir, community_dir = _make_dirs(tmp_path)
+    _write(community_dir / "birthday.json", _pack("Birthday Quiz"))
+
+    bank = QuestionBank(questions_dir=questions_dir, community_dir=community_dir)
+    bank.load_all_categories()
+
+    assert "community-birthday" in bank.get_categories()
+    assert bank.get_pack_versions()["community-birthday"]["name"] == "Birthday Quiz"
+
+
+def test_config_dir_packs_survive_an_integration_wipe(tmp_path: Path) -> None:
+    """The regression itself: wipe the whole integration questions tree (what
+    a HACS update does) and the host's pack is still there afterwards."""
+    questions_dir, community_dir = _make_dirs(tmp_path)
+    host_pack = _write(community_dir / "family.json", _pack("Family Quiz"))
+    # Something the host dropped in the *old* place, plus the shipped example.
+    _write(questions_dir / COMMUNITY_SUBDIR / "example-pack.json", _pack("Example"))
+
+    bank = QuestionBank(questions_dir=questions_dir, community_dir=community_dir)
+    bank.load_all_categories()
+    assert "community-family" in bank.get_categories()
+
+    # HACS replaces custom_components/quizify wholesale.
+    import shutil
+
+    shutil.rmtree(questions_dir)
+    questions_dir.mkdir(parents=True)
+    _write(questions_dir / COMMUNITY_SUBDIR / "example-pack.json", _pack("Example"))
+
+    assert host_pack.is_file(), "the host's pack must survive the update"
+    fresh = QuestionBank(questions_dir=questions_dir, community_dir=community_dir)
+    fresh.load_all_categories()
+    assert "community-family" in fresh.get_categories()
+
+
+def test_legacy_folder_is_still_scanned(tmp_path: Path) -> None:
+    """The shipped example pack lives in questions/community and keeps
+    loading — the new root is added, the old one is not dropped."""
+    questions_dir, community_dir = _make_dirs(tmp_path)
+    _write(questions_dir / COMMUNITY_SUBDIR / "example-pack.json", _pack("Example"))
+
+    bank = QuestionBank(questions_dir=questions_dir, community_dir=community_dir)
+    bank.load_all_categories()
+
+    assert "community-example-pack" in bank.get_categories()
+
+
+def test_bank_without_runtime_falls_back_to_legacy_folder(tmp_path: Path) -> None:
+    """A bank built without a community_dir (bare unit tests, standalone) is
+    unchanged: it scans only the in-integration folder and migrates nothing."""
+    questions_dir, _ = _make_dirs(tmp_path)
+    legacy = _write(
+        questions_dir / COMMUNITY_SUBDIR / "mine.json", _pack("Mine")
+    )
+
+    bank = QuestionBank(questions_dir=questions_dir)
+    bank.load_all_categories()
+
+    assert bank.community_dir is None
+    assert "community-mine" in bank.get_categories()
+    assert legacy.is_file()
+
+
+# ---------------------------------------------------------------------------
+# Unit level: migration out of the doomed folder
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_host_pack_is_migrated_to_config_dir(tmp_path: Path) -> None:
+    """A host who already had a pack in questions/community keeps it: the file
+    is MOVED into <config>/quizify/packs on the next load."""
+    questions_dir, community_dir = _make_dirs(tmp_path)
+    legacy = _write(
+        questions_dir / COMMUNITY_SUBDIR / "party.json", _pack("Party Quiz")
+    )
+
+    bank = QuestionBank(questions_dir=questions_dir, community_dir=community_dir)
+    bank.load_all_categories()
+
+    assert not legacy.exists(), "the pack must leave the folder HACS replaces"
+    moved = community_dir / "party.json"
+    assert moved.is_file()
+    assert json.loads(moved.read_text(encoding="utf-8"))["name"] == "Party Quiz"
+    # And it is still loaded, from its new home.
+    assert "community-party" in bank.get_categories()
+
+
+def test_shipped_example_pack_is_not_migrated(tmp_path: Path) -> None:
+    """Files the integration ships are release artefacts, not host data — they
+    stay put, so the migration never copies repo content into the config dir
+    (and never re-creates it after every update)."""
+    questions_dir, community_dir = _make_dirs(tmp_path)
+    assert "example-pack.json" in SHIPPED_COMMUNITY_PACKS
+    shipped = _write(
+        questions_dir / COMMUNITY_SUBDIR / "example-pack.json", _pack("Example")
+    )
+
+    bank = QuestionBank(questions_dir=questions_dir, community_dir=community_dir)
+    bank.load_all_categories()
+
+    assert shipped.is_file()
+    assert not (community_dir / "example-pack.json").exists()
+    assert "community-example-pack" in bank.get_categories()
+
+
+def test_migration_never_overwrites_an_existing_host_pack(tmp_path: Path) -> None:
+    """Same filename in both places: the host's copy in the config dir wins and
+    is not clobbered, and the leftover is not loaded twice."""
+    questions_dir, community_dir = _make_dirs(tmp_path)
+    _write(community_dir / "dupe.json", _pack("Newer", prefix="new"))
+    legacy = _write(
+        questions_dir / COMMUNITY_SUBDIR / "dupe.json", _pack("Older", prefix="old")
+    )
+
+    bank = QuestionBank(questions_dir=questions_dir, community_dir=community_dir)
+    bank.load_all_categories()
+
+    assert legacy.is_file(), "never delete the old copy we could not move"
+    assert json.loads(
+        (community_dir / "dupe.json").read_text(encoding="utf-8")
+    )["name"] == "Newer"
+    assert bank.get_pack_versions()["community-dupe"]["name"] == "Newer"
+    assert len(bank.categories["community-dupe"]) == 3
+
+
+def test_failed_migration_still_loads_the_pack(tmp_path: Path) -> None:
+    """If the move fails (read-only mount, permissions), the pack is still
+    loaded from the legacy folder — a failed migration degrades to the old
+    behaviour instead of losing the questions."""
+    questions_dir, community_dir = _make_dirs(tmp_path)
+    legacy = _write(
+        questions_dir / COMMUNITY_SUBDIR / "stuck.json", _pack("Stuck")
+    )
+
+    bank = QuestionBank(questions_dir=questions_dir, community_dir=community_dir)
+    with patch(
+        "custom_components.quizify.game.questions.shutil.move",
+        side_effect=OSError("read-only file system"),
+    ):
+        bank.load_all_categories()
+
+    assert legacy.is_file()
+    assert "community-stuck" in bank.get_categories()
+
+
+# ---------------------------------------------------------------------------
+# Unit level: reload actually reloads
+# ---------------------------------------------------------------------------
+
+
+def test_reload_picks_up_a_newly_dropped_pack(tmp_path: Path) -> None:
+    """The point of the reload path: drop a pack after the bank was loaded and
+    reload_categories() finds it — the _loaded short-circuit does not win."""
+    questions_dir, community_dir = _make_dirs(tmp_path)
+    community_dir.mkdir(parents=True, exist_ok=True)
+
+    bank = QuestionBank(questions_dir=questions_dir, community_dir=community_dir)
+    bank.load_all_categories()
+    assert "community-late" not in bank.get_categories()
+
+    _write(community_dir / "late.json", _pack("Late Arrival"))
+    bank.reload_categories()
+
+    assert "community-late" in bank.get_categories()
+    assert bank.get_pack_versions()["community-late"]["name"] == "Late Arrival"
+
+
+def test_force_defeats_the_loaded_short_circuit(tmp_path: Path) -> None:
+    """``load_all_categories(force=True)`` re-reads even when the bank thinks
+    it is loaded — the short-circuit is evaluated inside the method, so a
+    caller cannot end up with a silently skipped reload."""
+    questions_dir, community_dir = _make_dirs(tmp_path)
+    community_dir.mkdir(parents=True, exist_ok=True)
+
+    bank = QuestionBank(questions_dir=questions_dir, community_dir=community_dir)
+    bank.load_all_categories()
+    assert bank.is_loaded is True
+
+    _write(community_dir / "forced.json", _pack("Forced"))
+    assert "community-forced" not in bank.load_all_categories()
+    assert "community-forced" in bank.load_all_categories(force=True)
+
+
+def test_reload_drops_a_removed_pack_from_the_metadata(tmp_path: Path) -> None:
+    """A deleted pack disappears from get_pack_versions() too, not just from
+    the questions — the admin chips and /api/quizify/packs are built from that
+    metadata, so a stale entry would keep offering a pack that is gone."""
+    questions_dir, community_dir = _make_dirs(tmp_path)
+    pack = _write(community_dir / "temporary.json", _pack("Temporary"))
+
+    bank = QuestionBank(questions_dir=questions_dir, community_dir=community_dir)
+    bank.load_all_categories()
+    assert "community-temporary" in bank.get_pack_versions()
+
+    pack.unlink()
+    bank.reload_categories()
+
+    assert "community-temporary" not in bank.get_categories()
+    assert "community-temporary" not in bank.get_pack_versions()
+
+
+# ---------------------------------------------------------------------------
+# services.yaml / translations
+# ---------------------------------------------------------------------------
+
+
+def test_reload_packs_is_declared_in_services_yaml() -> None:
+    """The service is declared, so it shows up in Developer Tools → Actions
+    with a name and a description rather than as a bare domain.service."""
+    yaml = pytest.importorskip("yaml")
+    path = _REPO_ROOT / "custom_components" / "quizify" / "services.yaml"
+    declared = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert "reload_packs" in declared
+    assert declared["reload_packs"]["name"]
+    assert declared["reload_packs"]["description"]
+
+
+def test_reload_packs_has_strings_in_every_locale() -> None:
+    """Every locale that carries service strings carries this one too."""
+    base = _REPO_ROOT / "custom_components" / "quizify" / "translations"
+    for path in sorted(base.glob("*.json")):
+        data = json.loads(path.read_text(encoding="utf-8"))
+        services = data.get("services")
+        if not services:
+            continue
+        assert "reload_packs" in services, f"{path.name} misses reload_packs"
+        assert services["reload_packs"]["name"]
+        assert services["reload_packs"]["description"]
+
+
+def test_community_readme_points_at_the_config_dir() -> None:
+    """The docs and the code finally agree on where a host's packs go."""
+    readme = (
+        _REPO_ROOT
+        / "custom_components"
+        / "quizify"
+        / "questions"
+        / COMMUNITY_SUBDIR
+        / "README.md"
+    )
+    text = readme.read_text(encoding="utf-8")
+    assert f"quizify/{COMMUNITY_PACKS_DIRNAME}" in text
+    assert "quizify.reload_packs" in text
+
+
+# ---------------------------------------------------------------------------
+# Integration level: the reload service
+# ---------------------------------------------------------------------------
+
+pytest.importorskip("homeassistant")
+pytest.importorskip("pytest_homeassistant_custom_component")
+
+from homeassistant.core import HomeAssistant  # noqa: E402
+from homeassistant.exceptions import ServiceValidationError  # noqa: E402
+from homeassistant.setup import async_setup_component  # noqa: E402
+from pytest_homeassistant_custom_component.common import (  # noqa: E402
+    MockConfigEntry,
+)
+
+from custom_components.quizify.game.state import GamePhase  # noqa: E402
+
+pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+
+@pytest.fixture(autouse=True)
+def _clean_config_packs_dir():
+    """Keep the shared HA test config directory free of leftover packs.
+
+    ``pytest_homeassistant_custom_component`` hands every ``hass`` fixture the
+    same on-disk config directory, so a pack written by one test would still be
+    there for the next run (and for every other test in the suite). Wipe the
+    drop-in folder around each test.
+    """
+    from pytest_homeassistant_custom_component.common import (  # noqa: PLC0415
+        get_test_config_dir,
+    )
+
+    packs = Path(get_test_config_dir()) / "quizify" / COMMUNITY_PACKS_DIRNAME
+
+    def _wipe() -> None:
+        if packs.is_dir():
+            for leftover in packs.glob("*.json"):
+                leftover.unlink()
+
+    _wipe()
+    yield
+    _wipe()
+
+
+@pytest.fixture(autouse=True)
+def _stub_frontend_panel():
+    """Stub the frontend panel helpers (the hass_frontend wheel is absent under
+    the test harness). Mirrors test_game_control_services_367."""
+    panels: dict = {}
+
+    def _register_panel(_hass, *, frontend_url_path, **_kw):
+        panels[frontend_url_path] = True
+
+    def _remove_panel(_hass, path):
+        if path not in panels:
+            raise KeyError(path)
+        del panels[path]
+
+    with (
+        patch(
+            "homeassistant.components.frontend.async_register_built_in_panel",
+            side_effect=_register_panel,
+        ),
+        patch(
+            "homeassistant.components.frontend.async_remove_panel",
+            side_effect=_remove_panel,
+        ),
+    ):
+        yield panels
+
+
+@pytest.fixture
+async def http_hass(hass: HomeAssistant) -> HomeAssistant:
+    """A hass with the HTTP component set up (setup mounts routes on it)."""
+    assert await async_setup_component(hass, "http", {"http": {}})
+    await hass.async_block_till_done()
+    return hass
+
+
+async def _setup(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id) is True
+    await hass.async_block_till_done()
+    return entry
+
+
+async def test_reload_packs_service_registered(http_hass: HomeAssistant) -> None:
+    """Setup registers quizify.reload_packs."""
+    hass = http_hass
+    await _setup(hass)
+    assert hass.services.has_service(DOMAIN, "reload_packs")
+
+
+async def test_bank_reads_the_config_dir_under_hass(
+    http_hass: HomeAssistant,
+) -> None:
+    """Wired through the runtime: the bank's drop-in folder is
+    <config>/quizify/packs, not a folder inside the integration."""
+    hass = http_hass
+    await _setup(hass)
+    bank = hass.data[DOMAIN]["game"].question_bank
+    assert bank.community_dir == Path(
+        hass.config.path("quizify", COMMUNITY_PACKS_DIRNAME)
+    )
+    assert "custom_components" not in str(bank.community_dir)
+
+
+async def test_reload_packs_service_picks_up_a_new_pack(
+    http_hass: HomeAssistant,
+) -> None:
+    """The whole point: drop a pack into the config folder on a running HA,
+    call the service, and the pack is available — no restart."""
+    hass = http_hass
+    await _setup(hass)
+    bank = hass.data[DOMAIN]["game"].question_bank
+    assert "community-tonight" not in bank.get_categories()
+
+    target = Path(hass.config.path("quizify", COMMUNITY_PACKS_DIRNAME))
+    await hass.async_add_executor_job(
+        _write, target / "tonight.json", _pack("Tonight's Pack")
+    )
+
+    await hass.services.async_call(DOMAIN, "reload_packs", {}, blocking=True)
+    await hass.async_block_till_done()
+
+    assert "community-tonight" in bank.get_categories()
+    assert bank.get_pack_versions()["community-tonight"]["name"] == (
+        "Tonight's Pack"
+    )
+
+
+async def test_reload_packs_refused_mid_game(http_hass: HomeAssistant) -> None:
+    """Reloading under a running game would swap the bank beneath the queue the
+    players are answering, so it is refused with a clear message."""
+    hass = http_hass
+    await _setup(hass)
+    game = hass.data[DOMAIN]["game"]
+    game.start_game(num_rounds=10, lightning_enabled=False)
+    game.start_next_question()
+    assert game.phase == GamePhase.QUESTION_ACTIVE
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(DOMAIN, "reload_packs", {}, blocking=True)
+
+    hass.data[DOMAIN]["ws_handler"]._cancel_timer_tick()
+
+
+async def test_reload_packs_without_setup_raises_validation_error(
+    http_hass: HomeAssistant,
+) -> None:
+    """After the entry is unloaded the service raises ServiceValidationError,
+    not a raw KeyError."""
+    hass = http_hass
+    entry = await _setup(hass)
+    assert await hass.config_entries.async_unload(entry.entry_id) is True
+    await hass.async_block_till_done()
+    assert DOMAIN not in hass.data
+
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(DOMAIN, "reload_packs", {}, blocking=True)


### PR DESCRIPTION
Closes #743

## The problem

`QUESTIONS_DIR` points inside the integration, so `questions/community` — the only drop-in location the docs ever named — sits inside the directory HACS replaces wholesale on every update. A host who wrote a pack of family questions for the birthday party lost it at the next Quizify update, without a word.

The same README promised the pack is picked up on "a Home Assistant restart, or an in-app pack reload". There was no in-app reload: `reload_categories()` had no callers, no service was declared in `services.yaml`, and `load_all_categories` short-circuited on `self._loaded`. A restart was the only way in.

## Where packs live now

`<config>/quizify/packs/` — the host's own config directory, reached through `HARuntime.data_dir`, the same path the analytics store, the question history, the token store and the preset store already use. `QuestionBank` takes a `community_dir`; `QuizifyGameState` passes `runtime.data_dir / "packs"` when it has a runtime and `None` when it does not (bare unit tests, standalone dev server), in which case nothing changes for that bank at all.

Shipped packs keep loading from where they ship. Only the host's own drop-in location moved.

The folder is created on startup, best-effort, so it is there to be found rather than something a host has to guess into existence.

## Migration: move, not "read both and hope"

On every load, any `*.json` still sitting in `questions/community` is **moved** into `<config>/quizify/packs/`.

Moving rather than only reading both locations, because reading both would leave the host's file in the doomed directory: it would keep working until the next update deleted it, which is exactly the failure this issue is about, just postponed. A move takes the file out of harm's way once and the host never has to think about it.

The move is deliberately timid, and the old folder is still a scan root, so nothing is lost when a move cannot happen:

- **Shipped files are not moved.** `example-pack.json` is a release artefact, not host data; moving it would copy repo content into every user's config directory and re-create it there after every update. `SHIPPED_COMMUNITY_PACKS` names it, and the folder's README tells maintainers to extend that set when they merge a pack.
- **An existing file of the same name is never overwritten.** The copy in `<config>` wins (it is the first scan root, so the leftover loses the slug-collision check), and the old file is left alone rather than deleted.
- **A failed move is not a lost pack.** On `OSError` — read-only mount, permissions — the pack is logged and still loaded from the legacy folder. A failed migration degrades to the old behaviour instead of dropping the questions.

## The reload path

`quizify.reload_packs`, declared in `services.yaml` with strings in all five locales (en/de/es/fr/nl). It runs `reload_categories()` in an executor (glob + JSON parse of every pack is blocking I/O), and:

- **It is refused outside the lobby.** A running game's queue was built from the packs as they were; swapping the bank underneath it would point the round the players are answering at questions that are no longer loaded. `ServiceValidationError` with a message that says so.
- **The `_loaded` short-circuit cannot defeat it.** `load_all_categories` grew a `force` flag that is evaluated inside the method, so a concurrent load re-setting `_loaded` between the caller's reset and the call cannot turn a requested reload into a silent no-op.
- **The reload now also clears `_pack_versions`.** It did not before. The admin category chips and `/api/quizify/packs` are rendered from that metadata, so a reload that only cleared `_categories` kept offering a chip for a pack the host had just deleted. The stale queue from the previous load is dropped too.

## Docs

`questions/community/README.md` now opens with a warning not to drop packs there, names `<config>/quizify/packs/`, explains the automatic migration, and documents the reload service. The main README's "Custom Question Packs" section says the same and explains why the integration directory is the wrong place. The promise and the code finally agree.

## Tests

`tests/test_community_pack_location_743.py`, 19 tests: the new scan root, a pack surviving a simulated HACS wipe of the whole integration tree, the legacy folder still loading the shipped example, the no-runtime fallback, the migration and each of its three refusals (shipped / name collision / `OSError`), reload picking up a late arrival, `force=True` beating the short-circuit, a deleted pack leaving `get_pack_versions()`, the `services.yaml` and per-locale strings, the README promise, and the service end to end on a real `hass` fixture (registered, wired to the config dir, picks up a pack dropped on a running HA, refused mid-game, `ServiceValidationError` after unload).

**They fail without the fix.** With the source changes stashed the module cannot even import (`ImportError: cannot import name 'COMMUNITY_PACKS_DIRNAME'`). Restoring the new API surface but reverting the *behaviour* — single scan root, no migration, no `force`, no service — fails 12 of the 19 individually; the 7 that still pass are the ones asserting unchanged or gracefully-degraded behaviour, which is the point of having them.

Full gates green: `pytest -q` 2469 passed, `ruff check custom_components/` clean, `mypy custom_components/` clean. No `www/js/` changes, so no bundle rebuild.

## Not in this PR

The issue also mentions a lobby button wired to the reload and the validator/loader mismatch in `pack_submission.py:167-172` (estimate and image questions the loader accepts). Both are separate changes; this one is the data loss and the missing reload path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE
