### PR TITLE
fix: the reconnect snapshot forwards the frame instead of re-listing it

### DIFF
--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -2821,6 +2821,12 @@ class QuizifyGameState:
                 # style and the remaining time below to resume the blur at the
                 # right point instead of snapping to sharp.
                 "reveal_style": q.reveal_style,
+                # #730/#731: unconditionally, not only for estimates. The live
+                # ``question_started`` always carries the type, so a snapshot
+                # that only carries it sometimes is a field the restore path
+                # cannot forward without knowing which case it is in — exactly
+                # the asymmetry the parity test now forbids.
+                "question_type": q.type,
                 "time_limit": self._round_duration,
                 "time_remaining": round(remaining, 1),
             }
@@ -2828,7 +2834,6 @@ class QuizifyGameState:
             # answers so a reconnecting player rebuilds the slider, not the
             # 3-answer grid.
             if q.is_estimate:
-                snapshot["question"]["question_type"] = q.type
                 snapshot["question"]["estimate"] = {
                     "min": q.estimate_min,
                     "max": q.estimate_max,
@@ -2993,6 +2998,11 @@ class QuizifyGameState:
                     # shuffle is projected in round_message_builder.
                     "answers": [a.text for a in hs.question.answers],
                     "category": hs.question.category,
+                    # #730: the live ``hot_seat_question`` sends this to every
+                    # phone already, so withholding it here bought no secrecy
+                    # — it only left the restore path with one more field it
+                    # could never forward.
+                    "difficulty": hs.question.difficulty,
                     "image_url": hs.question.image_url,
                 }
             if stage == "result":

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -599,25 +599,7 @@
             case 'QUESTION_ACTIVE':
             case 'PLAYING':
                 if (msg.question) {
-                    handleQuestionStarted({
-                        question_text: msg.question.text,
-                        answers: msg.question.answers,
-                        // Use time_remaining for mid-round joiners, fall back to time_limit
-                        timer_duration: msg.question.time_remaining || msg.question.time_limit,
-                        round_num: msg.round,
-                        total_rounds: msg.total_rounds,
-                        category: msg.question.category,
-                        // #275: carry the question type + estimate metadata +
-                        // image through the snapshot path too. Without these the
-                        // first question (admin-as-player redirect lands on the
-                        // game_state snapshot, not a question_started event) fell
-                        // back to the A/B/C grid — estimate rounds rendered the
-                        // multiple-choice layout, and image questions lost their
-                        // banner — until the next per-round message arrived.
-                        question_type: msg.question.question_type,
-                        estimate: msg.question.estimate,
-                        image_url: msg.question.image_url
-                    });
+                    handleQuestionStarted(questionStartedFromSnapshot(msg));
 
                     // #14: if we're reconnecting mid-round and server thinks
                     // we've already submitted, lock the UI accordingly so we
@@ -827,6 +809,51 @@
             }
         }
         return 0;
+    }
+
+    /**
+     * A snapshot's ``question`` block, in the shape ``question_started`` has
+     * (#730/#731).
+     *
+     * This used to be an object literal that re-listed, by hand, every field
+     * worth forwarding — so every field added to the live payload had to be
+     * remembered a second time here, and twice it was not. #275 caught
+     * question_type / estimate / image_url only after estimate rounds had been
+     * rendering as an A/B/C grid, and reveal_style (#434) was never carried at
+     * all: a phone that reloaded during a progressive-reveal question got the
+     * picture sharp and could read the answer off it (#731).
+     *
+     * So it forwards the frame instead of re-listing it. Every key the server
+     * puts in ``snapshot.question`` rides along untouched, and only the fields
+     * that genuinely differ between "the round just started" and "the round is
+     * half over and this phone just came back" are named below. Adding a field
+     * to the live path now carries it here for free — and
+     * tests/test_snapshot_restore_parity_730_731.py fails if the snapshot ever
+     * stops carrying one of them.
+     */
+    function questionStartedFromSnapshot(msg) {
+        var q = msg.question || {};
+        var live = {};
+        for (var k in q) {
+            if (Object.prototype.hasOwnProperty.call(q, k)) live[k] = q[k];
+        }
+        // The live event's name for the same string.
+        live.question_text = q.text;
+        // The clock is the one thing a restore must NOT copy: the round is
+        // already running, so the countdown gets what is left of it rather
+        // than a fresh full round. time_limit is the fallback for a snapshot
+        // taken before the phase controller has a deadline.
+        live.timer_duration = q.time_remaining || q.time_limit;
+        // ...but the progressive blur is a fraction of the WHOLE round
+        // (remaining / duration). Handed time_remaining it would compute 1.0
+        // and restart the blur at maximum instead of resuming it two thirds
+        // of the way through — which is a different bug, not a fix (#731).
+        live.reveal_duration = q.time_limit || q.time_remaining;
+        // Not in the question block: the snapshot carries these one level up.
+        live.round_num = msg.round;
+        live.total_rounds = msg.total_rounds;
+        live.player_score = _myScore(msg);
+        return live;
     }
 
     /**

--- a/custom_components/quizify/www/js/player-game.js
+++ b/custom_components/quizify/www/js/player-game.js
@@ -393,7 +393,23 @@
         // shown (server already sanitises; this is defence-in-depth).
         // Absent/invalid/load-error → the banner is hidden so the answer
         // pills stay reachable above the fold (graceful text-only fallback).
-        renderQuestionImageBanner(data.image_url, data.reveal_style, data.timer_duration);
+        // #731: the blur is a fraction of the round, not of what is left of
+        // it. On the live path the two are the same number, so timer_duration
+        // was fine; on a restore it is the remaining seconds, which would draw
+        // full blur at the moment the phone comes back and then sharpen twice
+        // as fast. reveal_duration is the full round, set by the restore path.
+        renderQuestionImageBanner(
+            data.image_url, data.reveal_style,
+            data.reveal_duration || data.timer_duration
+        );
+        // Paint the blur at the position the round is actually at, rather than
+        // waiting up to a second for the first timer tick to correct it — on a
+        // restore that first frame would otherwise be the wrong picture. Guarded
+        // because renderQuestion is reached from paths that carry no clock, and
+        // a non-number here would compute a NaN blur radius.
+        if (typeof data.timer_duration === 'number') {
+            setRevealBlur(data.timer_duration);
+        }
 
         // #275: branch on the question type. Estimate questions swap the 3-
         // answer grid for a slider (Variant B). Toggle the two sections and

--- a/custom_components/quizify/www/js/player-hotseat.js
+++ b/custom_components/quizify/www/js/player-hotseat.js
@@ -379,14 +379,47 @@
                 stake: hs.stake,
                 bids: hs.bids || []
             });
-            handleQuestion({
-                you_are_seated: !!hs.you_are_seated,
-                answers: (hs.question && hs.question.answers) || [],
-                winner: hs.winner,
-                score: hs.own_bank
-            });
+            handleQuestion(questionMessageFromSnapshot(hs));
             if (hs.you_bet) lockBetUi(hs.you_bet);
         }
+    }
+
+    /**
+     * A snapshot's ``hot_seat`` block, in the shape ``hot_seat_question`` has
+     * (#730).
+     *
+     * The hand-written list this replaces forgot the question itself. The
+     * snapshot has carried ``hot_seat.question.text`` since #664 and the live
+     * handler has rendered it since #698 — but the restore path named four
+     * fields and ``question`` was not one of them, so the seat holder whose
+     * phone locked came back to three answer buttons under a blank question
+     * (fresh page) or the previous round's (in-tab reconnect), with the clock
+     * running and an unanswered question costing the whole stake (#653).
+     *
+     * Forwarding the frame is what stops that happening a third time: every
+     * key the server puts in the question block rides along, and only the
+     * fields that live outside it, or that a restore must recompute, are named
+     * here. See tests/test_snapshot_restore_parity_730_731.py.
+     */
+    function questionMessageFromSnapshot(hs) {
+        var q = hs.question || {};
+        var msg = {};
+        for (var k in q) {
+            if (Object.prototype.hasOwnProperty.call(q, k)) msg[k] = q[k];
+        }
+        // The live event's name for the same string — and the field #730 is
+        // about.
+        msg.question = q.text;
+        msg.answers = q.answers || [];
+        // Block-level, not question-level.
+        msg.winner = hs.winner;
+        msg.you_are_seated = !!hs.you_are_seated;
+        // The live payload sends the full answer window; a phone rejoining
+        // mid-window gets what the room has left of it, never a fresh one.
+        msg.seconds = hs.time_remaining;
+        // The bank the bets are percentages of, as of the auction.
+        msg.score = hs.own_bank;
+        return msg;
     }
 
     function lockBidUi(pct) {

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -4130,14 +4130,47 @@
                 stake: hs.stake,
                 bids: hs.bids || []
             });
-            handleQuestion({
-                you_are_seated: !!hs.you_are_seated,
-                answers: (hs.question && hs.question.answers) || [],
-                winner: hs.winner,
-                score: hs.own_bank
-            });
+            handleQuestion(questionMessageFromSnapshot(hs));
             if (hs.you_bet) lockBetUi(hs.you_bet);
         }
+    }
+
+    /**
+     * A snapshot's ``hot_seat`` block, in the shape ``hot_seat_question`` has
+     * (#730).
+     *
+     * The hand-written list this replaces forgot the question itself. The
+     * snapshot has carried ``hot_seat.question.text`` since #664 and the live
+     * handler has rendered it since #698 — but the restore path named four
+     * fields and ``question`` was not one of them, so the seat holder whose
+     * phone locked came back to three answer buttons under a blank question
+     * (fresh page) or the previous round's (in-tab reconnect), with the clock
+     * running and an unanswered question costing the whole stake (#653).
+     *
+     * Forwarding the frame is what stops that happening a third time: every
+     * key the server puts in the question block rides along, and only the
+     * fields that live outside it, or that a restore must recompute, are named
+     * here. See tests/test_snapshot_restore_parity_730_731.py.
+     */
+    function questionMessageFromSnapshot(hs) {
+        var q = hs.question || {};
+        var msg = {};
+        for (var k in q) {
+            if (Object.prototype.hasOwnProperty.call(q, k)) msg[k] = q[k];
+        }
+        // The live event's name for the same string — and the field #730 is
+        // about.
+        msg.question = q.text;
+        msg.answers = q.answers || [];
+        // Block-level, not question-level.
+        msg.winner = hs.winner;
+        msg.you_are_seated = !!hs.you_are_seated;
+        // The live payload sends the full answer window; a phone rejoining
+        // mid-window gets what the room has left of it, never a fresh one.
+        msg.seconds = hs.time_remaining;
+        // The bank the bets are percentages of, as of the auction.
+        msg.score = hs.own_bank;
+        return msg;
     }
 
     function lockBidUi(pct) {
@@ -4579,7 +4612,23 @@
         // shown (server already sanitises; this is defence-in-depth).
         // Absent/invalid/load-error → the banner is hidden so the answer
         // pills stay reachable above the fold (graceful text-only fallback).
-        renderQuestionImageBanner(data.image_url, data.reveal_style, data.timer_duration);
+        // #731: the blur is a fraction of the round, not of what is left of
+        // it. On the live path the two are the same number, so timer_duration
+        // was fine; on a restore it is the remaining seconds, which would draw
+        // full blur at the moment the phone comes back and then sharpen twice
+        // as fast. reveal_duration is the full round, set by the restore path.
+        renderQuestionImageBanner(
+            data.image_url, data.reveal_style,
+            data.reveal_duration || data.timer_duration
+        );
+        // Paint the blur at the position the round is actually at, rather than
+        // waiting up to a second for the first timer tick to correct it — on a
+        // restore that first frame would otherwise be the wrong picture. Guarded
+        // because renderQuestion is reached from paths that carry no clock, and
+        // a non-number here would compute a NaN blur radius.
+        if (typeof data.timer_duration === 'number') {
+            setRevealBlur(data.timer_duration);
+        }
 
         // #275: branch on the question type. Estimate questions swap the 3-
         // answer grid for a slider (Variant B). Toggle the two sections and
@@ -6166,25 +6215,7 @@
             case 'QUESTION_ACTIVE':
             case 'PLAYING':
                 if (msg.question) {
-                    handleQuestionStarted({
-                        question_text: msg.question.text,
-                        answers: msg.question.answers,
-                        // Use time_remaining for mid-round joiners, fall back to time_limit
-                        timer_duration: msg.question.time_remaining || msg.question.time_limit,
-                        round_num: msg.round,
-                        total_rounds: msg.total_rounds,
-                        category: msg.question.category,
-                        // #275: carry the question type + estimate metadata +
-                        // image through the snapshot path too. Without these the
-                        // first question (admin-as-player redirect lands on the
-                        // game_state snapshot, not a question_started event) fell
-                        // back to the A/B/C grid — estimate rounds rendered the
-                        // multiple-choice layout, and image questions lost their
-                        // banner — until the next per-round message arrived.
-                        question_type: msg.question.question_type,
-                        estimate: msg.question.estimate,
-                        image_url: msg.question.image_url
-                    });
+                    handleQuestionStarted(questionStartedFromSnapshot(msg));
 
                     // #14: if we're reconnecting mid-round and server thinks
                     // we've already submitted, lock the UI accordingly so we
@@ -6394,6 +6425,51 @@
             }
         }
         return 0;
+    }
+
+    /**
+     * A snapshot's ``question`` block, in the shape ``question_started`` has
+     * (#730/#731).
+     *
+     * This used to be an object literal that re-listed, by hand, every field
+     * worth forwarding — so every field added to the live payload had to be
+     * remembered a second time here, and twice it was not. #275 caught
+     * question_type / estimate / image_url only after estimate rounds had been
+     * rendering as an A/B/C grid, and reveal_style (#434) was never carried at
+     * all: a phone that reloaded during a progressive-reveal question got the
+     * picture sharp and could read the answer off it (#731).
+     *
+     * So it forwards the frame instead of re-listing it. Every key the server
+     * puts in ``snapshot.question`` rides along untouched, and only the fields
+     * that genuinely differ between "the round just started" and "the round is
+     * half over and this phone just came back" are named below. Adding a field
+     * to the live path now carries it here for free — and
+     * tests/test_snapshot_restore_parity_730_731.py fails if the snapshot ever
+     * stops carrying one of them.
+     */
+    function questionStartedFromSnapshot(msg) {
+        var q = msg.question || {};
+        var live = {};
+        for (var k in q) {
+            if (Object.prototype.hasOwnProperty.call(q, k)) live[k] = q[k];
+        }
+        // The live event's name for the same string.
+        live.question_text = q.text;
+        // The clock is the one thing a restore must NOT copy: the round is
+        // already running, so the countdown gets what is left of it rather
+        // than a fresh full round. time_limit is the fallback for a snapshot
+        // taken before the phase controller has a deadline.
+        live.timer_duration = q.time_remaining || q.time_limit;
+        // ...but the progressive blur is a fraction of the WHOLE round
+        // (remaining / duration). Handed time_remaining it would compute 1.0
+        // and restart the blur at maximum instead of resuming it two thirds
+        // of the way through — which is a different bug, not a fix (#731).
+        live.reveal_duration = q.time_limit || q.time_remaining;
+        // Not in the question block: the snapshot carries these one level up.
+        live.round_num = msg.round;
+        live.total_rounds = msg.total_rounds;
+        live.player_score = _myScore(msg);
+        return live;
     }
 
     /**

--- a/tests/test_snapshot_restore_parity_730_731.py
+++ b/tests/test_snapshot_restore_parity_730_731.py
@@ -1,0 +1,416 @@
+"""The restore path must carry what the live path carries (#730, #731).
+
+Two bugs, one shape. A phone that reloads mid-round never receives the one-shot
+event that opened the round — those are not re-sent — so the client rebuilds the
+same view from the ``game_state`` snapshot instead. Both restore paths did that
+by re-listing, in an object literal, the fields worth forwarding. Which means
+every field added to a live payload has to be remembered a second time, in a
+different file, by whoever adds it. Twice it was not:
+
+* **#730** — ``question`` was missing from the Hot Seat list. The snapshot has
+  carried ``hot_seat.question.text`` since #664 and the live handler has
+  rendered it since #698, but the restore never passed it. The seat holder
+  whose phone locked came back to three answer buttons under a blank question
+  (fresh page) or the previous round's (in-tab reconnect), clock running — and
+  an unanswered Hot Seat question costs the entire stake (#653).
+* **#731** — ``reveal_style`` was missing from the question list. A progressive
+  reveal starts the picture blurred and sharpens it as the timer drains, which
+  is only a mechanic if *no* phone can shortcut it. A reload handed that phone
+  the sharp picture for the rest of the round: cheap, repeatable, silent.
+
+#275 was the same bug a third time, caught earlier: estimate rounds rendered as
+an A/B/C grid because ``question_type``/``estimate`` were not on the list yet.
+
+So the fix is not "add the two fields". Both restore paths now forward the
+frame — every key the server puts in the block rides along — and name only the
+fields a restore must genuinely source elsewhere or recompute. The tests below
+pin both halves:
+
+1. the client forwards a field it has never heard of (run under node, on the
+   real functions), so a hand-written list cannot come back; and
+2. the server snapshot carries every field the live payload does, with the
+   handful of exceptions written out by name — so the client's forwarding has
+   something to forward.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO))
+
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+from custom_components.quizify.server.round_message_builder import (  # noqa: E402
+    RoundMessageBuilder,
+)
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    serialize_question_for_player,
+)
+
+JS = _REPO / "custom_components" / "quizify" / "www" / "js"
+PLAYER_CORE = JS / "player-core.js"
+PLAYER_GAME = JS / "player-game.js"
+PLAYER_HOTSEAT = JS / "player-hotseat.js"
+WEBSOCKET = _REPO / "custom_components" / "quizify" / "server" / "websocket.py"
+
+needs_node = pytest.mark.skipif(
+    shutil.which("node") is None, reason="node not installed"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+def _js_function(path: Path, name: str) -> str:
+    """The full source of a top-level ``function <name>(...) { ... }``.
+
+    Brace-matched rather than line-counted so the extraction survives the
+    function moving or growing. A missing function is an assertion failure with
+    a readable message, not an IndexError: this helper is how the tests below
+    reach the code under test, and "the restore path went back to a hand-written
+    literal" should read as exactly that.
+    """
+    source = path.read_text(encoding="utf-8")
+    marker = f"function {name}("
+    assert marker in source, f"{path.name} has no {marker[:-1]}"
+    start = source.index(marker)
+    depth, j = 0, source.index("{", start)
+    while True:
+        if source[j] == "{":
+            depth += 1
+        elif source[j] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : j + 1]
+        j += 1
+
+
+def _node(script: str) -> dict:
+    out = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, check=True
+    ).stdout
+    return json.loads(out)
+
+
+# ---------------------------------------------------------------------------
+# The client forwards the frame — the guard against a hand-written list
+# ---------------------------------------------------------------------------
+
+# A field name no version of this repo has ever seen. If the restore path is
+# re-listing fields by hand it cannot possibly forward this; if it forwards the
+# frame it cannot possibly drop it. That is the whole class of bug, in one key.
+_FUTURE_FIELD = "a_field_added_next_year"
+
+_SNAPSHOT_QUESTION = {
+    "text": "Which city is this?",
+    "answers": ["Lisbon", "Porto", "Faro"],
+    "category": "Geography",
+    "difficulty": "easy",
+    "image_url": "/quizify/static/img/packs/city.jpg",
+    "reveal_style": "progressive",
+    "question_type": "multiple_choice",
+    "time_limit": 30,
+    "time_remaining": 12.5,
+    _FUTURE_FIELD: "carried",
+}
+
+
+def _restored_question() -> dict:
+    """Run the real restore builder over a snapshot, under node.
+
+    ``_myScore`` reads the module's player state, which a snapshot on its own
+    cannot provide, so it is stubbed; everything else is the shipped function.
+    """
+    snapshot = {
+        "round": 3,
+        "total_rounds": 10,
+        "leaderboard": [],
+        "question": dict(_SNAPSHOT_QUESTION),
+    }
+    call = f"questionStartedFromSnapshot({json.dumps(snapshot)})"
+    return _node(
+        _js_function(PLAYER_CORE, "questionStartedFromSnapshot")
+        + "\nfunction _myScore() { return 42; }\n"
+        + f"console.log(JSON.stringify({call}));"
+    )
+
+
+@needs_node
+def test_the_question_restore_forwards_a_field_it_has_never_heard_of() -> None:
+    """The #731 fix, stated as the class rather than the instance."""
+    live = _restored_question()
+    assert live[_FUTURE_FIELD] == "carried", (
+        "the restore path is re-listing fields by hand again — the next field "
+        "added to question_started will be dropped exactly like reveal_style was"
+    )
+
+
+@needs_node
+def test_the_question_restore_carries_the_reveal_style() -> None:
+    """#731 itself: the field whose absence handed one phone the sharp picture."""
+    live = _restored_question()
+    assert live["reveal_style"] == "progressive"
+    assert live["image_url"] == _SNAPSHOT_QUESTION["image_url"]
+
+
+@needs_node
+def test_the_restored_clock_is_what_is_left_and_the_blur_is_the_whole_round() -> None:
+    """The two numbers that must NOT be the same on a restore.
+
+    The countdown gets the remaining seconds — a reconnect may not buy thinking
+    time. The blur is drawn as ``remaining / duration``, so it needs the full
+    round: given the remainder it computes 1.0 and restarts the reveal at
+    maximum blur, then sharpens at double speed. Right field, wrong number, and
+    the mechanic is broken in the other direction.
+    """
+    live = _restored_question()
+    assert live["timer_duration"] == 12.5, "the countdown must resume, not restart"
+    assert live["reveal_duration"] == 30, "the blur fraction is of the whole round"
+    assert live["question_text"] == _SNAPSHOT_QUESTION["text"]
+    assert live["round_num"] == 3 and live["total_rounds"] == 10
+
+
+def test_the_banner_takes_the_reveal_duration_when_the_restore_supplies_one() -> None:
+    """``reveal_duration`` is only carried if renderQuestion actually reads it."""
+    source = PLAYER_GAME.read_text(encoding="utf-8")
+    assert "data.reveal_duration || data.timer_duration" in source, (
+        "renderQuestion still hands the banner timer_duration, so a restore "
+        "restarts the progressive blur at maximum instead of resuming it (#731)"
+    )
+
+
+@needs_node
+def test_the_hot_seat_restore_carries_the_question_and_an_unknown_field() -> None:
+    """#730 and its class in one run.
+
+    ``question`` is the field the hand-written list forgot; the unknown one is
+    every field it would forget next.
+    """
+    hot_seat = {
+        "stage": "question",
+        "winner": "Anna",
+        "own_bank": 40,
+        "you_are_seated": True,
+        "time_remaining": 11.5,
+        "answer_seconds": 20,
+        "question": {
+            "text": "Which city is this?",
+            "answers": ["Lisbon", "Porto", "Faro"],
+            "category": "Geography",
+            "difficulty": "easy",
+            "image_url": "/quizify/static/img/packs/city.jpg",
+            _FUTURE_FIELD: "carried",
+        },
+    }
+    call = f"questionMessageFromSnapshot({json.dumps(hot_seat)})"
+    msg = _node(
+        _js_function(PLAYER_HOTSEAT, "questionMessageFromSnapshot")
+        + f"\nconsole.log(JSON.stringify({call}));"
+    )
+    assert msg["question"] == "Which city is this?", (
+        "the seat holder who reloads still gets the answer grid with no "
+        "question, and a timeout costs the whole stake (#730/#653)"
+    )
+    assert msg[_FUTURE_FIELD] == "carried"
+    assert msg["answers"] == ["Lisbon", "Porto", "Faro"]
+    assert msg["you_are_seated"] is True
+    assert msg["winner"] == "Anna"
+    assert msg["score"] == 40
+    # The room's remaining seconds, not a fresh window.
+    assert msg["seconds"] == 11.5
+
+
+# ---------------------------------------------------------------------------
+# The server carries what the client forwards
+# ---------------------------------------------------------------------------
+
+# Every field of the live ``question_started`` that snapshot["question"] does
+# NOT hold — each one named, with where the restore path gets it instead. This
+# map is the whole point of the test: adding a field to the live payload without
+# adding it to the snapshot fails here, and the only way to pass is to carry it
+# or to write down, here, why a restore sources it elsewhere.
+QUESTION_SOURCED_ELSEWHERE = {
+    "type": "the message envelope — a snapshot is not a question_started",
+    "question_text": 'renamed: snapshot["question"]["text"]',
+    "timer_duration": "recomputed: the remaining seconds, never a fresh round",
+    "round_num": 'snapshot["round"]',
+    "total_rounds": 'snapshot["total_rounds"]',
+    "player_score": 'snapshot["leaderboard"]',
+    "is_final_round": "derived: round_num >= total_rounds (isFinalRound)",
+}
+
+# The same map for the Hot Seat question. Shorter, because the restore reads
+# both the block and its nested question, so most fields are simply there.
+HOT_SEAT_SOURCED_ELSEWHERE = {
+    "type": "the message envelope",
+    "question": 'renamed: hot_seat["question"]["text"]',
+    "round_num": 'snapshot["round"]',
+    "total_rounds": 'snapshot["total_rounds"]',
+    "seconds": 'recomputed: hot_seat["time_remaining"]',
+    "score": 'renamed: hot_seat["own_bank"]',
+}
+
+
+def _game_in_question_active(tmp_path: Path, category: str) -> QuizifyGameState:
+    state = QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+    state.add_player("Alice", _ws())
+    state.add_player("Bob", _ws())
+    state.start_game(category=category, language="de", num_rounds=3, difficulty="easy")
+    assert state.start_next_question() is not None
+    assert state.phase == GamePhase.QUESTION_ACTIVE
+    return state
+
+
+@pytest.mark.parametrize(
+    "category",
+    [
+        # A multiple-choice pack and an estimate pack (#275): the estimate path
+        # adds fields to both payloads, and the parity has to hold for both.
+        "geographie",
+        "schaetzfragen-de",
+    ],
+)
+def test_every_live_question_field_reaches_the_snapshot(
+    tmp_path: Path, category: str
+) -> None:
+    state = _game_in_question_active(tmp_path, category)
+    question = state.get_current_question()
+    assert question is not None
+
+    live = serialize_question_for_player(
+        question,
+        [a.text for a in question.answers],
+        round_num=1,
+        total_rounds=3,
+        timer_duration=30.0,
+        player_score=0,
+    )
+    snapshot_question = state.get_state_snapshot()["question"]
+
+    missing = set(live) - set(snapshot_question)
+    assert missing == set(QUESTION_SOURCED_ELSEWHERE), (
+        "question_started and the snapshot have drifted apart. Fields the live "
+        f"path sends and the snapshot does not carry: "
+        f"{sorted(missing - set(QUESTION_SOURCED_ELSEWHERE))}. Either add them "
+        "to the snapshot in get_state_snapshot(), or add them to "
+        "QUESTION_SOURCED_ELSEWHERE with the reason a restore sources them "
+        "elsewhere. Fields listed as exceptions that the live path no longer "
+        f"sends: {sorted(set(QUESTION_SOURCED_ELSEWHERE) - missing)}."
+    )
+
+
+def test_the_question_type_is_in_the_snapshot_for_every_question(
+    tmp_path: Path,
+) -> None:
+    """It used to be added only for estimates.
+
+    A field the snapshot carries *sometimes* is worse than one it never
+    carries: the restore path cannot forward it without knowing which case it
+    is in, which is how the hand-written list justified itself.
+    """
+    state = _game_in_question_active(tmp_path, "geographie")
+    assert state.get_state_snapshot()["question"]["question_type"] == "multiple_choice"
+
+
+def _hot_seat_in_question_stage(tmp_path: Path) -> QuizifyGameState:
+    state = QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+    for name in ("Anna", "Ben", "Mira"):
+        state.add_player(name, _ws())
+    state.start_game(
+        category="picture-round-en", difficulty="easy", num_rounds=5, language="en"
+    )
+    for player in state.get_players():
+        player.score = 40
+    state.phase = GamePhase.ANSWER_REVEAL
+    assert state.start_hot_seat_auction()
+    state.hot_seat.record_bid("Anna", 50)
+    assert state.close_hot_seat_auction() == "Anna"
+    return state
+
+
+def _live_hot_seat_question_keys() -> set[str]:
+    """Keys of every ``hot_seat_question`` payload a *phone* receives.
+
+    Read off the source rather than duplicated here, so a field added to the
+    broadcast is picked up without anyone updating this test — the same reason
+    #698 reads the payload literal out of websocket.py. The region stops at the
+    admin/dashboard send: those carry ``correct_index``, which no phone gets and
+    no snapshot may ever hold.
+    """
+    source = WEBSOCKET.read_text(encoding="utf-8")
+    start = source.index('"type": "hot_seat_question"')
+    end = source.index("if sends:", start)
+    return set(re.findall(r'"([a-z_]+)":', source[start:end]))
+
+
+def test_every_live_hot_seat_question_field_reaches_the_snapshot(
+    tmp_path: Path,
+) -> None:
+    state = _hot_seat_in_question_stage(tmp_path)
+    projected = RoundMessageBuilder().project_snapshot_for_player(
+        state, snapshot=state.get_state_snapshot(), player=state.get_player("Anna")
+    )
+    block = projected["hot_seat"]
+    assert block["stage"] == "question"
+
+    # The block's own "question" key is the nested container, not the live
+    # payload's question *text* — dropping it keeps the two from cancelling out
+    # and hiding exactly the field #730 was about.
+    available = (set(block) - {"question"}) | set(block["question"])
+    missing = _live_hot_seat_question_keys() - available
+    assert missing == set(HOT_SEAT_SOURCED_ELSEWHERE), (
+        "hot_seat_question and the snapshot's hot_seat block have drifted "
+        f"apart. Sent live, absent from the snapshot: "
+        f"{sorted(missing - set(HOT_SEAT_SOURCED_ELSEWHERE))}. Carry them in "
+        "get_state_snapshot(), or name them in HOT_SEAT_SOURCED_ELSEWHERE. "
+        f"Listed but no longer sent: "
+        f"{sorted(set(HOT_SEAT_SOURCED_ELSEWHERE) - missing)}."
+    )
+
+
+def test_the_auction_snapshot_still_withholds_the_question(tmp_path: Path) -> None:
+    """The one thing parity must not be allowed to leak.
+
+    Bidding is a bet on yourself, not on a question you have already read, so
+    the auction stage carries no question block at all — and "forward the whole
+    frame" must never turn into "send the whole round early".
+    """
+    state = QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+    for name in ("Anna", "Ben", "Mira"):
+        state.add_player(name, _ws())
+    state.start_game(
+        category="picture-round-en", difficulty="easy", num_rounds=5, language="en"
+    )
+    for player in state.get_players():
+        player.score = 40
+    state.phase = GamePhase.ANSWER_REVEAL
+    assert state.start_hot_seat_auction()
+
+    block = state.get_state_snapshot()["hot_seat"]
+    assert block["stage"] == "auction"
+    assert "question" not in block


### PR DESCRIPTION
Closes #730
Closes #731

## The same defect twice

A phone that reloads mid-round never receives the one-shot event that opened the round — those are not re-sent. So the client rebuilds the view from the `game_state` snapshot instead, and both restore paths did that by re-listing, in an object literal, the fields worth forwarding. Every field added to a live payload therefore had to be remembered a second time, in a different file, by whoever added it.

- **#730** — `question` was not on the Hot Seat list. The snapshot has carried `hot_seat.question.text` since #664 and the live handler has rendered it since #698, but the restore path passed four fields and that was not one of them. The seat holder whose phone locked came back to three answer buttons under a blank question (fresh page) or the previous round's (in-tab reconnect), with the clock running. An unanswered Hot Seat question costs the entire stake (#653).
- **#731** — `reveal_style` was not on the question list, so `renderQuestionImageBanner` was called with `undefined` and drew the picture sharp. A progressive reveal only works if no phone can shortcut it; one refresh at the right second and that player has the full-resolution image for the rest of the round.

#275 was the third instance, caught earlier: estimate rounds rendered as an A/B/C grid because `question_type` / `estimate` / `image_url` were not on the list yet.

## Why not just add the two fields

Because that leaves the fourth one to be found the same way, by someone playing a real game. Both restore paths now **forward the frame**: every key the server puts in the block is copied across, and only the fields a restore must genuinely source elsewhere or recompute are named.

`player-core.js` gains `questionStartedFromSnapshot(msg)`, `player-hotseat.js` gains `questionMessageFromSnapshot(hs)`. New fields on the live path are carried for free the moment the snapshot carries them.

## What deliberately still differs

The task's warning is the load-bearing part of this change, so it is written into the code:

- **The countdown is not copied.** `timer_duration` stays `time_remaining`, not `time_limit` — a reconnect must not buy thinking time.
- **The blur is not the countdown.** `setRevealBlur` draws `remaining / duration`, so the reveal needs the *whole* round. Handed the remainder it computes 1.0 and restarts the blur at maximum, then sharpens at double speed — the right field with the wrong number is a different bug, not a fix. The restore therefore carries a separate `reveal_duration` (the full round), and `renderQuestion` uses `data.reveal_duration || data.timer_duration` so the live path is unchanged.
- **The auction still withholds the question.** Bidding is a bet on yourself, not on a question you have already read. "Forward the whole frame" must not become "send the round early", so there is a test that the auction-stage snapshot carries no question block at all.
- `round_num`, `total_rounds`, `player_score`, `is_final_round`, `you_are_seated`, `winner` and the Hot Seat bank live outside the question block or are derived; each is named in the code and in the test's exception map.

## Server side

Two fields the snapshot could not have forwarded even with a perfect client:

- `question_type` was added to the snapshot only for estimate questions. A field carried *sometimes* is worse than one never carried — it is what makes a hand-written list look necessary. It is now on every question.
- The Hot Seat block did not carry `difficulty`, which the live `hot_seat_question` already broadcasts to every phone. Withholding it bought no secrecy; it only left one more field the restore could never forward.

## Tests — `tests/test_snapshot_restore_parity_730_731.py`

Two layers, because the bug needs both halves to be true.

**The client forwards.** The real builders are extracted from the shipped JS and run under `node` (the pattern from #698; CI hard-requires node via `QUIZIFY_REQUIRE_NODE=1`). Each is handed a snapshot containing a field name no version of this repo has ever seen, and must forward it. A hand-written list cannot pass that, whatever fields it happens to list today.

**The server carries.** `question_started` and `hot_seat_question` are compared against their snapshot blocks key by key. Every live field the snapshot does not hold must appear in a module-level map naming where the restore gets it instead. The comparison is an equality, not a subset, so the map cannot silently rot either: adding a live field without carrying it fails, and leaving a stale exception behind fails too. The Hot Seat's live keys are read out of `websocket.py`, stopping before the admin/dashboard send — those carry `correct_index`, which no phone gets and no snapshot may ever hold.

**Does it fail without the fix?** Verified by stashing the four changed source files and re-running: **8 of 10 fail**, including both reported bugs and both class guards. The 2 that pass are the estimate parametrization (`question_type` was already present in that one case) and the auction-withholds-the-question invariant, which is a guard against this change and must pass both ways.

## Not fixed here

`handleQuestion` in the Hot Seat ignores `category` and `image_url` on the live path too, so a picture question in the chair shows no picture. The restore now forwards both, and the renderer drops them exactly as it does live — a live-path gap, not a restore gap, and out of scope for these two issues.

## Gates

`pytest -q` 2460 passed · `ruff check custom_components/` clean · `mypy custom_components/` clean · `build_bundle.py` + `build_css.py` re-run, regenerated bundle committed (drift job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE
