### PR TITLE
perf: warm the next question's image during the reveal

### DIFF
--- a/custom_components/quizify/game/questions.py
+++ b/custom_components/quizify/game/questions.py
@@ -963,6 +963,24 @@ class QuestionBank:
         self._queue_index += 1
         return question
 
+    def peek_next_question(self) -> Question | None:
+        """The question ``get_next_question`` will serve next, without taking it.
+
+        Read-only twin of the method above: same entry, no ``_queue_index``
+        advance and no lazy ``_build_queue`` (an empty queue means the game has
+        not started, and building one here would hand the *real* draw a
+        different order). Used by the image preload hint (#736), which needs to
+        know the next picture one round early.
+
+        NB: this is only the truthful answer for the plain draw. The adaptive
+        ("auto") mode serves through ``get_next_question_at_difficulty``, which
+        picks a *matching* entry out of the remaining window rather than the
+        head — the caller is responsible for not asking there.
+        """
+        if self._queue_index >= len(self._queue):
+            return None
+        return self._queue[self._queue_index]
+
     def get_next_question_at_difficulty(
         self, target_difficulty: str
     ) -> Question | None:

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -2659,6 +2659,50 @@ class QuizifyGameState:
         """Return the current question, or None."""
         return self._current_question
 
+    def peek_next_image_url(self) -> str | None:
+        """The image the *next* round will show, or None (#736).
+
+        Rides the ``round_summary`` broadcast so every client can warm the
+        picture during the reveal instead of fetching it after
+        ``question_started``, when the countdown deadline is already stamped
+        and up to twenty-one clients pull the same file at once.
+
+        Returns None — no hint, clients preload nothing — in the three cases
+        where the queue head is not what the next round will actually serve:
+
+        * **No next round.** On the last round the game goes to the finale.
+        * **Adaptive difficulty (#40).** ``get_next_question_at_difficulty``
+          picks by calibrated target out of the whole remaining window, so the
+          head is a guess. Warming the wrong file spends the bandwidth this
+          change exists to save.
+        * **A pending detour.** A Lightning Round (#285) or a Hot Seat auction
+          (#616) fires *before* the next queued question and draws from its own
+          pool, so the reveal is followed by the detour rather than by the head.
+
+        A question with no picture yields None too, which is the common case —
+        the hint key is simply absent from the payload then.
+        """
+        if self.round >= self.total_rounds:
+            return None
+        if self._calibrator is not None:
+            return None
+        next_round = self.round + 1
+        if next_round == self._lightning_target_round and not self._lightning_fired:
+            return None
+        if (
+            next_round == self._hot_seat_target_round
+            and not self._hot_seat_fired
+            and not self.team_mode
+        ):
+            # Mirrors ``should_trigger_hot_seat``: the auction is armed in team
+            # mode but never fires there (#669), so the queued question really
+            # is next and the hint stands.
+            return None
+        question = self._question_bank.peek_next_question()
+        if question is None:
+            return None
+        return question.image_url or None
+
     def get_leaderboard(self) -> list[dict[str, Any]]:
         """Return sorted leaderboard data — wire-identical to the live broadcast.
 

--- a/custom_components/quizify/server/protocol.py
+++ b/custom_components/quizify/server/protocol.py
@@ -198,11 +198,14 @@ SERVER_FRAMES: dict[str, FrameSpec] = {
         "last_round",
         "all_answers",
         "answer_distribution",
-        optional=("estimate",),
+        optional=("estimate", "next_image_url"),
         note=(
             "Three index spaces meet here — see the docstring on "
             "``serialize_round_summary``. ``question_id`` is what the 🚩 flag "
-            "button POSTs back. ``estimate`` only on estimate rounds (#275)."
+            "button POSTs back. ``estimate`` only on estimate rounds (#275). "
+            "``next_image_url`` (#736) is the next round's picture, sent only "
+            "when there is something worth warming during the reveal — absent "
+            "rather than empty, so a client can test for the key."
         ),
     ),
     "finale": _spec(

--- a/custom_components/quizify/server/round_message_builder.py
+++ b/custom_components/quizify/server/round_message_builder.py
@@ -363,6 +363,13 @@ class RoundMessageBuilder:
 
         question = summary.question
 
+        # #736: the picture the next round will show, so clients can warm it
+        # during the reveal. Resolved through getattr so the lightweight game
+        # doubles several tests use — which implement only what they exercise —
+        # keep working; they simply get no hint.
+        peek_next_image = getattr(game_state, "peek_next_image_url", None)
+        next_image_url = peek_next_image() if peek_next_image is not None else None
+
         # Estimate rounds (#275) carry no shuffled answers and no correct-tile
         # index — closeness is scored, and the reveal is a number line. Build a
         # minimal summary carrying the ``estimate`` block; the player/TV reveal
@@ -388,6 +395,7 @@ class RoundMessageBuilder:
                 question_id=question.id,
                 question_type=question.type,
                 estimate=summary.estimate,
+                next_image_url=next_image_url,
             )
             if store_cached is not None:
                 store_cached(cache_key, est_msg)
@@ -542,6 +550,7 @@ class RoundMessageBuilder:
             last_round=last_round,
             question_id=summary.question.id,
             display_order=game_state.shuffle_map,
+            next_image_url=next_image_url,
         )
         if store_cached is not None:
             store_cached(cache_key, msg)

--- a/custom_components/quizify/server/serializers.py
+++ b/custom_components/quizify/server/serializers.py
@@ -488,6 +488,7 @@ def serialize_round_summary(
     question_type: str = "multiple_choice",
     estimate: dict[str, Any] | None = None,
     display_order: list[int] | None = None,
+    next_image_url: str | None = None,
 ) -> dict[str, Any]:
     """Build round summary broadcast payload.
 
@@ -506,6 +507,14 @@ def serialize_round_summary(
 
     ``answer_distribution`` is emitted in CANONICAL space so the #151 bars
     attach to the tiles the dashboard actually drew.
+
+    ``next_image_url`` is the picture the NEXT round will show (#736), so
+    clients can warm it while the reveal is on screen instead of after
+    ``question_started``, with the countdown already running. It is a *hint*
+    and nothing more: the key is omitted when there is nothing to warm, and a
+    client that ignores it behaves exactly as before. Critically it is not the
+    round's own image — a client must never render it, only fetch it, or a
+    progressive-reveal question (#434) would be given away a round early.
     """
     # Compute answer distribution from all_answers. `answer_index` on those
     # entries is question-JSON order; the bars hang off the canonical grid,
@@ -544,6 +553,11 @@ def serialize_round_summary(
     # player reveal and the TV dashboard can plot every guess.
     if estimate is not None:
         summary["estimate"] = estimate
+    # #736: only present when there is something to warm. Absent beats a null
+    # here — every existing payload assertion in the suite stays exact, and a
+    # client can test one thing (`if (msg.next_image_url)`) rather than two.
+    if next_image_url:
+        summary["next_image_url"] = next_image_url
     return summary
 
 

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -2099,6 +2099,34 @@
             }
         }
 
+        // Issue #736: warm the NEXT round's picture during the reveal.
+        //
+        // renderQuestionImage above only ever runs on `question_started`, by
+        // which point player-core has already stamped the countdown deadline —
+        // so the image downloads while the clock drains, and every phone in the
+        // room is pulling the same file at the same instant. `round_summary`
+        // carries the hint; the reveal is when nothing else is on the wire.
+        //
+        // Held in a variable because a detached Image with no live reference
+        // can be collected mid-request in some browsers.
+        var preloadedImage = null;
+
+        function preloadNextImage(url) {
+            var safe = (window.QuizifyUtils && window.QuizifyUtils.safeImageUrl)
+                ? window.QuizifyUtils.safeImageUrl(url) : '';
+            if (!safe) return;
+            // DETACHED, never els.questionImage. That element still holds the
+            // round being revealed, so writing to it would swap the picture the
+            // room is looking at for the next one — and a progressive-reveal
+            // question (#434) would arrive unblurred, because the blur is added
+            // by renderQuestionImage and that has not run yet.
+            var img = new Image();
+            img.decoding = 'async';
+            img.onerror = function () { preloadedImage = null; };
+            img.src = safe;
+            preloadedImage = img;
+        }
+
         // ---- WebSocket ----
         function connect() {
             var proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -2185,6 +2213,10 @@
                 case 'round_summary':
                 case 'round_evaluated':
                     handleRoundSummary(msg);
+                    // #736: same preload as the phones. The TV is the 21st
+                    // client in the burst and the only one showing the picture
+                    // full-screen, so it has the most to lose from a late one.
+                    preloadNextImage(msg.next_image_url);
                     break;
                 case 'leaderboard_update':
                     // Kept: nothing has ever sent this (#619 found zero

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -403,6 +403,14 @@
 
             case 'round_summary':
                 handleRoundSummary(msg);
+                // #736: the reveal is the one stretch of the round with an idle
+                // network, and the server has told us which picture comes next.
+                // Warm it here so `question_started` finds it in cache instead
+                // of starting a 21-client burst with the countdown running.
+                if (msg.next_image_url && window.QuizifyPlayerGame
+                    && QuizifyPlayerGame.preloadNextImage) {
+                    QuizifyPlayerGame.preloadNextImage(msg.next_image_url);
+                }
                 break;
 
             case 'finale':

--- a/custom_components/quizify/www/js/player-game.js
+++ b/custom_components/quizify/www/js/player-game.js
@@ -339,6 +339,43 @@
         }
     }
 
+    // Issue #736: warm the NEXT round's picture while the reveal is on screen.
+    //
+    // Without this the first byte of the image is requested by
+    // renderQuestionImageBanner above, i.e. after `question_started` — and
+    // player-core stamps the countdown deadline from `timer_duration` in the
+    // same message, so the clock is already draining while up to twenty-one
+    // clients pull the same ~99 KB (worst case 331 KB) file off Home Assistant
+    // at once. The reveal is dead air on the network, and the hint rides
+    // `round_summary`, so the fetch moves there.
+    //
+    // The reference is kept on purpose: a detached Image with no live
+    // reference is collectable, and some browsers abandon its request.
+    var _preloadedImage = null;
+
+    function preloadNextImage(imgUrl) {
+        // Same sanitizer as the banner — a hint from the wire gets no more
+        // trust than the round's own image_url (#536/#540).
+        var safeImg = (window.QuizifyUtils && window.QuizifyUtils.safeImageUrl)
+            ? window.QuizifyUtils.safeImageUrl(imgUrl) : '';
+        if (!safeImg) return;
+        // DETACHED on purpose, and never `#question-image`. The reveal view
+        // keeps the question view's banner element rather than re-rendering it,
+        // so warming that element would paint the NEXT question over the
+        // current reveal — and on a progressive-reveal round (#434) it would
+        // hand out the unblurred picture a whole round early, since the blur is
+        // applied by renderQuestionImageBanner and nothing has run it yet.
+        // A `new Image()` never enters the document, so there is nothing to
+        // show and nothing to blur: it only fills the HTTP cache.
+        var img = new Image();
+        img.decoding = 'async';
+        // Failure is a non-event: the banner will request it again next round
+        // and run its own onerror fallback.
+        img.onerror = function () { _preloadedImage = null; };
+        img.src = safeImg;
+        _preloadedImage = img;
+    }
+
     // Wire the fullscreen zoom overlay once. The overlay shows the current
     // banner image at full size; closing returns to the game view.
     function _initImageZoom() {
@@ -1440,6 +1477,7 @@
         renderQuestion: renderQuestion,
         renderWagerWindow: renderWagerWindow,
         clearRevealBlur: clearRevealBlur,
+        preloadNextImage: preloadNextImage,
         handleAnswerClick: handleAnswerClick,
         confirmGuess: confirmGuess,
         releaseGuess: releaseGuess,

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -4565,6 +4565,43 @@
         }
     }
 
+    // Issue #736: warm the NEXT round's picture while the reveal is on screen.
+    //
+    // Without this the first byte of the image is requested by
+    // renderQuestionImageBanner above, i.e. after `question_started` — and
+    // player-core stamps the countdown deadline from `timer_duration` in the
+    // same message, so the clock is already draining while up to twenty-one
+    // clients pull the same ~99 KB (worst case 331 KB) file off Home Assistant
+    // at once. The reveal is dead air on the network, and the hint rides
+    // `round_summary`, so the fetch moves there.
+    //
+    // The reference is kept on purpose: a detached Image with no live
+    // reference is collectable, and some browsers abandon its request.
+    var _preloadedImage = null;
+
+    function preloadNextImage(imgUrl) {
+        // Same sanitizer as the banner — a hint from the wire gets no more
+        // trust than the round's own image_url (#536/#540).
+        var safeImg = (window.QuizifyUtils && window.QuizifyUtils.safeImageUrl)
+            ? window.QuizifyUtils.safeImageUrl(imgUrl) : '';
+        if (!safeImg) return;
+        // DETACHED on purpose, and never `#question-image`. The reveal view
+        // keeps the question view's banner element rather than re-rendering it,
+        // so warming that element would paint the NEXT question over the
+        // current reveal — and on a progressive-reveal round (#434) it would
+        // hand out the unblurred picture a whole round early, since the blur is
+        // applied by renderQuestionImageBanner and nothing has run it yet.
+        // A `new Image()` never enters the document, so there is nothing to
+        // show and nothing to blur: it only fills the HTTP cache.
+        var img = new Image();
+        img.decoding = 'async';
+        // Failure is a non-event: the banner will request it again next round
+        // and run its own onerror fallback.
+        img.onerror = function () { _preloadedImage = null; };
+        img.src = safeImg;
+        _preloadedImage = img;
+    }
+
     // Wire the fullscreen zoom overlay once. The overlay shows the current
     // banner image at full size; closing returns to the game view.
     function _initImageZoom() {
@@ -5666,6 +5703,7 @@
         renderQuestion: renderQuestion,
         renderWagerWindow: renderWagerWindow,
         clearRevealBlur: clearRevealBlur,
+        preloadNextImage: preloadNextImage,
         handleAnswerClick: handleAnswerClick,
         confirmGuess: confirmGuess,
         releaseGuess: releaseGuess,
@@ -6099,6 +6137,14 @@
 
             case 'round_summary':
                 handleRoundSummary(msg);
+                // #736: the reveal is the one stretch of the round with an idle
+                // network, and the server has told us which picture comes next.
+                // Warm it here so `question_started` finds it in cache instead
+                // of starting a 21-client burst with the countdown running.
+                if (msg.next_image_url && window.QuizifyPlayerGame
+                    && QuizifyPlayerGame.preloadNextImage) {
+                    QuizifyPlayerGame.preloadNextImage(msg.next_image_url);
+                }
                 break;
 
             case 'finale':

--- a/tests/test_image_preload_hint_736.py
+++ b/tests/test_image_preload_hint_736.py
@@ -1,0 +1,361 @@
+"""The next round's picture is warmed during the reveal (#736).
+
+Nothing preloaded a question image. ``renderQuestionImageBanner`` set
+``img.src`` on ``question_started``, the television did the same, and
+``player-core`` stamps the countdown deadline from ``timer_duration`` in that
+very message — so the download started with the clock already draining, and up
+to twenty-one clients pulled the same file at the same instant. The 67 pack
+images average 99 KB and the largest is 331 KB, which makes the worst round a
+~7 MB burst out of Home Assistant at the one moment the round cannot absorb it.
+
+The fix moves the fetch one round earlier, into the reveal — the only stretch
+of a round with an idle network. ``round_summary`` carries a
+``next_image_url`` hint and every client warms it.
+
+Two failure modes are worth more than the speed-up, so they are pinned first:
+
+1. **A hint that is a guess.** Adaptive difficulty (#40) does not serve the
+   queue head, and a Lightning Round (#285) or Hot Seat auction (#616) fires
+   before the next queued question. Warming the wrong file spends exactly the
+   bandwidth this change exists to save.
+2. **A picture shown early.** The reveal keeps the question view's ``<img>``
+   rather than re-rendering it, so a preload that touched that element would
+   paint the next question over the current reveal — and a progressive-reveal
+   question (#434) would arrive unblurred a whole round early, because the blur
+   is applied by the render path and that has not run yet. Every client must
+   preload into a DETACHED ``new Image()``.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.questions import (  # noqa: E402
+    Answer,
+    Question,
+)
+from custom_components.quizify.game.state import (  # noqa: E402
+    QuizifyGameState,
+    RoundSummary,
+)
+from custom_components.quizify.server.round_message_builder import (  # noqa: E402
+    RoundMessageBuilder,
+)
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    serialize_round_summary,
+)
+
+WWW = _REPO_ROOT / "custom_components" / "quizify" / "www"
+
+IMG_NEXT = "/quizify/static/img/packs/picture-round/next.webp"
+
+
+def _fake_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+class _Runtime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+    def create_task(self, coro):  # noqa: ANN001
+        import asyncio
+
+        return asyncio.ensure_future(coro)
+
+
+@pytest.fixture
+def state(tmp_path: Path) -> QuizifyGameState:
+    st = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="test")
+    st.add_player("A", _fake_ws())
+    return st
+
+
+def _question(qid: str, image_url: str = "") -> Question:
+    return Question(
+        id=qid,
+        question=f"Q {qid}?",
+        answers=[Answer("a", True), Answer("b", False), Answer("c", False)],
+        image_url=image_url,
+    )
+
+
+def _pin_queue(state: QuizifyGameState, questions: list[Question]) -> None:
+    """Replace the drawn queue with an explicit one, nothing served yet."""
+    state._question_bank._queue = list(questions)
+    state._question_bank._queue_index = 0
+
+
+# ---------------------------------------------------------------------------
+# The peek itself — read-only, and only where the head is really next
+# ---------------------------------------------------------------------------
+
+
+class TestPeekNextQuestion:
+    def test_peek_returns_the_head_without_consuming_it(
+        self, state: QuizifyGameState
+    ) -> None:
+        state.start_game(num_rounds=10)
+        _pin_queue(state, [_question("q1"), _question("q2")])
+        bank = state._question_bank
+
+        assert bank.peek_next_question().id == "q1"
+        # The whole point: peeking twice must not move the queue on, or the
+        # hint would silently eat the round it is describing.
+        assert bank.peek_next_question().id == "q1"
+        assert bank.get_next_question().id == "q1"
+        assert bank.peek_next_question().id == "q2"
+
+    def test_peek_on_an_exhausted_queue_is_none(
+        self, state: QuizifyGameState
+    ) -> None:
+        state.start_game(num_rounds=10)
+        _pin_queue(state, [_question("q1")])
+        state._question_bank.get_next_question()
+        assert state._question_bank.peek_next_question() is None
+
+
+class TestPeekNextImageUrl:
+    def test_hint_is_the_next_rounds_picture(self, state: QuizifyGameState) -> None:
+        state.start_game(num_rounds=10)
+        _pin_queue(state, [_question("q2", IMG_NEXT)])
+        state.round = 1
+
+        assert state.peek_next_image_url() == IMG_NEXT
+
+    def test_a_next_question_without_a_picture_yields_no_hint(
+        self, state: QuizifyGameState
+    ) -> None:
+        state.start_game(num_rounds=10)
+        _pin_queue(state, [_question("q2")])
+        state.round = 1
+
+        assert state.peek_next_image_url() is None
+
+    def test_no_hint_on_the_last_round(self, state: QuizifyGameState) -> None:
+        """There is no next round — the finale follows."""
+        state.start_game(num_rounds=5)
+        _pin_queue(state, [_question("q6", IMG_NEXT)])
+        state.round = 5
+
+        assert state.peek_next_image_url() is None
+
+    def test_no_hint_in_adaptive_mode(self, state: QuizifyGameState) -> None:
+        """#40 serves by calibrated target, not by queue head.
+
+        The head is a guess there, and a preload of the wrong file costs the
+        room the bandwidth this whole change is meant to give back.
+        """
+        state.start_game(num_rounds=10, difficulty="auto")
+        _pin_queue(state, [_question("q2", IMG_NEXT)])
+        state.round = 1
+
+        assert state.peek_next_image_url() is None
+
+    def test_no_hint_when_a_lightning_round_comes_first(
+        self, state: QuizifyGameState
+    ) -> None:
+        """#285 fires BEFORE the next queued question, from its own pool."""
+        state.start_game(num_rounds=10, lightning_seed=14)
+        assert state.lightning_target_round == 3
+        _pin_queue(state, [_question("q3", IMG_NEXT)])
+
+        state.round = 2  # about to enter round 3 — the Lightning target
+        assert state.peek_next_image_url() is None
+
+        # Once it has fired, the queued question really is next again.
+        state._lightning_fired = True
+        assert state.peek_next_image_url() == IMG_NEXT
+
+    def test_no_hint_when_the_hot_seat_auction_comes_first(
+        self, state: QuizifyGameState
+    ) -> None:
+        state.start_game(num_rounds=10, lightning_enabled=False, hot_seat_seed=14)
+        target = state._hot_seat_target_round
+        assert target is not None
+        _pin_queue(state, [_question("qN", IMG_NEXT)])
+
+        state.round = target - 1
+        assert state.peek_next_image_url() is None
+
+        state._hot_seat_fired = True
+        assert state.peek_next_image_url() == IMG_NEXT
+
+
+# ---------------------------------------------------------------------------
+# The wire: an optional key, absent when there is nothing to warm
+# ---------------------------------------------------------------------------
+
+
+def _summary(**extra) -> dict:
+    return serialize_round_summary(
+        correct_answer_index=0,
+        correct_answer_text="a",
+        fun_fact="",
+        leaderboard=[],
+        round_num=1,
+        total_rounds=10,
+        **extra,
+    )
+
+
+class TestRoundSummaryPayload:
+    def test_hint_rides_the_round_summary(self) -> None:
+        assert _summary(next_image_url=IMG_NEXT)["next_image_url"] == IMG_NEXT
+
+    @pytest.mark.parametrize("value", [None, ""])
+    def test_key_is_absent_when_there_is_nothing_to_warm(self, value) -> None:
+        """Absent, not null.
+
+        Every other payload assertion in the suite stays exact, and a client
+        tests one thing (``if (msg.next_image_url)``) rather than two.
+        """
+        assert "next_image_url" not in _summary(next_image_url=value)
+
+
+class _FakeGameState:
+    """Minimal stand-in exposing only what RoundMessageBuilder touches."""
+
+    def __init__(self, question: Question, *, hint: str | None) -> None:
+        self._question = question
+        self.round = 3
+        self.total_rounds = 10
+        self.round_duration = 20.0
+        self.shuffle_map = [0, 1, 2]
+        self.shuffled_answers = [a.text for a in question.answers]
+        self._summary = RoundSummary(
+            question=question,
+            correct_answer=question.answers[0],
+            fun_fact=question.fun_fact,
+        )
+        if hint is not None:
+            self.peek_next_image_url = lambda: hint  # noqa: E731
+
+    def get_players(self) -> list:
+        return []
+
+    def get_ranked_participants(self) -> list:
+        return []
+
+    def get_player_shuffle(self, player_name: str) -> list[int]:
+        return self.shuffle_map
+
+    def get_round_summary(self) -> RoundSummary:
+        return self._summary
+
+
+class TestBuilderWiring:
+    def test_builder_puts_the_hint_on_the_broadcast(self) -> None:
+        msg = RoundMessageBuilder().build_round_summary(
+            _FakeGameState(_question("q1"), hint=IMG_NEXT)
+        )
+        assert msg["next_image_url"] == IMG_NEXT
+
+    def test_a_state_without_the_peek_still_builds(self) -> None:
+        """Several tests drive the builder with a lightweight double.
+
+        They implement only what they exercise, so the hint is resolved
+        through ``getattr`` — those states simply get no hint rather than an
+        AttributeError mid-broadcast.
+        """
+        msg = RoundMessageBuilder().build_round_summary(
+            _FakeGameState(_question("q1"), hint=None)
+        )
+        assert "next_image_url" not in msg
+
+
+# ---------------------------------------------------------------------------
+# The clients: warm it, never show it
+# ---------------------------------------------------------------------------
+
+
+PLAYER_GAME = WWW / "js" / "player-game.js"
+PLAYER_CORE = WWW / "js" / "player-core.js"
+DASHBOARD = WWW / "dashboard.html"
+
+
+class TestClientsPreload:
+    def test_player_core_warms_the_hint_on_round_summary(self) -> None:
+        src = PLAYER_CORE.read_text("utf-8")
+        block = src.split("case 'round_summary':", 1)[1][:800]
+        assert "next_image_url" in block
+        assert "preloadNextImage" in block
+
+    def test_player_exposes_the_preload_helper(self) -> None:
+        src = PLAYER_GAME.read_text("utf-8")
+        assert "function preloadNextImage(" in src
+        assert "preloadNextImage: preloadNextImage" in src
+
+    def test_television_warms_the_hint_on_round_summary(self) -> None:
+        src = DASHBOARD.read_text("utf-8")
+        assert "function preloadNextImage(" in src
+        assert "preloadNextImage(msg.next_image_url)" in src
+
+    @pytest.mark.parametrize("path", [PLAYER_GAME, DASHBOARD])
+    def test_preload_uses_a_detached_image(self, path: Path) -> None:
+        """The one rule that keeps a progressive-reveal round honest (#434).
+
+        A preload that wrote to the banner element would paint the NEXT
+        question over the reveal the room is still looking at, unblurred —
+        the blur is applied by the render path, and that has not run yet.
+        ``new Image()`` never enters the document, so there is nothing to
+        show and nothing to blur.
+        """
+        body = _function_body(path.read_text("utf-8"), "preloadNextImage")
+        assert "new Image()" in body
+        # Comments stripped: both helpers *name* the banner element to explain
+        # why they stay away from it, and the point is that the code does not
+        # touch it.
+        code = _strip_comments(body)
+        assert "getElementById" not in code
+        assert "questionImage" not in code
+        assert "question-image" not in code
+        assert "image-zoom-img" not in code
+
+    @pytest.mark.parametrize("path", [PLAYER_GAME, DASHBOARD])
+    def test_preload_sanitizes_the_url(self, path: Path) -> None:
+        """A hint off the wire gets no more trust than image_url (#536/#540)."""
+        body = _function_body(path.read_text("utf-8"), "preloadNextImage")
+        assert "safeImageUrl" in body
+
+    @pytest.mark.parametrize("path", [PLAYER_GAME, DASHBOARD])
+    def test_preload_keeps_a_reference_to_the_image(self, path: Path) -> None:
+        """A detached Image with no live reference can be collected mid-request.
+
+        Some browsers then abandon the fetch, which turns the whole preload
+        into a no-op that still looks correct in review.
+        """
+        body = _function_body(path.read_text("utf-8"), "preloadNextImage")
+        assert re.search(r"preloadedImage\s*=\s*img", body, re.IGNORECASE)
+
+
+def _strip_comments(src: str) -> str:
+    """Drop ``//`` line comments so prose about an element isn't read as use."""
+    return "\n".join(re.sub(r"//.*$", "", line) for line in src.splitlines())
+
+
+def _function_body(src: str, name: str) -> str:
+    """Extract ``function <name>(...) { ... }`` by brace balance."""
+    start = src.index(f"function {name}(")
+    depth = 0
+    for i in range(src.index("{", start), len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+    raise AssertionError(f"unbalanced braces in {name}")


### PR DESCRIPTION
Closes #736

## The problem

Nothing preloaded a question image. `renderQuestionImageBanner` set `img.src` on `question_started` (`www/js/player-game.js`), the television did the same (`www/dashboard.html`), and `player-core.js` stamps the countdown deadline from `timer_duration` in that very message. The download therefore started with the clock already draining, and up to twenty-one clients pulled the same file at the same instant.

## What changed

The reveal is the only stretch of a round with an idle network, and by then the server already knows what comes next. `round_summary` now carries an optional `next_image_url`; every client warms it into a **detached** `new Image()`.

* `questions.py` — `peek_next_question()`, a read-only twin of `get_next_question()` (no index advance, no lazy `_build_queue`).
* `state.py` — `peek_next_image_url()`, which decides whether the queue head really is next.
* `serializers.py` / `round_message_builder.py` — the key rides `round_summary`, and is **omitted** rather than null when there is nothing to warm, so every existing payload assertion stays exact and clients test one thing.
* `player-game.js` (`preloadNextImage`, exported), `player-core.js` (dispatch on `round_summary`), `dashboard.html` (the same pair), plus the rebuilt `player.bundle.js`.

The hint is withheld in the three cases where the queue head is a guess: the last round (the finale follows), adaptive difficulty (#40 serves by calibrated target across the whole remaining window), and a round that a Lightning detour (#285) or a Hot Seat auction (#616) fires before — those draw from their own pools. Warming the wrong file spends exactly the bandwidth this change gives back.

## No early reveal

The preload never touches `#question-image`. The reveal view keeps the question view's banner element rather than re-rendering it, so writing to it would paint the *next* question over the reveal the room is looking at — and on a progressive-reveal question (#434) it would arrive **unblurred** a whole round early, because the blur is applied by `renderQuestionImageBanner` and that has not run yet. A `new Image()` never enters the document: nothing to show, nothing to blur. Both clients also run the hint through `QuizifyUtils.safeImageUrl`, so a URL off the wire gets no more trust than `image_url` (#536/#540).

Four tests pin this rather than the prose: the preload body must contain `new Image()`, and (with `//` comments stripped, since both helpers *name* the element to explain why they avoid it) must not contain `getElementById`, `questionImage`, `question-image` or `image-zoom-img`.

## How much of the wait this removes, and how I know

**All of it, on 7 of 10 rounds in a default game.**

*The bytes* — measured over `www/img/packs`, 67 `.webp` files: total 6.32 MiB, mean 96.6 KiB (98,929 B), median 76.6 KiB, p90 193 KiB, max 331 KiB (338,944 B, `picture-round/self-portrait-straw-hat.webp`). This matches the issue's figures. The worst round is 21 × 331 KiB ≈ 6.8 MiB.

*The coverage* — driven through a real `QuizifyGameState` over a full 10-round game (`num_rounds=10, lightning_seed=7, hot_seat_seed=3` → Hot Seat round 4, Lightning round 5). Eight of the ten boundaries produce a hint; one of those eight is the lobby, which never broadcasts a `round_summary`, so **7 of 10 rounds are preloaded**. The three that are not: round 1 (nothing precedes it) and the two detour target rounds. With both detours off — the *With kids* preset, or a host who switched them off — it is 9 of 10.

*The window* — for a preloaded round the fetch is removed from the countdown entirely, not shortened. There is no auto-advance in the codebase: the reveal ends when the host taps "Next Round", so the preload has at least as long as it takes to read a fun fact. On a link where the worst-case 6.8 MiB burst takes the "one to three seconds" the issue reports, that entire window now falls before `question_started` instead of inside it.

## What this does not do

* **Round 1 is still cold.** Its boundary is the lobby, where players are mid-redirect and reconnecting after `start_game`; a preload there competes with the join it depends on. Left alone deliberately.
* **The two detour rounds are still cold.** A Lightning Round or a Hot Seat auction is itself a long idle stretch that could carry the preload — a separate change, with its own hint on its own message.
* **The images are not recompressed.** The issue's second suggestion (≤1280px / ~120 KB) is content work on 67 files and belongs in its own PR; it would cut the burst further rather than move it.

## Gates

`pytest -q` → 2399 passed. `ruff check custom_components/` → clean. `mypy custom_components/` → clean, 48 files. Bundle rebuilt with `scripts/build_bundle.py` and committed.

**Tests fail without the fix** — verified by stashing the nine changed source files: 21 of the 22 new tests fail, and pass again once the stash is restored. The one that passes either way is `test_a_state_without_the_peek_still_builds`, which asserts a lightweight game double still builds a summary; it is a guard on the `getattr` resolution, not a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE
