### PR TITLE
The wire contract in protocol.py is now checked against the frames the server sends

### DIFF
--- a/custom_components/quizify/server/protocol.py
+++ b/custom_components/quizify/server/protocol.py
@@ -1,266 +1,379 @@
-"""Single source of truth for the Quizify WebSocket protocol.
+"""The Quizify WebSocket wire contract — declared here, checked by CI.
 
-Every message that crosses the WS boundary has a typed dataclass here.
-Server code that builds payloads should construct one of these and call
-``.to_dict()`` instead of writing a raw dict literal. That way:
+Every frame the server sends is a plain dict literal built where the event
+happens (``websocket.py``, ``serializers.py``, ``round_message_builder.py``,
+``connection.py``). This module does not build them and is not imported by
+them: it *declares* their field sets, and ``tests/test_protocol.py`` reads the
+real literals out of the source with ``ast`` and fails when a build site and
+the declaration disagree.
 
-* New required fields can't be silently dropped (the dataclass requires
-  them in the constructor).
-* Clients reading the field can grep this file and find every message
-  shape in one place — no more "where does ``best_streak`` come from?".
-* The frontend JS keeps using plain objects, but the TypeScript-style
-  comments below document the shape so a future ``.d.ts`` generator
-  has somewhere to read from.
+That is the whole point of the file. Adding a key to a frame without adding it
+here is a red test, not a silent divergence — which is what happened to
+``all_time`` on ``joined`` and ``teams`` on the roster frame (#749).
 
-This file is intentionally dependency-free: only stdlib, only
-dataclasses. It is imported by ``serializers.py`` and friends; cycles
-would be expensive here, so don't import from those modules back into
-this one.
+What is NOT covered, so nobody reads more into a green run than is there:
+
+* Only dict literals inside ``custom_components/quizify/`` that carry a
+  literal ``"type"`` key, plus the ``d["k"] = v`` lines that add to the same
+  local afterwards. A frame assembled some other way is invisible here.
+  ``game_state`` is the live example: the snapshot in
+  ``game/state.py::get_state_snapshot`` gets its ``type`` stamped on by the
+  caller, so the entry below describes only the leaderboard-refresh literal in
+  ``round_message_builder.py``.
+* Field *names*, not value types. Nothing here catches an int that turned into
+  a string.
+* Frames marked ``dynamic_keys`` merge a dict with ``**`` at the build site;
+  only the keys spelled out in the literal can be checked.
+
+The client→server direction is a flat set of type strings
+(``CLIENT_MESSAGE_TYPES``); the same test pins it against the handler's real
+``_DISPATCH`` table instead of grepping for a source pattern.
+
+Dependency-free on purpose: stdlib only, no imports from the modules it
+describes.
 """
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
-from typing import Any, Literal
+from dataclasses import dataclass, field
 
 # ---------------------------------------------------------------------------
-# Server → Client message shapes
+# Server → Client frames
 # ---------------------------------------------------------------------------
 
 
-@dataclass
-class JoinedMessage:
-    """Confirms a player joined or reconnected.
+@dataclass(frozen=True)
+class FrameSpec:
+    """The declared shape of one server → client frame.
 
-    Sent unicast to the player whose WS just authenticated.
-    Frontend dispatch: handleMessage 'joined' / 'reconnected'.
+    ``required`` keys must be present at EVERY site that builds the frame;
+    ``optional`` keys may be present at some and absent at others (a
+    conditional ``payload["x"] = …`` after the literal, or a second builder
+    that carries fewer fields). ``"type"`` itself is implied and is never
+    listed.
     """
 
-    type: Literal["joined", "reconnected"]
-    player_id: str  # canonical player name
-    session_token: str  # opaque, used to resume after WS drop
-    color: str  # CSS hex, e.g. "#E88A7F"
-    is_admin: bool
-    powerup: str | None = None  # currently held power-up type or None
-
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+    required: frozenset[str]
+    optional: frozenset[str] = field(default_factory=frozenset)
+    #: True when the literal is merged with ``**something`` — the rest of the
+    #: payload is a runtime dict and cannot be checked from the source.
+    dynamic_keys: bool = False
+    note: str = ""
 
 
-@dataclass
-class PlayerListMessage:
-    """Broadcast when the lobby roster changes.
-
-    The client uses this to render the lobby/in-game player chips.
-    Each entry includes ``is_admin`` so the host can show admin controls
-    in the player UI after admin-self-join.
-    """
-
-    type: Literal["player_joined", "player_left"]
-    players: list[dict[str, Any]]
-
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+def _spec(
+    *required: str,
+    optional: tuple[str, ...] = (),
+    dynamic_keys: bool = False,
+    note: str = "",
+) -> FrameSpec:
+    return FrameSpec(
+        required=frozenset(required),
+        optional=frozenset(optional),
+        dynamic_keys=dynamic_keys,
+        note=note,
+    )
 
 
-@dataclass
-class WagerWindowMessage:
-    """The final round's betting window (#656), sent per-player.
-
-    Per-player because ``player_score`` is the bank the slider bets against.
-    Note what is NOT here: ``question_text`` and ``answers``. The bet is
-    placed on the category alone — the question follows in a separate
-    ``question_started`` once the window closes, and only then does a clock
-    start.
-    """
-
-    type: Literal["wager_window"]
-    round_num: int
-    total_rounds: int
-    category: str
-    difficulty: str
-    window_duration: float
-    player_score: int
-
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
-
-
-@dataclass
-class WagerProgressMessage:
-    """Host/TV view of the betting window (#656).
-
-    Carries the tally and who the room is waiting for — never the amounts.
-    ``window_duration`` is present only on the opening message; the refreshes
-    sent as bets arrive omit it so the TV countdown is not restarted.
-    """
-
-    type: Literal["wager_progress"]
-    round_num: int
-    total_rounds: int
-    locked_in: int
-    player_count: int
-    waiting_on: list[str]
-
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
-
-
-@dataclass
-class QuestionStartedMessage:
-    """One round's question, sent per-player so each phone gets its own
-    shuffled A/B/C order (anti-cheat against couch-neighbour collusion).
-
-    ``answers`` is the SHUFFLED list — the client renders these as
-    buttons in order. The server tracks the per-player shuffle map so
-    it can translate the player's submitted index back to the original.
-    """
-
-    type: Literal["question_started"]
-    question_text: str
-    answers: list[str]
-    timer_duration: float
-    round_num: int
-    total_rounds: int
-    category: str
-    difficulty: str
-    # Optional image URL for the question (issue #25). Empty string when
-    # the question carries no image.
-    image_url: str = ""
-    # How that image is uncovered (#434): "" shows it outright, "progressive"
-    # starts it blurred and sharpens it as the timer runs down.
-    reveal_style: str = ""
-
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
-
-
-@dataclass
-class TimerTickMessage:
-    """Sub-second timer update sent per-player.
-
-    Per-player because freeze and time-boost power-ups can change one
-    player's remaining time without changing others'.
-    """
-
-    type: Literal["timer_tick"]
-    remaining: float  # seconds, rounded to 1 decimal
-
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
-
-
-@dataclass
-class AnswerResultMessage:
-    """Unicast reply after a player submits an answer.
-
-    The client uses this to lock the buttons and start the local "I
-    answered" feedback. The full breakdown (speed/streak/difficulty)
-    is also computed here so the reveal screen has data even if the
-    player disconnects before round end.
-    """
-
-    type: Literal["answer_result"]
-    correct: bool
-    points_earned: int
-    speed_bonus: int
-    streak_bonus: int
-    difficulty_multiplier: float
-    new_streak: int = 0
-
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
-
-
-@dataclass
-class RoundSummaryMessage:
-    """Broadcast at end-of-round. Carries the canonical (admin-view)
-    correct answer + distribution; per-player customisation happens in
-    the client which already has its own shuffled buttons.
-
-    ``question_id`` is required by the 🚩 flag-question button — without
-    it, players can't report ambiguous or wrong questions back to the
-    pack maintainer.
-    """
-
-    type: Literal["round_summary"]
-    correct_answer_index: int  # in the CANONICAL shuffle (admin's view)
-    correct_answer: str  # the answer text — clients match on this
-    question_id: str
-    fun_fact: str
-    leaderboard: list[dict[str, Any]]
-    players: list[dict[str, Any]]
-    round: int
-    total_rounds: int
-    last_round: bool
-    all_answers: list[dict[str, Any]]
-    answer_distribution: list[dict[str, Any]]
-    question_text: str
-
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
-
-
-@dataclass
-class FinaleMessage:
-    """Broadcast when the game ends — podium + full leaderboard + superlatives."""
-
-    type: Literal["finale"]
-    podium: list[dict[str, Any]]  # [{rank, name, score}, ...]
-    leaderboard: list[dict[str, Any]]  # full sorted board
-    all_players: list[dict[str, Any]]  # alias of leaderboard (back-compat)
-    superlatives: list[dict[str, Any]] = field(default_factory=list)
-
-    def to_dict(self) -> dict[str, Any]:
-        # asdict on dataclass-with-default-factory works but drops empty
-        # lists/dicts here is intentional — clients tolerate missing keys.
-        return asdict(self)
-
-
-@dataclass
-class GameStateMessage:
-    """Full snapshot — sent to a freshly-connecting client so it can
-    jump to the right view without waiting for the next round event."""
-
-    type: Literal["game_state"]
-    phase: str  # GamePhase enum value
-    round: int
-    total_rounds: int
-    players: list[dict[str, Any]]
-    leaderboard: list[dict[str, Any]] = field(default_factory=list)
-    question: dict[str, Any] | None = None
-    pause_reason: str | None = None  # only set when phase == PAUSED
-
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
-
-
-@dataclass
-class ErrorMessage:
-    """Generic error reply. ``code`` is one of the ERR_* const strings
-    in const.py; client looks up a localized message by code."""
-
-    type: Literal["error"]
-    code: str
-    message: str  # human-readable English fallback
-
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+SERVER_FRAMES: dict[str, FrameSpec] = {
+    # --- join / reconnect -------------------------------------------------
+    "joined": _spec(
+        "player_id",
+        "session_token",
+        "color",
+        "is_admin",
+        "powerup",
+        "all_time",
+        note=(
+            "Unicast to the player whose WS just authenticated. ``all_time`` "
+            "is that one player's standing (#371) and rides this frame rather "
+            "than the roster broadcast, which would ship everyone's history to "
+            "every phone; ``None`` for a first-timer."
+        ),
+    ),
+    "reconnected": _spec(
+        "player_id",
+        "session_token",
+        "powerup",
+        "all_time",
+        note=(
+            "The resume twin of ``joined`` — and deliberately NOT the same "
+            "shape: colour and admin flag are already on the client that is "
+            "reconnecting, so they are not resent."
+        ),
+    ),
+    "reconnect_failed": _spec(
+        note="Unknown or expired session token; the client falls back to join.",
+    ),
+    # --- lobby roster -----------------------------------------------------
+    "player_joined": _spec(
+        "players",
+        "teams",
+        note=(
+            "Roster broadcast, coalesced over one window (#453) so a burst of "
+            "joins is one frame. ``teams`` rides along because a player "
+            "leaving also leaves their team and the last one out dissolves it "
+            "(#365) — without it the lobby keeps showing a team nobody is in."
+        ),
+    ),
+    "player_left": _spec(
+        "players",
+        "teams",
+        note="Same builder and shape as ``player_joined``; only the animation differs.",
+    ),
+    "kicked": _spec(
+        "reason",
+        note="Unicast to the removed player before their socket is closed.",
+    ),
+    "game_reset": _spec(note="Broadcast when the host resets the game."),
+    # --- teams (#365) -----------------------------------------------------
+    "teams_update": _spec("teams"),
+    "team_joined": _spec("team"),
+    "team_left": _spec(),
+    "team_answer": _spec(
+        "team_id",
+        "answer_index",
+        "members",
+        "set_by",
+        "lock_seconds",
+    ),
+    # --- question / round -------------------------------------------------
+    "question_started": _spec(
+        "question_text",
+        "answers",
+        "timer_duration",
+        "round_num",
+        "total_rounds",
+        "category",
+        "difficulty",
+        "image_url",
+        "reveal_style",
+        "question_type",
+        optional=(
+            # serialize_question_for_player only
+            "player_score",
+            "is_final_round",
+            # serialize_question_for_admin only — the TV may show the answer
+            "correct_answer",
+            "estimate",
+        ),
+        note=(
+            "Two builders: the per-player one (own shuffled ``answers``, so "
+            "couch neighbours can't copy an index) and the admin/TV one, which "
+            "adds ``correct_answer`` and drops the per-player fields. Anything "
+            "only one of them sends is optional here."
+        ),
+    ),
+    "timer_tick": _spec(
+        "remaining",
+        note="Per-player: freeze and time-boost change one player's clock only.",
+    ),
+    "answer_result": _spec(
+        "correct",
+        "points_earned",
+        "speed_bonus",
+        "streak_bonus",
+        "difficulty_multiplier",
+        "new_streak",
+        "new_total",
+        "milestone_bonus",
+        "milestone_streak",
+    ),
+    "guess_accepted": _spec(
+        note="Estimate-round ack so the client can lock its slider.",
+    ),
+    "answer_progress": _spec("submitted", "total", "players"),
+    "streak_milestone": _spec("player_name", "streak", "bonus"),
+    "round_summary": _spec(
+        "correct_answer_index",
+        "correct_answer_index_original",
+        "correct_answer",
+        "question_id",
+        "question_text",
+        "question_type",
+        "fun_fact",
+        "leaderboard",
+        "players",
+        "round",
+        "total_rounds",
+        "last_round",
+        "all_answers",
+        "answer_distribution",
+        optional=("estimate",),
+        note=(
+            "Three index spaces meet here — see the docstring on "
+            "``serialize_round_summary``. ``question_id`` is what the 🚩 flag "
+            "button POSTs back. ``estimate`` only on estimate rounds (#275)."
+        ),
+    ),
+    "finale": _spec(
+        "podium",
+        "leaderboard",
+        "all_players",
+        optional=("superlatives", "share"),
+        note=(
+            "``all_players`` is the same list object as ``leaderboard`` (#415); "
+            "``superlatives`` is omitted when empty rather than sent as []."
+        ),
+    ),
+    "evening_tally": _spec(
+        dynamic_keys=True,
+        note="The tally dict is spread into the frame (#612).",
+    ),
+    "head_to_head": _spec(
+        "at",
+        dynamic_keys=True,
+        note="The duel dict is spread into the frame (#613).",
+    ),
+    "all_time_update": _spec("all_time"),
+    "game_state": _spec(
+        "phase",
+        "round",
+        "total_rounds",
+        "players",
+        "leaderboard",
+        "player_count",
+        optional=("lightning",),
+        note=(
+            "Declared for the leaderboard-refresh literal in "
+            "``round_message_builder``. The full snapshot sent on connect and "
+            "reconnect is built in ``game/state.py::get_state_snapshot`` and "
+            "typed by its caller, so it is outside what this file can check."
+        ),
+    ),
+    # --- wager (#656) -----------------------------------------------------
+    "wager_window": _spec(
+        "round_num",
+        "total_rounds",
+        "category",
+        "difficulty",
+        "window_duration",
+        "player_score",
+        note=(
+            "Per-player, because ``player_score`` is the bank the slider bets "
+            "against. No question text: the bet is placed on the category "
+            "alone, and the question follows in its own ``question_started``."
+        ),
+    ),
+    "wager_progress": _spec(
+        "round_num",
+        "total_rounds",
+        "locked_in",
+        "player_count",
+        "waiting_on",
+        optional=("window_duration", "category", "difficulty"),
+        note=(
+            "Host/TV view: the tally and who the room waits for, never the "
+            "amounts. The three optional fields mark the OPENING message; the "
+            "refreshes sent as bets arrive omit them so the TV countdown is "
+            "not restarted."
+        ),
+    ),
+    "wager_accepted": _spec("wager"),
+    # --- power-ups --------------------------------------------------------
+    "powerup_assigned": _spec("powerup_type"),
+    "powerup_applied": _spec(
+        "powerup_type",
+        "source_player",
+        optional=(
+            "target_player",
+            "joker_remove_index",
+            "freeze_duration",
+            "stolen_points",
+        ),
+        note=(
+            "One type string, three build sites: only the fields that power-up "
+            "actually carries are sent, so everything past the source player "
+            "is optional."
+        ),
+    ),
+    # --- reactions --------------------------------------------------------
+    "reaction": _spec("player_name", "emoji"),
+    "reaction_bonus": _spec(
+        "from_player",
+        "from_players",
+        "to_players",
+        "leaderboard",
+    ),
+    # --- lightning round (#42, #285) --------------------------------------
+    "lightning_splash": _spec("num_questions", "seconds_per_question"),
+    "lightning_question": _spec(
+        "index",
+        "num_questions",
+        "question_text",
+        "answers",
+        "category",
+        "image_url",
+        "seconds",
+    ),
+    "lightning_tick": _spec("index", "remaining"),
+    "lightning_answer_result": _spec("index", "correct", "score"),
+    "lightning_team_answer": _spec(
+        "index",
+        "answer_index",
+        "members",
+        "set_by",
+        "lock_seconds",
+    ),
+    "lightning_recap": _spec("recap"),
+    # --- hot seat (#616) --------------------------------------------------
+    "hot_seat_auction": _spec("round_num", "total_rounds", "seconds", "players"),
+    "hot_seat_auction_you": _spec("seconds", "score"),
+    "hot_seat_bid_accepted": _spec("bid", "points"),
+    "hot_seat_bid_count": _spec("count", "total"),
+    "hot_seat_bet_accepted": _spec("bet", "side", "points"),
+    "hot_seat_no_bids": _spec(),
+    "hot_seat_awarded": _spec("winner", "bids", "stake", "pct"),
+    "hot_seat_question": _spec(
+        "round_num",
+        "total_rounds",
+        "winner",
+        "question",
+        "difficulty",
+        "image_url",
+        "seconds",
+    ),
+    "hot_seat_answer_accepted": _spec(),
+    "hot_seat_tick": _spec("phase", "remaining"),
+    "hot_seat_result": _spec(
+        "round_num",
+        "total_rounds",
+        "scores",
+        dynamic_keys=True,
+        note="The settlement dict is spread into the frame.",
+    ),
+    # --- errors -----------------------------------------------------------
+    "error": _spec(
+        "code",
+        "message",
+        note=(
+            "``code`` is one of the ERR_* constants in const.py; the client "
+            "looks up a localized string by code and uses ``message`` — plain "
+            "English — only as a fallback."
+        ),
+    ),
+}
 
 
 # ---------------------------------------------------------------------------
-# Client → Server message keys (no dataclasses — the server validates
-# field by field in _handle_*). Listed here so a future schema-aware
-# router can swap in a real validator.
+# Client → Server message types
 # ---------------------------------------------------------------------------
 
-#: Every message type the server's _handle_message dispatch accepts.
-#: Kept as a frozenset so tests can assert dispatch coverage. NOTE:
-#: "reaction" is BOTH a client→server message (player taps an emoji
-#: button → server may award a +1 bonus during reveal) AND a server→
-#: client broadcast (every other client sees the floating animation).
-CLIENT_MESSAGE_TYPES: frozenset[str] = frozenset({
-    "admin_connect",
+#: Types that never reach ``QuizifyWebSocketHandler._DISPATCH``: they are
+#: handled before it, on their own authorization paths.
+OUT_OF_BAND_CLIENT_TYPES: frozenset[str] = frozenset({
+    "admin_connect",  # first frame of an ?role=admin socket
+    "admin_auth",     # token frame that grants that socket the admin role
+    "reset_game",     # allowed from a non-admin socket in specific states
+})
+
+#: Every message type the server accepts from a client. The dispatched ones
+#: must equal ``_DISPATCH.keys()`` exactly — the test imports the handler and
+#: compares, so a type added to one side and not the other is a red run.
+#: NOTE: "reaction" travels in BOTH directions — a player taps an emoji
+#: (client→server, may earn a +1 during reveal) and every other client sees
+#: the floating animation (server→client).
+CLIENT_MESSAGE_TYPES: frozenset[str] = OUT_OF_BAND_CLIENT_TYPES | frozenset({
     "join",
     "reconnect",
     "get_state",
@@ -277,12 +390,15 @@ CLIENT_MESSAGE_TYPES: frozenset[str] = frozenset({
     "next_question",
     "next_round",
     "end_game",
-    "reset_game",
     "play_again",
     "pause_game",
     "resume_game",
     "admin_skip",
     "kick_player",
+    # Host configuration (#494, #281), gated on WS-level admin (#724) because
+    # both reach Home Assistant service calls with host-supplied entity ids.
+    "configure_tts",
+    "configure_house",
     # Lightning Round (issue #42 mechanics, #285 auto-trigger): the round now
     # fires automatically mid-game — there is no host start/end action any
     # more. Players still submit via lightning_answer (separate from
@@ -295,45 +411,3 @@ CLIENT_MESSAGE_TYPES: frozenset[str] = frozenset({
     "join_team",
     "leave_team",
 })
-
-
-# ---------------------------------------------------------------------------
-# Equivalent TypeScript declarations — kept hand-maintained as a comment
-# block so a future generator has the right starting point. Update both
-# sides when the dataclasses above change.
-# ---------------------------------------------------------------------------
-
-TYPESCRIPT_DECLARATIONS = """
-// Hand-maintained mirror of server/protocol.py. Update both when the
-// shape changes — there is no codegen yet.
-//
-// type WsServerMessage =
-//   | { type: 'joined' | 'reconnected'; player_id: string; session_token: string;
-//       color: string; is_admin: boolean; powerup: string | null; }
-//   | { type: 'player_joined' | 'player_left'; players: Player[]; }
-//   | { type: 'wager_window'; round_num: number; total_rounds: number;
-//       category: string; difficulty: string; window_duration: number;
-//       player_score: number; }
-//   | { type: 'wager_progress'; round_num: number; total_rounds: number;
-//       locked_in: number; player_count: number; waiting_on: string[];
-//       window_duration?: number; category?: string; difficulty?: string; }
-//   | { type: 'question_started'; question_text: string; answers: string[];
-//       timer_duration: number; round_num: number; total_rounds: number;
-//       category: string; difficulty: string; image_url?: string;
-//       reveal_style?: '' | 'progressive'; }
-//   | { type: 'timer_tick'; remaining: number; }
-//   | { type: 'answer_result'; correct: boolean; points_earned: number;
-//       speed_bonus: number; streak_bonus: number; difficulty_multiplier: number;
-//       new_streak: number; }
-//   | { type: 'round_summary'; correct_answer_index: number; correct_answer: string;
-//       question_id: string; fun_fact: string; leaderboard: LeaderboardEntry[];
-//       players: Player[]; round: number; total_rounds: number; last_round: boolean;
-//       all_answers: AnswerEntry[]; answer_distribution: DistEntry[];
-//       question_text: string; }
-//   | { type: 'finale'; podium: PodiumEntry[]; leaderboard: LeaderboardEntry[];
-//       all_players: LeaderboardEntry[]; superlatives: Superlative[]; }
-//   | { type: 'game_state'; phase: GamePhase; round: number; total_rounds: number;
-//       players: Player[]; leaderboard?: LeaderboardEntry[]; question?: QuestionState;
-//       pause_reason?: 'admin_paused' | 'admin_disconnected'; }
-//   | { type: 'error'; code: string; message: string; };
-"""

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -80,8 +80,10 @@ _LOGGER = logging.getLogger(__name__)
 # Single source of truth for the wire strings the dispatch table keys on, so
 # a typo is a NameError at import time instead of a silently-dead branch.
 # ``admin_connect`` and ``reset_game`` live OUTSIDE the dispatch table (special
-# authorization paths) but are named here for completeness. Keep in sync with
-# ``server/protocol.py::CLIENT_MESSAGE_TYPES``.
+# authorization paths) but are named here for completeness.
+# ``server/protocol.py::CLIENT_MESSAGE_TYPES`` declares the same set for the
+# client side; ``tests/test_protocol.py`` compares it against ``_DISPATCH``
+# below, so the two cannot drift apart unnoticed (#749).
 MSG_ADMIN_CONNECT = "admin_connect"
 MSG_RESET_GAME = "reset_game"
 MSG_JOIN = "join"

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,156 +1,369 @@
-"""Tests for the WebSocket protocol contract.
+"""The wire contract in ``server/protocol.py``, checked against the source.
 
-These tests guard against the C3 class of bug: server code adds/removes
-a field in a payload, but the client still reads the old key and gets
-``undefined``. The dataclasses in server/protocol.py are the single
-source of truth; tests here check they serialize to the shape the
-client expects, and that the server's actual dispatch covers every
-client-message type listed in CLIENT_MESSAGE_TYPES.
+Guards the C3 class of bug: the server adds or drops a key in a payload, the
+client still reads the old one and gets ``undefined``.
+
+This file replaces a guard that could not fail. The previous version grepped
+``websocket.py`` for ``msg_type == "…"``; the #363 dispatch-table refactor
+removed that pattern entirely, so the matched set was always empty and
+``test_no_orphan_handlers`` passed on an empty comparison for months while
+``all_time`` and ``teams`` drifted onto live frames (#749).
+
+Nothing is grepped now:
+
+* the server→client frames are parsed out of the real dict literals with
+  ``ast`` and compared field-by-field with ``SERVER_FRAMES``;
+* ``CLIENT_MESSAGE_TYPES`` is compared against the handler's imported
+  ``_DISPATCH`` table.
+
+To prove it can fail: add a key to any frame in ``server/websocket.py`` and
+run this file — ``test_no_build_site_sends_an_undeclared_key`` goes red and
+names the key, the frame and the line.
 """
 
 from __future__ import annotations
 
+import ast
 import sys
+from collections import defaultdict
+from dataclasses import dataclass
 from pathlib import Path
-
-import pytest
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(_REPO_ROOT))
 
 from custom_components.quizify.server.protocol import (  # noqa: E402
     CLIENT_MESSAGE_TYPES,
-    AnswerResultMessage,
-    ErrorMessage,
-    FinaleMessage,
-    GameStateMessage,
-    JoinedMessage,
-    PlayerListMessage,
-    QuestionStartedMessage,
-    RoundSummaryMessage,
-    TimerTickMessage,
+    OUT_OF_BAND_CLIENT_TYPES,
+    SERVER_FRAMES,
 )
 
+_PACKAGE = _REPO_ROOT / "custom_components" / "quizify"
 
-class TestServerMessageShapes:
-    def test_joined_has_required_fields(self) -> None:
-        m = JoinedMessage(
-            type="joined",
-            player_id="Alice",
-            session_token="abc",
-            color="#FF6B6B",
-            is_admin=False,
-        ).to_dict()
-        for k in ("type", "player_id", "session_token", "color", "is_admin", "powerup"):
-            assert k in m
+# The one frame whose wire ``type`` is a variable rather than a literal: the
+# coalesced roster broadcast picks ``player_joined`` or ``player_left`` at
+# flush time (#453). Keyed by ``module::function`` so it survives edits above
+# it, and asserted to be the ONLY such site — a second one has to be declared
+# here on purpose rather than slipping through unchecked.
+_DYNAMIC_TYPE_SITES: dict[str, tuple[str, ...]] = {
+    "server/websocket.py::_flush_roster_after_window": (
+        "player_joined",
+        "player_left",
+    ),
+}
 
-    def test_question_started_carries_shuffled_answers(self) -> None:
-        m = QuestionStartedMessage(
-            type="question_started",
-            question_text="?",
-            answers=["A", "B", "C"],
-            timer_duration=30.0,
-            round_num=1,
-            total_rounds=10,
-            category="cat",
-            difficulty="medium",
-        ).to_dict()
-        assert m["answers"] == ["A", "B", "C"]
-        assert m["timer_duration"] == 30.0
 
-    def test_round_summary_includes_question_id_for_flag_button(self) -> None:
-        m = RoundSummaryMessage(
-            type="round_summary",
-            correct_answer_index=0,
-            correct_answer="Foo",
-            question_id="geo_037",  # required by 🚩 button
-            fun_fact="",
-            leaderboard=[],
-            players=[],
-            round=1,
-            total_rounds=10,
-            last_round=False,
-            all_answers=[],
-            answer_distribution=[],
-            question_text="?",
-        ).to_dict()
-        assert m["question_id"] == "geo_037"
+@dataclass(frozen=True)
+class _FrameSite:
+    """One dict literal in the source that builds a wire frame."""
 
-    def test_finale_default_collections(self) -> None:
-        m = FinaleMessage(
-            type="finale",
-            podium=[],
-            leaderboard=[],
-            all_players=[],
-        ).to_dict()
-        assert m["superlatives"] == []
+    module: str
+    lineno: int
+    function: str
+    #: The literal ``type`` value, or None when it is a variable.
+    type_name: str | None
+    #: Value of a non-literal ``type``, unparsed — for the error message.
+    type_expr: str
+    #: Everything the frame can carry: the literal keys plus any added by a
+    #: later ``payload["x"] = …`` on the same local.
+    keys: frozenset[str]
+    #: Only the keys spelled out in the literal itself. A key added by a
+    #: later assignment may sit behind an ``if``, so it cannot be treated as
+    #: unconditionally present.
+    literal_keys: frozenset[str]
+    has_spread: bool
 
-    def test_game_state_phase_field(self) -> None:
-        m = GameStateMessage(
-            type="game_state",
-            phase="LOBBY",
-            round=0,
-            total_rounds=10,
-            players=[],
-        ).to_dict()
-        assert m["phase"] == "LOBBY"
+    @property
+    def where(self) -> str:
+        return f"{self.module}:{self.lineno} ({self.function})"
 
-    def test_error_round_trip(self) -> None:
-        m = ErrorMessage(type="error", code="INVALID_ACTION", message="nope").to_dict()
-        assert m == {"type": "error", "code": "INVALID_ACTION", "message": "nope"}
+    @property
+    def scope_key(self) -> str:
+        return f"{self.module}::{self.function}"
+
+
+def _own_nodes(scope: ast.AST) -> list[ast.AST]:
+    """Every node belonging to ``scope``, not descending into nested defs."""
+    out: list[ast.AST] = []
+    stack: list[ast.AST] = [scope]
+    while stack:
+        node = stack.pop()
+        out.append(node)
+        for child in ast.iter_child_nodes(node):
+            # A nested def is its own scope and gets its own pass, so its
+            # locals never bleed into this one.
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            stack.append(child)
+    return out
+
+
+def _scopes(tree: ast.Module) -> list[tuple[str, ast.AST]]:
+    scopes: list[tuple[str, ast.AST]] = [("<module>", tree)]
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            scopes.append((node.name, node))
+    return scopes
+
+
+def _literal_str_key(node: ast.expr | None) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _scan_module(path: Path, module: str) -> list[_FrameSite]:
+    tree = ast.parse(path.read_text("utf-8"))
+    sites: list[_FrameSite] = []
+    seen: set[int] = set()
+
+    for func_name, scope in _scopes(tree):
+        nodes = _own_nodes(scope)
+
+        # ``payload = {...}`` — remember which local holds which literal.
+        holder_of: dict[int, str] = {}
+        for node in nodes:
+            if isinstance(node, ast.Assign) and len(node.targets) == 1:
+                target, value = node.targets[0], node.value
+            elif isinstance(node, ast.AnnAssign) and node.value is not None:
+                target, value = node.target, node.value
+            else:
+                continue
+            if isinstance(target, ast.Name) and isinstance(value, ast.Dict):
+                holder_of[id(value)] = target.id
+
+        # ``payload["extra"] = …`` — a conditional field on the same frame.
+        added_later: dict[str, set[str]] = defaultdict(set)
+        for node in nodes:
+            if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+                continue
+            target = node.targets[0]
+            if not isinstance(target, ast.Subscript):
+                continue
+            key = _literal_str_key(target.slice)
+            if isinstance(target.value, ast.Name) and key is not None:
+                added_later[target.value.id].add(key)
+
+        for node in nodes:
+            if not isinstance(node, ast.Dict) or id(node) in seen:
+                continue
+            keys: set[str] = set()
+            type_name: str | None = None
+            type_expr = ""
+            has_type = False
+            has_spread = False
+            for key_node, value_node in zip(node.keys, node.values, strict=True):
+                if key_node is None:
+                    has_spread = True
+                    continue
+                key = _literal_str_key(key_node)
+                if key is None:
+                    continue
+                keys.add(key)
+                if key == "type":
+                    has_type = True
+                    type_name = _literal_str_key(value_node)
+                    if type_name is None:
+                        type_expr = ast.unparse(value_node)
+            if not has_type:
+                continue
+            seen.add(id(node))
+            literal_keys = set(keys)
+            holder = holder_of.get(id(node))
+            if holder is not None:
+                keys |= added_later.get(holder, set())
+            sites.append(
+                _FrameSite(
+                    module=module,
+                    lineno=node.lineno,
+                    function=func_name,
+                    type_name=type_name,
+                    type_expr=type_expr,
+                    keys=frozenset(keys - {"type"}),
+                    literal_keys=frozenset(literal_keys - {"type"}),
+                    has_spread=has_spread,
+                )
+            )
+    return sites
+
+
+def _scan_package() -> list[_FrameSite]:
+    sites: list[_FrameSite] = []
+    for path in sorted(_PACKAGE.rglob("*.py")):
+        sites.extend(_scan_module(path, path.relative_to(_PACKAGE).as_posix()))
+    return sites
+
+
+SITES = _scan_package()
+LITERAL_SITES = [s for s in SITES if s.type_name is not None]
+DYNAMIC_SITES = [s for s in SITES if s.type_name is None]
+
+
+class TestScannerItself:
+    """If the scanner stops finding frames the rest of this file is vacuous —
+    exactly the failure mode #749 was about. Pin a floor and a known frame."""
+
+    def test_the_scan_finds_the_frames(self) -> None:
+        assert len(LITERAL_SITES) > 40, (
+            "The frame scanner found almost nothing — it has stopped matching "
+            "how the server builds payloads, so every other test here passes "
+            "on an empty set."
+        )
+
+    def test_a_known_frame_is_seen_with_its_fields(self) -> None:
+        joined = [s for s in LITERAL_SITES if s.type_name == "joined"]
+        assert joined, "No build site found for the 'joined' frame"
+        assert "session_token" in joined[0].keys
+
+
+class TestServerFrames:
+    def test_every_frame_built_is_declared(self) -> None:
+        built = {s.type_name for s in LITERAL_SITES}
+        undeclared = sorted(built - set(SERVER_FRAMES))
+        assert not undeclared, (
+            f"Frames the server sends with nothing declared in protocol.py: "
+            f"{undeclared}. Add a FrameSpec for each."
+        )
+
+    def test_every_declared_frame_is_built(self) -> None:
+        built = {s.type_name for s in LITERAL_SITES}
+        for scoped in _DYNAMIC_TYPE_SITES.values():
+            built |= set(scoped)
+        unbuilt = sorted(set(SERVER_FRAMES) - built)
+        assert not unbuilt, (
+            f"protocol.py declares frames no build site sends: {unbuilt}. "
+            "Either the frame was removed (drop the FrameSpec) or it is "
+            "assembled in a way this scan cannot see (say so in its note)."
+        )
+
+    def test_every_build_site_sends_the_required_keys(self) -> None:
+        problems: list[str] = []
+        for site in LITERAL_SITES:
+            spec = SERVER_FRAMES.get(site.type_name or "")
+            if spec is None:
+                continue
+            missing = sorted(spec.required - site.keys)
+            if missing:
+                problems.append(
+                    f"{site.type_name} at {site.where} is missing declared "
+                    f"required field(s) {missing}"
+                )
+        assert not problems, "\n".join(problems)
+
+    def test_no_build_site_sends_an_undeclared_key(self) -> None:
+        problems: list[str] = []
+        for site in LITERAL_SITES:
+            spec = SERVER_FRAMES.get(site.type_name or "")
+            if spec is None:
+                continue
+            extra = sorted(site.keys - spec.required - spec.optional)
+            if extra:
+                problems.append(
+                    f"{site.type_name} at {site.where} sends undeclared "
+                    f"field(s) {extra} — add them to its FrameSpec in "
+                    f"server/protocol.py (required if every build site sends "
+                    f"them, optional otherwise)"
+                )
+        assert not problems, "\n".join(problems)
+
+    def test_declared_optional_fields_are_really_optional(self) -> None:
+        """A field spelled out in every build site's literal is required —
+        leaving it optional lets a builder quietly stop sending it.
+
+        Only literal keys count. A ``payload["x"] = …`` after the literal may
+        sit behind an ``if``, and from the source alone there is no telling.
+        """
+        sites_by_type: dict[str, list[_FrameSite]] = defaultdict(list)
+        for site in LITERAL_SITES:
+            sites_by_type[site.type_name or ""].append(site)
+        problems: list[str] = []
+        for type_name, spec in SERVER_FRAMES.items():
+            sites = sites_by_type.get(type_name, [])
+            if not sites or spec.dynamic_keys:
+                continue
+            always = set.intersection(*(set(s.literal_keys) for s in sites))
+            over_declared = sorted(spec.optional & always)
+            if over_declared:
+                problems.append(
+                    f"{type_name}: {over_declared} declared optional but sent "
+                    f"by every build site — move them to required"
+                )
+        assert not problems, "\n".join(problems)
+
+    def test_spread_sites_are_the_declared_ones(self) -> None:
+        """``{**payload, "type": …}`` hides the rest of the fields from this
+        scan. Which frames do that is part of the contract, not an accident."""
+        spread_in_source = {
+            s.type_name for s in LITERAL_SITES if s.has_spread
+        }
+        declared = {t for t, spec in SERVER_FRAMES.items() if spec.dynamic_keys}
+        assert spread_in_source == declared, (
+            f"Frames merging a runtime dict with ** : {sorted(spread_in_source)}; "
+            f"declared as dynamic_keys: {sorted(declared)}. These must match — "
+            "the fields of a spread frame cannot be checked from the source, "
+            "so protocol.py has to say which frames give that up."
+        )
+
+    def test_dynamically_typed_frames_are_declared(self) -> None:
+        found = {s.scope_key: s for s in DYNAMIC_SITES}
+        assert set(found) == set(_DYNAMIC_TYPE_SITES), (
+            f"Frames whose wire 'type' is a variable: {sorted(found)}; "
+            f"accounted for: {sorted(_DYNAMIC_TYPE_SITES)}. A frame typed at "
+            "runtime cannot be matched to a FrameSpec automatically — list it "
+            "in _DYNAMIC_TYPE_SITES with the types it can carry."
+        )
+        problems: list[str] = []
+        for scope_key, type_names in _DYNAMIC_TYPE_SITES.items():
+            site = found[scope_key]
+            for type_name in type_names:
+                spec = SERVER_FRAMES[type_name]
+                missing = sorted(spec.required - site.keys)
+                extra = sorted(site.keys - spec.required - spec.optional)
+                if missing or extra:
+                    problems.append(
+                        f"{type_name} at {site.where} (type from "
+                        f"{site.type_expr!r}): missing {missing}, "
+                        f"undeclared {extra}"
+                    )
+        assert not problems, "\n".join(problems)
 
 
 class TestClientDispatchCoverage:
-    """The server's _handle_message dispatch must implement every key
-    listed in CLIENT_MESSAGE_TYPES. If a new key is added to the set
-    here without a handler, this test fails — prevents silent typos."""
+    """``CLIENT_MESSAGE_TYPES`` against the handler's real dispatch table.
 
-    def test_every_listed_client_message_is_handled(self) -> None:
-        # Read websocket.py and grep the dispatch — cheaper than
-        # importing the full ws machinery (which needs aiohttp + a
-        # runtime). Direct text search is brittle but acceptable for
-        # what's essentially a compile-time check.
-        ws_src = (
-            _REPO_ROOT
-            / "custom_components"
-            / "quizify"
-            / "server"
-            / "websocket.py"
-        ).read_text("utf-8")
+    Imported, not grepped — that is the #749 fix. Importing ``websocket``
+    needs aiohttp, which the test requirements already pull in.
+    """
 
-        missing: list[str] = []
-        for msg_type in CLIENT_MESSAGE_TYPES:
-            needle = f'msg_type == "{msg_type}"'
-            if needle not in ws_src and f"msg_type in (\"{msg_type}\"" not in ws_src:
-                # Some types are matched via `in (...)` — check generously
-                if f'"{msg_type}"' not in ws_src:
-                    missing.append(msg_type)
-        assert not missing, f"Client message types with no server handler: {missing}"
+    def test_declared_types_match_the_dispatch_table(self) -> None:
+        from custom_components.quizify.server.websocket import (
+            QuizifyWebSocketHandler,
+        )
 
-    def test_no_orphan_handlers(self) -> None:
-        """If the server handles a type that's NOT in CLIENT_MESSAGE_TYPES,
-        flag it — usually that's a leftover/dead branch."""
-        import re
+        dispatched = set(QuizifyWebSocketHandler._DISPATCH)
+        declared = set(CLIENT_MESSAGE_TYPES) - set(OUT_OF_BAND_CLIENT_TYPES)
+        assert declared == dispatched, (
+            f"Declared but not dispatched: {sorted(declared - dispatched)}; "
+            f"dispatched but not declared: {sorted(dispatched - declared)}. "
+            "Add the type to CLIENT_MESSAGE_TYPES or remove the handler."
+        )
 
-        ws_src = (
-            _REPO_ROOT
-            / "custom_components"
-            / "quizify"
-            / "server"
-            / "websocket.py"
-        ).read_text("utf-8")
+    def test_out_of_band_types_are_not_in_the_dispatch_table(self) -> None:
+        from custom_components.quizify.server.websocket import (
+            QuizifyWebSocketHandler,
+        )
 
-        # Find every msg_type == "X" comparison
-        found = set(re.findall(r'msg_type == "([a-z_]+)"', ws_src))
-        # Also find msg_type in ("X", "Y") tuples
-        for match in re.findall(r'msg_type in \(([^)]+)\)', ws_src):
-            for piece in match.split(","):
-                piece = piece.strip().strip('"').strip("'")
-                if piece:
-                    found.add(piece)
+        overlap = OUT_OF_BAND_CLIENT_TYPES & set(QuizifyWebSocketHandler._DISPATCH)
+        assert not overlap, (
+            f"{sorted(overlap)} are declared as handled before the dispatch "
+            "table but are also in it — one of the two is wrong."
+        )
 
-        orphans = found - CLIENT_MESSAGE_TYPES
-        assert not orphans, (
-            f"Server handles client-message types not in protocol contract: {orphans}. "
-            "Add them to CLIENT_MESSAGE_TYPES or remove the handler."
+    def test_out_of_band_types_are_handled_in_the_source(self) -> None:
+        """These three take their own authorization paths, so there is no
+        table to compare against; assert each is at least reachable."""
+        ws_src = (_PACKAGE / "server" / "websocket.py").read_text("utf-8")
+        missing = [t for t in OUT_OF_BAND_CLIENT_TYPES if f'"{t}"' not in ws_src]
+        assert not missing, (
+            f"Out-of-band client types with no mention in websocket.py: {missing}"
         )


### PR DESCRIPTION
Closes #749.

## The choice

The issue offered two end states. I took the first one — **make the contract real but small** — but with one part of the second folded in: the dataclasses are deleted.

Both halves of that need an argument.

**Why not delete the file.** The drift happened because nothing checked. Deleting `protocol.py` and moving the truth next to the frames means moving it into comments, and a comment enforces exactly as much as the docstring that started this issue did. Something has to hold a declaration a test can compare against, and this file is the obvious place for it. Made real, it earns its keep on the first frame someone edits.

**Why not keep the dataclasses.** They existed to be constructed from, and after making them accurate they would still be constructed by nobody — a second hand-maintained copy of the field names, which is the failure mode being fixed. Keeping them and adding a checkable table would have meant two declarations of the same thing drifting against each other. So the file keeps its job and loses the mechanism that never did it.

**Why not the obvious refactor.** Building every frame through `protocol.py` means touching a 4.5k-line `websocket.py` and two serializer modules — not this week's entry, and not necessary for the goal. The declaration is checked against the literals where they are.

## What changed

`SERVER_FRAMES` maps each of the 47 server→client frame types to a `FrameSpec` — required fields, optional fields, and a note. `tests/test_protocol.py` walks `custom_components/quizify/` with `ast`, pulls the field set out of every dict literal carrying a `"type"` key (plus the `payload["x"] = …` lines that add to the same local afterwards), and compares. A key at a build site that is not declared, or a declared required key a build site does not send, is a red test that names the key, the frame and the line.

The declared shapes are what the server sends **today**, drift included and now written down:

- `joined` carries `all_time` (#371);
- `player_joined` / `player_left` carry `teams` (#365);
- `reconnected` is its own shape — it never sent the `color`/`is_admin` the shared `JoinedMessage` dataclass required, because the reconnecting client already has them;
- `question_started` has two builders (per-player, admin/TV) whose fields differ, so what only one sends is declared optional;
- `answer_result`, `round_summary` and `finale` gained the fields they had actually grown.

`CLIENT_MESSAGE_TYPES` gains `configure_tts`, `configure_house` and `admin_auth`, and is now compared against the imported `QuizifyWebSocketHandler._DISPATCH` instead of a source pattern. The three types handled before the table (`admin_connect`, `admin_auth`, `reset_game`) are declared separately in `OUT_OF_BAND_CLIENT_TYPES` and asserted **not** to be in it.

## What the check cannot see, said out loud

A green run should not be read as more than it is, so the limits are declared rather than left to be discovered:

- **`dynamic_keys`** — `evening_tally`, `head_to_head` and `hot_seat_result` merge a runtime dict with `**`; only the spelled-out keys are checkable. Which frames give that up is part of the declaration, and a *new* `**` frame fails the test until it is declared.
- **The roster frame's type is a variable** (`player_joined` or `player_left`, chosen at flush time), so it is listed in `_DYNAMIC_TYPE_SITES` and checked against both specs. A second such site fails the test rather than slipping through.
- **`game_state`** — the entry covers the leaderboard-refresh literal in `round_message_builder.py`. The snapshot sent on connect and reconnect is built in `game/state.py::get_state_snapshot` and typed by its caller, so it is outside what a literal scan can reach. The note says so.
- **Field names, not value types.** An `int` that becomes a `str` still passes.

There is also a test on the scanner itself: if it stops matching how frames are built, it fails instead of quietly finding nothing — which is precisely how the old guard died.

## Verification

The tests fail without the fix.

- `git stash push custom_components/quizify/server/protocol.py custom_components/quizify/server/websocket.py` → `tests/test_protocol.py` fails to collect (`ImportError: cannot import name 'OUT_OF_BAND_CLIENT_TYPES'`). Restored with `git stash pop`.
- The sharper check, since an import error proves little: adding one key to the `joined` literal in `websocket.py` and running the suite unchanged gives

  ```
  FAILED tests/test_protocol.py::TestServerFrames::test_no_build_site_sends_an_undeclared_key
  joined at server/websocket.py:1022 (_handle_join) sends undeclared field(s)
  ['brand_new_key'] — add them to its FrameSpec in server/protocol.py
  ```

  That is the failure the old guard could not produce. Reverted afterwards.

Gates, rebased on `origin/main` (through #760): `pytest -q` 2483 passed · `ruff check custom_components/` clean · `mypy custom_components/` clean on 48 files. No `www/js/` changes, so no bundle rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE
