### PR TITLE
fix: a refused join returns the button and names the reason (#729)

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Quizify speaks your guests' language.
 
 The UI follows the game language (since v1.1.24) — pick German in the pack-picker and the entire admin / player / dashboard surface switches to German labels, tooltips, error messages, fun-fact labels, and end-game awards. Switch to English or Spanish and the whole thing flips.
 
-681 i18n keys, full parity between all three locales, validated in CI.
+692 i18n keys, full parity between all three locales, validated in CI.
 
 ---
 

--- a/custom_components/quizify/const.py
+++ b/custom_components/quizify/const.py
@@ -64,6 +64,15 @@ ERR_INVALID_ACTION = "INVALID_ACTION"
 ERR_ADMIN_REQUIRED = "ADMIN_REQUIRED"
 ERR_GAME_FULL = "GAME_FULL"
 ERR_NO_QUESTIONS_REMAINING = "NO_QUESTIONS_REMAINING"
+#: This connection already holds a connected player under a different name
+#: (#244, #729). Split out of ERR_INVALID_ACTION so the join form can say
+#: "you are already in this game" instead of "Invalid action" — the guest is
+#: not doing anything wrong and has nothing to retype.
+ERR_ALREADY_JOINED = "ALREADY_JOINED"
+#: The per-IP join-flood limiter refused the join (#361, #729). Split out of
+#: ERR_INVALID_ACTION so a whole room behind one NAT that trips the window is
+#: told to wait, rather than being shown a generic failure it cannot act on.
+ERR_JOIN_RATE_LIMITED = "JOIN_RATE_LIMITED"
 
 # Question structure
 ANSWERS_PER_QUESTION = 3

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -14,12 +14,15 @@ from aiohttp import WSMsgType, web
 
 from custom_components.quizify.const import (
     ERR_ADMIN_REQUIRED,
+    ERR_ALREADY_JOINED,
     ERR_ALREADY_SUBMITTED,
     ERR_FROZEN,
     ERR_GAME_ALREADY_STARTED,
+    ERR_GAME_ENDED,
     ERR_GAME_FULL,
     ERR_GAME_NOT_STARTED,
     ERR_INVALID_ACTION,
+    ERR_JOIN_RATE_LIMITED,
     ERR_NAME_INVALID,
     ERR_NAME_TAKEN,
     ERR_NO_QUESTIONS_REMAINING,
@@ -625,7 +628,7 @@ class QuizifyWebSocketHandler:
                             "Per-IP join rate limit exceeded for %s", remote
                         )
                         await self._conn.send_error(
-                            ws, ERR_INVALID_ACTION, "Too many join attempts"
+                            ws, ERR_JOIN_RATE_LIMITED, "Too many join attempts"
                         )
                         continue
                     try:
@@ -876,7 +879,7 @@ class QuizifyWebSocketHandler:
             )
             await self._conn.send_error(
                 ws,
-                ERR_INVALID_ACTION,
+                ERR_ALREADY_JOINED,
                 "Already joined as a player",
             )
             return
@@ -1100,12 +1103,19 @@ class QuizifyWebSocketHandler:
             )
         else:
             # English i18n-fallback strings only — the client localizes off
-            # the structured ``code`` via ``t('errors.<CODE>')`` and only falls
-            # back to this ``message`` if the key is missing (player-core.js).
+            # the structured ``code`` via ``t('join.refused.<CODE>')`` and only
+            # falls back to this ``message`` if the key is missing
+            # (player-core.js).
+            #
+            # #729: every code ``add_player`` can return must appear here.
+            # ``ERR_GAME_ENDED`` did not, so a guest who scanned a QR code from
+            # a finished game got the bare "Failed to join" — no hint that the
+            # game was over and the host had to start a new one.
             error_messages = {
                 ERR_NAME_TAKEN: "Name already taken",
                 ERR_NAME_INVALID: "Please enter a name",
                 ERR_GAME_FULL: "Game is full",
+                ERR_GAME_ENDED: "This game has already finished",
             }
             await self._conn.send_error(
                 ws, error_code or ERR_INVALID_ACTION,

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -14,7 +14,18 @@
     "namePlaceholder": "Dein Name",
     "joinButton": "Beitreten",
     "joining": "Beitreten…",
-    "languageAria": "Sprache der Oberfläche"
+    "languageAria": "Sprache der Oberfläche",
+    "refused": {
+      "NAME_TAKEN": "Unter diesem Namen spielt schon jemand. Nimm einen anderen — häng eine Zahl oder deinen Anfangsbuchstaben an — und tippe wieder auf Beitreten.",
+      "NAME_INVALID": "Dieser Name geht nicht. Nutze 1 bis 20 Zeichen und tippe dann wieder auf Beitreten.",
+      "GAME_FULL": "Das Spiel ist voll — mehr als 20 Mitspieler gehen nicht. Bitte den Host, Platz zu machen, oder schau am Fernseher zu.",
+      "GAME_ENDED": "Dieses Spiel ist schon zu Ende. Bitte den Host, ein neues zu starten, und scanne dann den QR-Code noch einmal.",
+      "ALREADY_JOINED": "Du bist auf diesem Gerät schon im Spiel. Geh zurück zu dem Tab, mit dem du beigetreten bist, statt einen zweiten zu öffnen.",
+      "JOIN_RATE_LIMITED": "Zu viele Beitritts-Versuche aus deinem Netz. Warte etwa eine Minute und tippe dann wieder auf Beitreten.",
+      "NO_CONNECTION": "Wir erreichen das Spiel nicht. Prüf, ob du im selben WLAN wie der Host bist, und tippe auf Erneut verbinden — wenn es weiter nicht klappt, bitte den Host um einen neuen QR-Code.",
+      "INVALID_ACTION": "Der Beitritt konnte nicht verarbeitet werden. Tippe noch einmal auf Beitreten — wenn es weiter nicht klappt, bitte den Host um einen neuen QR-Code.",
+      "UNKNOWN": "Wir konnten dich nicht ins Spiel holen. Tippe noch einmal auf Beitreten — wenn es weiter nicht klappt, bitte den Host um einen neuen QR-Code."
+    }
   },
   "lobby": {
     "title": "Lobby",
@@ -644,7 +655,9 @@
     "RATE_LIMITED": "Zu viele Einsendungen. Bitte kurz warten und erneut versuchen.",
     "GITHUB_ERROR": "Der Einsende-Dienst ist gerade nicht erreichbar. Später erneut versuchen.",
     "SUBMIT_DISABLED": "Pack-Einsendung ist nicht konfiguriert.",
-    "ADMIN_REQUIRED": "Dieses Fenster ist nicht der Host — der Befehl wurde abgelehnt. Öffne das Admin-Fenster erneut über Home Assistant."
+    "ADMIN_REQUIRED": "Dieses Fenster ist nicht der Host — der Befehl wurde abgelehnt. Öffne das Admin-Fenster erneut über Home Assistant.",
+    "ALREADY_JOINED": "Bereits beigetreten",
+    "JOIN_RATE_LIMITED": "Zu viele Beitritts-Versuche"
   },
   "page": {
     "titleAdmin": "Quizify — Admin",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -14,7 +14,18 @@
     "namePlaceholder": "Your name",
     "joinButton": "Join Game",
     "joining": "Joining…",
-    "languageAria": "Interface language"
+    "languageAria": "Interface language",
+    "refused": {
+      "NAME_TAKEN": "Someone is already playing under that name. Pick another one — add a number or your last initial — and tap Join Game again.",
+      "NAME_INVALID": "That name won't work. Use 1 to 20 characters, then tap Join Game again.",
+      "GAME_FULL": "The game is full — 20 players is the limit. Ask the host to make room, or watch along on the TV.",
+      "GAME_ENDED": "This game has already finished. Ask the host to start a new one, then scan the QR code again.",
+      "ALREADY_JOINED": "You are already in this game on this device. Go back to the tab you joined from instead of opening a second one.",
+      "JOIN_RATE_LIMITED": "Too many join attempts from your network. Wait about a minute, then tap Join Game again.",
+      "NO_CONNECTION": "We can't reach the game. Check that you are on the same Wi-Fi as the host and tap Retry connection — if it keeps failing, ask the host for a fresh QR code.",
+      "INVALID_ACTION": "The game couldn't process your join. Tap Join Game again — if it keeps failing, ask the host for a fresh QR code.",
+      "UNKNOWN": "We couldn't get you into the game. Tap Join Game again — if it keeps failing, ask the host for a fresh QR code."
+    }
   },
   "lobby": {
     "title": "Lobby",
@@ -644,7 +655,9 @@
     "RATE_LIMITED": "Too many submissions. Please wait a moment and try again.",
     "GITHUB_ERROR": "Submission service is unavailable right now. Try again later.",
     "SUBMIT_DISABLED": "Pack submission is not configured.",
-    "ADMIN_REQUIRED": "This window is not the host — the command was refused. Reopen the admin window from Home Assistant."
+    "ADMIN_REQUIRED": "This window is not the host — the command was refused. Reopen the admin window from Home Assistant.",
+    "ALREADY_JOINED": "Already joined",
+    "JOIN_RATE_LIMITED": "Too many join attempts"
   },
   "page": {
     "titleAdmin": "Quizify — Admin",

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -14,7 +14,18 @@
     "namePlaceholder": "Tu nombre",
     "joinButton": "Unirse al juego",
     "joining": "Uniéndose…",
-    "languageAria": "Idioma de la interfaz"
+    "languageAria": "Idioma de la interfaz",
+    "refused": {
+      "NAME_TAKEN": "Ya hay alguien jugando con ese nombre. Elige otro — añade un número o tu inicial — y pulsa Unirse al juego otra vez.",
+      "NAME_INVALID": "Ese nombre no vale. Usa de 1 a 20 caracteres y pulsa Unirse al juego otra vez.",
+      "GAME_FULL": "La partida está llena: el límite son 20 jugadores. Pide al anfitrión que haga sitio, o mira la partida en la tele.",
+      "GAME_ENDED": "Esta partida ya ha terminado. Pide al anfitrión que empiece una nueva y vuelve a escanear el código QR.",
+      "ALREADY_JOINED": "Ya estás en esta partida desde este dispositivo. Vuelve a la pestaña con la que te uniste en vez de abrir una segunda.",
+      "JOIN_RATE_LIMITED": "Demasiados intentos de unirse desde tu red. Espera un minuto y pulsa Unirse al juego otra vez.",
+      "NO_CONNECTION": "No podemos conectar con la partida. Comprueba que estás en la misma wifi que el anfitrión y pulsa Reintentar conexión; si sigue fallando, pide al anfitrión un código QR nuevo.",
+      "INVALID_ACTION": "No se ha podido procesar tu entrada. Pulsa Unirse al juego otra vez; si sigue fallando, pide al anfitrión un código QR nuevo.",
+      "UNKNOWN": "No hemos podido meterte en la partida. Pulsa Unirse al juego otra vez; si sigue fallando, pide al anfitrión un código QR nuevo."
+    }
   },
   "lobby": {
     "title": "Sala de espera",
@@ -644,7 +655,9 @@
     "RATE_LIMITED": "Demasiados envíos. Espera un momento e inténtalo de nuevo.",
     "GITHUB_ERROR": "El servicio de envío no está disponible ahora mismo. Inténtalo más tarde.",
     "SUBMIT_DISABLED": "El envío de paquetes no está configurado.",
-    "ADMIN_REQUIRED": "Esta ventana no es la del anfitrión: el comando fue rechazado. Vuelve a abrir la ventana de administración desde Home Assistant."
+    "ADMIN_REQUIRED": "Esta ventana no es la del anfitrión: el comando fue rechazado. Vuelve a abrir la ventana de administración desde Home Assistant.",
+    "ALREADY_JOINED": "Ya te has unido",
+    "JOIN_RATE_LIMITED": "Demasiados intentos de unirse"
   },
   "page": {
     "titleAdmin": "Quizify — Administración",

--- a/custom_components/quizify/www/js/player-core.js
+++ b/custom_components/quizify/www/js/player-core.js
@@ -122,6 +122,10 @@
                         var _at = QuizifyUtils.readAdminToken();
                         if (_at) joinMsg.admin_token = _at;
                     }
+                    // #729: arm the answer timeout for this auto-join too —
+                    // a refusal here (a stale name taken mid-game) has to
+                    // reach the guest, not vanish into the reconnect loop.
+                    beginJoinPending();
                     send('join', joinMsg);
                 }
                 // else: waiting for auto-join interval or user to click join
@@ -238,6 +242,7 @@
                 // handling the broadcast directly makes the return to the
                 // join screen deterministic instead of relying on the
                 // close + reconnect_failed race.
+                endJoinPending();
                 pu.clearSession();
                 state.sessionToken = null;
                 state.playerName = null;
@@ -277,6 +282,7 @@
 
             case 'joined':
             case 'reconnected':
+                endJoinPending();
                 state.playerName = msg.player_id || state.playerName;
                 state.playerId = msg.player_id;
                 if (msg.session_token) {
@@ -1266,8 +1272,23 @@
         //   t('errors.<CODE>') returns the localized string OR the key
         //   itself if missing. We treat key-as-result as "no translation"
         //   and fall back to server message, then to errors.UNKNOWN.
-        var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
-        var key = 'errors.' + (msg.code || 'UNKNOWN');
+        var t = _t();
+        var code = msg.code || 'UNKNOWN';
+
+        // #729: a join is in flight — the error is a refusal, and the join
+        // form owns it. This used to be gated on `!state.playerName`, which
+        // handleJoinClick sets BEFORE the join goes out, so the branch was
+        // dead for every single refusal: the guest was left with a disabled
+        // button reading "Joining…", no reason and no way back.
+        // The old `!state.playerName` condition is kept as a second trigger —
+        // it still catches an error that lands on the join form outside a
+        // tracked join — but `joinPending` is the one that actually fires.
+        if (state.joinPending || (!state.playerName && els.joinBtn)) {
+            pu.showToast(showJoinRefusal(code, msg.message));
+            return;
+        }
+
+        var key = 'errors.' + code;
         var translated = t(key);
         var userMsg;
         if (translated && translated !== key) {
@@ -1290,23 +1311,99 @@
         // answer for it (teams are set / that team dissolved), and showing it
         // there is what keeps the player from asking the host (#365).
         if (msg.code === 'TEAM_CLOSED' && team) team.handleTeamError();
+    }
 
-        // If the error happened during join, reset the button so the user can retry
-        if (!state.playerName && els.joinBtn) {
-            els.joinBtn.disabled = false;
-            els.joinBtn.textContent = t('join.joinButton');
-            if (els.nameInput) els.nameInput.style.borderColor = '#D65858';
-            // The toast fades after a few seconds, taking the reason with it;
-            // the red border alone doesn't say *why* the join failed (#426).
-            // Persist the translated reason in the inline validation message
-            // (the input's aria-describedby target) so it stays visible and
-            // is announced to screen readers. Cleared on the next input.
-            var vmsg = document.getElementById('name-validation-msg');
-            if (vmsg) {
-                vmsg.textContent = userMsg;
-                vmsg.classList.remove('hidden');
-            }
+    // ============================================
+    // Join Refusals (#729)
+    // ============================================
+
+    // How long a join may sit unanswered before we tell the guest something
+    // is wrong. A refusal comes back in milliseconds; this only fires when
+    // nothing comes back at all — the per-IP connection cap answers the
+    // upgrade with a plain HTTP 429 (server/websocket.py), so the socket
+    // never opens and no `error` frame is ever sent. Before #729 that left
+    // the button on "Joining…" with nothing else on screen.
+    var JOIN_ANSWER_TIMEOUT_MS = 10000;
+    var _joinTimeout = null;
+
+    // Refusals that invalidate the name we hold. Without clearing it, the
+    // reconnect loop in player-utils keeps firing (it is gated on
+    // state.playerName) and re-sends the very name the server just refused,
+    // so the guest watches a silent retry storm instead of a join form.
+    var JOIN_REFUSALS_CLEARING_NAME = [
+        'NAME_TAKEN', 'NAME_INVALID', 'GAME_FULL', 'GAME_ENDED', 'ALREADY_JOINED'
+    ];
+
+    function _t() {
+        return (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
+    }
+
+    // Prefer the join-specific wording (`join.refused.<CODE>`), which tells
+    // the guest what to DO. `errors.<CODE>` is the terse label used for
+    // in-game toasts ("Name already taken") and is only a fallback here.
+    function joinRefusalText(code, serverMessage) {
+        var t = _t();
+        var candidates = ['join.refused.' + code, 'errors.' + code];
+        for (var i = 0; i < candidates.length; i++) {
+            var value = t(candidates[i]);
+            if (value && value !== candidates[i]) return value;
         }
+        if (serverMessage) return serverMessage;
+        return t('join.refused.UNKNOWN');
+    }
+
+    function beginJoinPending() {
+        state.joinPending = true;
+        if (_joinTimeout) clearTimeout(_joinTimeout);
+        _joinTimeout = setTimeout(function () {
+            _joinTimeout = null;
+            if (state.joinPending) showJoinRefusal('NO_CONNECTION', null);
+        }, JOIN_ANSWER_TIMEOUT_MS);
+    }
+
+    function endJoinPending() {
+        state.joinPending = false;
+        if (_joinTimeout) { clearTimeout(_joinTimeout); _joinTimeout = null; }
+    }
+
+    // Put the join form back in a usable state AND leave the reason on
+    // screen. The toast alone fades after three seconds and takes the reason
+    // with it (#426); the button alone says nothing at all (#729).
+    // Returns the text shown so the caller can reuse it for the toast.
+    function showJoinRefusal(code, serverMessage) {
+        endJoinPending();
+        var t = _t();
+        var text = joinRefusalText(code, serverMessage);
+
+        if (JOIN_REFUSALS_CLEARING_NAME.indexOf(code) !== -1) {
+            state.playerName = null;
+            state.playerId = null;
+            state.sessionToken = null;
+            pu.clearSession();
+            // A refusal can arrive on an auto-rejoin, with the guest sitting
+            // behind the reconnecting overlay or on the lobby. Put them back
+            // on the form the message belongs to.
+            if (pu.hideReconnectingOverlay) pu.hideReconnectingOverlay();
+            state.isReconnecting = false;
+            state.reconnectAttempts = 0;
+            pu.showView('join-view');
+        }
+
+        if (els.joinBtn) {
+            els.joinBtn.disabled = false;
+            els.joinBtn.textContent = code === 'NO_CONNECTION'
+                ? t('connection.retryConnection')
+                : t('join.joinButton');
+        }
+        if (els.nameInput) els.nameInput.style.borderColor = '#D65858';
+        // The input's aria-describedby target: persistent and announced to
+        // screen readers, cleared on the next keystroke (setupJoinForm).
+        var vmsg = document.getElementById('name-validation-msg');
+        if (vmsg) {
+            vmsg.textContent = text;
+            vmsg.classList.remove('hidden');
+        }
+        return text;
     }
 
     // ============================================
@@ -1342,6 +1439,13 @@
         var result = pu.validateName(els.nameInput.value);
         if (!result.valid) return;
 
+        // Setting the name here is load-bearing: the onOpen handler below
+        // auto-sends the join off state.playerName when the socket wasn't
+        // open at click time, and player-utils gates its whole reconnect
+        // loop on it. So the ordering stays; what changes (#729) is that the
+        // refusal path no longer *infers* "we are joining" from the absence
+        // of a name — beginJoinPending() says so outright.
+        beginJoinPending();
         state.playerName = result.name;
         els.joinBtn.disabled = true;
         els.joinBtn.textContent = t('join.joining');
@@ -1716,6 +1820,15 @@
         // Fallback: if WS hasn't opened after 10s, re-enable join button with error hint
         _wsOpenTimeout = setTimeout(function () {
             if (!state.ws || state.ws.readyState !== WebSocket.OPEN) {
+                // #729: say WHY, persistently. The per-IP connection cap
+                // refuses the upgrade with an HTTP 429 the WebSocket API
+                // never surfaces, so a relabelled button was the guest's
+                // only clue that anything had gone wrong.
+                var vmsgConn = document.getElementById('name-validation-msg');
+                if (vmsgConn) {
+                    vmsgConn.textContent = joinRefusalText('NO_CONNECTION', null);
+                    vmsgConn.classList.remove('hidden');
+                }
                 if (els.joinBtn) {
                     var tRetry = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
                     els.joinBtn.disabled = false;

--- a/custom_components/quizify/www/js/player-utils.js
+++ b/custom_components/quizify/www/js/player-utils.js
@@ -16,6 +16,12 @@
         ws: null,
         playerName: null,
         playerId: null,
+        // #729: true from the moment a join is sent (or queued behind a
+        // pending connect) until the server answers `joined` / `error`.
+        // The join-error reset used to key on `!playerName`, which
+        // handleJoinClick had already filled in — so the guard was dead for
+        // every refusal and the button sat on "Joining…" forever.
+        joinPending: false,
         sessionToken: null,
         isAdmin: false,
         currentView: null,
@@ -630,6 +636,10 @@
         feedbackLabel: feedbackLabel,
         generateQR: generateQR,
         showToast: showToast,
+        // #729: a join refused mid-reconnect has to pull the guest out from
+        // under the reconnecting overlay, or the reason lands on a screen
+        // nobody can see.
+        hideReconnectingOverlay: hideReconnectingOverlay,
         saveSession: saveSession,
         getSession: getSession,
         clearSession: clearSession,

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -21,6 +21,12 @@
         ws: null,
         playerName: null,
         playerId: null,
+        // #729: true from the moment a join is sent (or queued behind a
+        // pending connect) until the server answers `joined` / `error`.
+        // The join-error reset used to key on `!playerName`, which
+        // handleJoinClick had already filled in — so the guard was dead for
+        // every refusal and the button sat on "Joining…" forever.
+        joinPending: false,
         sessionToken: null,
         isAdmin: false,
         currentView: null,
@@ -635,6 +641,10 @@
         feedbackLabel: feedbackLabel,
         generateQR: generateQR,
         showToast: showToast,
+        // #729: a join refused mid-reconnect has to pull the guest out from
+        // under the reconnecting overlay, or the reason lands on a screen
+        // nobody can see.
+        hideReconnectingOverlay: hideReconnectingOverlay,
         saveSession: saveSession,
         getSession: getSession,
         clearSession: clearSession,
@@ -5856,6 +5866,10 @@
                         var _at = QuizifyUtils.readAdminToken();
                         if (_at) joinMsg.admin_token = _at;
                     }
+                    // #729: arm the answer timeout for this auto-join too —
+                    // a refusal here (a stale name taken mid-game) has to
+                    // reach the guest, not vanish into the reconnect loop.
+                    beginJoinPending();
                     send('join', joinMsg);
                 }
                 // else: waiting for auto-join interval or user to click join
@@ -5972,6 +5986,7 @@
                 // handling the broadcast directly makes the return to the
                 // join screen deterministic instead of relying on the
                 // close + reconnect_failed race.
+                endJoinPending();
                 pu.clearSession();
                 state.sessionToken = null;
                 state.playerName = null;
@@ -6011,6 +6026,7 @@
 
             case 'joined':
             case 'reconnected':
+                endJoinPending();
                 state.playerName = msg.player_id || state.playerName;
                 state.playerId = msg.player_id;
                 if (msg.session_token) {
@@ -7000,8 +7016,23 @@
         //   t('errors.<CODE>') returns the localized string OR the key
         //   itself if missing. We treat key-as-result as "no translation"
         //   and fall back to server message, then to errors.UNKNOWN.
-        var t = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
-        var key = 'errors.' + (msg.code || 'UNKNOWN');
+        var t = _t();
+        var code = msg.code || 'UNKNOWN';
+
+        // #729: a join is in flight — the error is a refusal, and the join
+        // form owns it. This used to be gated on `!state.playerName`, which
+        // handleJoinClick sets BEFORE the join goes out, so the branch was
+        // dead for every single refusal: the guest was left with a disabled
+        // button reading "Joining…", no reason and no way back.
+        // The old `!state.playerName` condition is kept as a second trigger —
+        // it still catches an error that lands on the join form outside a
+        // tracked join — but `joinPending` is the one that actually fires.
+        if (state.joinPending || (!state.playerName && els.joinBtn)) {
+            pu.showToast(showJoinRefusal(code, msg.message));
+            return;
+        }
+
+        var key = 'errors.' + code;
         var translated = t(key);
         var userMsg;
         if (translated && translated !== key) {
@@ -7024,23 +7055,99 @@
         // answer for it (teams are set / that team dissolved), and showing it
         // there is what keeps the player from asking the host (#365).
         if (msg.code === 'TEAM_CLOSED' && team) team.handleTeamError();
+    }
 
-        // If the error happened during join, reset the button so the user can retry
-        if (!state.playerName && els.joinBtn) {
-            els.joinBtn.disabled = false;
-            els.joinBtn.textContent = t('join.joinButton');
-            if (els.nameInput) els.nameInput.style.borderColor = '#D65858';
-            // The toast fades after a few seconds, taking the reason with it;
-            // the red border alone doesn't say *why* the join failed (#426).
-            // Persist the translated reason in the inline validation message
-            // (the input's aria-describedby target) so it stays visible and
-            // is announced to screen readers. Cleared on the next input.
-            var vmsg = document.getElementById('name-validation-msg');
-            if (vmsg) {
-                vmsg.textContent = userMsg;
-                vmsg.classList.remove('hidden');
-            }
+    // ============================================
+    // Join Refusals (#729)
+    // ============================================
+
+    // How long a join may sit unanswered before we tell the guest something
+    // is wrong. A refusal comes back in milliseconds; this only fires when
+    // nothing comes back at all — the per-IP connection cap answers the
+    // upgrade with a plain HTTP 429 (server/websocket.py), so the socket
+    // never opens and no `error` frame is ever sent. Before #729 that left
+    // the button on "Joining…" with nothing else on screen.
+    var JOIN_ANSWER_TIMEOUT_MS = 10000;
+    var _joinTimeout = null;
+
+    // Refusals that invalidate the name we hold. Without clearing it, the
+    // reconnect loop in player-utils keeps firing (it is gated on
+    // state.playerName) and re-sends the very name the server just refused,
+    // so the guest watches a silent retry storm instead of a join form.
+    var JOIN_REFUSALS_CLEARING_NAME = [
+        'NAME_TAKEN', 'NAME_INVALID', 'GAME_FULL', 'GAME_ENDED', 'ALREADY_JOINED'
+    ];
+
+    function _t() {
+        return (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
+    }
+
+    // Prefer the join-specific wording (`join.refused.<CODE>`), which tells
+    // the guest what to DO. `errors.<CODE>` is the terse label used for
+    // in-game toasts ("Name already taken") and is only a fallback here.
+    function joinRefusalText(code, serverMessage) {
+        var t = _t();
+        var candidates = ['join.refused.' + code, 'errors.' + code];
+        for (var i = 0; i < candidates.length; i++) {
+            var value = t(candidates[i]);
+            if (value && value !== candidates[i]) return value;
         }
+        if (serverMessage) return serverMessage;
+        return t('join.refused.UNKNOWN');
+    }
+
+    function beginJoinPending() {
+        state.joinPending = true;
+        if (_joinTimeout) clearTimeout(_joinTimeout);
+        _joinTimeout = setTimeout(function () {
+            _joinTimeout = null;
+            if (state.joinPending) showJoinRefusal('NO_CONNECTION', null);
+        }, JOIN_ANSWER_TIMEOUT_MS);
+    }
+
+    function endJoinPending() {
+        state.joinPending = false;
+        if (_joinTimeout) { clearTimeout(_joinTimeout); _joinTimeout = null; }
+    }
+
+    // Put the join form back in a usable state AND leave the reason on
+    // screen. The toast alone fades after three seconds and takes the reason
+    // with it (#426); the button alone says nothing at all (#729).
+    // Returns the text shown so the caller can reuse it for the toast.
+    function showJoinRefusal(code, serverMessage) {
+        endJoinPending();
+        var t = _t();
+        var text = joinRefusalText(code, serverMessage);
+
+        if (JOIN_REFUSALS_CLEARING_NAME.indexOf(code) !== -1) {
+            state.playerName = null;
+            state.playerId = null;
+            state.sessionToken = null;
+            pu.clearSession();
+            // A refusal can arrive on an auto-rejoin, with the guest sitting
+            // behind the reconnecting overlay or on the lobby. Put them back
+            // on the form the message belongs to.
+            if (pu.hideReconnectingOverlay) pu.hideReconnectingOverlay();
+            state.isReconnecting = false;
+            state.reconnectAttempts = 0;
+            pu.showView('join-view');
+        }
+
+        if (els.joinBtn) {
+            els.joinBtn.disabled = false;
+            els.joinBtn.textContent = code === 'NO_CONNECTION'
+                ? t('connection.retryConnection')
+                : t('join.joinButton');
+        }
+        if (els.nameInput) els.nameInput.style.borderColor = '#D65858';
+        // The input's aria-describedby target: persistent and announced to
+        // screen readers, cleared on the next keystroke (setupJoinForm).
+        var vmsg = document.getElementById('name-validation-msg');
+        if (vmsg) {
+            vmsg.textContent = text;
+            vmsg.classList.remove('hidden');
+        }
+        return text;
     }
 
     // ============================================
@@ -7076,6 +7183,13 @@
         var result = pu.validateName(els.nameInput.value);
         if (!result.valid) return;
 
+        // Setting the name here is load-bearing: the onOpen handler below
+        // auto-sends the join off state.playerName when the socket wasn't
+        // open at click time, and player-utils gates its whole reconnect
+        // loop on it. So the ordering stays; what changes (#729) is that the
+        // refusal path no longer *infers* "we are joining" from the absence
+        // of a name — beginJoinPending() says so outright.
+        beginJoinPending();
         state.playerName = result.name;
         els.joinBtn.disabled = true;
         els.joinBtn.textContent = t('join.joining');
@@ -7450,6 +7564,15 @@
         // Fallback: if WS hasn't opened after 10s, re-enable join button with error hint
         _wsOpenTimeout = setTimeout(function () {
             if (!state.ws || state.ws.readyState !== WebSocket.OPEN) {
+                // #729: say WHY, persistently. The per-IP connection cap
+                // refuses the upgrade with an HTTP 429 the WebSocket API
+                // never surfaces, so a relabelled button was the guest's
+                // only clue that anything had gone wrong.
+                var vmsgConn = document.getElementById('name-validation-msg');
+                if (vmsgConn) {
+                    vmsgConn.textContent = joinRefusalText('NO_CONNECTION', null);
+                    vmsgConn.classList.remove('hidden');
+                }
                 if (els.joinBtn) {
                     var tRetry = (window.QuizifyI18n && window.QuizifyI18n.t) || function (k) { return k; };
                     els.joinBtn.disabled = false;

--- a/tests/test_join_refusal_visible_729.py
+++ b/tests/test_join_refusal_visible_729.py
@@ -1,0 +1,330 @@
+"""A refused join must return the button and name the reason (#729).
+
+``handleJoinClick`` sets ``state.playerName`` *before* the join goes out —
+deliberately, because the ``onOpen`` handler auto-sends the join off that name
+when the socket was not open at click time, and ``player-utils`` gates its
+whole reconnect loop on it. The join-error reset in ``handleError``, however,
+was guarded by ``if (!state.playerName && els.joinBtn)``. By the time any
+refusal arrived the name was always set, so the guard never fired once: the
+guest was left with a disabled button reading "Joining…", no reason, and no
+way back.
+
+The fix does not move the assignment. It stops the refusal path *inferring*
+"we are joining" from the absence of a name and has ``handleJoinClick`` say so
+outright (``state.joinPending``), then makes the refusal genuinely visible:
+button re-enabled, reason persisted in the inline validation message, and the
+refused name released so the reconnect loop does not quietly re-send it.
+
+The second half is wording. Every reason the server can refuse a join for
+needs a sentence a guest can act on, in all three languages. "Name already
+taken" is a label, not an instruction — it does not tell the guest to add a
+number and tap Join again. These tests pin both halves, plus the two refusals
+that had no code of their own at all (the duplicate self-join and the per-IP
+join flood, both shipped as a bare ``INVALID_ACTION``) and the one that had a
+code but no wire message (``GAME_ENDED``, which fell through to the generic
+"Failed to join").
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.const import (  # noqa: E402
+    ERR_GAME_ENDED,
+    ERR_INVALID_ACTION,
+)
+
+#: Spelled out rather than imported from const: these are wire values the
+#: phone matches on (``t('join.refused.<CODE>')``), so the test has to break
+#: if the string changes, not follow it.
+ERR_ALREADY_JOINED = "ALREADY_JOINED"
+ERR_JOIN_RATE_LIMITED = "JOIN_RATE_LIMITED"
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+_WWW = _REPO_ROOT / "custom_components" / "quizify" / "www"
+I18N_DIR = _WWW / "i18n"
+PLAYER_CORE = _WWW / "js" / "player-core.js"
+PLAYER_BUNDLE = _WWW / "js" / "player.bundle.js"
+_COMPONENT = _REPO_ROOT / "custom_components" / "quizify"
+REGISTRY_PY = _COMPONENT / "game" / "player_registry.py"
+WEBSOCKET_PY = _COMPONENT / "server" / "websocket.py"
+
+LANGUAGES = ("de", "en", "es")
+
+#: Every way a join can be refused, as the phone sees it. The first six come
+#: off the wire; NO_CONNECTION is the one the client has to invent, because
+#: the per-IP connection cap answers the upgrade with an HTTP 429 and no
+#: WebSocket is ever opened to carry an error frame.
+JOIN_REFUSAL_CODES = (
+    "NAME_TAKEN",
+    "NAME_INVALID",
+    "GAME_FULL",
+    "GAME_ENDED",
+    "ALREADY_JOINED",
+    "JOIN_RATE_LIMITED",
+    "INVALID_ACTION",
+    "NO_CONNECTION",
+    "UNKNOWN",
+)
+
+#: Refusals that make the held name worthless. Leaving it set keeps the
+#: reconnect loop (gated on ``state.playerName``) re-sending the very name the
+#: server just refused.
+CODES_THAT_RELEASE_THE_NAME = (
+    "NAME_TAKEN",
+    "NAME_INVALID",
+    "GAME_FULL",
+    "GAME_ENDED",
+)
+
+
+# ---------------------------------------------------------------------------
+# Harness (mirrors tests/test_admin_refusal_visible_586.py)
+# ---------------------------------------------------------------------------
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    ws.close = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+def _handler(game: QuizifyGameState, tmp_path: Path):
+    runtime = _FakeRuntime(tmp_path)
+    handler = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    handler._conn = ConnectionManager(runtime, lambda: game)
+    handler._get_game_state = lambda: game  # type: ignore[assignment]
+    sent: list[dict] = []
+
+    async def _send_error(ws, code, message) -> None:
+        sent.append({"code": code, "message": message})
+
+    handler._conn.send_error = _send_error  # type: ignore[assignment]
+    handler._conn.broadcast = AsyncMock()  # type: ignore[assignment]
+    return handler, sent
+
+
+def _function_body(source: str, name: str) -> str:
+    """Return the text of ``function <name>(`` up to the next top-level function."""
+    start = source.index(f"function {name}(")
+    rest = source[start + 1 :]
+    end = rest.find("\n    function ")
+    return rest if end == -1 else rest[:end]
+
+
+# ---------------------------------------------------------------------------
+# The bug itself: the reset must not be inferred from the absent name
+# ---------------------------------------------------------------------------
+
+
+def test_the_refusal_branch_knows_a_join_is_in_flight() -> None:
+    """``handleError`` must key the join reset on an explicit pending flag.
+
+    Keyed on ``!state.playerName`` it is dead code, because
+    ``handleJoinClick`` filled the name in before the join was sent.
+    """
+    body = _function_body(PLAYER_CORE.read_text(encoding="utf-8"), "handleError")
+    assert "state.joinPending" in body, (
+        "handleError still infers 'we are joining' from state.playerName — "
+        "the branch is dead for every refusal (#729)"
+    )
+
+
+def test_clicking_join_declares_the_join_pending() -> None:
+    """Nothing sets the flag, nothing resets the button."""
+    body = _function_body(PLAYER_CORE.read_text(encoding="utf-8"), "handleJoinClick")
+    assert "beginJoinPending()" in body, (
+        "handleJoinClick does not mark the join as pending, so a refusal has "
+        "no way to tell that the button belongs to it (#729)"
+    )
+
+
+def test_a_successful_join_clears_the_pending_flag() -> None:
+    """Otherwise the answer timeout fires ten seconds into a joined game."""
+    source = PLAYER_CORE.read_text(encoding="utf-8")
+    joined = source.index("case 'joined':")
+    assert "endJoinPending()" in source[joined : joined + 400], (
+        "the 'joined' branch never clears joinPending — the join answer "
+        "timeout would fire on a player who is already in the game"
+    )
+
+
+def test_the_refused_name_is_released() -> None:
+    """A held-but-refused name keeps the reconnect loop re-sending it."""
+    source = PLAYER_CORE.read_text(encoding="utf-8")
+    body = _function_body(source, "showJoinRefusal")
+    assert "state.playerName = null" in body, (
+        "a refused join keeps state.playerName, so player-utils keeps "
+        "reconnecting and re-sending the refused name (#729)"
+    )
+    listed = source[source.index("JOIN_REFUSALS_CLEARING_NAME") :][:400]
+    for code in CODES_THAT_RELEASE_THE_NAME:
+        assert code in listed, f"{code} does not release the refused name"
+
+
+def test_the_reason_survives_the_toast() -> None:
+    """A three-second toast is not a message; the inline text is."""
+    body = _function_body(PLAYER_CORE.read_text(encoding="utf-8"), "showJoinRefusal")
+    assert "name-validation-msg" in body, (
+        "the refusal is only toasted — it fades in three seconds and the "
+        "guest is back to a bare button (#426, #729)"
+    )
+    assert "els.joinBtn.disabled = false" in body, (
+        "the refusal never re-enables the join button — this is the stuck "
+        "'Joining…' the issue reports"
+    )
+
+
+def test_the_shipped_bundle_carries_the_fix() -> None:
+    """player.html loads the bundle, not the modules (the #625 trap)."""
+    bundle = PLAYER_BUNDLE.read_text(encoding="utf-8")
+    assert "joinPending" in bundle and "join.refused." in bundle, (
+        "player.bundle.js is stale — run: python3 scripts/build_bundle.py"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wording: every refusal, every language, something a guest can act on
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("lang", LANGUAGES)
+@pytest.mark.parametrize("code", JOIN_REFUSAL_CODES)
+def test_every_refusal_has_wording_a_guest_can_act_on(lang: str, code: str) -> None:
+    data = json.loads((I18N_DIR / f"{lang}.json").read_text(encoding="utf-8"))
+    text = data.get("join", {}).get("refused", {}).get(code, "")
+    assert text.strip(), f"{lang}.json has no join.refused.{code}"
+
+    label = data.get("errors", {}).get(code, "")
+    assert text != label, (
+        f"{lang}.json reuses the terse errors.{code} label for the join "
+        "refusal — a label names the problem, it does not tell the guest "
+        "what to do next"
+    )
+    # A sentence, not a label: the wording has to carry a next step.
+    assert len(text.split()) >= 8, (
+        f"join.refused.{code} in {lang}.json is too short to say what the "
+        f"guest should do: {text!r}"
+    )
+
+
+def test_the_three_languages_stay_in_key_parity() -> None:
+    keys = {
+        lang: set(
+            json.loads((I18N_DIR / f"{lang}.json").read_text(encoding="utf-8"))["join"][
+                "refused"
+            ]
+        )
+        for lang in LANGUAGES
+    }
+    assert keys["de"] == keys["en"] == keys["es"], (
+        f"join.refused key sets drifted: {keys}"
+    )
+    assert set(JOIN_REFUSAL_CODES) <= keys["en"]
+
+
+# ---------------------------------------------------------------------------
+# Server: no refusal may reach the phone unnamed
+# ---------------------------------------------------------------------------
+
+
+def test_every_registry_refusal_is_named_on_the_wire() -> None:
+    """The join handler's fallback map must cover all of ``add_player``.
+
+    ``ERR_GAME_ENDED`` was missing, so a guest scanning the QR code of a
+    finished game got the bare "Failed to join".
+    """
+    registry = REGISTRY_PY.read_text(encoding="utf-8")
+    add_player = registry[registry.index("def add_player(") : registry.index(
+        "def get_player("
+    )]
+    refusals = set(re.findall(r"return False, (ERR_\w+)", add_player))
+    assert refusals, "could not find any refusal in PlayerRegistry.add_player"
+
+    handler = WEBSOCKET_PY.read_text(encoding="utf-8")
+    error_map = handler[handler.index("error_messages = {") :][:600]
+    for code in sorted(refusals):
+        assert code in error_map, (
+            f"{code} can refuse a join but has no message in the join "
+            "handler's fallback map — the guest gets 'Failed to join'"
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_finished_game_says_it_is_finished(
+    game: QuizifyGameState, tmp_path: Path
+) -> None:
+    handler, sent = _handler(game, tmp_path)
+    game.add_player = lambda name, ws: (False, ERR_GAME_ENDED)  # type: ignore[assignment]
+
+    ws = _ws()
+    handler._conn.add_connection(ws, is_admin=False, is_dashboard=False)
+    await handler._handle_join(ws, {"name": "Guest"}, game)
+
+    assert sent, "the join was refused without telling the phone anything"
+    assert sent[-1]["code"] == ERR_GAME_ENDED
+    assert sent[-1]["message"] != "Failed to join", (
+        "a finished game still answers with the generic fallback (#729)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_duplicate_self_join_has_its_own_code(
+    game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """Shipped as INVALID_ACTION, which localizes to "Invalid action".
+
+    The guest is already in the game on this device and has nothing to
+    retype; the join form has to be able to say exactly that.
+    """
+    handler, sent = _handler(game, tmp_path)
+    ws = _ws()
+    handler._conn.add_connection(ws, is_admin=False, is_dashboard=False)
+    game.add_player("Guest", ws)
+
+    await handler._handle_join(ws, {"name": "Someone Else"}, game)
+
+    assert sent, "the duplicate self-join was refused silently"
+    assert sent[-1]["code"] == ERR_ALREADY_JOINED, (
+        "the duplicate self-join still answers INVALID_ACTION — the phone "
+        "cannot tell it apart from a malformed frame"
+    )
+
+
+def test_the_join_flood_has_its_own_code() -> None:
+    """A whole room behind one NAT can trip the limiter (#361, #701).
+
+    Told "Invalid action", nobody waits — they hammer the button, which is
+    exactly what keeps the window full.
+    """
+    source = WEBSOCKET_PY.read_text(encoding="utf-8")
+    branch = source[source.index("Per-IP join rate limit exceeded") :][:400]
+    assert ERR_JOIN_RATE_LIMITED in branch, (
+        "the join-flood refusal is still a bare INVALID_ACTION"
+    )
+    assert ERR_INVALID_ACTION not in branch


### PR DESCRIPTION
The guest's phone said "Joining…" and never said anything else. No reason, no retry, no way back — they hand you the phone.

## The dead guard

`handleJoinClick` sets `state.playerName` before the join goes out, and it has to: the `onOpen` handler auto-sends the join off that name when the socket was not open at click time, and `player-utils` gates its whole reconnect loop on it. The join-error reset in `handleError`, though, was guarded by `if (!state.playerName && els.joinBtn)`. By the time any refusal arrived the name was always set, so that branch never ran once — not for `NAME_TAKEN`, not for `GAME_FULL`, not for anything.

So the assignment stays where it is. What changes is that the refusal path no longer *infers* "we are joining" from the absence of a name: `handleJoinClick` says so outright via `state.joinPending`, cleared on `joined`. The refusal then

- re-enables the button and puts its label back,
- persists the reason in `#name-validation-msg` (the input's `aria-describedby` target), which survives the three-second toast and is announced to screen readers,
- releases the refused name, so the reconnect loop stops silently re-sending it from behind a "Reconnecting" overlay the guest cannot see past.

A join can also go *unanswered* rather than refused: the per-IP connection cap answers the upgrade with a plain HTTP 429, so no socket opens and no error frame is ever sent. A ten-second answer timeout covers that case with wording of its own instead of an indefinite "Joining…".

## What the refusals say now

Three reasons had nothing a guest could act on:

| Reason | Before | Now |
| --- | --- | --- |
| `NAME_TAKEN` | "Name already taken" | tells them to add a number or an initial and tap Join again |
| `NAME_INVALID` | "Please enter a name" | names the 1–20 character limit |
| `GAME_FULL` | "Game is full" | names the 20-player cap, offers watching on the TV |
| `GAME_ENDED` | **"Failed to join"** — the code had no entry in the join handler's fallback map at all | ask the host to start a new game, then re-scan the QR code |
| duplicate self-join | **`INVALID_ACTION`** → "Invalid action" | its own `ALREADY_JOINED` code: go back to the tab you joined from |
| per-IP join flood | **`INVALID_ACTION`** → "Invalid action" | its own `JOIN_RATE_LIMITED` code: wait about a minute |
| connection cap (HTTP 429) | nothing — the button just sat there | check you are on the host's Wi‑Fi, tap Retry connection |

Each one is keyed as `join.refused.<CODE>` in de/en/es, like the rest of the player-facing strings, and is preferred over the terse `errors.<CODE>` label the in-game toasts keep using. A label names the problem; these say what to do next.

## Tests

`tests/test_join_refusal_visible_729.py` — 38 cases, **all 38 fail on `main`** (verified with `git stash`):

- the `handleError` join branch must key on an explicit pending flag, not on the absent name
- clicking Join must declare the join pending; a successful join must clear it
- the refusal must re-enable the button, write `#name-validation-msg`, and release the refused name
- the shipped `player.bundle.js` must carry the fix (`player.html` loads the bundle, not the modules — the #625 trap)
- every refusal has non-empty, distinct-from-the-label wording in all three languages, in key parity
- every code `PlayerRegistry.add_player` can return is named in the join handler's fallback map (scanned from the source, so a new refusal cannot be added without wording)
- a finished game does not answer "Failed to join"; the duplicate self-join and the join flood each answer their own code

Full suite 2536 passed, `ruff check custom_components/` and `mypy custom_components/` clean, bundle rebuilt.

Closes #729

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE
