### PR TITLE
The television and the host page show power-ups and reactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ Quizify speaks your guests' language.
 
 The UI follows the game language (since v1.1.24) — pick German in the pack-picker and the entire admin / player / dashboard surface switches to German labels, tooltips, error messages, fun-fact labels, and end-game awards. Switch to English or Spanish and the whole thing flips.
 
-674 i18n keys, full parity between all three locales, validated in CI.
+676 i18n keys, full parity between all three locales, validated in CI.
 
 ---
 

--- a/custom_components/quizify/www/admin.html
+++ b/custom_components/quizify/www/admin.html
@@ -1024,6 +1024,12 @@
         </div>
     </div>
 
+    <!-- #741: the power-up strip and the reveal reactions, identical to the
+         television's. Both sit outside the page columns — the strip owns the
+         top edge for four seconds, the reaction layer owns the whole screen. -->
+    <div id="powerup-banners" class="powerup-banners" role="status" aria-live="polite"></div>
+    <div id="reaction-layer" class="reaction-layer-board" aria-hidden="true"></div>
+
     <!-- Error toast -->
     <div id="error-toast" class="toast hidden" role="alert" aria-live="assertive"></div>
 

--- a/custom_components/quizify/www/css/src/06-admin.css
+++ b/custom_components/quizify/www/css/src/06-admin.css
@@ -264,3 +264,119 @@ footer {
     100% { transform: rotate(360deg); }
 }
 
+
+/* ===================================================================
+   POWER-UP BANNER STRIP + REVEAL REACTIONS (#741)
+   The host page was missing the same two cases the television was: a
+   steal moved the leaderboard in front of the host with no account of
+   why. Same strip, same rules — see dashboard.html for the television
+   twin; the tokens differ only because this page uses the shared
+   --color-* set instead of the board's --dash-* set.
+   =================================================================== */
+.powerup-banners {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1200;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    pointer-events: none;
+}
+
+.powerup-banner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-sm, 12px);
+    padding: 14px 24px;
+    /* Soft Parlor is a cream page, so the strip is its inverse: the ink
+       token as the ground, cream type on it. A cream strip on a cream
+       page would need a hairline to exist at all. */
+    background: var(--color-text-primary);
+    color: var(--color-bg-primary);
+    font-size: clamp(16px, 2vw, 22px);
+    font-weight: 600;
+    line-height: 1.25;
+    text-align: center;
+    box-shadow: 0 6px 24px rgba(42, 40, 32, 0.22);
+    animation: powerup-banner-in 260ms cubic-bezier(0.2, 0.8, 0.3, 1) both;
+}
+
+.powerup-banner.is-leaving {
+    animation: powerup-banner-out 260ms ease-in both;
+}
+
+.powerup-banner-icon {
+    font-size: clamp(20px, 2.4vw, 28px);
+    line-height: 1;
+    flex-shrink: 0;
+}
+
+.powerup-banner-name {
+    color: var(--color-gold);
+    font-weight: 700;
+}
+
+.powerup-banner-points {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    color: var(--color-gold);
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+}
+
+@keyframes powerup-banner-in {
+    from { transform: translateY(-100%); opacity: 0; }
+    to   { transform: translateY(0);     opacity: 1; }
+}
+
+@keyframes powerup-banner-out {
+    from { transform: translateY(0);     opacity: 1; }
+    to   { transform: translateY(-100%); opacity: 0; }
+}
+
+/* What a steal cost, on the two rows it moved. */
+.leaderboard-delta {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.85em;
+    font-weight: 700;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-variant-numeric: tabular-nums;
+}
+
+.leaderboard-delta.is-up {
+    color: var(--color-success);
+    background: var(--color-success-light);
+}
+
+.leaderboard-delta.is-down {
+    color: var(--color-error);
+    background: var(--color-error-light);
+}
+
+/* Reveal reactions. Reveal only — over a live question the movement
+   would compete with reading the answers. */
+.reaction-layer-board {
+    position: fixed;
+    inset: 0;
+    z-index: 1100;
+    pointer-events: none;
+    overflow: hidden;
+}
+
+.floating-reaction-board {
+    position: absolute;
+    bottom: 0;
+    font-size: clamp(32px, 4vw, 56px);
+    line-height: 1;
+    animation: floating-reaction-board-rise 3s ease-out forwards;
+    will-change: transform, opacity;
+}
+
+@keyframes floating-reaction-board-rise {
+    0%   { transform: translateY(0)     scale(0.6); opacity: 0; }
+    12%  { transform: translateY(-8vh)  scale(1);   opacity: 1; }
+    100% { transform: translateY(-78vh) scale(1.1); opacity: 0; }
+}

--- a/custom_components/quizify/www/css/styles.css
+++ b/custom_components/quizify/www/css/styles.css
@@ -3477,6 +3477,122 @@ footer {
     100% { transform: rotate(360deg); }
 }
 
+
+/* ===================================================================
+   POWER-UP BANNER STRIP + REVEAL REACTIONS (#741)
+   The host page was missing the same two cases the television was: a
+   steal moved the leaderboard in front of the host with no account of
+   why. Same strip, same rules — see dashboard.html for the television
+   twin; the tokens differ only because this page uses the shared
+   --color-* set instead of the board's --dash-* set.
+   =================================================================== */
+.powerup-banners {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1200;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    pointer-events: none;
+}
+
+.powerup-banner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-sm, 12px);
+    padding: 14px 24px;
+    /* Soft Parlor is a cream page, so the strip is its inverse: the ink
+       token as the ground, cream type on it. A cream strip on a cream
+       page would need a hairline to exist at all. */
+    background: var(--color-text-primary);
+    color: var(--color-bg-primary);
+    font-size: clamp(16px, 2vw, 22px);
+    font-weight: 600;
+    line-height: 1.25;
+    text-align: center;
+    box-shadow: 0 6px 24px rgba(42, 40, 32, 0.22);
+    animation: powerup-banner-in 260ms cubic-bezier(0.2, 0.8, 0.3, 1) both;
+}
+
+.powerup-banner.is-leaving {
+    animation: powerup-banner-out 260ms ease-in both;
+}
+
+.powerup-banner-icon {
+    font-size: clamp(20px, 2.4vw, 28px);
+    line-height: 1;
+    flex-shrink: 0;
+}
+
+.powerup-banner-name {
+    color: var(--color-gold);
+    font-weight: 700;
+}
+
+.powerup-banner-points {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    color: var(--color-gold);
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+}
+
+@keyframes powerup-banner-in {
+    from { transform: translateY(-100%); opacity: 0; }
+    to   { transform: translateY(0);     opacity: 1; }
+}
+
+@keyframes powerup-banner-out {
+    from { transform: translateY(0);     opacity: 1; }
+    to   { transform: translateY(-100%); opacity: 0; }
+}
+
+/* What a steal cost, on the two rows it moved. */
+.leaderboard-delta {
+    font-family: 'JetBrains Mono', ui-monospace, monospace;
+    font-size: 0.85em;
+    font-weight: 700;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-variant-numeric: tabular-nums;
+}
+
+.leaderboard-delta.is-up {
+    color: var(--color-success);
+    background: var(--color-success-light);
+}
+
+.leaderboard-delta.is-down {
+    color: var(--color-error);
+    background: var(--color-error-light);
+}
+
+/* Reveal reactions. Reveal only — over a live question the movement
+   would compete with reading the answers. */
+.reaction-layer-board {
+    position: fixed;
+    inset: 0;
+    z-index: 1100;
+    pointer-events: none;
+    overflow: hidden;
+}
+
+.floating-reaction-board {
+    position: absolute;
+    bottom: 0;
+    font-size: clamp(32px, 4vw, 56px);
+    line-height: 1;
+    animation: floating-reaction-board-rise 3s ease-out forwards;
+    will-change: transform, opacity;
+}
+
+@keyframes floating-reaction-board-rise {
+    0%   { transform: translateY(0)     scale(0.6); opacity: 0; }
+    12%  { transform: translateY(-8vh)  scale(1);   opacity: 1; }
+    100% { transform: translateY(-78vh) scale(1.1); opacity: 0; }
+}
 /* ==========================================
    Player Page: END VIEW
    ========================================== */

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -1016,6 +1016,131 @@
             letter-spacing: 0.04em;
         }
 
+        /* #741: what a steal actually cost, on the two rows it moved. The
+           strip above says what happened; the rows say what it was worth —
+           the leaderboard is where the change is. */
+        .dashboard-leaderboard .leaderboard-delta {
+            font-family: 'JetBrains Mono', ui-monospace, monospace;
+            font-size: clamp(14px, 1.3vw, 20px);
+            font-weight: 700;
+            padding: 2px 8px;
+            border-radius: 4px;
+            font-variant-numeric: tabular-nums;
+        }
+        .dashboard-leaderboard .leaderboard-delta.is-up {
+            color: var(--dash-success);
+            background: rgba(127, 168, 151, 0.16);
+        }
+        .dashboard-leaderboard .leaderboard-delta.is-down {
+            color: var(--dash-error);
+            background: rgba(214, 106, 106, 0.14);
+        }
+
+        /* ===================
+           POWER-UP BANNER STRIP (#741) — the room's only account of a power-up
+           that landed on somebody *else*. Fixed to the top edge, so it takes
+           the round-indicator line for its four seconds and leaves the
+           question text alone. Two at once stack rather than replacing one
+           another: the container is a column and each strip carries its own
+           timer, so the one appended first is also the first to leave.
+
+           It carries a sentence, not a symbol. An icon on a leaderboard row
+           assumes the viewer knows what the icon means, and the room does not.
+           =================== */
+        .dashboard-powerup-banners {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            z-index: 45;
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+            pointer-events: none;
+        }
+
+        .dashboard-powerup-banner {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: clamp(12px, 1.4vw, 24px);
+            padding: clamp(12px, 1.4vw, 22px) clamp(24px, 3vw, 48px);
+            /* Soft Parlor is a cream board, so the strip is its inverse: the
+               ink token as the ground, cream type on it. A cream strip on a
+               cream board would need a hairline to exist at all, and a
+               hairline is not something you read from a sofa. */
+            background: var(--dash-text-white);
+            color: var(--dash-bg-primary);
+            font-family: 'DM Sans', sans-serif;
+            /* #376/#707: content the room reads, not an eyebrow label. */
+            font-size: clamp(20px, 2.2vw, 38px);
+            font-weight: 600;
+            line-height: 1.2;
+            text-align: center;
+            box-shadow: 0 6px 24px rgba(42, 40, 32, 0.22);
+            animation: dashboard-powerup-in 260ms cubic-bezier(0.2, 0.8, 0.3, 1) both;
+        }
+
+        .dashboard-powerup-banner.is-leaving {
+            animation: dashboard-powerup-out 260ms ease-in both;
+        }
+
+        .dashboard-powerup-icon {
+            font-size: clamp(24px, 2.6vw, 44px);
+            line-height: 1;
+            flex-shrink: 0;
+        }
+
+        .dashboard-powerup-name {
+            color: var(--dash-gold);
+            font-weight: 700;
+        }
+
+        .dashboard-powerup-points {
+            font-family: 'JetBrains Mono', ui-monospace, monospace;
+            color: var(--dash-gold);
+            font-weight: 700;
+            font-variant-numeric: tabular-nums;
+        }
+
+        @keyframes dashboard-powerup-in {
+            from { transform: translateY(-100%); opacity: 0; }
+            to   { transform: translateY(0);     opacity: 1; }
+        }
+
+        @keyframes dashboard-powerup-out {
+            from { transform: translateY(0);     opacity: 1; }
+            to   { transform: translateY(-100%); opacity: 0; }
+        }
+
+        /* ===================
+           REVEAL REACTIONS (#741) — the emoji every phone already rains, on
+           the one screen the whole room is looking at. Reveal only: over a
+           live question the movement would compete with reading the answers.
+           =================== */
+        .dashboard-reaction-layer {
+            position: fixed;
+            inset: 0;
+            z-index: 30;
+            pointer-events: none;
+            overflow: hidden;
+        }
+
+        .dashboard-floating-reaction {
+            position: absolute;
+            bottom: 0;
+            font-size: clamp(40px, 4vw, 72px);
+            line-height: 1;
+            animation: dashboard-reaction-rise 3s ease-out forwards;
+            will-change: transform, opacity;
+        }
+
+        @keyframes dashboard-reaction-rise {
+            0%   { transform: translateY(0)     scale(0.6); opacity: 0; }
+            12%  { transform: translateY(-8vh)  scale(1);   opacity: 1; }
+            100% { transform: translateY(-78vh) scale(1.1); opacity: 0; }
+        }
+
         /* ===================
            PAUSED OVERLAY (#296) — freezes the timer + dims the board.
            Mirrors the player paused-view intent (game.paused / pausedHint)
@@ -1630,6 +1755,13 @@
         <span data-i18n="dashboard.reconnecting">Reconnecting…</span>
     </div>
 
+    <!-- #741: the power-up strip and the reveal reactions. Both sit outside
+         <main> on purpose — the strip owns the top edge for four seconds and
+         the reaction layer owns the whole screen, and neither may join the
+         column layout that the question and the leaderboard share. -->
+    <div id="powerup-banners" class="dashboard-powerup-banners" role="status" aria-live="polite"></div>
+    <div id="reaction-layer" class="dashboard-reaction-layer" aria-hidden="true"></div>
+
     <main class="dashboard-container">
         <div class="dashboard-header">
             <h1 class="wordmark">
@@ -1841,6 +1973,11 @@
         // lightning_splash / game_state(LIGHTNING) payload's seconds_per_question
         // so a non-15s round drives the shared timer bar with the right divisor.
         var lightningSeconds = 15;
+        // #741: which phase the board believes it is in. The reveal is the
+        // only phase reactions are allowed over, and nothing on this page
+        // tracked the phase before — handleGameState read msg.phase and threw
+        // it away. Mirrors admin.js's currentPhase, set from the same events.
+        var currentPhase = 'LOBBY';
 
         // ---- DOM ----
         var views = {
@@ -1858,6 +1995,9 @@
             lobbyJoinUrlEl: document.getElementById('lobby-join-url'),
             lobbyPlayers: document.getElementById('lobby-players'),
             roundIndicator: document.getElementById('round-indicator'),
+            // #741: power-up strip stack + floating-reaction layer.
+            powerupBanners: document.getElementById('powerup-banners'),
+            reactionLayer: document.getElementById('reaction-layer'),
             timerFill: document.getElementById('timer-fill'),
             answerProgress: document.getElementById('answer-progress'),
             eveningTally: document.getElementById('evening-tally'),
@@ -2206,6 +2346,7 @@
                     handleFinale(msg);
                     break;
                 case 'game_reset':
+                    currentPhase = 'LOBBY';
                     setPaused(false);
                     showView('waiting');
                     // #374: back to the lobby — repaint QR + roster (a reset
@@ -2244,10 +2385,151 @@
                     lobbyTeams = msg.teams || [];
                     renderLobbyPlayers(lastLobbyPlayers);
                     break;
+                // #741: both of these are full broadcasts — the television
+                // socket has always received them and had nowhere to put
+                // them. Anna froze Ben and the board showed nothing; the
+                // room watched points move with no account of why.
+                case 'powerup_applied':
+                    handlePowerUpApplied(msg);
+                    break;
+                case 'reaction':
+                    showDashboardReaction(msg.emoji);
+                    break;
+                case 'reaction_bonus':
+                    handleReactionBonus(msg);
+                    break;
             }
         }
 
+        // ============================================
+        // #741 — power-ups and reactions on the big screen
+        // ============================================
+
+        // Only the power-ups that land on somebody *else* go on the board.
+        // JOKER, DOUBLE_POINTS and TIME_BOOST change nothing but the user's
+        // own turn: putting them up would mean something is on screen almost
+        // constantly, and then none of it means anything.
+        var POWERUP_BANNER_MS = 4000;
+        var POWERUP_BANNER_EXIT_MS = 260;
+        var BOARD_POWERUPS = {
+            freeze: {
+                icon: '\uD83E\uDDCA',
+                key: 'dashboard.powerupFreeze',
+                fallback: '{source} froze {target}'
+            },
+            steal: {
+                icon: '\uD83E\uDD77',
+                key: 'dashboard.powerupSteal',
+                fallback: '{source} stole {points} points from {target}'
+            }
+        };
+
+        // Fills a whole-sentence template. The placeholders are substituted
+        // here rather than through i18n.t(key, vars) for two reasons: the
+        // names and the point count are marked up (gold, tabular), and German
+        // and Spanish put them in a different order than English — so the unit
+        // that gets translated has to be the whole sentence, never fragments
+        // concatenated in English order.
+        function powerUpSentenceHtml(spec, vars) {
+            return t(spec.key, spec.fallback).replace(/\{(\w+)\}/g, function (_m, name) {
+                var value = vars[name];
+                if (value == null) return '';
+                var cls = name === 'points'
+                    ? 'dashboard-powerup-points'
+                    : 'dashboard-powerup-name';
+                return '<span class="' + cls + '">' + escapeHtml(String(value)) + '</span>';
+            });
+        }
+
+        function handlePowerUpApplied(msg) {
+            var spec = BOARD_POWERUPS[msg.powerup_type];
+            if (!spec) return;
+            var source = msg.source_player || '';
+            var target = msg.target_player || '';
+            // Both names or no sentence — "Anna froze" is worse than silence.
+            if (!source || !target) return;
+            var points = Math.abs(Number(msg.stolen_points) || 0);
+            showPowerUpBanner(spec, { source: source, target: target, points: points });
+            if (msg.powerup_type === 'steal' && points > 0) {
+                showScoreDeltas([
+                    { name: source, points: points },
+                    { name: target, points: -points }
+                ]);
+            }
+        }
+
+        function showPowerUpBanner(spec, vars) {
+            if (!els.powerupBanners) return;
+            var el = document.createElement('div');
+            el.className = 'dashboard-powerup-banner';
+            el.innerHTML =
+                '<span class="dashboard-powerup-icon" aria-hidden="true">' + spec.icon + '</span>' +
+                '<span class="dashboard-powerup-text">' + powerUpSentenceHtml(spec, vars) + '</span>';
+            els.powerupBanners.appendChild(el);
+            // Each strip owns its own timer, so a second one arriving mid-stand
+            // stacks underneath and the older one still leaves first.
+            setTimeout(function () {
+                el.classList.add('is-leaving');
+                setTimeout(function () {
+                    if (el.parentNode) el.parentNode.removeChild(el);
+                }, POWERUP_BANNER_EXIT_MS);
+            }, POWERUP_BANNER_MS);
+        }
+
+        // Transient +/- chips on the two rows a steal moved. Held in state
+        // rather than poked into the DOM, because game_state repaints the
+        // leaderboard every few seconds and would wipe them mid-stand.
+        var SCORE_DELTA_MS = 4000;
+        var scoreDeltas = {};
+        var scoreDeltaTimer = null;
+        var lastLeaderboardPlayers = null;
+
+        function showScoreDeltas(deltas) {
+            deltas.forEach(function (d) {
+                if (d.name) scoreDeltas[d.name] = d.points;
+            });
+            if (lastLeaderboardPlayers) renderLeaderboard(els.leaderboard, lastLeaderboardPlayers);
+            if (scoreDeltaTimer) clearTimeout(scoreDeltaTimer);
+            scoreDeltaTimer = setTimeout(function () {
+                scoreDeltas = {};
+                scoreDeltaTimer = null;
+                if (lastLeaderboardPlayers) renderLeaderboard(els.leaderboard, lastLeaderboardPlayers);
+            }, SCORE_DELTA_MS);
+        }
+
+        function scoreDeltaHtml(name) {
+            var delta = scoreDeltas[name];
+            if (!delta) return '';
+            return '<span class="leaderboard-delta ' + (delta < 0 ? 'is-down' : 'is-up') + '">' +
+                (delta < 0 ? '\u2212' : '+') + Math.abs(delta) + '</span>';
+        }
+
+        function showDashboardReaction(emoji) {
+            // Reveal only. Over a live question the movement competes with
+            // reading the answers, which is the one thing the board is for.
+            if (currentPhase !== 'ANSWER_REVEAL') return;
+            if (!els.reactionLayer || !emoji) return;
+            // No throttle of our own: the server already collapses the buffer
+            // to one frame per distinct player+emoji per flush window.
+            var el = document.createElement('div');
+            el.className = 'dashboard-floating-reaction';
+            el.textContent = emoji;
+            el.style.left = (6 + Math.random() * 84) + '%';
+            els.reactionLayer.appendChild(el);
+            setTimeout(function () {
+                if (el.parentNode) el.parentNode.removeChild(el);
+            }, 3200);
+        }
+
+        function handleReactionBonus(msg) {
+            // The +1s are already awarded and already on the server's
+            // leaderboard — render it now instead of letting the number lag
+            // the animation until the next game_state frame arrives.
+            if (msg.leaderboard) renderLeaderboard(els.leaderboard, msg.leaderboard);
+        }
+
         function handleGameState(msg) {
+            if (msg.phase) currentPhase = msg.phase;
             if (msg.leaderboard) renderLeaderboard(els.leaderboard, msg.leaderboard);
 
             // #296: the paused scrim is independent of the underlying view —
@@ -2414,6 +2696,7 @@
 
         // ---- Lightning (#296) — mirrors admin.js handlers for the TV. ----
         function handleLightningSplash(msg) {
+            currentPhase = 'LIGHTNING';
             showView('lightning');
             if (els.lightningSplash) els.lightningSplash.hidden = false;
             if (els.lightningQuestionSection) els.lightningQuestionSection.hidden = true;
@@ -2429,6 +2712,7 @@
         }
 
         function handleLightningQuestion(msg) {
+            currentPhase = 'LIGHTNING';
             showView('lightning');
             if (els.lightningSplash) els.lightningSplash.hidden = true;
             if (els.lightningQuestionSection) els.lightningQuestionSection.hidden = false;
@@ -2466,6 +2750,7 @@
         }
 
         function handleLightningRecap(recap) {
+            currentPhase = 'LIGHTNING_RECAP';
             showView('lightningRecap');
             if (els.lightningRecapLeaderboard) {
                 renderLeaderboard(els.lightningRecapLeaderboard, recap.leaderboard || []);
@@ -2491,6 +2776,7 @@
          * down, not the answer clock — that one has not started yet.
          */
         function handleWagerProgress(msg) {
+            currentPhase = 'WAGER_ACTIVE';
             showView('question');
             els.funFact.classList.remove('visible');
 
@@ -2548,6 +2834,7 @@
         }
 
         function handleHotSeatAuction(msg) {
+            currentPhase = 'HOT_SEAT_AUCTION';
             hotSeatFrame(msg.round_num, msg.total_rounds);
             els.questionCategory.textContent = '';
             els.questionText.textContent = hotSeatT(
@@ -2583,6 +2870,7 @@
         }
 
         function handleHotSeatQuestion(msg) {
+            currentPhase = 'HOT_SEAT';
             // ``question`` is the field name on the wire (see
             // _broadcast_hot_seat_question); the snapshot path passes the
             // same shape so both routes land here identically.
@@ -2598,6 +2886,7 @@
         }
 
         function handleHotSeatResult(msg) {
+            currentPhase = 'HOT_SEAT_REVEAL';
             // #698: the settlement had no consumer on any surface. The board
             // stayed on the question with the bar at zero until the host
             // advanced, so the room never learned whether the chair paid off —
@@ -2658,6 +2947,7 @@
         }
 
         function handleQuestionStarted(msg) {
+            currentPhase = 'QUESTION_ACTIVE';
             showView('question');
             els.funFact.classList.remove('visible');
 
@@ -2808,6 +3098,7 @@
         }
 
         function handleRoundSummary(msg) {
+            currentPhase = 'ANSWER_REVEAL';
             var summary = msg.round_summary || msg;
 
             // #434: the summary keeps the question view's image element, so
@@ -2947,6 +3238,7 @@
         }
 
         function handleFinale(msg) {
+            currentPhase = 'FINALE';
             showView('finale');
 
             // #613: clear last game's duel before this game's arrives on
@@ -2971,6 +3263,9 @@
         // ---- Renderers ----
         function renderLeaderboard(container, players) {
             if (!container || !players) return;
+            // #741: remembered so an expiring steal chip can repaint the same
+            // rows without waiting for the next frame from the server.
+            if (container === els.leaderboard) lastLeaderboardPlayers = players;
             // Show top 5 in game view, all in finale
             var capped = container === els.leaderboard;
             var list = capped ? players.slice(0, 5) : players;
@@ -2981,6 +3276,7 @@
                     '<span class="leaderboard-rank' + rankClass + '">' + rank + '</span>' +
                     '<span class="leaderboard-name">' + escapeHtml(p.name) + '</span>' +
                     '<span class="leaderboard-score">' + p.score + '</span>' +
+                    scoreDeltaHtml(p.name) +
                     (p.streak > 1 ? '<span class="leaderboard-streak">' + p.streak + 'x</span>' : '') +
                     '</div>';
             }).join('');

--- a/custom_components/quizify/www/i18n/de.json
+++ b/custom_components/quizify/www/i18n/de.json
@@ -563,7 +563,9 @@
     "h2hRecent": "letzte 90 Tage",
     "tonightGames": "{games} Spiele",
     "tonightWins": "{wins} Siege",
-    "tonightWinsOne": "1 Sieg"
+    "tonightWinsOne": "1 Sieg",
+    "powerupFreeze": "{source} hat {target} eingefroren",
+    "powerupSteal": "{source} stiehlt {points} Punkte von {target}"
   },
   "connection": {
     "connected": "Verbunden",

--- a/custom_components/quizify/www/i18n/en.json
+++ b/custom_components/quizify/www/i18n/en.json
@@ -563,7 +563,9 @@
     "h2hRecent": "last 90 days",
     "tonightGames": "{games} games",
     "tonightWins": "{wins} wins",
-    "tonightWinsOne": "1 win"
+    "tonightWinsOne": "1 win",
+    "powerupFreeze": "{source} froze {target}",
+    "powerupSteal": "{source} stole {points} points from {target}"
   },
   "connection": {
     "connected": "Connected",

--- a/custom_components/quizify/www/i18n/es.json
+++ b/custom_components/quizify/www/i18n/es.json
@@ -563,7 +563,9 @@
     "h2hRecent": "últimos 90 días",
     "tonightGames": "{games} partidas",
     "tonightWins": "{wins} victorias",
-    "tonightWinsOne": "1 victoria"
+    "tonightWinsOne": "1 victoria",
+    "powerupFreeze": "{source} ha congelado a {target}",
+    "powerupSteal": "{source} le roba {points} puntos a {target}"
   },
   "connection": {
     "connected": "Conectado",

--- a/custom_components/quizify/www/js/admin.js
+++ b/custom_components/quizify/www/js/admin.js
@@ -193,6 +193,10 @@
         adminQuestion: document.getElementById('admin-question'),
         adminCorrect: document.getElementById('admin-correct'),
         gameLeaderboard: document.getElementById('game-leaderboard'),
+        // #741: the same power-up strip the television got, on the screen
+        // where the host notices why the points jumped.
+        powerupBanners: document.getElementById('powerup-banners'),
+        reactionLayer: document.getElementById('reaction-layer'),
         nextQuestionBtn: document.getElementById('next-question-btn'),
         endGameBtn: document.getElementById('end-game-btn'),
         resetGameBtn: document.getElementById('reset-game-btn'),
@@ -1555,6 +1559,18 @@
             case 'lightning_recap':
                 handleAdminLightningRecap(msg.recap || {});
                 break;
+            // #741: full broadcasts the host page received and dropped. A
+            // steal moved the leaderboard in front of the host with no
+            // account of why, and the reveal's reactions were phone-private.
+            case 'powerup_applied':
+                handlePowerUpApplied(msg);
+                break;
+            case 'reaction':
+                showAdminReaction(msg.emoji);
+                break;
+            case 'reaction_bonus':
+                handleReactionBonus(msg);
+                break;
             case 'error':
                 // The initial admin_connect attempt before authentication
                 // returns "Admin only" — that's expected handshake noise,
@@ -2084,8 +2100,137 @@
         }
     }
 
+    // ============================================
+    // #741 — power-ups and reactions on the host screen
+    // ============================================
+
+    // Same strip, same rules as the television (dashboard.html): only the
+    // power-ups that land on somebody *else*. JOKER, DOUBLE_POINTS and
+    // TIME_BOOST touch nothing but the user's own turn, so showing them would
+    // put something on screen almost constantly and none of it would mean
+    // anything.
+    var POWERUP_BANNER_MS = 4000;
+    var POWERUP_BANNER_EXIT_MS = 260;
+    var SCORE_DELTA_MS = 4000;
+    var BOARD_POWERUPS = {
+        freeze: {
+            icon: '\uD83E\uDDCA',
+            key: 'dashboard.powerupFreeze',
+            fallback: '{source} froze {target}'
+        },
+        steal: {
+            icon: '\uD83E\uDD77',
+            key: 'dashboard.powerupSteal',
+            fallback: '{source} stole {points} points from {target}'
+        }
+    };
+
+    var _scoreDeltas = {};
+    var _scoreDeltaTimer = null;
+    var _lastGameLeaderboard = null;
+
+    // Whole-sentence template, filled here rather than through _t(key, vars):
+    // the names and the point count are marked up, and German and Spanish
+    // order them differently from English — so the translated unit has to be
+    // the entire sentence, never fragments concatenated in English order.
+    function powerUpSentenceHtml(spec, vars) {
+        var template = _t(spec.key);
+        if (!template || template === spec.key) template = spec.fallback;
+        return template.replace(/\{(\w+)\}/g, function (_m, name) {
+            var value = vars[name];
+            if (value == null) return '';
+            var cls = name === 'points' ? 'powerup-banner-points' : 'powerup-banner-name';
+            return '<span class="' + cls + '">' + escapeHtml(String(value)) + '</span>';
+        });
+    }
+
+    function handlePowerUpApplied(msg) {
+        var spec = BOARD_POWERUPS[msg.powerup_type];
+        if (!spec) return;
+        var source = msg.source_player || '';
+        var target = msg.target_player || '';
+        // Both names or no sentence — "Anna froze" is worse than silence.
+        if (!source || !target) return;
+        var points = Math.abs(Number(msg.stolen_points) || 0);
+        showPowerUpBanner(spec, { source: source, target: target, points: points });
+        if (msg.powerup_type === 'steal' && points > 0) {
+            showScoreDeltas([
+                { name: source, points: points },
+                { name: target, points: -points }
+            ]);
+        }
+    }
+
+    function showPowerUpBanner(spec, vars) {
+        if (!els.powerupBanners) return;
+        var el = document.createElement('div');
+        el.className = 'powerup-banner';
+        el.innerHTML =
+            '<span class="powerup-banner-icon" aria-hidden="true">' + spec.icon + '</span>' +
+            '<span class="powerup-banner-text">' + powerUpSentenceHtml(spec, vars) + '</span>';
+        els.powerupBanners.appendChild(el);
+        // Each strip carries its own timer, so a second one arriving mid-stand
+        // stacks underneath and the older one still leaves first.
+        setTimeout(function () {
+            el.classList.add('is-leaving');
+            setTimeout(function () {
+                if (el.parentNode) el.parentNode.removeChild(el);
+            }, POWERUP_BANNER_EXIT_MS);
+        }, POWERUP_BANNER_MS);
+    }
+
+    // Transient +/- chips on the two rows a steal moved. Kept in state because
+    // game_state repaints the leaderboard every few seconds and would
+    // otherwise wipe them mid-stand.
+    function showScoreDeltas(deltas) {
+        deltas.forEach(function (d) {
+            if (d.name) _scoreDeltas[d.name] = d.points;
+        });
+        if (_lastGameLeaderboard) renderLeaderboard(els.gameLeaderboard, _lastGameLeaderboard);
+        if (_scoreDeltaTimer) clearTimeout(_scoreDeltaTimer);
+        _scoreDeltaTimer = setTimeout(function () {
+            _scoreDeltas = {};
+            _scoreDeltaTimer = null;
+            if (_lastGameLeaderboard) renderLeaderboard(els.gameLeaderboard, _lastGameLeaderboard);
+        }, SCORE_DELTA_MS);
+    }
+
+    function scoreDeltaHtml(name) {
+        var delta = _scoreDeltas[name];
+        if (!delta) return '';
+        return '<span class="leaderboard-delta ' + (delta < 0 ? 'is-down' : 'is-up') + '">' +
+            (delta < 0 ? '\u2212' : '+') + Math.abs(delta) + '</span>';
+    }
+
+    function showAdminReaction(emoji) {
+        // Reveal only, same rule as the television: over a live question the
+        // movement competes with reading. The server already collapses the
+        // buffer to one frame per distinct player+emoji per flush window, so
+        // there is nothing left to throttle here.
+        if (currentPhase !== 'ANSWER_REVEAL') return;
+        if (!els.reactionLayer || !emoji) return;
+        var el = document.createElement('div');
+        el.className = 'floating-reaction-board';
+        el.textContent = emoji;
+        el.style.left = (6 + Math.random() * 84) + '%';
+        els.reactionLayer.appendChild(el);
+        setTimeout(function () {
+            if (el.parentNode) el.parentNode.removeChild(el);
+        }, 3200);
+    }
+
+    function handleReactionBonus(msg) {
+        // The +1s are already awarded and already in this payload's
+        // leaderboard — render it now instead of letting the number lag the
+        // animation until the next game_state frame.
+        if (msg.leaderboard) renderLeaderboard(els.gameLeaderboard, msg.leaderboard);
+    }
+
     function renderLeaderboard(container, players) {
         if (!container) return;
+        // #741: remembered so an expiring steal chip can repaint the same rows
+        // without waiting for the next frame from the server.
+        if (container === els.gameLeaderboard) _lastGameLeaderboard = players;
         container.innerHTML = players
             .map(function (p, i) {
                 var rank = p.rank || i + 1;
@@ -2094,6 +2239,7 @@
                     '<span class="leaderboard-rank' + rankClass + '">' + rank + '</span>' +
                     '<span class="leaderboard-name">' + escapeHtml(p.name) + '</span>' +
                     '<span class="leaderboard-score">' + p.score + '</span>' +
+                    scoreDeltaHtml(p.name) +
                     (p.streak > 1 ? '<span class="leaderboard-streak">' + p.streak + 'x</span>' : '') +
                     '</div>';
             })

--- a/tests/test_board_powerups_and_reactions_741.py
+++ b/tests/test_board_powerups_and_reactions_741.py
@@ -1,0 +1,226 @@
+"""#741 — the television (and the host page) never showed power-ups or reactions.
+
+``powerup_applied`` and ``reaction`` are both **full** broadcasts
+(``server/websocket.py``: ``self._conn.broadcast(...)``), so the television
+socket has always received them. ``dashboard.html``'s message switch had a case
+for neither, and no ``default:`` branch — so the frames arrived and were thrown
+away in silence. ``admin.js`` was missing exactly the same three cases.
+
+What the room saw: Anna freezes Ben, Ben's phone ices over, the big screen shows
+nothing. A steal moves points on the leaderboard with no explanation. During the
+reveal every phone rains emoji while the television stays static.
+
+What is pinned here, beyond "the cases exist":
+
+* **Only the power-ups that hit someone else.** ``FREEZE`` and ``STEAL`` go on
+  the screen; ``JOKER``, ``DOUBLE_POINTS`` and ``TIME_BOOST`` change nothing but
+  the user's own turn. Showing those would mean something is on the screen
+  almost constantly, and then none of it means anything.
+* **A sentence, not a symbol.** An icon on a leaderboard row assumes the viewer
+  knows what the icon means, and the room does not.
+* **Whole sentences in the bundles.** German and Spanish order the player name,
+  the point count and the target differently from English, so the translated
+  unit has to be the entire sentence with placeholders — fragments concatenated
+  in English order produce a German television speaking English grammar.
+* **Reactions only over the reveal.** Over a live question the movement would
+  compete with reading the answers.
+* **``reaction_bonus`` renders its own leaderboard**, so the +1 does not lag its
+  own animation until the next ``game_state`` frame.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parent.parent
+_WWW = _REPO / "custom_components" / "quizify" / "www"
+_DASHBOARD = _WWW / "dashboard.html"
+_ADMIN_JS = _WWW / "js" / "admin.js"
+_ADMIN_HTML = _WWW / "admin.html"
+_ADMIN_CSS = _WWW / "css" / "src" / "06-admin.css"
+_I18N = _WWW / "i18n"
+
+LANGUAGES = ("de", "en", "es")
+
+# The two surfaces that show the room what happened: the television and the
+# host's page. Both were missing the same cases, so both are checked the same.
+BOARDS = {
+    "dashboard.html": _DASHBOARD,
+    "admin.js": _ADMIN_JS,
+}
+
+
+def _bundle(code: str) -> dict:
+    return json.loads((_I18N / f"{code}.json").read_text("utf-8"))
+
+
+@pytest.mark.parametrize("name", sorted(BOARDS))
+@pytest.mark.parametrize(
+    "message_type", ["powerup_applied", "reaction", "reaction_bonus"]
+)
+def test_the_board_has_a_case_for_the_broadcast(name: str, message_type: str) -> None:
+    """The frames arrived; there was nowhere to put them."""
+    source = BOARDS[name].read_text(encoding="utf-8")
+    assert f"case '{message_type}':" in source, (
+        f"{name} still drops the {message_type} broadcast on the floor"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(BOARDS))
+def test_only_the_power_ups_that_hit_someone_else_reach_the_screen(name: str) -> None:
+    """A strip that is up constantly says nothing.
+
+    JOKER / DOUBLE_POINTS / TIME_BOOST affect only the player's own turn, so
+    they are deliberately absent from the table that drives the strip.
+    """
+    source = BOARDS[name].read_text(encoding="utf-8")
+    match = re.search(r"var BOARD_POWERUPS = \{(.*?)\n    \};", source, re.S)
+    if match is None:
+        match = re.search(r"var BOARD_POWERUPS = \{(.*?)\n        \};", source, re.S)
+    assert match, f"{name} has no BOARD_POWERUPS table"
+    table = match.group(1)
+    assert "freeze:" in table, f"{name} does not put a freeze on the screen"
+    assert "steal:" in table, f"{name} does not put a steal on the screen"
+    for own_turn in ("joker", "double_points", "time_boost"):
+        assert f"{own_turn}:" not in table, (
+            f"{name} shows {own_turn}, which only ever changed the user's own "
+            "turn — the strip would be up constantly and mean nothing"
+        )
+
+
+@pytest.mark.parametrize("name", sorted(BOARDS))
+def test_the_strip_shows_a_sentence_and_not_only_a_symbol(name: str) -> None:
+    """The whole point of the choice: the room does not read icons."""
+    source = BOARDS[name].read_text(encoding="utf-8")
+    assert "function powerUpSentenceHtml(" in source, (
+        f"{name} builds no sentence for the strip"
+    )
+    assert "dashboard.powerupFreeze" in source and "dashboard.powerupSteal" in source, (
+        f"{name} does not reach for the translated sentences"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(BOARDS))
+def test_reactions_are_reveal_only(name: str) -> None:
+    """Over a live question the movement competes with reading the answers."""
+    source = BOARDS[name].read_text(encoding="utf-8")
+    match = re.search(
+        r"function (?:showDashboardReaction|showAdminReaction)\((.*?)\n    \}",
+        source,
+        re.S,
+    )
+    if match is None:
+        match = re.search(
+            r"function (?:showDashboardReaction|showAdminReaction)\((.*?)\n        \}",
+            source,
+            re.S,
+        )
+    assert match, f"{name} has no floating-reaction renderer"
+    body = match.group(1)
+    assert "ANSWER_REVEAL" in body, (
+        f"{name} rains emoji over a live question — the reveal gate is missing"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(BOARDS))
+def test_the_steal_also_moves_the_leaderboard_rows(name: str) -> None:
+    """The strip says what happened; the rows say what it cost."""
+    source = BOARDS[name].read_text(encoding="utf-8")
+    assert "function scoreDeltaHtml(" in source, f"{name} renders no point delta"
+    render = source[source.index("function renderLeaderboard(") :][:1600]
+    assert "scoreDeltaHtml(p.name)" in render, (
+        f"{name}'s leaderboard rows never show the delta a steal produced"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(BOARDS))
+def test_the_reaction_bonus_repaints_the_leaderboard_at_once(name: str) -> None:
+    """Otherwise the +1 lags its own animation until the next game_state."""
+    source = BOARDS[name].read_text(encoding="utf-8")
+    match = re.search(r"function handleReactionBonus\(msg\) \{(.*?)\n(    |        )\}", source, re.S)
+    assert match, f"{name} has no reaction_bonus handler"
+    assert "msg.leaderboard" in match.group(1), (
+        f"{name} ignores the leaderboard the bonus frame already carries"
+    )
+
+
+@pytest.mark.parametrize("name", sorted(BOARDS))
+def test_two_at_once_stack_instead_of_replacing_each_other(name: str) -> None:
+    """A second strip appends under the first; the oldest still leaves first."""
+    source = BOARDS[name].read_text(encoding="utf-8")
+    match = re.search(r"function showPowerUpBanner\(spec, vars\) \{(.*?)\n(    |        )\}\n", source, re.S)
+    assert match, f"{name} has no strip renderer"
+    body = match.group(1)
+    assert "appendChild" in body, (
+        f"{name} does not append — a second strip would replace the first"
+    )
+    assert "powerupBanners.innerHTML" not in body, (
+        f"{name} clears the stack before appending, so only one strip is ever up"
+    )
+
+
+def test_both_boards_declare_the_strip_and_the_reaction_layer() -> None:
+    """The JS looks these up by id; without the markup it is a silent no-op."""
+    for page in (_DASHBOARD, _ADMIN_HTML):
+        html = page.read_text(encoding="utf-8")
+        assert 'id="powerup-banners"' in html, f"{page.name} has no strip container"
+        assert 'id="reaction-layer"' in html, f"{page.name} has no reaction layer"
+
+
+@pytest.mark.parametrize(
+    "css,selector",
+    [
+        (_DASHBOARD, ".dashboard-powerup-banners"),
+        (_ADMIN_CSS, ".powerup-banners"),
+    ],
+)
+def test_the_stack_is_a_column(css: Path, selector: str) -> None:
+    """Stacking is a layout property, not something the JS can assert."""
+    text = css.read_text(encoding="utf-8")
+    start = text.index(selector + " {")
+    body = text[start : text.index("}", start)]
+    assert "flex-direction: column" in body, (
+        f"{selector} is not a column — two strips at once would sit side by side"
+    )
+
+
+@pytest.mark.parametrize("code", LANGUAGES)
+def test_every_language_carries_both_sentences(code: str) -> None:
+    """A German television must not show an English sentence."""
+    dashboard = _bundle(code)["dashboard"]
+    for key in ("powerupFreeze", "powerupSteal"):
+        assert key in dashboard, f"{code}.json is missing dashboard.{key}"
+        assert dashboard[key].strip(), f"{code}.json has an empty dashboard.{key}"
+
+
+@pytest.mark.parametrize("code", LANGUAGES)
+def test_the_sentences_are_whole_sentences_with_placeholders(code: str) -> None:
+    """Not fragments concatenated in English order.
+
+    German and Spanish put the name, the count and the target in a different
+    order, and only a full-sentence template can express that.
+    """
+    dashboard = _bundle(code)["dashboard"]
+    freeze = set(re.findall(r"\{(\w+)\}", dashboard["powerupFreeze"]))
+    steal = set(re.findall(r"\{(\w+)\}", dashboard["powerupSteal"]))
+    assert freeze == {"source", "target"}, (
+        f"{code}.json dashboard.powerupFreeze interpolates {freeze}"
+    )
+    assert steal == {"source", "target", "points"}, (
+        f"{code}.json dashboard.powerupSteal interpolates {steal}"
+    )
+
+
+@pytest.mark.parametrize("code", ("de", "es"))
+def test_the_translations_are_actually_translated(code: str) -> None:
+    """A copied English string passes a key-parity check and still lies."""
+    english = _bundle("en")["dashboard"]
+    other = _bundle(code)["dashboard"]
+    for key in ("powerupFreeze", "powerupSteal"):
+        assert other[key] != english[key], (
+            f"{code}.json dashboard.{key} is still the English sentence"
+        )


### PR DESCRIPTION
Closes #741

## What the room saw

`powerup_applied` and `reaction` are full broadcasts (`server/websocket.py`), so the television socket has always received them. `www/dashboard.html`'s message switch had a case for neither and no `default:` branch; `www/js/admin.js` was missing the same three cases. The frames arrived and were dropped in silence.

Anna freezes Ben — Ben's phone ices over, the big screen shows nothing. A steal moves points on the leaderboard with no explanation. During the reveal every phone rains emoji while the television stays static.

## What is on the board now

**A banner strip at the top.** It slides in, stands for four seconds, slides out. It takes the round-indicator line while it stands; the question text stays clear. Two at once **stack** underneath each other rather than replacing one another — each strip carries its own timer, so the oldest is also the first to leave.

It shows a **sentence**, not a symbol: "Anna hat Ben eingefroren", "Anna stiehlt 40 Punkte von Ben". That sentence is the whole point of the choice — an icon on a leaderboard row assumes the viewer knows what the icon means, and the room does not.

**Only the power-ups that hit someone else.** `FREEZE` and `STEAL` go on the screen. `JOKER`, `DOUBLE_POINTS` and `TIME_BOOST` affect only the player's own turn and are deliberately not shown — otherwise something is on screen almost constantly and none of it means anything. This was the open question in the design draft and it was not answered, so the recommendation stands as built; say the word and the table that drives the strip (`BOARD_POWERUPS`) takes another entry in one line.

**The steal also flashes the point delta on both rows it moved.** The strip says what happened, the rows say what it cost — the leaderboard is where the change actually is. The chips are held in state rather than poked into the DOM, because `game_state` repaints the leaderboard every few seconds and would otherwise wipe them mid-stand.

**Reactions rise over the reveal, and only over the reveal.** Over a live question the movement would compete with reading the answers. The server already de-duplicates (one `reaction` frame per distinct player+emoji per flush window), so there is no client-side throttle. `dashboard.html` never tracked the phase before — `handleGameState` read `msg.phase` and threw it away — so it now keeps a `currentPhase` set from the same events `admin.js` already used for its own.

**`reaction_bonus` renders the leaderboard it already carries**, so the +1 no longer lags its own animation until the next `game_state` frame.

**The host page got the same strip, the same rules.** It is the screen where the host notices why the points jumped.

## Language

`dashboard.powerupFreeze` and `dashboard.powerupSteal` in de/en/es. Both are whole-sentence templates with `{source}` / `{target}` / `{points}` placeholders, substituted client-side so the names and the count can be marked up — German and Spanish order them differently from English, so fragments concatenated in English order would give a German television English grammar. A test pins the placeholder sets across the three bundles and that neither translation is still the English string.

## One deliberate deviation from the brief

The brief said "ink `--dash-text-white` on the dark ground". Since the Soft Parlor repaint, `--dash-text-white` **is** the dark ink (`#2A2820`) on a cream board, so ink-on-dark would be invisible. The strip is built as the board's inverse instead: `--dash-text-white` as the ground, `--dash-bg-primary` for the sentence, `--dash-gold` for the player name and the point count. That keeps every named token, keeps the gold, and reads from a sofa — a cream strip on a cream board would need a hairline to exist at all, and a hairline is not readable at three metres.

## Verification

Rendered headless at 1920×1080 with a stubbed socket, German locale, both strips stacked, the deltas on the two rows and reactions rising over the reveal: `/private/tmp/claude-501/-Users-markusholzhauser-Development-Claude-quizifybot/e2f1b307-f27b-412d-8a39-268cc1c0c654/scratchpad/quizify-741-tv-strip.png`

`tests/test_board_powerups_and_reactions_741.py` — 29 tests, all 29 fail on `origin/main` (verified by stashing the source changes) and pass with the fix. Full gates green locally and in CI: `pytest -q`, `ruff check custom_components/`, `mypy custom_components/`. `build_bundle.py` and `build_css.py` re-run; neither produced a diff against the rebased base, so the `drift` job is clean. `README.md`'s quoted i18n key count moved 674 → 676, which `test_docs_pack_counts.py` requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE

