### PR TITLE
ci: test both ends of the supported Home Assistant range

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,9 @@ jobs:
         # Which release this leg actually resolved to is the one fact a reader
         # of a red log needs first, and the unpinned leg cannot be read off the
         # requirements file.
-        run: python -c "import homeassistant; print('Home Assistant', homeassistant.__version__)"
+        # `homeassistant.const`, not `homeassistant` — the package itself has
+        # never carried a `__version__`.
+        run: python -c "from homeassistant.const import __version__; print('Home Assistant', __version__)"
 
       - name: Run tests
         # Enforce the worker-contract gate: a missing node here is a hard

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,54 @@ on:
 
 jobs:
   pytest:
+    # Two points, both ends of the range this project promises to support
+    # (issue #740):
+    #
+    #   pytest          — today's Home Assistant, on the Python it requires.
+    #                     `requirements_test.txt` leaves the harness unpinned,
+    #                     so this leg follows core upstream on its own. It is
+    #                     the check that used to be frozen: a `homeassistant
+    #                     <2026.3` cap held it on 2026.2 for seven months while
+    #                     core reached 2026.9, which meant every removal after
+    #                     2026.2 reached a user before it reached CI.
+    #   pytest-ha-floor — the 2024.12.0 minimum that hacs.json and README:447
+    #                     advertise, pinned exactly in
+    #                     requirements_test_ha_floor.txt.
+    #
+    # Deliberately NOT a fan-out over every release in between. Each leg costs
+    # ~3 minutes on every PR, and an API this integration uses is either
+    # present across the whole range or it breaks at one end — the ends are
+    # where the evidence is. A third point would have to earn its wall-clock by
+    # naming a failure the ends miss.
+    #
+    # `name:` is set per entry rather than left to GitHub, which would rename
+    # this check to `pytest (3.14, …)` and silently orphan the required check
+    # the repo merges on. The modern leg keeps the name `pytest`; the floor is
+    # additive.
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    strategy:
+      # Report both ends. The interesting failure is usually "one end broke,
+      # the other didn't", and fail-fast throws away exactly that half.
+      fail-fast: false
+      matrix:
+        include:
+          - name: pytest
+            # Home Assistant 2026.3+ requires Python 3.14.2. When core moves
+            # its floor again this job fails loudly on the next PR — bump it
+            # here rather than capping HA back down.
+            python-version: "3.14"
+            requirements: requirements_test.txt
+          - name: pytest-ha-floor
+            # HA 2024.12 supports 3.12+; 3.13 is the newest it runs on.
+            python-version: "3.13"
+            requirements: requirements_test_ha_floor.txt
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version }}
 
       # Node is required for the worker ⇄ integration contract check
       # (cf-workers/contract-check.mjs + `node --check`). ubuntu-latest ships
@@ -33,7 +74,13 @@ jobs:
           # so the HA-dependent modules (config_flow, binary_sensor) are
           # importable and their tests actually run here (issue #271). HA is a
           # heavy dep, kept scoped to this test job only.
-          pip install -r requirements_test.txt
+          pip install -r ${{ matrix.requirements }}
+
+      - name: Show the Home Assistant version under test
+        # Which release this leg actually resolved to is the one fact a reader
+        # of a red log needs first, and the unpinned leg cannot be read off the
+        # requirements file.
+        run: python -c "import homeassistant; print('Home Assistant', homeassistant.__version__)"
 
       - name: Run tests
         # Enforce the worker-contract gate: a missing node here is a hard
@@ -44,6 +91,9 @@ jobs:
         run: pytest tests/ -v
 
       - name: Byte-compile component (catches syntax errors)
+        # Runs on both legs on purpose: this is what keeps the shipped code
+        # parseable by the floor's Python, which mypy no longer checks (it now
+        # tracks the Python current HA needs — see pyproject.toml).
         run: |
           python -m compileall -q custom_components/quizify
 
@@ -80,15 +130,23 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          # Matches the `pytest` leg: current HA needs 3.14.2.
+          python-version: "3.14"
 
       - name: Install mypy + runtime/framework deps
         run: |
           python -m pip install --upgrade pip
           # HA (+ its transitive aiohttp/voluptuous) so framework imports
-          # resolve; capped < 2026.3 to stay on the 3.13-compatible line, same
-          # constraint the test job uses. mypy pinned for a deterministic gate.
-          pip install "homeassistant<2026.3" "mypy==1.13.0"
+          # resolve. UNCAPPED since #740 — a type-check against a Home
+          # Assistant nobody runs any more checks types nobody has. mypy stays
+          # pinned for a deterministic gate; 1.13.0 was from November 2024 and
+          # could not parse the 3.14 syntax current HA ships.
+          #
+          # There is no floor counterpart to this job. A type error that shows
+          # up only against HA 2024.12 would have to come from a signature core
+          # changed since — which the floor pytest leg catches at runtime, for
+          # less wall-clock than a second full mypy install.
+          pip install homeassistant "mypy==2.3.1"
 
       - name: mypy type-check
         run: mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,14 @@ select = [
 # (homeassistant.*, aiohttp.*, voluptuous, …) whose type stubs are absent or
 # incomplete — everything else is still checked normally.
 [tool.mypy]
-python_version = "3.13"
+# Tracks the Python that the Home Assistant release under test runs on, not the
+# oldest one the integration supports: mypy has to *parse* the framework it is
+# checking against, and HA >= 2026.3 uses 3.14-only syntax (parenthesis-free
+# `except` groups in `config_entries.py`), which a lower setting rejects
+# outright — "errors prevented further checking" (#740). Our own code staying
+# runnable on the declared floor's Python is covered by the floor pytest job,
+# which byte-compiles `custom_components/quizify` under 3.13.
+python_version = "3.14"
 files = ["custom_components/quizify"]
 # The package uses absolute `custom_components.quizify.*` imports, but there is
 # no `custom_components/__init__.py` (HA loads it as a namespace path). Anchor

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,25 +1,37 @@
-# Test/dev dependencies for running the Quizify test suite.
+# Test/dev dependencies for running the Quizify test suite against the Home
+# Assistant release users are actually on today.
 #
 # The first block is the lightweight set the pure-Python tests need (no HA).
 # The second block pulls in Home Assistant + its custom-component test harness
 # so the HA-dependent modules (config_flow.py, binary_sensor.py) can be
 # imported and exercised under test (issue #271).
 #
-# `homeassistant` is a heavy dependency and requires Python 3.13+, so it is
-# only installed in CI's test job — never in the shipped integration. Tests
-# that need it use `pytest.importorskip("homeassistant")` and are skipped
-# (not failed) where it is absent.
+# `homeassistant` is a heavy dependency and tracks a recent Python (2026.3+
+# requires 3.14.2), so it is only installed in CI's test jobs — never in the
+# shipped integration. Tests that need it use
+# `pytest.importorskip("homeassistant")` and are skipped (not failed) where it
+# is absent.
+#
+# The declared floor — Home Assistant 2024.12.0, per hacs.json and README:447 —
+# is covered by the separate `requirements_test_ha_floor.txt` and the
+# `pytest-ha-floor` CI job. Between them the two files bracket the whole
+# supported range.
 
 aiohttp
 voluptuous
 pytest
 pytest-asyncio
 
-# HA test harness. HA >= 2026.3 requires Python 3.14.2, but CI runs 3.13 — so
-# cap HA below that and let pip resolve the matching
-# pytest-homeassistant-custom-component (it pins an exact HA transitively). The
-# pair pip lands on is the newest 3.13-compatible one — still comfortably newer
-# than the manifest minimum (HA 2024.1+). Tests use importorskip, so a missing
-# HA only skips, never fails.
-homeassistant<2026.3
+# HA test harness, deliberately UNPINNED (#740).
+#
+# pytest-homeassistant-custom-component pins one exact `homeassistant` release
+# transitively, so whatever pip lands on here IS the Home Assistant version
+# this job tests. Leaving it open means the job follows core upstream by
+# itself: a deprecation or a removal in a new release breaks CI on the next PR
+# instead of surfacing in a user's issue months later.
+#
+# That is the whole point. This line used to read `homeassistant<2026.3`, and
+# the cap quietly froze the suite on 2026.2 for seven months while core reached
+# 2026.9. If a core release does break the build, do not re-add a cap: fix the
+# incompatibility, or pin *and* open an issue to remove the pin again.
 pytest-homeassistant-custom-component

--- a/requirements_test_ha_floor.txt
+++ b/requirements_test_ha_floor.txt
@@ -1,0 +1,22 @@
+# Test dependencies for the declared MINIMUM Home Assistant version (#740).
+#
+# hacs.json and README:447 promise Home Assistant 2024.12+, and
+# tests/test_declared_ha_floor_607.py pins why (ConfigFlowResult,
+# StaticPathConfig, the automatic OptionsFlow.config_entry property). Until
+# this file existed nothing exercised that promise — a floor is a claim about
+# code that runs, not a number in a manifest.
+#
+# Unlike requirements_test.txt this IS pinned exactly, and should be: the floor
+# is a fixed point by definition. It moves when hacs.json moves, and
+# test_declared_ha_floor_607.py is the argument for moving it.
+#
+# pytest-homeassistant-custom-component 0.13.195 pins homeassistant==2024.12.5
+# — the last 2024.12 patch — and with it the contemporaneous pytest 8.3.3 /
+# pytest-asyncio 0.24.0. Runs on Python 3.13 (HA 2024.12 supports 3.12+).
+
+aiohttp
+voluptuous
+pytest
+pytest-asyncio
+
+pytest-homeassistant-custom-component==0.13.195

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,8 @@ modules (regression seen after merging parallel feature PRs, 2026-06-09).
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import inspect
 import random
 import sys
 from pathlib import Path
@@ -19,6 +21,38 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _warm_the_dns_resolver():
+    """Spawn aiohttp's resolver thread before anyone is counting (#740).
+
+    When ``aiodns`` is installed — Home Assistant depends on it —
+    ``aiohttp.resolver.DefaultResolver`` is ``AsyncResolver``, and the first
+    one ever constructed leaves behind a permanent pycares daemon thread named
+    ``_run_safe_shutdown_loop``. Whichever test happens to open the first
+    ``TestClient`` therefore appears to leak a thread.
+
+    Today's harness allow-lists that name explicitly; the
+    pytest-homeassistant-custom-component that ships with the declared HA floor
+    (2024.12) predates the allow-list and fails the test instead. Creating the
+    resolver once, at session start, puts the thread in place before any test's
+    "threads before" snapshot is taken — which is also simply more honest than
+    charging it to an arbitrary test.
+    """
+    with contextlib.suppress(Exception):  # pragma: no cover - env dependent
+        from aiohttp.resolver import DefaultResolver
+
+        async def _warm() -> None:
+            resolver = DefaultResolver()
+            try:
+                await resolver.resolve("127.0.0.1", 80)
+            finally:
+                await resolver.close()
+
+        asyncio.run(_warm())
+    asyncio.set_event_loop(asyncio.new_event_loop())
+    yield
 
 
 @pytest.fixture(autouse=True)
@@ -79,7 +113,22 @@ def _mixed_draw_serves_multiple_choice():
 
 
 @pytest.fixture(autouse=True)
-def _fresh_event_loop():
+def _fresh_event_loop(request):
+    """Give every *synchronous* test a fresh, open loop.
+
+    Only synchronous tests. An ``async def`` test is driven by pytest-asyncio,
+    which owns the loop it runs on and hands the same loop to the harness
+    fixtures (``hass``, ``http_hass``) that ran during setup. Installing a
+    different loop here used to be invisible because pytest-asyncio 1.x sets
+    its own loop back afterwards — but on the pytest-asyncio 0.24 that ships
+    with the declared HA floor (2024.12) it wins, and the test body then awaits
+    on a loop the fixture's executor futures were never attached to:
+    42 tests died with "attached to a different loop" (#740). Leaving async
+    tests alone is correct on every version: their loop is not ours to swap.
+    """
+    if inspect.iscoroutinefunction(request.function):
+        yield
+        return
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     try:
@@ -89,6 +138,66 @@ def _fresh_event_loop():
             loop.close()
         finally:
             asyncio.set_event_loop(asyncio.new_event_loop())
+
+
+_COMPONENT_ROOT = str(Path(__file__).resolve().parent.parent / "custom_components")
+
+
+def _is_component_task(task: asyncio.Task) -> bool:
+    """True when the task is running one of *our* coroutines."""
+    code = getattr(task.get_coro(), "cr_code", None)
+    return code is not None and code.co_filename.startswith(_COMPONENT_ROOT)
+
+
+@pytest.fixture(autouse=True)
+def _cancel_component_background_tasks():
+    """Run the teardown these unit tests never had (#740).
+
+    Eight places in the integration arm a background timer — the roster,
+    progress and reaction debounces, the round-timer tick, the wager window,
+    the disconnect grace, the admin-session grace, the question-stats save.
+    Every one of them is cancelled in production: by ``_cancel_roster_flush``,
+    by ``_handle_disconnect``, by ``async_flush`` on config-entry unload. The
+    tests below construct the handler bare, trigger the timer and end — nobody
+    unloads anything, so the task is simply left pending.
+
+    That went unnoticed for as long as it did because the old
+    ``_fresh_event_loop`` above swapped the loop before
+    pytest-homeassistant-custom-component's ``verify_cleanup`` looked at it, so
+    the check counted tasks on an empty loop. With the swap gone it sees the
+    real one and fails 78 tests. This fixture supplies the missing unload:
+    cancel what our own modules left running, and only that. Tasks belonging to
+    Home Assistant, aiohttp or the harness are untouched, so ``verify_cleanup``
+    still gates everything it was there to gate — including the integration's
+    real unload path, which ``test_unload_detaches_consumers_605``,
+    ``test_ws_route_survives_reload_606`` and ``test_question_stats_flush_588``
+    assert directly.
+    """
+    yield
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:  # pragma: no cover - no loop left to clean
+        return
+    if not all(
+        callable(getattr(loop, name, None))
+        for name in ("is_closed", "is_running", "run_until_complete")
+    ):
+        # A test replaced ``asyncio.get_event_loop`` with a stub clock
+        # (test_performance_169) and monkeypatch has not undone it yet. There
+        # is no loop to inspect, and nothing of ours was scheduled on one.
+        return
+    if loop.is_closed() or loop.is_running():
+        return
+    pending = [
+        task
+        for task in asyncio.all_tasks(loop)
+        if not task.done() and _is_component_task(task)
+    ]
+    if not pending:
+        return
+    for task in pending:
+        task.cancel()
+    loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
 
 
 # pytest-homeassistant-custom-component (a CI-only test dep, #271) pulls in

--- a/tests/test_ci_ha_matrix_740.py
+++ b/tests/test_ci_ha_matrix_740.py
@@ -1,0 +1,96 @@
+"""The CI matrix must keep testing both ends of the supported range (#740).
+
+A version matrix is not a thing you build once. The cap this issue removed —
+``homeassistant<2026.3`` — was itself added for a good reason (Python 3.13 could
+not run anything newer), and then outlived it by seven months without anybody
+noticing, because a cap looks the same on the day it is right and on the day it
+is wrong. The same is true of the floor leg: it is one ``continue-on-error:``
+away from existing without gating anything, which is how #1593 rotted.
+
+So the shape is asserted here, in the suite that runs on every PR, rather than
+left to whoever next edits the workflow:
+
+* the current-HA leg tracks upstream (no upper bound on the harness),
+* the floor leg is pinned (a floor that drifts is not a floor),
+* both legs gate — nothing in the workflow is advisory,
+* the check named ``pytest`` still exists, because that is the name the repo
+  merges on.
+
+None of this proves the suite passes on either version. That is what the two
+jobs themselves are for; this file only keeps them honest about what they are.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "test.yml"
+CURRENT_REQS = REPO_ROOT / "requirements_test.txt"
+FLOOR_REQS = REPO_ROOT / "requirements_test_ha_floor.txt"
+
+_HARNESS = "pytest-homeassistant-custom-component"
+
+
+def _requirement_lines(path: Path) -> list[str]:
+    """Every non-comment, non-blank line, stripped."""
+    return [
+        line.strip()
+        for line in path.read_text().splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def test_the_current_leg_is_not_capped() -> None:
+    """No upper bound anywhere near Home Assistant in the tracking file.
+
+    ``<``, ``<=`` and ``==`` all freeze it; ``~=`` freezes the minor. The
+    harness pins an exact core release transitively, so pinning the harness
+    pins Home Assistant just as effectively as naming it.
+    """
+    for line in _requirement_lines(CURRENT_REQS):
+        name = re.split(r"[<>=!~\[]", line, maxsplit=1)[0].strip()
+        if name in {"homeassistant", _HARNESS}:
+            assert line == name, (
+                f"{CURRENT_REQS.name} pins {name!r} as {line!r}. This file is the "
+                "leg that is supposed to follow Home Assistant upstream; a bound "
+                "here is how the matrix froze on 2026.2 (#740)."
+            )
+
+
+def test_the_floor_leg_is_pinned_exactly() -> None:
+    """The opposite rule, for the opposite reason: a floor that moves is not one."""
+    pins = [
+        line for line in _requirement_lines(FLOOR_REQS) if line.startswith(_HARNESS)
+    ]
+    assert len(pins) == 1, f"{FLOOR_REQS.name} must name the harness exactly once"
+    assert re.fullmatch(rf"{re.escape(_HARNESS)}==\d+\.\d+\.\d+", pins[0]), (
+        f"{FLOOR_REQS.name} must pin the harness to an exact version, got {pins[0]!r}"
+    )
+
+
+def test_both_legs_are_wired_into_the_workflow() -> None:
+    """Both requirement files are actually installed by a job."""
+    workflow = WORKFLOW.read_text()
+    assert "requirements: requirements_test.txt" in workflow
+    assert "requirements: requirements_test_ha_floor.txt" in workflow
+    assert "pip install -r ${{ matrix.requirements }}" in workflow
+
+
+def test_the_required_check_keeps_its_name() -> None:
+    """Branch protection and the merge habit both key off ``pytest``.
+
+    Letting GitHub derive matrix check names would rename it to
+    ``pytest (3.14, requirements_test.txt)`` and orphan the requirement.
+    """
+    workflow = WORKFLOW.read_text()
+    assert "name: ${{ matrix.name }}" in workflow
+    assert re.search(r"^\s*- name: pytest$", workflow, re.MULTILINE)
+    assert re.search(r"^\s*- name: pytest-ha-floor$", workflow, re.MULTILINE)
+
+
+def test_no_job_is_advisory() -> None:
+    """A job that cannot fail the build is a job that stopped working quietly."""
+    workflow = WORKFLOW.read_text()
+    assert "continue-on-error" not in workflow


### PR DESCRIPTION
Closes #740.

## The matrix, and why it is only two points

| check | Python | Home Assistant | pinned? |
|---|---|---|---|
| `pytest` | 3.14 | whatever is current (2026.9.0 today) | no — tracks upstream |
| `pytest-ha-floor` | 3.13 | 2024.12.5 | yes, exactly |

Two points, both ends of the range this repo advertises. Not a fan-out over the
releases in between: an API this integration uses is either present across the
whole range or it breaks at one end, and each leg costs about three minutes of
wall-clock on every PR. A third point would have to name a failure the ends
miss, and I could not name one.

The two legs are pinned in opposite directions on purpose:

* **Current leg unpinned.** `pytest-homeassistant-custom-component` pins one
  exact core release transitively, so whatever pip lands on *is* the version
  under test. A pin here is precisely what caused this issue: the old
  `homeassistant<2026.3` was right the day it was written (3.13 could not run
  anything newer) and wrong for the seven months after. Leaving it open means a
  breaking core release fails CI on the next PR rather than in a user's issue.
  The cost is that an unrelated PR can go red because HA shipped — that is the
  signal, arriving at the right time.
* **Floor leg pinned exactly.** A floor that drifts is not a floor. It moves
  when `hacs.json` moves, and `test_declared_ha_floor_607.py` is the argument
  for moving it.

`name:` is set per matrix entry rather than left to GitHub, which would have
renamed the check to `pytest (3.14, requirements_test.txt)` and orphaned the
required check the repo merges on. **All six existing checks keep their names**
— `pytest`, `lint`, `mypy`, `drift`, `Hassfest validation`, `HACS validation`.
`pytest-ha-floor` is a seventh, and it gates: nothing in the workflow is
`continue-on-error`.

## Does the suite pass on current Home Assistant?

It does now. It did not when I first ran it, and neither did the floor. Both
failures were real and both are fixed here; nothing was deferred to a follow-up
issue.

Run locally against three environments (scratch venvs, not committed):

| environment | this branch's base | this branch |
|---|---|---|
| HA 2026.9.0 / py3.14 | 2551 passed, **90 errors** | 2556 passed |
| HA 2024.12.5 / py3.13 | 2504 passed, **47 failed, 1 error** | 2556 passed |
| HA 2026.2.3 / py3.13 (the pin CI uses today) | 2556 passed | 2556 passed |

The third row is the regression check: none of this breaks the version CI
merges on right now. (Counts are against `ad0c24e`, the current tip of `main`;
the failure counts drift a little as tests are added, which is itself the
argument for having the jobs rather than a one-off audit.)

### 1. Floor: 47 × "attached to a different loop"

`tests/conftest.py` had an autouse `_fresh_event_loop` that swapped in a new
event loop for **every** test, async ones included. pytest-asyncio 1.x quietly
sets its own loop back afterwards, so this was invisible. The 0.24.0 that ships
with HA 2024.12 does not, and the test body then awaited on a loop that the
`hass` / `http_hass` fixtures' executor futures had never been attached to.

The fixture now returns early for coroutine tests. Their loop belongs to
pytest-asyncio; it was never ours to swap. Sync tests calling `asyncio.run()`
themselves — the case the fixture was written for in 2026-06 — are unaffected.

### 2. Both ends: 90 × "Lingering task after test"

With the loop swap gone, `verify_cleanup` finally looked at the loop the tests
actually ran on, and found background tasks pending in 90 of them:

```
49  QuizifyWebSocketHandler._flush_roster_after_window
15  QuizifyWebSocketHandler._start_timer_tick.<locals>.tick_loop
10  ConnectionManager.schedule_admin_timeout.<locals>.admin_timeout
 5  QuizifyWebSocketHandler._handle_disconnect.<locals>.remove_after_timeout
 4  QuizifyWebSocketHandler._flush_progress_after_window
 3  QuizifyWebSocketHandler._start_wager_window.<locals>.window
 3  QuestionStatsService._debounced_save
 1  QuizifyWebSocketHandler._flush_reactions_after_window
```

Worth being precise about what this is and is not. Every one of those eight
timers **is** cancelled in production — `_cancel_roster_flush`,
`_handle_disconnect`, `async_flush` on config-entry unload. There is no leak in
the shipped integration. The tests construct the handler bare, arm a timer and
end; nobody unloads anything, because no unit test ever had a teardown for the
object graph it built. The old loop swap had been hiding that by counting tasks
on an empty loop.

So the fix is the missing teardown, not a suppression: a fixture that cancels
tasks whose coroutine is defined under `custom_components/`, and only those.
Tasks belonging to Home Assistant, aiohttp or the harness are untouched, so
`verify_cleanup` still gates everything it was there to gate — including the
integration's real unload path, which `test_unload_detaches_consumers_605`,
`test_ws_route_survives_reload_606` and `test_question_stats_flush_588` assert
directly.

### 3. Floor: one lingering *thread*

The first `aiohttp` `AsyncResolver` ever constructed leaves a permanent pycares
daemon thread called `_run_safe_shutdown_loop`, so whichever test opens the
first `TestClient` appears to leak a thread. Today's harness allow-lists that
name explicitly; the 2024.12-era one predates the allow-list. The resolver is
now built once at session start, before any test's thread snapshot — which is
also more honest than charging a shared cost to an arbitrary test.

## mypy

Uncapped Home Assistant, same reasoning as the pytest leg: type-checking
against a core nobody runs checks types nobody has. `mypy` goes 1.13.0 → 2.3.1
because 1.13.0 is from November 2024 and cannot parse the 3.14 syntax current
core ships (`config_entries.py:912`, parenthesis-free `except` group) — it dies
with `errors prevented further checking` before reaching our code.
`python_version` moves to 3.14 for the same reason: mypy has to parse the
framework it is checking against. Clean, 48 source files.

No floor counterpart to this job. A type error visible only against HA 2024.12
would have to come from a signature core changed since, and the floor pytest
leg catches that at runtime for less wall-clock than a second mypy install.
Our own code staying parseable by the floor's Python is covered by the
byte-compile step, which now runs on both legs.

## Also in here

* `requirements_test.txt`'s comment claimed the harness was "still comfortably
  newer than the manifest minimum (HA 2024.1+)". Both halves were wrong:
  `custom_components/quizify/manifest.json` declares **no** minimum HA version
  at all — the floor lives in `hacs.json` (2024.12.0) and README:447 — and
  2024.1 contradicted both. Rewritten to cite the real source.
* `tests/test_ci_ha_matrix_740.py` asserts the shape so it cannot rot back: no
  upper bound on the tracking leg, an exact pin on the floor leg, both wired
  into the workflow, the `pytest` check name intact, and no `continue-on-error`
  anywhere.
* Unpinned `hassfest@master` / `hacs/action@main` left alone, as the issue asks.

## One thing to do after merging

`pytest-ha-floor` is a new check name. Branch protection is currently off on
`main`, so nothing breaks — but if required checks are ever switched on, that
name needs to go in the list alongside the six.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE
