### PR TITLE
Drop the frame spec for a message that is no longer sent

### DIFF
--- a/custom_components/quizify/server/protocol.py
+++ b/custom_components/quizify/server/protocol.py
@@ -183,7 +183,6 @@ SERVER_FRAMES: dict[str, FrameSpec] = {
         note="Estimate-round ack so the client can lock its slider.",
     ),
     "answer_progress": _spec("submitted", "total", "players"),
-    "streak_milestone": _spec("player_name", "streak", "bonus"),
     "round_summary": _spec(
         "correct_answer_index",
         "correct_answer_index_original",


### PR DESCRIPTION
`main` is red. #758 and #766 were each green against a `main` that did not contain the other, and merging the second broke the first.

#766 declared every server frame in `SERVER_FRAMES` and added a test that fails when the declaration and the actual build sites disagree. #758 deleted the `streak_milestone` broadcast — it promised a television flash nobody ever built, and its real consumers (TTS, the HA bus event) are separate calls. Together: a contract declaring a frame no build site sends.

Removing the spec is exactly what the new test asks for when a frame goes away.

Worth saying plainly: the guard did its job on its first day. The inconsistency is real, it was introduced by a merge rather than by either change, and nothing but this test would have noticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE