### PR TITLE
chore: 1.15.0-RC1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to Quizify are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [1.15.0-RC1] — 2026-09-05
+
+Twenty-four entries, chosen in one sitting and built in one.
+
+### 🔒 The house was open
+
+A guest could claim the free admin slot and drive the host's lights, speakers and scenes
+with no Home Assistant credential. Two minutes after the host closed their tab the
+persisted token was deleted, and any device on the network could take over.
+
+### 📺 The room can see what happens
+
+Power-ups and reactions reach the television at last: a sentence, not a symbol. The end
+screen's awards, the reconnect pill and the estimate reveal all speak the room's language
+and its size.
+
+### 🧾 Nothing disappears any more
+
+Your own question packs survive an update. A removed player is told so. A reload no longer
+loses the question, and Spanish evenings are narrated in Spanish.
+
+### 🎯 And the scores are right
+
+Two teams of the same name are two teams, a guest who joins between rounds is not a
+timeout, and no lightning question is scored after the finale.
+
 ## [1.14.0-RC1] — 2026-09-03
 
 Every fix in this release ended somebody's evening.

--- a/custom_components/quizify/manifest.json
+++ b/custom_components/quizify/manifest.json
@@ -11,5 +11,5 @@
   "documentation": "https://github.com/mholzi/quizify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/quizify/issues",
-  "version": "1.14.0-RC1"
+  "version": "1.15.0-RC1"
 }


### PR DESCRIPTION
Changelog entry and manifest version for the week's plan. **No tag and no release** — that is Markus's call.

Twenty-two of the twenty-four entries are merged. The two that are not are #737 and #738, which are one PR (#767): self-hosting the fonts also removes the render-blocking CDN links. That PR is waiting on a decision, because Cabinet Grotesk cannot be redistributed under an MIT licence and dropping it visibly changes the display face. If it lands, the changelog gains a line about the fonts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4W86AsrHXEWHffenT7JdE