### PR TITLE
fix(tv): the result screen fits its awards, and drops the question counter

### DIFF
--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -1395,6 +1395,103 @@
             }
         }
 
+        /* #775: the awards column clipped at every television resolution, and
+           the cause was never in the vertical arithmetic above — it came from
+           the shared styles.css. That sheet's `.award-card`, written for the
+           phone's end view (css/src/05-finale.css), caps the card at
+           `max-width: 160px`, and dashboard.html has loaded styles.css since
+           the day the file was created. The split layout's own override sets
+           `min-width: 0; width: 100%` but never `max-width`, so what this file
+           calls a horizontal pill was really a 160px oval: every award broke
+           one word per line ("avg 1.5s / per / correct / answer") and 247px of
+           text sat inside a 98px box.
+
+           So the answer to "did #694 miss the awards, or did something grow
+           since": neither. #694/#695 measured the awards at the width the oval
+           forced and budgeted around it. The cap was there the whole time and
+           was never the thing they removed.
+
+           Releasing the cap lets each award use the two lines it was designed
+           for, and the room that frees is what the leaderboard and the title
+           below were being squeezed out of. */
+        #finale-view .dashboard-finale--split .awards-grid {
+            /* Column direction plus `flex-wrap: wrap` means a list taller than
+               the box wraps into a SECOND column instead of staying a list.
+               There is only ever one column here. */
+            flex-wrap: nowrap;
+        }
+        #finale-view .dashboard-finale--split .award-card {
+            max-width: none;
+            width: 100%;
+            min-width: 0;
+            flex-direction: row;
+        }
+
+        /* #775: the same sheet also spends the column's height on margins this
+           layout never asked for — `.awards-section { margin: var(--space-xl)
+           auto }` is 32px above and 32px below, `.awards-title { margin-bottom:
+           var(--space-lg) }` another 24px, so 88px of the 518px right column at
+           1280x720 went to whitespace between blocks that already space
+           themselves with `gap`. That is most of what was still hanging over
+           the bottom edge after the width cap came off.
+
+           The `text-align: center` those rules carry is a phone decision too: a
+           centred name over a centred detail line looks deliberate in a 160px
+           oval and ragged in a 700px pill, and `.award-card` here already says
+           `text-align: left`. */
+        #finale-view .awards-section,
+        #finale-view .awards-title,
+        #finale-view .award-icon,
+        #finale-view .award-name,
+        #finale-view .award-winner,
+        #finale-view .award-detail {
+            margin: 0;
+        }
+        #finale-view .award-name,
+        #finale-view .award-winner,
+        #finale-view .award-detail {
+            text-align: left;
+        }
+
+        /* #775: which block gives way when the column is short was decided by
+           flex-shrink arithmetic, and flex shrinks proportionally to size — so
+           the leaderboard, being the tallest item, kept the most and the awards
+           box was squeezed to 93px around 183px of cards. Eight players and two
+           awards left both cards cut through the middle.
+
+           Made explicit instead: the awards are exactly as tall as the cards
+           they hold and never give way, the leaderboard card is the only thing
+           that shrinks — down to its three-row floor, scrolling the remaining
+           players inside its own list — and the duel line is pinned to the
+           bottom edge with an auto margin so the column still reads as full.
+           Which award is the *last* one shown is then a question of how many
+           fit, and fitAwards() answers it by counting whole cards rather than
+           by clipping one. */
+        .dashboard-finale--split .awards-section {
+            flex: 0 0 auto;
+        }
+        .dashboard-finale--split .dashboard-h2h--end {
+            margin-top: auto;
+        }
+        /* #691 again: `hidden` is a UA rule, and .award-card sets display,
+           so the attribute does nothing on its own. fitAwards() relies on it. */
+        .award-card[hidden] { display: none; }
+
+        /* #775: the title overflowed by 9-10px at all three resolutions, for
+           two reasons that compound. css/src/08-responsive.css carries
+           `#finale-view .podium-title { font-size: clamp(2.4rem, 4.8vw, 4.2rem) }`
+           — an id selector, so it has been quietly beating the 48px cap that
+           #694 set below for exactly this budget, and the television has been
+           drawing "Result" at 67px all along. On top of that `line-height: 1`
+           makes the content box shorter than the font's own line box, so the
+           descenders fall outside it. Reclaiming the intended cap (scoped by
+           id, so the responsive sheet no longer wins) and giving the line real
+           height settles both. */
+        #finale-view .podium-title {
+            font-size: clamp(28px, 3.6vw, 48px);
+            line-height: 1.3;
+        }
+
         .dashboard-finale::before {
             /* Single spotlight from above — replaces confetti */
             content: "";
@@ -3074,6 +3171,11 @@
                 + ' – ' + msg.right_wins + ' ' + escapeHtml(msg.right)
                 + '<span class="h2h-scope">' + escapeHtml(t('dashboard.h2hRecent')) + '</span>';
             target.classList.remove('hidden');
+            // #775: on the end screen this line takes a slice of the column the
+            // awards were already sized against — it arrives a beat later, on
+            // analytics_recorded. Re-fit rather than let it push a card out of
+            // the picture.
+            if (target === els.endH2h) fitAwards();
         }
 
         function handleEveningTally(msg) {
@@ -3277,6 +3379,15 @@
             currentPhase = 'FINALE';
             showView('finale');
 
+            // #777: the counter belongs to the questions, not to the result.
+            // Left alone it kept saying "Question 5 / 5" under an empty
+            // progress bar — the two contradicted each other on the same
+            // screen and it read as if a sixth question were coming. The
+            // result screen already names itself ("Result"), so the header
+            // line goes quiet, exactly as it does on game_reset.
+            if (els.roundIndicator) els.roundIndicator.textContent = '';
+            els.timerFill.style.width = '0%';
+
             // #613: clear last game's duel before this game's arrives on
             // analytics_recorded, a beat later. Leaving it up would show the
             // PREVIOUS game's standing under this game's podium.
@@ -3425,6 +3536,92 @@
                     '</div>';
                 grid.appendChild(card);
             });
+
+            fitAwards();
+        }
+
+        /* #775: the height the finale leaderboard is guaranteed — its header
+           plus three rows (#695) — read off the card that is on screen rather
+           than carried as a constant. Every hand-derived pixel figure in this
+           file went stale the moment a font or a padding moved; this one
+           cannot. */
+        function leaderboardFloorPx() {
+            var card = document.querySelector('.finale-leaderboard-card');
+            var list = card && card.querySelector('.dashboard-leaderboard');
+            if (!card || !list) return 0;
+            var header = card.querySelector('.card-header');
+            var cs = getComputedStyle(list);
+            var rows = [].slice.call(list.children);
+            var keep = Math.min(3, rows.length);
+            var rowsPx = 0;
+            for (var i = 0; i < keep; i++) rowsPx += rows[i].offsetHeight;
+            if (keep > 1) rowsPx += (parseFloat(cs.rowGap) || 0) * (keep - 1);
+            return (header ? header.offsetHeight : 0)
+                + rowsPx
+                + (parseFloat(cs.paddingTop) || 0) + (parseFloat(cs.paddingBottom) || 0)
+                + (card.offsetHeight - card.clientHeight);  // the card's borders
+        }
+
+        /* #775: the right-hand column of the result screen is exactly as tall
+           as the television, and three blocks want that height — the awards,
+           the final leaderboard and the duel line. Every previous attempt
+           divided it with a budget derived by hand (#692, #694, #695), and each
+           one held only for the player count and the screen it was measured on;
+           the moment a line moved, the block that lost was cut through the
+           middle.
+
+           The awards are the block that can be shortened without losing a fact:
+           every award is also on every player's phone (js/player-end.js). So
+           the board shows as many WHOLE award cards as the leftover height
+           holds and drops the rest. Nothing is ever cut in half again, at any
+           resolution, player count or award count — and no number in this file
+           has to be re-derived when a line is added.
+
+           Re-run whenever the column's budget moves: the duel line arrives a
+           beat after the finale (analytics_recorded), and a television can be
+           resized. */
+        function fitAwards() {
+            var section = document.getElementById('awards-section');
+            var column = document.querySelector('.dashboard-finale-right');
+            if (!section || !column || section.classList.contains('hidden')) return;
+            var grid = section.querySelector('.awards-grid');
+            var title = section.querySelector('.awards-title');
+            if (!grid) return;
+
+            // Everything back in flow first — the budget may have grown since
+            // the last run (the window got taller, the duel line never came).
+            var cards = [].slice.call(grid.querySelectorAll('.award-card'));
+            cards.forEach(function(card) { card.hidden = false; });
+
+            var colGap = parseFloat(getComputedStyle(column).rowGap) || 0;
+            var secGap = parseFloat(getComputedStyle(section).rowGap) || 0;
+            var h2hVisible = els.endH2h && !els.endH2h.classList.contains('hidden');
+            var budget = column.clientHeight
+                - leaderboardFloorPx() - colGap
+                - (h2hVisible ? els.endH2h.offsetHeight + colGap : 0);
+
+            // The section grows into slack, so its own height says nothing
+            // about what it needs — ask its children.
+            function needed() {
+                return (title ? title.offsetHeight + secGap : 0) + grid.offsetHeight;
+            }
+
+            // Never drop the last one: one award the room can read beats an
+            // empty strip where two were earned.
+            var i;
+            for (i = cards.length - 1; i > 0 && needed() > budget; i--) {
+                cards[i].hidden = true;
+            }
+
+            // The budget is arithmetic and arithmetic can be wrong — a font
+            // that measures differently, a duel line that wraps to two rows.
+            // So the last word goes to the column itself: while anything still
+            // hangs past its bottom edge, one more award steps back. This is
+            // the rule that makes "nothing is ever cut in half" true rather
+            // than merely intended.
+            for (i = cards.length - 1; i > 0 && column.scrollHeight > column.clientHeight; i--) {
+                cards[i].hidden = true;
+            }
         }
 
         function escapeHtml(text) {
@@ -3449,6 +3646,25 @@
                 window.QuizifyI18n.initPageTranslations(document);
             });
         }
+        // #775: a television that changes resolution, a browser window resized
+        // while the result is up, or a font that finishes loading a beat late
+        // all change the column the awards were fitted to. Watch the column
+        // itself rather than the window: it is the box the budget is measured
+        // against, and it changes in cases no resize event accompanies.
+        // Hiding a card changes the awards' height, not the column's, so this
+        // does not feed itself.
+        var fitAwardsTimer = null;
+        function scheduleFitAwards() {
+            clearTimeout(fitAwardsTimer);
+            fitAwardsTimer = setTimeout(fitAwards, 100);
+        }
+        var finaleColumn = document.querySelector('.dashboard-finale-right');
+        if (finaleColumn && typeof ResizeObserver === 'function') {
+            new ResizeObserver(scheduleFitAwards).observe(finaleColumn);
+        } else {
+            window.addEventListener('resize', scheduleFitAwards);
+        }
+
         connect();
     })();
     </script>


### PR DESCRIPTION
Closes #775
Closes #777

Both defects live on the television's result screen, so they land together.

## #775 — the awards were never fitted, they were fitted *around*

The issue asks whether v1.13.0-RC3 (#694) simply never covered the awards column, or whether something grew since. Neither.

`dashboard.html` loads the shared `styles.css` — it always has, since the file was created — and that sheet's `.award-card`, written for the phone's end view (`css/src/05-finale.css`), carries `max-width: 160px`. The split layout's own override sets `min-width: 0; width: 100%` but never `max-width`. So what the dashboard's stylesheet calls a horizontal pill has always been a 160px oval, every award broke one word per line ("avg 1.5s / per / correct / answer"), and 247px of text sat inside a 98px box. #694 and #695 measured the awards at the width the oval forced and budgeted the column around it. The cap was there the whole time and was never the thing they removed.

Three more leaks from the same sheet were costing the column height and legibility:

| Leak | Cost |
|---|---|
| `.awards-section { margin: var(--space-xl) auto }` | 64px in the 518px column at 720p |
| `.awards-title { margin-bottom: var(--space-lg) }` | another 24px |
| `.award-name / .award-winner / .award-detail { text-align: center }` | a centred name over a centred detail line inside a 700px pill |
| `#finale-view .podium-title { font-size: clamp(2.4rem, 4.8vw, 4.2rem) }` in `08-responsive.css` | an id selector beating the 48px cap #694 set here for this exact budget — the television has been drawing "Result" at 67px |

The title's remaining 9–10px was `line-height: 1`, which makes the content box shorter than the font's own line box, so the descenders fell outside it.

### Which block gives way

That was left to `flex-shrink`, and flex shrinks in proportion to size — so the leaderboard, being the tallest item, kept the most and the awards box was squeezed to 93px around 183px of cards. Eight players and two awards left both cards cut through the middle.

It is explicit now: the awards never shrink, the leaderboard card is the only thing that does (down to its three-row floor, scrolling the remaining players inside its own list, as #695 intended), and the duel line is pinned to the bottom edge with an auto margin so the column still reads as full.

Which award is the *last* one shown is then a question of how many fit, and `fitAwards()` answers it by counting whole cards rather than by clipping one. Every award is also on every player's phone (`js/player-end.js`), so the awards are the block that can be shortened without losing a fact. Two things keep it honest: the leaderboard's floor is measured off the card that is on screen rather than carried as another hand-derived constant, and the column itself has the last word — while anything still hangs past its bottom edge, one more award steps back. A `ResizeObserver` on the column re-fits when the television changes resolution or a late font reflows the rows.

### Measurements

Live 1.15.0-RC1 build on the real Home Assistant, driven over CDP. Three players, two awards, head-to-head line present, settled screen with no animation in flight — `scrollHeight - clientHeight`:

| Element | 1280×720 | 1366×768 | 1920×1080 |
|---|---|---|---|
| `.awards-section` | **149 → 0** | **112 → 0** | **89 → 0** |
| `.dashboard-leaderboard` | **17 → 0** | **23 → 0** | **36 → 0** |
| `.podium-title` | **9 → 0** | **9 → 0** | **10 → 0** |

The "before" column reproduces the issue's table exactly, measured with the same harness.

Beyond the three cases the issue asks for, thirty combinations were driven end to end — 1280×720 / 1366×768 / 1920×1080 against 2, 3, 4, 5, 6, 8 and 10 players with 2 to 7 awards. All thirty: zero overflow on `.awards-section` and `.podium-title`, zero content past the right column's bottom edge, both awards fully readable, and the leaderboard clipping nothing with three players or fewer (with more, its list scrolls inside itself, which is the design).

At 720p both awards read in full: "FASTEST FINGER · CLEO" and "COMEBACK KING · BERT", each on one line, with all three leaderboard rows and the duel line under them. At 1080p each award keeps its detail line.

## #777 — the counter belonged to the questions

The header kept `QUESTION 5 / 5` on the result screen while the progress bar underneath was already reset to empty, so the two contradicted each other on the same screen and it read as if a sixth question were coming. `handleFinale()` now clears the line and the bar, exactly as `game_reset` already does. No replacement text: the screen already names itself ("Result"), and a lone number in the header adds nothing — this also avoids a new i18n key in three bundles. The clearing sits in `handleFinale()`, so it covers the reconnect path too, where the snapshot's `FINALE` case comes through the same function.

## Checks

- `pytest -q` — 2745 passed
- `ruff check custom_components/` — clean (no `ruff format`, per the repo's rule)
- `scripts/build_css.py` and `scripts/build_bundle.py` re-run; neither generated file changed
- Verified against the live build on the real Home Assistant over CDP; `www/` was rsynced for each iteration and restored to the committed state afterwards, with no Home Assistant restart

## Found, not fixed

- At 1920×1080 the left column is still largely empty next to a comparatively narrow right column — the issue notes it as context. The clipping is gone without touching the 1.4/1 split, and rebalancing it is a layout change to the podium's showcase rather than a bug fix, so it is left alone deliberately.
- `dashboard.html` carries a comment claiming it is "self-contained (no styles.css)". It is not, and that belief is what let four rules from the phone's stylesheet govern the television for this long. Worth a sweep of the other views for the same class of leak; out of scope here.
- The branch is cut from `97850f2` and `origin/main` has since moved to `916da94`; it needs a rebase before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
