### PR TITLE
chore: 1.15.0-RC2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,27 @@
 All notable changes to Quizify are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
-## [1.15.0-RC1] — 2026-09-05
+## [1.15.0-RC2] — 2026-09-05
 
-Twenty-four entries, chosen in one sitting and built in one.
+Twenty-four entries, chosen in one sitting and built in one — then played, which
+found four more.
+
+### 📺 The room could not read its own result screen
+
+A whole game on real hardware showed the end screen clipping its awards at every
+television resolution: at 720p "FASTEST FINGER ·" broke mid-word and the second
+award was not on screen at all. The cause was never the television's own
+arithmetic — it was a phone stylesheet's `max-width: 160px` reaching the
+television and turning a wide pill into a narrow oval. The leaderboard's last row
+and the title's descenders came free with it, and the header no longer claims a
+sixth question after the fifth.
+
+### 🗣 And an English game spoke German on the phones
+
+Pick English, and every phone showed a German frame around English questions.
+The lobby genuinely told them German: only starting a game ever wrote the host's
+choice, so a phone joining before that was stamped with the default. The choice
+now reaches the lobby, and a change of flag reaches phones already waiting.
 
 ### 🔒 The house was open
 

--- a/custom_components/quizify/manifest.json
+++ b/custom_components/quizify/manifest.json
@@ -11,5 +11,5 @@
   "documentation": "https://github.com/mholzi/quizify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/quizify/issues",
-  "version": "1.15.0-RC1"
+  "version": "1.15.0-RC2"
 }


### PR DESCRIPTION
Second release candidate for v1.15.0. Manifest to `1.15.0-RC2`; the changelog section is renamed and gains the two beats the live test earned.

`v1.15.0-RC1` was played end to end on real hardware — a whole game, three phones, the television at 720p, 768p and 1080p — and it found four defects that 2745 green tests did not: [#775](https://github.com/mholzi/quizify/issues/775), [#776](https://github.com/mholzi/quizify/issues/776), [#777](https://github.com/mholzi/quizify/issues/777), [#778](https://github.com/mholzi/quizify/issues/778). All four are fixed and on `main` ([#779](https://github.com/mholzi/quizify/pull/779), [#780](https://github.com/mholzi/quizify/pull/780)).

No pack file has changed since RC1; 36 packs, 36 entries in `versions.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRRrXDQZuWRazEeZMn5ACN