### PR TITLE
chore: release 1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to Quizify are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
-## [1.15.0-RC2] — 2026-09-05
+## [1.15.0] — 2026-09-06
 
 Twenty-four entries, chosen in one sitting and built in one — then played, which
 found four more.

--- a/custom_components/quizify/manifest.json
+++ b/custom_components/quizify/manifest.json
@@ -11,5 +11,5 @@
   "documentation": "https://github.com/mholzi/quizify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/quizify/issues",
-  "version": "1.15.0-RC2"
+  "version": "1.15.0"
 }


### PR DESCRIPTION
Drops the RC suffix for the stable cut.

- `manifest.json`: `1.15.0-RC2` → `1.15.0`
- `CHANGELOG.md`: heading `[1.15.0-RC2] — 2026-09-05` → `[1.15.0] — 2026-09-06` (actual ship date)

Release gates, checked before anything was written:

| Gate | Result |
|---|---|
| `live_test.bestanden` | true — two games on real hardware, 2026-09-06 |
| `veto` | false |
| rc installed on HA | HACS reports `installed_version v1.15.0-RC2` |
| `compare/v1.15.0-RC2...main` | `ahead_by 0`, status `identical` |
| checks on `d21dbf6` | 7/7 success |

🤖 Generated with [Claude Code](https://claude.com/claude-code)