### PR TITLE
refactor: one JSON persistence layer for every store (#790)

### DIFF
--- a/custom_components/quizify/analytics.py
+++ b/custom_components/quizify/analytics.py
@@ -7,12 +7,12 @@ enabling historical analysis through the analytics dashboard.
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
-import os
 import time
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, TypedDict
+
+from .storage import JsonFile
 
 if TYPE_CHECKING:
     from .runtime import Runtime
@@ -98,6 +98,7 @@ class QuizifyAnalytics:
         """Initialize analytics storage."""
         self._runtime = runtime
         self._path = runtime.data_dir / "analytics.json"
+        self._file = JsonFile(runtime, self._path, label="Analytics file")
         self._data: AnalyticsData = self._empty_data()
         self._games_since_prune = 0
         self._save_lock = asyncio.Lock()
@@ -150,50 +151,44 @@ class QuizifyAnalytics:
         return data  # type: ignore[return-value]
 
     async def load(self) -> None:
-        """Load analytics data from file."""
+        """Load analytics data from file.
+
+        A file that will not parse is not a reason to fail setup (#700): the
+        shared store degrades it to ``None`` with a warning and we start from
+        an empty record, rewriting the file so the next run is clean again.
+        """
+        existed = await self._file.exists()
+        raw = await self._file.load(None)
+        if raw is None:
+            self._data = self._empty_data()
+            if existed:
+                # The file was there but unusable — replace it.
+                await self._save()
+            return
         try:
-            if self._path.exists():
-                content = await self._runtime.run_in_executor(self._path.read_text)
-                raw = json.loads(content)
-                self._data = self._migrate(raw)
-                _LOGGER.debug(
-                    "Loaded analytics: %d games, %d all-time players",
-                    len(self._data.get("games", [])),
-                    len(self._data.get("all_time_players", {})),
-                )
-                await self._prune_old_records()
-            else:
-                self._data = self._empty_data()
-        except (json.JSONDecodeError, KeyError, TypeError) as err:
+            self._data = self._migrate(raw)
+        except (KeyError, TypeError, AttributeError) as err:
             _LOGGER.warning("Analytics file corrupted, recreating: %s", err)
             self._data = self._empty_data()
             await self._save()
+            return
+        _LOGGER.debug(
+            "Loaded analytics: %d games, %d all-time players",
+            len(self._data.get("games", [])),
+            len(self._data.get("all_time_players", {})),
+        )
+        await self._prune_old_records()
 
     async def _save(self) -> None:
-        """Persist analytics data with atomic write."""
+        """Persist analytics data with atomic write.
+
+        The serialize runs inside the executor (#304): a full game's analytics
+        is ~0.5–1 MB and ``json.dumps`` on the event loop would block every
+        connected phone for its duration. Snapshot the dict reference first so
+        the executor sees one consistent object.
+        """
         async with self._save_lock:
-            try:
-                def _mkdir() -> None:
-                    self._path.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
-
-                await self._runtime.run_in_executor(_mkdir)
-                temp_path = self._path.with_suffix(".tmp")
-                # Serialize *inside* the executor closure (#304): a full game's
-                # analytics is ~0.5–1 MB and ``json.dumps`` previously ran on
-                # the event loop, blocking it for the whole serialize while only
-                # the write was offloaded. Snapshot the dict reference so the
-                # executor sees a consistent object; drop ``indent=2`` (the file
-                # is machine-read, never hand-edited) to roughly halve both the
-                # payload size and the serialize cost.
-                data = self._data
-
-                def _write_atomic() -> None:
-                    temp_path.write_text(json.dumps(data))
-                    os.replace(temp_path, self._path)
-
-                await self._runtime.run_in_executor(_write_atomic)
-            except OSError as err:
-                _LOGGER.error("Failed to save analytics: %s", err)
+            await self._file.save(self._data)
 
     def schedule_save(self) -> None:
         """Schedule non-blocking save."""

--- a/custom_components/quizify/game/questions.py
+++ b/custom_components/quizify/game/questions.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..const import ANSWERS_PER_QUESTION, DEFAULT_AVOID_RECENT_REPEATS
+from ..storage import read_json, write_json
 from .seasons import parse_season
 
 if TYPE_CHECKING:
@@ -1105,20 +1106,27 @@ class QuestionBank:
         self._avoid_recent_repeats = bool(enabled)
 
     def _read_history(self) -> None:
-        """Blocking read of the history file. MUST run off the event loop."""
+        """Blocking read of the history file. MUST run off the event loop.
+
+        Parsing and the corrupt-file policy come from
+        :mod:`custom_components.quizify.storage` (#790) — the primitives
+        rather than :class:`~custom_components.quizify.storage.JsonFile`,
+        because this method is itself the blocking half of the pair and is
+        also called synchronously by the standalone dev server, which has no
+        runtime to offload through.
+        """
         history_path = self._history_path
         if history_path is None:
             return
-        if history_path.exists():
-            try:
-                raw = json.loads(history_path.read_text(encoding="utf-8"))
-                self._history = {k: float(v) for k, v in raw.items()}
-                _LOGGER.debug("Loaded question history: %d entries", len(self._history))
-            except (json.JSONDecodeError, ValueError, OSError) as exc:
-                _LOGGER.warning("Failed to load question history: %s", exc)
-                self._history = {}
-        else:
+        raw = read_json(history_path, {}, label="Question history")
+        try:
+            self._history = {k: float(v) for k, v in raw.items()}
+        except (AttributeError, TypeError, ValueError) as exc:
+            _LOGGER.warning("Question history has an unusable shape: %s", exc)
             self._history = {}
+            return
+        if self._history:
+            _LOGGER.debug("Loaded question history: %d entries", len(self._history))
 
     def load_history(self, history_path: Path) -> None:
         """Load question history from a JSON file (synchronous).
@@ -1145,17 +1153,11 @@ class QuestionBank:
         if self._history_path is None:
             return
         snapshot = dict(self._history)
-        try:
-            self._history_path.parent.mkdir(parents=True, exist_ok=True)
-            # Compact (no indent): the history map is machine-read only and
-            # grows one entry per seen question, so pretty-printing just
-            # inflates the file + write cost. Matches the compact writes in
-            # analytics.py / question_stats (#457).
-            self._history_path.write_text(
-                json.dumps(snapshot), encoding="utf-8"
-            )
-        except OSError as exc:
-            _LOGGER.warning("Failed to save question history: %s", exc)
+        # Compact (no indent) and atomic tmp-then-replace, both inherited from
+        # the shared writer (#790). Before that, this was the one store in the
+        # integration writing straight over the live file: a crash mid-write
+        # left a half-serialised history that the next start could not parse.
+        write_json(self._history_path, snapshot, label="Question history")
 
     def save_history(self) -> None:
         """Persist question history to disk (synchronous).

--- a/custom_components/quizify/question_stats.py
+++ b/custom_components/quizify/question_stats.py
@@ -13,12 +13,12 @@ level stats grow with the pack catalogue, not with games played.
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
-import os
 import time
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, TypedDict
+
+from .storage import JsonFile
 
 if TYPE_CHECKING:
     from .runtime import Runtime
@@ -54,28 +54,41 @@ class QuestionStatsService:
     def __init__(self, runtime: Runtime) -> None:
         self._runtime = runtime
         self._path = runtime.data_dir / "question_stats.json"
+        self._file = JsonFile(runtime, self._path, label="Question stats file")
         self._data: QuestionStatsData = {"version": 1, "questions": {}}
         self._save_lock = asyncio.Lock()
         self._dirty = False
         self._save_timer: asyncio.Future[None] | None = None
 
     async def load(self) -> None:
+        """Read the stats file, degrading a broken one to an empty record.
+
+        Parse failures are handled by the shared store (#790, #700); what is
+        left here is the lenient *migration* — a file of the right syntax but
+        the wrong shape (a bare list, a missing ``questions`` key) must not
+        take setup down either.
+        """
+        raw = await self._file.load(None)
+        if raw is None:
+            return
         try:
-            if self._path.exists():
-                content = await self._runtime.run_in_executor(self._path.read_text)
-                raw = json.loads(content)
-                # Lenient migration: tolerate missing keys.
-                self._data = {
-                    "version": int(raw.get("version", 1)),
-                    "questions": raw.get("questions") or {},
-                }
-                _LOGGER.debug(
-                    "Loaded question stats: %d questions tracked",
-                    len(self._data["questions"]),
-                )
-        except (json.JSONDecodeError, KeyError, TypeError) as err:
+            if not isinstance(raw, dict):
+                raise TypeError(f"expected an object, got {type(raw).__name__}")
+            questions = raw.get("questions") or {}
+            if not isinstance(questions, dict):
+                raise TypeError("'questions' is not an object")
+            self._data = {
+                "version": int(raw.get("version", 1)),
+                "questions": questions,
+            }
+        except (KeyError, TypeError, ValueError) as err:
             _LOGGER.warning("Question stats file corrupted, recreating: %s", err)
             self._data = {"version": 1, "questions": {}}
+            return
+        _LOGGER.debug(
+            "Loaded question stats: %d questions tracked",
+            len(self._data["questions"]),
+        )
 
     def record_round(
         self,
@@ -173,22 +186,10 @@ class QuestionStatsService:
         if not self._dirty:
             return
         async with self._save_lock:
-            try:
-                def _mkdir() -> None:
-                    self._path.parent.mkdir(mode=0o755, parents=True, exist_ok=True)
-                await self._runtime.run_in_executor(_mkdir)
-                temp_path = self._path.with_suffix(".tmp")
-                # Serialize inside the executor closure (#304) so the (often
-                # large) ``json.dumps`` runs off the event loop, not just the
-                # write; drop ``indent=2`` since the file is machine-read.
-                data = self._data
-                def _write() -> None:
-                    temp_path.write_text(json.dumps(data))
-                    os.replace(temp_path, self._path)
-                await self._runtime.run_in_executor(_write)
+            # The serialize runs inside the executor (#304) so the (often
+            # large) ``json.dumps`` is off the event loop, not just the write.
+            if await self._file.save(self._data):
                 self._dirty = False
-            except OSError as err:
-                _LOGGER.error("Failed to save question stats: %s", err)
 
     def _schedule_save(self) -> None:
         """(Re-)arm the debounced write after a recorded round (#588).

--- a/custom_components/quizify/server/flag_store.py
+++ b/custom_components/quizify/server/flag_store.py
@@ -1,0 +1,93 @@
+"""The player-flagged-questions log, as an object rather than as view code.
+
+A player who hits a wrong, ambiguous or broken question taps "report" and one
+line lands in ``flagged.jsonl`` next to the rest of Quizify's state. The pack
+maintainer reads them back on the analytics dashboard, or with ``jq``.
+
+Until #790 this file had no name in the codebase: the append (with its
+size-trim) was written inline in ``flag_question_view`` and the parse loop
+inline in ``flag_list_view``, which meant the only way to test either was
+through an HTTP request, and load-time validation was nobody's job. Both
+halves live here now, on top of :class:`~custom_components.quizify.storage.JsonlFile`,
+so the views call :meth:`add` and :meth:`list` and nothing else.
+
+Two policies belong to the store rather than to the HTTP layer:
+
+* **The file is capped.** An unauthenticated POST writes here, so the log
+  trims its oldest half at :data:`MAX_BYTES` instead of growing forever.
+* **The client IP never leaves the host.** It is recorded on disk for the
+  operator's own forensics and stripped from everything :meth:`list` returns
+  (#305) — the ``/api/quizify/*`` routes carry no HA auth, so a response is a
+  publication.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+from ..storage import JsonlFile
+
+if TYPE_CHECKING:
+    from ..runtime import Runtime
+
+#: Cap on the log. ~256 KB is thousands of reports — far more than a host will
+#: ever read — while staying small enough that the trim rewrite is cheap.
+MAX_BYTES = 256 * 1024
+
+#: Bounds on the caller-supplied strings (#357). Without them an anonymous
+#: POST could append a megabyte-long single line, and because the size-trim
+#: runs *before* the append that one line would still land.
+QUESTION_ID_MAX = 64
+REASON_MAX = 200
+PLAYER_NAME_MAX = 50
+
+#: Recorded on disk, never returned. See the module docstring.
+_PRIVATE_FIELDS = frozenset({"remote"})
+
+FILENAME = "flagged.jsonl"
+
+
+class FlagStore:
+    """Append-only log of questions players reported as wrong or unclear."""
+
+    def __init__(self, runtime: Runtime, filename: str = FILENAME) -> None:
+        self._file = JsonlFile(
+            runtime, runtime.data_dir / filename, label="Question flag log"
+        )
+
+    async def add(
+        self,
+        question_id: str,
+        *,
+        reason: str = "",
+        player_name: str = "",
+        remote: str = "",
+    ) -> dict[str, Any]:
+        """Record one flag and return the entry as stored.
+
+        Every caller-supplied field is truncated here rather than at the call
+        site, so a second entry point cannot forget to do it.
+        """
+        entry: dict[str, Any] = {
+            "ts": int(time.time()),
+            "question_id": str(question_id)[:QUESTION_ID_MAX],
+            "reason": str(reason)[:REASON_MAX],
+            "player_name": str(player_name)[:PLAYER_NAME_MAX],
+            "remote": str(remote),
+        }
+        await self._file.append(entry, max_bytes=MAX_BYTES)
+        return entry
+
+    async def list(self) -> list[dict[str, Any]]:
+        """Return every recorded flag, oldest first, without the client IP.
+
+        A line that will not parse — a torn last entry from a process that
+        died mid-append — is skipped rather than fatal, and so is a line that
+        parsed into something other than an object.
+        """
+        return [
+            {k: v for k, v in entry.items() if k not in _PRIVATE_FIELDS}
+            for entry in await self._file.read_all()
+            if isinstance(entry, dict)
+        ]

--- a/custom_components/quizify/server/pack_news.py
+++ b/custom_components/quizify/server/pack_news.py
@@ -27,15 +27,12 @@ they already know.
 from __future__ import annotations
 
 import asyncio
-import json
-import logging
-import os
 from typing import TYPE_CHECKING
+
+from ..storage import JsonFile
 
 if TYPE_CHECKING:
     from ..runtime import Runtime
-
-_LOGGER = logging.getLogger(__name__)
 
 _SCHEMA_VERSION = 1
 
@@ -44,8 +41,9 @@ class PackNewsStore:
     """Atomic JSON file remembering which packs the host has already seen."""
 
     def __init__(self, runtime: Runtime, filename: str = "pack_news.json") -> None:
-        self._runtime = runtime
-        self._path = runtime.data_dir / filename
+        self._file = JsonFile(
+            runtime, runtime.data_dir / filename, label="Pack news store"
+        )
         self._lock = asyncio.Lock()
 
     async def _read(self) -> dict:
@@ -54,31 +52,16 @@ class PackNewsStore:
         A corrupt file is treated as a first run rather than an error: the
         worst case is one suppressed banner, and refusing to serve the admin
         page over an unreadable bookkeeping file would be the larger failure.
+        That is the shared ``warn_and_default`` policy of
+        :mod:`custom_components.quizify.storage`; the only thing left to do
+        here is reject a well-formed file of the wrong *shape*.
         """
-        if not self._path.exists():
-            return {}
-        try:
-            content = await self._runtime.run_in_executor(self._path.read_text)
-            data = json.loads(content)
-        except (OSError, json.JSONDecodeError) as err:
-            _LOGGER.warning("Pack news store corrupt or unreadable: %s", err)
-            return {}
+        data = await self._file.load({})
         return data if isinstance(data, dict) else {}
 
     async def _write(self, data: dict) -> None:
         """Atomically persist *data* as JSON (best-effort)."""
-        tmp = self._path.with_suffix(".tmp")
-        content = json.dumps(data)
-
-        def _do_write() -> None:
-            self._path.parent.mkdir(parents=True, exist_ok=True)
-            tmp.write_text(content)
-            os.replace(tmp, self._path)
-
-        try:
-            await self._runtime.run_in_executor(_do_write)
-        except OSError as err:
-            _LOGGER.warning("Failed to persist pack news: %s", err)
+        await self._file.save(data)
 
     async def sync(self, installed: set[str]) -> list[str]:
         """Fold the currently installed packs into the record; return pending.

--- a/custom_components/quizify/server/preset_store.py
+++ b/custom_components/quizify/server/preset_store.py
@@ -9,24 +9,22 @@ The presets live on the **server**, not in the browser: a preset saved on the
 living-room tablet has to exist on the host's phone too, and a browser-local
 store fails that the first time a second device is used.
 
-Written in the shape of :mod:`server.token_store` — same executor-offloaded,
-atomic write-then-replace, same tolerance for a corrupt file (a broken presets
-file must never stop the game from starting; it degrades to "no presets").
+Persistence goes through :class:`custom_components.quizify.storage.JsonFile`
+(#790) — same executor-offloaded, atomic write-then-replace as every other
+store, and the same tolerance for a corrupt file (a broken presets file must
+never stop the game from starting; it degrades to "no presets").
 """
 
 from __future__ import annotations
 
 import asyncio
-import json
-import logging
-import os
 import secrets
 from typing import TYPE_CHECKING, Any
 
+from ..storage import JsonFile
+
 if TYPE_CHECKING:
     from ..runtime import Runtime
-
-_LOGGER = logging.getLogger(__name__)
 
 #: Hard caps. A JSON file that grows without limit is a slow leak, and the
 #: chip row stops being one-tap long before twenty entries.
@@ -50,8 +48,9 @@ class PresetStore:
     """Named game setups, persisted as one small JSON file."""
 
     def __init__(self, runtime: Runtime, filename: str = "presets.json") -> None:
-        self._runtime = runtime
-        self._path = runtime.data_dir / filename
+        self._file = JsonFile(
+            runtime, runtime.data_dir / filename, label="Preset store"
+        )
         self._lock = asyncio.Lock()
 
     # ------------------------------------------------------------------
@@ -59,30 +58,14 @@ class PresetStore:
     # ------------------------------------------------------------------
 
     async def _read(self) -> list[dict[str, Any]]:
-        if not self._path.exists():
-            return []
-        try:
-            content = await self._runtime.run_in_executor(self._path.read_text)
-            data = json.loads(content)
-        except (OSError, json.JSONDecodeError) as err:
-            _LOGGER.warning("Preset store corrupt or unreadable: %s", err)
-            return []
+        data = await self._file.load({})
         presets = data.get("presets") if isinstance(data, dict) else None
-        return [p for p in presets if isinstance(p, dict)] if presets else []
+        if not isinstance(presets, list):
+            return []
+        return [p for p in presets if isinstance(p, dict)]
 
     async def _write(self, presets: list[dict[str, Any]]) -> None:
-        tmp = self._path.with_suffix(".tmp")
-        content = json.dumps({"version": SCHEMA_VERSION, "presets": presets})
-
-        def _do() -> None:
-            self._path.parent.mkdir(parents=True, exist_ok=True)
-            tmp.write_text(content)
-            os.replace(tmp, self._path)
-
-        try:
-            await self._runtime.run_in_executor(_do)
-        except OSError as err:
-            _LOGGER.warning("Failed to persist presets: %s", err)
+        await self._file.save({"version": SCHEMA_VERSION, "presets": presets})
 
     # ------------------------------------------------------------------
     # API

--- a/custom_components/quizify/server/token_store.py
+++ b/custom_components/quizify/server/token_store.py
@@ -6,66 +6,42 @@ outside of Home Assistant. The on-disk format is intentionally simple
 but we only persist a single value, so the difference is invisible to the
 caller. The standalone and HA paths cannot share a token file (different
 locations), and that's fine — admin bootstraps once per host.
+
+The read/write routine itself lives in :mod:`custom_components.quizify.storage`
+(#790) — this class is just the token's name for it.
 """
 
 from __future__ import annotations
 
 import asyncio
-import contextlib
-import json
-import logging
-import os
 from typing import TYPE_CHECKING
+
+from ..storage import JsonFile
 
 if TYPE_CHECKING:
     from ..runtime import Runtime
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class TokenStore:
     """Atomic JSON file for the persisted admin session token."""
 
     def __init__(self, runtime: Runtime, filename: str = "admin_token.json") -> None:
-        self._runtime = runtime
-        self._path = runtime.data_dir / filename
+        self._file = JsonFile(
+            runtime, runtime.data_dir / filename, label="Admin token store"
+        )
         self._lock = asyncio.Lock()
 
     async def load(self) -> dict | None:
         """Return the persisted dict, or None if missing/corrupt."""
-        if not self._path.exists():
-            return None
-        try:
-            content = await self._runtime.run_in_executor(self._path.read_text)
-            return json.loads(content)
-        except (OSError, json.JSONDecodeError) as err:
-            _LOGGER.warning("Admin token store corrupt or unreadable: %s", err)
-            return None
+        data = await self._file.load(None)
+        return data if isinstance(data, dict) else None
 
     async def save(self, data: dict) -> None:
         """Atomically persist *data* as JSON."""
         async with self._lock:
-            tmp = self._path.with_suffix(".tmp")
-            content = json.dumps(data)
-
-            def _write() -> None:
-                self._path.parent.mkdir(parents=True, exist_ok=True)
-                tmp.write_text(content)
-                os.replace(tmp, self._path)
-
-            try:
-                await self._runtime.run_in_executor(_write)
-            except OSError as err:
-                _LOGGER.warning("Failed to persist admin token: %s", err)
+            await self._file.save(data)
 
     async def remove(self) -> None:
         """Delete the storage file (idempotent)."""
         async with self._lock:
-            def _rm() -> None:
-                with contextlib.suppress(FileNotFoundError):
-                    self._path.unlink()
-
-            try:
-                await self._runtime.run_in_executor(_rm)
-            except OSError as err:
-                _LOGGER.warning("Failed to delete admin token file: %s", err)
+            await self._file.remove()

--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -22,6 +22,7 @@ from aiohttp import web
 
 from ..game.seasons import is_in_season, parse_season, pick_active_season
 from .context import APP_CTX_KEY
+from .flag_store import FlagStore
 from .pack_news import PackNewsStore
 from .pack_submission import (
     request_pack_view,
@@ -1145,18 +1146,28 @@ async def pack_news_dismiss_view(request: web.Request) -> web.Response:
 # Question flagging
 # ---------------------------------------------------------------------------
 #
-# Append-only JSONL log of player-flagged questions. Lives next to the
-# other dev/HA state in the runtime's data_dir. Each line is one report;
-# the pack maintainer can `jq` through it to find ambiguous or wrong
-# questions surfaced by real play.
+# The log itself lives in :mod:`server.flag_store` (#790) — file layout, the
+# size cap, the field bounds and the IP stripping are all its business. What
+# stays here is the HTTP shape: the rate limit, the request parsing and the
+# admin gate on the read.
 
-_FLAG_FILE = "flagged.jsonl"
-_FLAG_MAX_BYTES = 256 * 1024  # cap at ~256 KB to bound disk use
-_FLAG_REASON_MAX = 200
-# Cap the caller-supplied question_id (#357). Without a bound an anonymous POST
-# could append a ~1 MB entry, and the size-trim runs BEFORE the append so an
-# oversized single line would still persist. Real ids are short slugs.
-_FLAG_QUESTION_ID_MAX = 64
+_FLAG_STORE_KEY = "quizify_flag_store"
+
+
+def _flag_store(request: web.Request) -> FlagStore:
+    """Return the per-app flag log, creating it once.
+
+    Cached on the application like the preset and pack-news stores so the two
+    views share one object. The bounds on the stored fields (#357) and the
+    size cap now live in :mod:`server.flag_store`, not here.
+    """
+    store = request.app.get(_FLAG_STORE_KEY)
+    if store is None:
+        store = FlagStore(_get_ctx(request).runtime)
+        request.app[_FLAG_STORE_KEY] = store
+    return store
+
+
 # Per-IP rate limit on the unauthenticated flag POST (#357). Mirrors the
 # pack-submit guard: generous for a real "flag a few questions" burst, tight
 # enough that the endpoint can't be hammered into unbounded executor disk
@@ -1176,8 +1187,6 @@ async def flag_question_view(request: web.Request) -> web.Response:
     is best-effort (clients without an auth model can lie, but that's fine
     for a "raise the maintainer's attention" signal).
     """
-    ctx = _get_ctx(request)
-
     # Per-IP rate limit (#357). Reject early — before the JSON parse and the
     # executor disk write — so a flood can't pin the loop or grow the file.
     if not _flag_rate_limiter.check(request.remote or ""):
@@ -1191,38 +1200,16 @@ async def flag_question_view(request: web.Request) -> web.Response:
     question_id = (body or {}).get("question_id")
     if not isinstance(question_id, str) or not question_id:
         return web.json_response({"error": "missing_question_id"}, status=400)
-    # Bound the caller-supplied id before it is persisted (#357).
-    question_id = question_id[:_FLAG_QUESTION_ID_MAX]
 
-    reason = str((body or {}).get("reason", ""))[:_FLAG_REASON_MAX]
-    player_name = str((body or {}).get("player_name", ""))[:50]
-
-    entry = {
-        "ts": int(time.time()),
-        "question_id": question_id,
-        "reason": reason,
-        "player_name": player_name,
-        "remote": request.remote or "",
-    }
-
-    flag_path = ctx.runtime.data_dir / _FLAG_FILE
-
-    def _append() -> None:
-        flag_path.parent.mkdir(parents=True, exist_ok=True)
-        # Refuse to grow unbounded — drop oldest half if we hit the cap.
-        # JSONL is append-friendly, this is a rare event, so a copy-trim
-        # is acceptable. Keeps the cap from being silently bypassed.
-        if flag_path.exists() and flag_path.stat().st_size >= _FLAG_MAX_BYTES:
-            try:
-                lines = flag_path.read_text("utf-8").splitlines()
-                flag_path.write_text("\n".join(lines[len(lines) // 2:]) + "\n", "utf-8")
-            except OSError:
-                pass
-        with flag_path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
-
-    await ctx.runtime.run_in_executor(_append)
-    _LOGGER.info("Question flagged: %s (reason=%r)", question_id, reason[:40])
+    entry = await _flag_store(request).add(
+        question_id,
+        reason=str((body or {}).get("reason", "")),
+        player_name=str((body or {}).get("player_name", "")),
+        remote=request.remote or "",
+    )
+    _LOGGER.info(
+        "Question flagged: %s (reason=%r)", entry["question_id"], entry["reason"][:40]
+    )
     return web.json_response({"ok": True})
 
 
@@ -1236,32 +1223,9 @@ async def flag_list_view(request: web.Request) -> web.Response:
     """
     if not _is_admin_authenticated(request):
         return _unauthorized()
-    ctx = _get_ctx(request)
-    flag_path = ctx.runtime.data_dir / _FLAG_FILE
-
-    def _read() -> list[dict]:
-        if not flag_path.exists():
-            return []
-        entries: list[dict] = []
-        for line in flag_path.read_text("utf-8").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                entries.append(json.loads(line))
-            except ValueError:
-                continue
-        return entries
-
-    entries = await ctx.runtime.run_in_executor(_read)
-    # #305: never return the stored client IP (``remote``) to callers — the
-    # /api/quizify/* routes are added to hass.http.app.router with NO HA auth,
-    # so /flags is readable unauthenticated. The IP is still stored on disk for
-    # operator forensics; it is simply stripped from the response so an
-    # anonymous caller can't enumerate the IPs of everyone who flagged a
-    # question. Strip it defensively per entry (older entries may pre-date this).
-    sanitized = [{k: v for k, v in e.items() if k != "remote"} for e in entries]
-    return web.json_response({"flags": sanitized})
+    # The store strips the stored client IP (#305) — the /api/quizify/* routes
+    # are registered with NO HA auth, so a response is a publication.
+    return web.json_response({"flags": await _flag_store(request).list()})
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/quizify/storage.py
+++ b/custom_components/quizify/storage.py
@@ -1,0 +1,336 @@
+"""One JSON-on-disk routine for every store in the integration (#790).
+
+Quizify persists eight small files — the admin token, saved presets, pack
+news, analytics, per-question stats, the question history, the flag log — and
+until this module existed each of them hand-wrote the same three steps:
+``read_text`` in an executor, ``json.loads``, and a ``tmp.write_text`` +
+``os.replace`` back out. Seven copies, seven sets of ``except`` clauses, and
+seven private opinions about what a corrupt file means.
+
+Two shipped bugs came out of that spread rather than out of any one store:
+
+``#700``
+    A malformed community pack took setup down. Degrading a broken file to a
+    default was a policy some of the copies had and others did not.
+
+``#588``
+    Question stats were lost on a restart, because the "save often enough"
+    policy had been worked out once, in analytics, and never shared.
+
+So the routine lives here once. The blocking primitives (:func:`read_json`,
+:func:`write_json`, :func:`append_jsonl`, :func:`read_jsonl`) are the whole
+implementation; :class:`JsonFile` and :class:`JsonlFile` are thin async
+wrappers that offload them through the runtime's executor. Callers that are
+*already* inside an executor thread — the question history in
+``game/questions.py`` keeps a synchronous API for the standalone dev server —
+use the primitives directly and get the same corrupt-file policy and the same
+atomic write as everybody else.
+
+Two invariants the whole integration now shares:
+
+* **A readable default beats a crash.** A truncated, half-written or
+  hand-mangled file logs a warning and yields the caller's default. Nothing
+  here raises at the caller unless it explicitly asks for ``on_corrupt="raise"``.
+* **A write is all-or-nothing.** Every write goes to a sibling ``.tmp`` and is
+  moved into place with :func:`os.replace`, so a reader never sees a partial
+  file and a crash mid-write leaves the previous version intact.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from .runtime import Runtime
+
+_LOGGER = logging.getLogger(__name__)
+
+#: What to do when a file exists but cannot be parsed.
+#:
+#: ``"warn_and_default"``
+#:     Log a warning naming the file and hand the caller its default. The
+#:     policy every store in Quizify wants: a bookkeeping file that got
+#:     truncated must never be the reason a game cannot start (#700).
+#: ``"raise"``
+#:     Re-raise. For a caller that genuinely cannot proceed without the data
+#:     and would rather fail loudly than run on a default.
+OnCorrupt = Literal["warn_and_default", "raise"]
+
+#: Mode for directories created on demand. Matches what analytics and question
+#: stats already asked for; the umask narrows it further on most hosts.
+DIR_MODE = 0o755
+
+
+def _describe(path: Path, label: str | None) -> str:
+    """Human-readable name for log lines — the label if given, else the file."""
+    return label or path.name
+
+
+# ---------------------------------------------------------------------------
+# Blocking primitives (MUST NOT run on the event loop)
+# ---------------------------------------------------------------------------
+
+
+def read_json(
+    path: Path,
+    default: Any = None,
+    *,
+    on_corrupt: OnCorrupt = "warn_and_default",
+    label: str | None = None,
+) -> Any:
+    """Return the JSON decoded from *path*, or *default*.
+
+    *default* is returned when the file is missing, unreadable or unparseable.
+    The caller owns the object it passes: this function never copies it, so
+    pass a fresh literal rather than a shared module-level constant.
+    """
+    try:
+        content = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return default
+    except OSError as err:
+        # An unreadable file is a corrupt file as far as the caller is
+        # concerned — permissions, a vanished mount, a directory where a file
+        # was expected. Same policy, so the same branch.
+        if on_corrupt == "raise":
+            raise
+        _LOGGER.warning("%s unreadable, using default: %s", _describe(path, label), err)
+        return default
+
+    try:
+        return json.loads(content)
+    except (json.JSONDecodeError, ValueError, UnicodeDecodeError) as err:
+        if on_corrupt == "raise":
+            raise
+        _LOGGER.warning("%s corrupt, using default: %s", _describe(path, label), err)
+        return default
+
+
+def write_json(path: Path, data: Any, *, label: str | None = None) -> bool:
+    """Atomically write *data* to *path* as JSON. Returns success.
+
+    Serialisation happens here rather than at the call site so it lands in the
+    executor thread with the write (#304): a full evening of analytics is a
+    megabyte or so, and ``json.dumps`` on the event loop stalls every
+    connected phone for the length of the serialise.
+
+    Compact separators, no ``indent``: these files are machine-read, never
+    hand-edited, and pretty-printing roughly doubles both the payload and the
+    serialise cost.
+    """
+    tmp = path.with_suffix(".tmp")
+    try:
+        content = json.dumps(data)
+    except (TypeError, ValueError) as err:
+        _LOGGER.error("Failed to serialise %s: %s", _describe(path, label), err)
+        return False
+    try:
+        path.parent.mkdir(mode=DIR_MODE, parents=True, exist_ok=True)
+        tmp.write_text(content, encoding="utf-8")
+        os.replace(tmp, path)
+    except OSError as err:
+        _LOGGER.error("Failed to persist %s: %s", _describe(path, label), err)
+        # Leave no half-written sibling behind to be mistaken for a real file.
+        with contextlib.suppress(OSError):
+            tmp.unlink()
+        return False
+    return True
+
+
+def remove_file(path: Path, *, label: str | None = None) -> bool:
+    """Delete *path* if it is there. Idempotent; returns success."""
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return True
+    except OSError as err:
+        _LOGGER.warning("Failed to delete %s: %s", _describe(path, label), err)
+        return False
+    return True
+
+
+def append_jsonl(
+    path: Path,
+    entry: Any,
+    *,
+    max_bytes: int | None = None,
+    label: str | None = None,
+) -> bool:
+    """Append one JSON line to *path*, trimming the file first if it is full.
+
+    ``max_bytes`` is a soft cap on an append-only log: when the file has
+    reached it, the oldest half of the lines are dropped before the new entry
+    goes on. The trim rewrites through a ``.tmp`` like every other write here,
+    so a crash during it cannot leave the log truncated mid-line.
+    """
+    try:
+        serialised = json.dumps(entry, ensure_ascii=False)
+    except (TypeError, ValueError) as err:
+        _LOGGER.error(
+            "Failed to serialise entry for %s: %s", _describe(path, label), err
+        )
+        return False
+
+    try:
+        path.parent.mkdir(mode=DIR_MODE, parents=True, exist_ok=True)
+        if max_bytes is not None and path.exists() and path.stat().st_size >= max_bytes:
+            _trim_jsonl(path, label=label)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(serialised + "\n")
+    except OSError as err:
+        _LOGGER.error("Failed to append to %s: %s", _describe(path, label), err)
+        return False
+    return True
+
+
+def _trim_jsonl(path: Path, *, label: str | None = None) -> None:
+    """Drop the oldest half of *path*'s lines. Best-effort, never raises."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError) as err:
+        _LOGGER.warning("Could not trim %s: %s", _describe(path, label), err)
+        return
+    kept = lines[len(lines) // 2 :]
+    tmp = path.with_suffix(".tmp")
+    try:
+        tmp.write_text("\n".join(kept) + "\n", encoding="utf-8")
+        os.replace(tmp, path)
+    except OSError as err:
+        _LOGGER.warning("Could not trim %s: %s", _describe(path, label), err)
+        with contextlib.suppress(OSError):
+            tmp.unlink()
+
+
+def read_jsonl(path: Path, *, label: str | None = None) -> list[Any]:
+    """Return every parseable line of *path* as decoded JSON.
+
+    A single unparseable line is skipped, not fatal: a JSONL log's whole point
+    is that a torn last line — the process died mid-append — costs one entry
+    rather than the file.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return []
+    except (OSError, UnicodeDecodeError) as err:
+        _LOGGER.warning("%s unreadable: %s", _describe(path, label), err)
+        return []
+
+    entries: list[Any] = []
+    skipped = 0
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            entries.append(json.loads(line))
+        except ValueError:
+            skipped += 1
+    if skipped:
+        _LOGGER.warning(
+            "%s: skipped %d unparseable line(s)", _describe(path, label), skipped
+        )
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Async wrappers
+# ---------------------------------------------------------------------------
+
+
+class JsonFile:
+    """One JSON file, read and written off the event loop.
+
+    ``JsonFile(runtime, path)`` binds a location; the store above it keeps the
+    schema, the locking and the meaning. Deliberately not a cache — every
+    :meth:`load` reads the file — because the stores that want an in-memory
+    copy (analytics, question stats) already hold one and the ones that do not
+    (presets, pack news) read rarely and would rather be correct after an
+    external edit.
+    """
+
+    def __init__(
+        self, runtime: Runtime, path: Path, *, label: str | None = None
+    ) -> None:
+        self._runtime = runtime
+        self._path = Path(path)
+        self._label = label
+
+    @property
+    def path(self) -> Path:
+        """The file this instance is bound to."""
+        return self._path
+
+    async def exists(self) -> bool:
+        """Whether the file is there (checked in the executor)."""
+        return bool(await self._runtime.run_in_executor(self._path.exists))
+
+    async def load(
+        self,
+        default: Any = None,
+        *,
+        on_corrupt: OnCorrupt = "warn_and_default",
+    ) -> Any:
+        """Return the decoded contents, or *default* if unusable."""
+
+        def _read() -> Any:
+            return read_json(
+                self._path, default, on_corrupt=on_corrupt, label=self._label
+            )
+
+        return await self._runtime.run_in_executor(_read)
+
+    async def save(self, data: Any) -> bool:
+        """Atomically persist *data*. Returns whether it landed."""
+
+        def _write() -> bool:
+            return write_json(self._path, data, label=self._label)
+
+        return bool(await self._runtime.run_in_executor(_write))
+
+    async def remove(self) -> bool:
+        """Delete the file (idempotent). Returns success."""
+
+        def _rm() -> bool:
+            return remove_file(self._path, label=self._label)
+
+        return bool(await self._runtime.run_in_executor(_rm))
+
+
+class JsonlFile:
+    """One append-only JSON-lines log, read and written off the event loop."""
+
+    def __init__(
+        self, runtime: Runtime, path: Path, *, label: str | None = None
+    ) -> None:
+        self._runtime = runtime
+        self._path = Path(path)
+        self._label = label
+
+    @property
+    def path(self) -> Path:
+        """The file this instance is bound to."""
+        return self._path
+
+    async def append(self, entry: Any, max_bytes: int | None = None) -> bool:
+        """Append one entry, trimming the oldest half at *max_bytes*."""
+
+        def _append() -> bool:
+            return append_jsonl(
+                self._path, entry, max_bytes=max_bytes, label=self._label
+            )
+
+        return bool(await self._runtime.run_in_executor(_append))
+
+    async def read_all(self) -> list[Any]:
+        """Return every parseable entry, oldest first."""
+
+        def _read() -> list[Any]:
+            return read_jsonl(self._path, label=self._label)
+
+        return await self._runtime.run_in_executor(_read)

--- a/tests/test_backend_correctness_batch.py
+++ b/tests/test_backend_correctness_batch.py
@@ -350,10 +350,8 @@ class TestFlagListNoIpLeak:
         import json as _json
         from types import SimpleNamespace
 
-        from custom_components.quizify.server.views import (
-            _FLAG_FILE,
-            flag_list_view,
-        )
+        from custom_components.quizify.server.flag_store import FILENAME as _FLAG_FILE
+        from custom_components.quizify.server.views import flag_list_view
 
         # Write a flag entry that includes a stored client IP (as flag_view does).
         flag_path = tmp_path / _FLAG_FILE

--- a/tests/test_flag_rate_limit_357.py
+++ b/tests/test_flag_rate_limit_357.py
@@ -24,6 +24,7 @@ sys.path.insert(0, str(_REPO_ROOT))
 
 from custom_components.quizify.server import views  # noqa: E402
 from custom_components.quizify.server.context import APP_CTX_KEY  # noqa: E402
+from custom_components.quizify.server.flag_store import FILENAME  # noqa: E402
 
 
 class _Runtime:
@@ -57,7 +58,7 @@ def test_valid_flag_persists(tmp_path: Path) -> None:
     views._flag_rate_limiter.forget(ip)
     resp = asyncio.run(_post(_ctx(tmp_path), ip, {"question_id": "geo_037"}))
     assert resp.status == 200
-    lines = (tmp_path / views._FLAG_FILE).read_text("utf-8").splitlines()
+    lines = (tmp_path / FILENAME).read_text("utf-8").splitlines()
     assert json.loads(lines[0])["question_id"] == "geo_037"
 
 
@@ -105,7 +106,7 @@ def test_question_id_is_capped_at_64_chars(tmp_path: Path) -> None:
         _post(_ctx(tmp_path), ip, {"question_id": "x" * 5000})
     )
     assert resp.status == 200
-    entry = json.loads((tmp_path / views._FLAG_FILE).read_text("utf-8").splitlines()[0])
+    entry = json.loads((tmp_path / FILENAME).read_text("utf-8").splitlines()[0])
     assert entry["question_id"] == "x" * 64
 
 
@@ -120,5 +121,5 @@ def test_over_limit_does_not_write(tmp_path: Path) -> None:
         await _post(ctx, ip, {"question_id": "OVERFLOW"})
 
     asyncio.run(run())
-    body = (tmp_path / views._FLAG_FILE).read_text("utf-8")
+    body = (tmp_path / FILENAME).read_text("utf-8")
     assert "OVERFLOW" not in body  # the rejected POST wrote nothing

--- a/tests/test_json_storage_layer_790.py
+++ b/tests/test_json_storage_layer_790.py
@@ -1,0 +1,279 @@
+"""Tests for the shared JSON persistence layer (#790).
+
+Seven stores used to hand-write the same read-in-executor / atomic-write
+routine, each with its own idea of what a corrupt file means. Two shipped bugs
+came out of that spread — #700 (a malformed file took setup down) and #588
+(a save policy that existed in one store and not the others).
+
+These tests pin the two properties the layer exists to guarantee *for every
+store at once*, which is why they are written against `storage.py` and then
+re-asserted through each ported store:
+
+  * **A broken file degrades to the caller's default, with a warning.** A
+    truncated JSON file, a file of the wrong shape, an unreadable one — none
+    of them may raise at the caller.
+  * **A write is all-or-nothing.** Content goes to a sibling ``.tmp`` and is
+    moved into place with ``os.replace``; a failure part-way leaves the
+    previous version of the file intact and no stray ``.tmp`` behind.
+
+Both fail without `custom_components/quizify/storage.py`: the module simply
+does not import.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.storage import (  # noqa: E402
+    JsonFile,
+    JsonlFile,
+    append_jsonl,
+    read_json,
+    read_jsonl,
+    write_json,
+)
+
+
+class _Runtime:
+    """Minimal Runtime double — runs the blocking work inline."""
+
+    def __init__(self, data_dir: Path) -> None:
+        self.data_dir = data_dir
+
+    def create_task(self, coro):  # noqa: ANN001
+        return asyncio.ensure_future(coro)
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+
+# ---------------------------------------------------------------------------
+# Corrupt-file policy (#700)
+# ---------------------------------------------------------------------------
+
+
+class TestCorruptFileDegradesToDefault:
+    def test_a_truncated_file_yields_the_default(self, tmp_path: Path) -> None:
+        """The #700 shape: the process died mid-write, the file is half JSON."""
+        path = tmp_path / "half.json"
+        path.write_text('{"packs": ["geo", "his', encoding="utf-8")
+
+        assert read_json(path, {"packs": []}) == {"packs": []}
+
+    def test_it_warns_and_names_the_file(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Silent degradation would hide a real disk problem for months."""
+        path = tmp_path / "presets.json"
+        path.write_text("not json at all", encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING):
+            read_json(path, [], label="Preset store")
+
+        assert "Preset store" in caplog.text
+
+    def test_a_missing_file_is_not_corrupt(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A first run is the normal case and must not log a warning."""
+        with caplog.at_level(logging.WARNING):
+            assert read_json(tmp_path / "absent.json", {"a": 1}) == {"a": 1}
+        assert caplog.text == ""
+
+    def test_an_unreadable_file_also_degrades(self, tmp_path: Path) -> None:
+        """A directory where a file was expected: OSError, not JSONDecodeError.
+
+        Three of the seven original copies caught only ``JSONDecodeError`` on
+        the read path, so this case propagated out of ``load()`` and up into
+        setup.
+        """
+        path = tmp_path / "state.json"
+        path.mkdir()
+
+        assert read_json(path, {"ok": True}) == {"ok": True}
+
+    def test_raise_is_available_for_callers_that_want_it(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "broken.json"
+        path.write_text("{", encoding="utf-8")
+
+        with pytest.raises(json.JSONDecodeError):
+            read_json(path, {}, on_corrupt="raise")
+
+    @pytest.mark.asyncio
+    async def test_json_file_load_applies_the_same_policy(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "async.json"
+        path.write_text('{"a":', encoding="utf-8")
+
+        assert await JsonFile(_Runtime(tmp_path), path).load({"a": 0}) == {"a": 0}
+
+
+# ---------------------------------------------------------------------------
+# Atomic writes
+# ---------------------------------------------------------------------------
+
+
+class TestWritesAreAtomic:
+    def test_the_content_goes_through_a_tmp_sibling(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A reader must never observe a partially written target file.
+
+        Asserted by capturing what ``os.replace`` was handed: if the payload
+        were written straight to the target there would be no replace at all.
+        """
+        path = tmp_path / "analytics.json"
+        seen: list[tuple[str, str]] = []
+        real_replace = os.replace
+
+        def _spy(src, dst):  # noqa: ANN001
+            seen.append((Path(src).name, Path(dst).name))
+            # The target must not exist yet — the payload lives in the tmp.
+            assert Path(src).read_text(encoding="utf-8") == '{"games": [1, 2]}'
+            return real_replace(src, dst)
+
+        monkeypatch.setattr(os, "replace", _spy)
+        assert write_json(path, {"games": [1, 2]}) is True
+
+        assert seen == [("analytics.tmp", "analytics.json")]
+        assert json.loads(path.read_text(encoding="utf-8")) == {"games": [1, 2]}
+
+    def test_a_failed_write_leaves_the_previous_version_intact(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Disk full half-way through: yesterday's file must still be readable."""
+        path = tmp_path / "question_stats.json"
+        path.write_text('{"version": 1, "questions": {"q1": 3}}', encoding="utf-8")
+
+        def _boom(src, dst):  # noqa: ANN001
+            raise OSError(28, "No space left on device")
+
+        monkeypatch.setattr(os, "replace", _boom)
+        assert write_json(path, {"version": 1, "questions": {}}) is False
+
+        assert json.loads(path.read_text(encoding="utf-8")) == {
+            "version": 1,
+            "questions": {"q1": 3},
+        }
+
+    def test_a_failed_write_leaves_no_stray_tmp(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = tmp_path / "presets.json"
+
+        def _boom(src, dst):  # noqa: ANN001
+            raise OSError("nope")
+
+        monkeypatch.setattr(os, "replace", _boom)
+        write_json(path, {"presets": []})
+
+        assert list(tmp_path.iterdir()) == []
+
+    def test_the_parent_directory_is_created(self, tmp_path: Path) -> None:
+        path = tmp_path / "fresh" / "install" / "pack_news.json"
+
+        assert write_json(path, {"known": []}) is True
+        assert json.loads(path.read_text(encoding="utf-8")) == {"known": []}
+
+    def test_an_unserialisable_payload_does_not_touch_the_file(
+        self, tmp_path: Path
+    ) -> None:
+        """The old copies serialised inside the write closure, so a bad payload
+        aborted after the target had already been opened."""
+        path = tmp_path / "state.json"
+        path.write_text('{"good": true}', encoding="utf-8")
+
+        assert write_json(path, {"when": object()}) is False
+        assert json.loads(path.read_text(encoding="utf-8")) == {"good": True}
+
+    @pytest.mark.asyncio
+    async def test_json_file_round_trips(self, tmp_path: Path) -> None:
+        store = JsonFile(_Runtime(tmp_path), tmp_path / "sub" / "round.json")
+
+        assert await store.save({"n": 1}) is True
+        assert await store.load(None) == {"n": 1}
+        assert await store.exists() is True
+        assert await store.remove() is True
+        assert await store.load({"n": 0}) == {"n": 0}
+        # Removing an absent file is not an error.
+        assert await store.remove() is True
+
+
+# ---------------------------------------------------------------------------
+# JSONL
+# ---------------------------------------------------------------------------
+
+
+class TestJsonlLog:
+    def test_append_then_read_back(self, tmp_path: Path) -> None:
+        path = tmp_path / "flagged.jsonl"
+
+        append_jsonl(path, {"question_id": "q1"})
+        append_jsonl(path, {"question_id": "q2"})
+
+        assert read_jsonl(path) == [{"question_id": "q1"}, {"question_id": "q2"}]
+
+    def test_a_torn_line_costs_one_entry_not_the_file(self, tmp_path: Path) -> None:
+        """A process killed mid-append leaves half a line behind."""
+        path = tmp_path / "flagged.jsonl"
+        path.write_text(
+            '{"question_id": "q1"}\n{"question_id": "q2"\n{"question_id": "q3"}\n',
+            encoding="utf-8",
+        )
+
+        assert read_jsonl(path) == [{"question_id": "q1"}, {"question_id": "q3"}]
+
+    def test_the_log_is_capped_by_dropping_the_oldest_half(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "flagged.jsonl"
+        for i in range(40):
+            append_jsonl(path, {"i": i})
+        size = path.stat().st_size
+
+        append_jsonl(path, {"i": 40}, max_bytes=size)
+
+        entries = read_jsonl(path)
+        assert entries[0] == {"i": 20}
+        assert entries[-1] == {"i": 40}
+
+    def test_the_trim_is_atomic_too(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed trim must not truncate the log — the append still happens."""
+        path = tmp_path / "flagged.jsonl"
+        for i in range(10):
+            append_jsonl(path, {"i": i})
+
+        def _boom(src, dst):  # noqa: ANN001
+            raise OSError("nope")
+
+        monkeypatch.setattr(os, "replace", _boom)
+        append_jsonl(path, {"i": 10}, max_bytes=1)
+
+        entries = read_jsonl(path)
+        assert entries[0] == {"i": 0}
+        assert entries[-1] == {"i": 10}
+
+    def test_a_missing_log_reads_as_empty(self, tmp_path: Path) -> None:
+        assert read_jsonl(tmp_path / "never-written.jsonl") == []
+
+    @pytest.mark.asyncio
+    async def test_jsonl_file_offloads(self, tmp_path: Path) -> None:
+        log = JsonlFile(_Runtime(tmp_path), tmp_path / "deep" / "flagged.jsonl")
+
+        assert await log.append({"a": 1}) is True
+        assert await log.read_all() == [{"a": 1}]

--- a/tests/test_stores_share_one_policy_790.py
+++ b/tests/test_stores_share_one_policy_790.py
@@ -1,0 +1,253 @@
+"""Every store now degrades a broken file the same way (#790).
+
+The point of `storage.py` is not that one more module exists — it is that the
+corrupt-file policy stops being a per-store opinion. Before the port each of
+these cases was handled by *some* of the seven copies and not the others:
+
+  * question stats caught ``JSONDecodeError`` but not the ``AttributeError``
+    a JSON array produces on ``raw.get(...)``,
+  * analytics caught ``JSONDecodeError`` but let an ``OSError`` from the read
+    escape ``load()`` and take setup down with it — the #700 shape,
+  * the question history caught ``OSError`` on the read but wrote straight
+    over the live file, so a crash mid-write produced the corrupt file the
+    *next* start would choke on,
+  * the token store returned whatever JSON it found, array or string included.
+
+Each test below drives the store it names, not the storage module, so it
+fails if that store is ever reverted to its own implementation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.analytics import QuizifyAnalytics  # noqa: E402
+from custom_components.quizify.game.questions import QuestionBank  # noqa: E402
+from custom_components.quizify.question_stats import (  # noqa: E402
+    QuestionStatsService,
+)
+from custom_components.quizify.server.flag_store import FlagStore  # noqa: E402
+from custom_components.quizify.server.pack_news import PackNewsStore  # noqa: E402
+from custom_components.quizify.server.preset_store import PresetStore  # noqa: E402
+from custom_components.quizify.server.token_store import TokenStore  # noqa: E402
+
+
+class _Runtime:
+    def __init__(self, data_dir: Path) -> None:
+        self.data_dir = data_dir
+
+    def create_task(self, coro):  # noqa: ANN001
+        return asyncio.ensure_future(coro)
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+
+#: Files that are syntactically fine but the wrong *shape*, plus one that is
+#: not JSON at all. A store must survive all of them.
+BROKEN = ("[]", '"a string"', "null", "{", "")
+
+
+class TestQuestionStats:
+    @pytest.mark.parametrize("content", BROKEN)
+    @pytest.mark.asyncio
+    async def test_a_broken_file_leaves_an_empty_record(
+        self, tmp_path: Path, content: str
+    ) -> None:
+        (tmp_path / "question_stats.json").write_text(content, encoding="utf-8")
+        svc = QuestionStatsService(_Runtime(tmp_path))
+
+        await svc.load()
+
+        assert svc.get_hardest() == []
+        # Still usable afterwards — this is the #588 path.
+        svc.record_round("q1", [(True, 2.0)])
+        await svc.save_if_dirty()
+        on_disk = json.loads((tmp_path / "question_stats.json").read_text("utf-8"))
+        assert on_disk["questions"]["q1"]["shown_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_file_does_not_raise(self, tmp_path: Path) -> None:
+        (tmp_path / "question_stats.json").mkdir()
+
+        await QuestionStatsService(_Runtime(tmp_path)).load()
+
+
+class TestAnalytics:
+    @pytest.mark.parametrize("content", BROKEN)
+    @pytest.mark.asyncio
+    async def test_a_broken_file_leaves_an_empty_record(
+        self, tmp_path: Path, content: str
+    ) -> None:
+        (tmp_path / "analytics.json").write_text(content, encoding="utf-8")
+        analytics = QuizifyAnalytics(_Runtime(tmp_path))
+
+        await analytics.load()
+
+        assert analytics.get_games() == []
+
+    @pytest.mark.asyncio
+    async def test_a_broken_file_is_rewritten_so_the_next_start_is_clean(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "analytics.json"
+        path.write_text("{ truncated", encoding="utf-8")
+
+        await QuizifyAnalytics(_Runtime(tmp_path)).load()
+
+        assert json.loads(path.read_text("utf-8"))["games"] == []
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_file_does_not_raise(self, tmp_path: Path) -> None:
+        """The #700 shape: ``load()`` used to let the OSError escape."""
+        (tmp_path / "analytics.json").mkdir()
+
+        await QuizifyAnalytics(_Runtime(tmp_path)).load()
+
+
+class TestQuestionHistory:
+    @pytest.mark.parametrize("content", BROKEN)
+    def test_a_broken_history_starts_empty(
+        self, tmp_path: Path, content: str
+    ) -> None:
+        path = tmp_path / "question_history.json"
+        path.write_text(content, encoding="utf-8")
+        bank = QuestionBank()
+
+        bank.load_history(path)
+
+        bank.record_shown("q1")
+        bank.save_history()
+        assert list(json.loads(path.read_text("utf-8"))) == ["q1"]
+
+    def test_the_history_write_is_atomic(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """It was the one store writing straight over the live file."""
+        path = tmp_path / "question_history.json"
+        bank = QuestionBank()
+        bank.load_history(path)
+        bank.record_shown("q1")
+        bank.save_history()
+
+        def _boom(src, dst):  # noqa: ANN001
+            raise OSError("no space")
+
+        monkeypatch.setattr(os, "replace", _boom)
+        bank.record_shown("q2")
+        bank.save_history()
+
+        # The failed write left the previous, complete history in place.
+        assert list(json.loads(path.read_text("utf-8"))) == ["q1"]
+
+
+class TestTokenStore:
+    @pytest.mark.parametrize("content", BROKEN)
+    @pytest.mark.asyncio
+    async def test_a_broken_token_file_reads_as_no_token(
+        self, tmp_path: Path, content: str
+    ) -> None:
+        """A non-object payload must re-bootstrap, not be handed to the caller
+        as if it were a token record."""
+        (tmp_path / "admin_token.json").write_text(content, encoding="utf-8")
+
+        assert await TokenStore(_Runtime(tmp_path)).load() is None
+
+
+class TestPresetStore:
+    @pytest.mark.parametrize("content", BROKEN + ('{"presets": "nope"}',))
+    @pytest.mark.asyncio
+    async def test_a_broken_file_degrades_to_no_presets(
+        self, tmp_path: Path, content: str
+    ) -> None:
+        (tmp_path / "presets.json").write_text(content, encoding="utf-8")
+        store = PresetStore(_Runtime(tmp_path))
+
+        assert await store.list() == []
+        # And saving over it repairs the file.
+        await store.save({"name": "Family night"})
+        assert [p["name"] for p in await store.list()] == ["Family night"]
+
+
+class TestPackNews:
+    @pytest.mark.parametrize("content", BROKEN)
+    @pytest.mark.asyncio
+    async def test_a_broken_file_is_treated_as_a_first_run(
+        self, tmp_path: Path, content: str
+    ) -> None:
+        (tmp_path / "pack_news.json").write_text(content, encoding="utf-8")
+        store = PackNewsStore(_Runtime(tmp_path))
+
+        assert await store.sync({"geography", "history"}) == []
+        assert await store.sync({"geography", "history", "world-cup"}) == [
+            "world-cup"
+        ]
+
+
+class TestFlagStore:
+    """The flag log had no name at all until #790 — it was two inline blocks
+    in ``views.py``, so neither half could be tested without an HTTP request."""
+
+    @pytest.mark.asyncio
+    async def test_add_then_list(self, tmp_path: Path) -> None:
+        store = FlagStore(_Runtime(tmp_path))
+
+        await store.add("geo_037", reason="ambiguous", player_name="Ann")
+
+        assert await store.list() == [
+            {
+                "ts": pytest.approx(await _now(), abs=5),
+                "question_id": "geo_037",
+                "reason": "ambiguous",
+                "player_name": "Ann",
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_the_client_ip_is_stored_but_never_returned(
+        self, tmp_path: Path
+    ) -> None:
+        store = FlagStore(_Runtime(tmp_path))
+
+        await store.add("geo_037", remote="203.0.113.42")
+
+        assert "203.0.113.42" in (tmp_path / "flagged.jsonl").read_text("utf-8")
+        assert "remote" not in (await store.list())[0]
+
+    @pytest.mark.asyncio
+    async def test_the_fields_are_bounded_by_the_store(
+        self, tmp_path: Path
+    ) -> None:
+        """#357 lived in the view; a second caller would have missed it."""
+        store = FlagStore(_Runtime(tmp_path))
+
+        entry = await store.add("x" * 500, reason="y" * 500, player_name="z" * 500)
+
+        assert len(entry["question_id"]) == 64
+        assert len(entry["reason"]) == 200
+        assert len(entry["player_name"]) == 50
+
+    @pytest.mark.asyncio
+    async def test_a_torn_line_costs_one_entry(self, tmp_path: Path) -> None:
+        path = tmp_path / "flagged.jsonl"
+        path.write_text(
+            '{"question_id": "q1"}\n{"question_id": "q2"\n"a string"\n',
+            encoding="utf-8",
+        )
+
+        assert await FlagStore(_Runtime(tmp_path)).list() == [{"question_id": "q1"}]
+
+
+async def _now() -> int:
+    import time
+
+    return int(time.time())


### PR DESCRIPTION
Closes #790

Seven copies of the same routine — `read_text` in an executor, `json.loads`, `tmp.write_text` + `os.replace` back out — lived in the integration, each with its own `except` clauses and its own idea of what a corrupt file means. Two shipped bugs came out of that spread rather than out of any one store: **#700**, where a malformed file took setup down because the degrade-to-default policy existed in some copies and not others, and **#588**, where a save policy worked out once in analytics was never shared.

## What is new

`custom_components/quizify/storage.py` holds the routine once. The blocking primitives (`read_json`, `write_json`, `append_jsonl`, `read_jsonl`) are the whole implementation; `JsonFile(runtime, path)` and `JsonlFile(runtime, path)` are thin async wrappers that offload them through the runtime's executor.

Two invariants the whole integration now shares:

* **A readable default beats a crash.** A truncated, mis-shaped or unreadable file logs one warning that names the file and yields the caller's default. `load(default, on_corrupt="raise")` is there for a caller that would rather fail loudly, but nothing in the tree asks for it.
* **A write is all-or-nothing.** Every write goes to a sibling `.tmp` and is moved into place with `os.replace`. A failure part-way leaves the previous version of the file intact and no stray `.tmp` behind, and an unserialisable payload never opens the target at all.

## Stores ported

All six named in the issue, plus the flag log — **nothing is left on its own implementation.**

| Store | Now uses |
|---|---|
| `server/token_store.py` | `JsonFile` |
| `server/pack_news.py` | `JsonFile` |
| `server/preset_store.py` | `JsonFile` |
| `analytics.py` | `JsonFile` |
| `question_stats.py` | `JsonFile` |
| `game/questions.py` (question history) | the blocking primitives directly |
| `server/views.py` (flag JSONL) | the new `server/flag_store.py`, on `JsonlFile` |

The question history takes the primitives rather than `JsonFile` because it keeps a synchronous API for the standalone dev server and the tests, and its `_read_history` / `_write_history` *are* the blocking half of the pair — there is no runtime to offload through at that layer. It gets the same corrupt-file policy and the same atomic write. It was also the one store writing straight over its live file, so a crash mid-write used to produce exactly the corrupt file the next start would choke on; that is closed here.

`FlagStore` gives the flag log a name for the first time. The size cap, the #357 field bounds and the #305 IP stripping move out of `views.py` and into the store, where a second caller cannot forget them; the views keep the HTTP shape (rate limit, parsing, admin gate) and call `add()` / `list()`. The change to `views.py` is confined to those two call sites.

## Behaviour

Preserved wherever the old code had an opinion — the existing tests pin the on-disk shape and stayed green untouched, apart from two that imported `views._FLAG_FILE` and now import `flag_store.FILENAME`.

Where the old code had *no* opinion, the shared policy applies, and that is the point of the issue:

* `question_stats.json` containing a JSON array raised an uncaught `AttributeError` on `raw.get(...)`.
* An `OSError` on the analytics read escaped `load()` — the #700 shape.
* The question history raised `AttributeError` on a JSON array for the same reason.
* `TokenStore.load()` returned whatever JSON it found, array or bare string included.

All four now warn and degrade.

## Failing first

`git stash` on the six ported stores, keeping the new tests and the two new modules — so each failure is the store's own, not a missing import:

```
$ git stash push -- <the six stores>
$ pytest tests/test_stores_share_one_policy_790.py
14 failed, 25 passed
```

The 14 are question stats (4), analytics (4), the question history (4, including the atomic-write test), and the token store (2). Stashing `custom_components/` wholesale instead fails both new files at collection: no `custom_components.quizify.storage`, no `custom_components.quizify.server.flag_store`.

## Tests

`tests/test_json_storage_layer_790.py` (18) covers the layer itself — the corrupt-file policy including the unreadable-file case, the atomic write asserted by spying on `os.replace` (the payload must already be complete in the `.tmp` when it is handed over), the failed-write and stray-`.tmp` cases, and the JSONL trim.

`tests/test_stores_share_one_policy_790.py` (39) re-asserts the policy through each store, so a store that ever goes back to its own implementation fails here.

Suite: **2839 passed** (2782 before, +57). `ruff check custom_components/` clean, `mypy` clean at 50 source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)