### PR TITLE
fix(teams): reset team scores on a rematch, credit the reaction bonus to the team, and share one round-closing tail

### DIFF
--- a/custom_components/quizify/game/scoring.py
+++ b/custom_components/quizify/game/scoring.py
@@ -116,6 +116,30 @@ ESTIMATE_MIN_POINTS = 5
 # Flat bonus for landing exactly on the true value.
 ESTIMATE_EXACT_BONUS = 25
 
+# How close a guess has to land, as a fraction of the question's slider span,
+# to count as "the group got this one" for the auto-difficulty calibrator
+# (#810). Deliberately NOT the exact-hit test: distance == 0 on a slider that
+# runs 0…1000 is a coin-flip event, so feeding `exact` to the calibrator would
+# make every estimate round a unanimous "make it easier" vote and walk an
+# auto-mode game down to EASY and hold it there — a worse bug than the missing
+# feed. A tenth of the span is the same shape of judgement the reveal already
+# draws on the number line: inside the band you were in the neighbourhood.
+ESTIMATE_CALIBRATION_BAND = 0.10
+
+
+def estimate_within_calibration_band(
+    distance: float, span: float | None
+) -> bool:
+    """Whether a guess ``distance`` from the truth counts as correct (#810).
+
+    ``span`` is the question's ``estimate_max - estimate_min``. Without a
+    usable span (a malformed question that slipped past the parser) there is
+    no scale to judge closeness against, so only an exact hit counts.
+    """
+    if span is None or span <= 0:
+        return distance == 0
+    return distance <= span * ESTIMATE_CALIBRATION_BAND
+
 
 def calculate_estimate_scores(
     guesses: dict[str, float],

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -49,6 +49,7 @@ from .questions import (
 from .scoring import (
     calculate_estimate_scores,
     calculate_podium,
+    estimate_within_calibration_band,
 )
 from .scoring_engine import ScoringEngine, wager_loss
 from .team import ANSWER_CHANGE_LOCK_SECONDS, Team, TeamRegistry
@@ -724,11 +725,21 @@ class QuizifyGameState:
             if not player.connected
         ]
         for name in stale_names:
-            self._player_registry.remove_player(name)
+            # Through the game-level remove_player, not the registry's (#799):
+            # the registry only knows the roster, so a direct call dropped the
+            # player but left their name in ``Team.members``. A team whose
+            # members had all gone dark therefore survived as a zombie row that
+            # timed out every round and could never be dissolved.
+            self.remove_player(name)
 
         # Reset player scores
         for player in self._player_registry.players.values():
             player.reset_for_new_game()
+
+        # Reset team scores (#799). Teams deliberately outlive reset_to_lobby
+        # so the one-tap rematch keeps the room — but their tallies must not,
+        # or game 2 opens on game 1's leaderboard.
+        self._team_registry.reset_for_new_game()
 
         # Reset power-ups
         self._powerup_manager.reset()
@@ -1418,9 +1429,10 @@ class QuizifyGameState:
             )
 
         # Estimate rounds (#275) are scored by closeness across all players,
-        # not per-answer correctness. They build their own RoundSummary and
-        # short-circuit the MC correctness/scoring path below — but still share
-        # the downstream phase transition + broadcast (handled in the helper).
+        # not per-answer correctness, so they short-circuit the MC
+        # correctness/scoring path below. Both paths end in ``_close_round``,
+        # which owns the summary, the phase transition, the calibrator feed,
+        # the stats and the broadcast (#810).
         if question.is_estimate:
             return self._evaluate_estimate_round(question)
 
@@ -1479,7 +1491,41 @@ class QuizifyGameState:
             # average is that they've experienced a scored round.
             player.rounds_played += 1
 
-        # Build per-player results
+        return self._close_round(question, correct_answer, player_correct)
+
+    def _close_round(
+        self,
+        question: Question,
+        correct_answer: Answer,
+        correctness: dict[str, bool],
+        *,
+        estimate: dict[str, Any] | None = None,
+        calibration_correctness: dict[str, bool] | None = None,
+    ) -> RoundSummary:
+        """The tail every round evaluator shares (#810).
+
+        Both evaluators used to carry their own copy of this sequence, and the
+        copies had drifted: the estimate path never fed the ``GroupCalibrator``,
+        so since #566 (every pack carries estimate questions) an auto-mode room
+        contributed no signal on those rounds at all. One helper, two callers,
+        no second chance to drift.
+
+        Each caller does its own scoring and hands over:
+
+        * ``correctness`` — participant name -> did they get it right. Drives
+          the per-player ``AnswerResult`` the reveal renders and the
+          per-question stats. For estimate rounds this is the exact-hit test,
+          unchanged.
+        * ``calibration_correctness`` — the same shape, but for the
+          auto-difficulty signal, defaulting to ``correctness``. The estimate
+          path passes a *different* dict on purpose; see
+          ``estimate_within_calibration_band``.
+        * ``estimate`` — the number-line reveal block, MC rounds pass None.
+        """
+        if calibration_correctness is None:
+            calibration_correctness = correctness
+
+        # Build per-player results (connected only).
         results: list[AnswerResult] = []
         for player in self._player_registry.players.values():
             if not player.connected:
@@ -1487,7 +1533,7 @@ class QuizifyGameState:
             results.append(
                 AnswerResult(
                     player_id=player.name,
-                    correct=player_correct.get(player.name, False),
+                    correct=correctness.get(player.name, False),
                     points_earned=player.round_score,
                     new_streak=player.streak,
                     new_total=player.score,
@@ -1502,6 +1548,7 @@ class QuizifyGameState:
             fun_fact=question.fun_fact,
             results=results,
             leaderboard=leaderboard,
+            estimate=estimate,
         )
 
         self.phase = GamePhase.ANSWER_REVEAL
@@ -1522,7 +1569,9 @@ class QuizifyGameState:
             ]
             total = len(participants)
             correct = sum(
-                1 for p in participants if player_correct.get(p.name, False)
+                1
+                for p in participants
+                if calibration_correctness.get(p.name, False)
             )
             self._calibrator.record_round(correct=correct, total=total)
             new_target = self._calibrator.next_target()
@@ -1543,7 +1592,7 @@ class QuizifyGameState:
         if self._question_stats is not None:
             try:
                 submitted_results = [
-                    (player_correct.get(p.name, False), p.last_elapsed)
+                    (correctness.get(p.name, False), p.last_elapsed)
                     for p in self._player_registry.players.values()
                     if p.submitted
                 ]
@@ -1575,7 +1624,9 @@ class QuizifyGameState:
         full, exact = bonus), applies them to player scores, and builds a
         RoundSummary whose ``estimate`` block carries the number-line reveal
         data. Non-guessers score 0 and break their streak, same as an MC
-        timeout. Mirrors the MC path's downstream phase transition + broadcast.
+        timeout. The round-closing tail (summary, phase, calibrator, stats,
+        broadcast) is ``_close_round``, shared with the MC path — this method
+        does the scoring and nothing else (#810).
         """
         answer_val = (
             question.estimate_answer
@@ -1652,24 +1703,6 @@ class QuizifyGameState:
         if self.team_mode:
             self._apply_estimate_results_to_teams(carriers, scores)
 
-        # Build per-player results (connected only).
-        results: list[AnswerResult] = []
-        for player in self._player_registry.players.values():
-            if not player.connected:
-                continue
-            entry = scores.get(player.name)
-            results.append(
-                AnswerResult(
-                    player_id=player.name,
-                    correct=bool(entry and entry["exact"]),
-                    points_earned=player.round_score,
-                    new_streak=player.streak,
-                    new_total=player.score,
-                )
-            )
-
-        leaderboard = self.get_leaderboard()
-
         # A synthetic "correct answer" so the rest of the pipeline (which reads
         # ``RoundSummary.correct_answer.text``) keeps working for estimate
         # rounds. The text is the true value with its unit.
@@ -1678,33 +1711,31 @@ class QuizifyGameState:
 
         estimate_block = self._build_estimate_reveal(question, answer_val, scores)
 
-        self._round_summary = RoundSummary(
-            question=question,
-            correct_answer=correct_answer,
-            fun_fact=question.fun_fact,
-            results=results,
-            leaderboard=leaderboard,
-            estimate=estimate_block,
+        # Two correctness readings, on purpose (#810).
+        #
+        # ``exact`` is what the reveal and the per-question stats have always
+        # meant by correct on an estimate round, and stays that way: the number
+        # line either landed on the value or it did not.
+        #
+        # The auto-difficulty calibrator needs a different reading. Distance
+        # zero on a slider is close to unattainable, so feeding it ``exact``
+        # would score every estimate round 0/N and march an auto-mode game down
+        # to EASY — the reason the calibrator feed was better off missing than
+        # naively copied. It gets "did the guess land inside the band" instead,
+        # which is the judgement the reveal's number line already invites.
+        exact_correct = {
+            name: bool(entry["exact"]) for name, entry in scores.items()
+        }
+        span = (
+            question.estimate_max - question.estimate_min
+            if question.estimate_max is not None
+            and question.estimate_min is not None
+            else None
         )
-
-        self.phase = GamePhase.ANSWER_REVEAL
-
-        # Per-question stats: estimate rounds record an "exact-or-not" signal +
-        # elapsed so the stat pipeline stays populated. Closeness has no clean
-        # correct/wrong, so an exact hit counts as correct.
-        if self._question_stats is not None:
-            try:
-                submitted_results = [
-                    (bool(scores.get(p.name, {}).get("exact")), p.last_elapsed)
-                    for p in self._player_registry.players.values()
-                    if p.submitted
-                ]
-                self._question_stats.record_round(question.id, submitted_results)
-            except Exception:  # noqa: BLE001
-                _LOGGER.exception("Failed to record estimate question stats")
-
-        for player in self._player_registry.players.values():
-            player.joined_late = False
+        close_correct = {
+            name: estimate_within_calibration_band(entry["distance"], span)
+            for name, entry in scores.items()
+        }
 
         _LOGGER.info(
             "Estimate round %d evaluated (answer=%s, %d guesses), "
@@ -1713,9 +1744,14 @@ class QuizifyGameState:
             answer_val,
             len(guesses),
         )
-        self._fire_broadcast("round_evaluated")
 
-        return self._round_summary
+        return self._close_round(
+            question,
+            correct_answer,
+            exact_correct,
+            estimate=estimate_block,
+            calibration_correctness=close_correct,
+        )
 
     @staticmethod
     def _format_estimate_value(question: Question, value: float) -> str:
@@ -2011,6 +2047,11 @@ class QuizifyGameState:
 
         for player in self._player_registry.players.values():
             player.reset_for_new_game()
+
+        # Same reason as in start_game (#799): the FINALE's "Play again" lands
+        # here, and a leaderboard that still reads Sofa 120 / Cara 0 before the
+        # first question of the rematch is the bug this closes.
+        self._team_registry.reset_for_new_game()
 
         self._notify_state_callbacks()
 
@@ -2808,6 +2849,24 @@ class QuizifyGameState:
             if self._team_registry.get_by_member(p.name) is None
         ]
         return teams + solo
+
+    def get_ranked_participant_for(self, player_name: str) -> Any | None:
+        """The row on the leaderboard that a given player's points land in.
+
+        Their team in team mode, themselves otherwise — and themselves in team
+        mode too when they joined no team, since a solo player keeps their own
+        row (see ``get_ranked_participants``). Returns None for a name that is
+        not in the game.
+
+        Exists because anything that awards points to "whoever answered" has to
+        award them to the participant the room can actually see. The reveal
+        reaction bonus did not, and paid a team member's shadow score (#800).
+        """
+        if self.team_mode:
+            team = self._team_registry.get_by_member(player_name)
+            if team is not None:
+                return team
+        return self._player_registry.get_player(player_name)
 
     def get_round_summary(self) -> RoundSummary | None:
         """Return the last round summary."""

--- a/custom_components/quizify/game/team.py
+++ b/custom_components/quizify/game/team.py
@@ -103,6 +103,16 @@ class Team:
     is_admin: bool = False
     round_score_breakdown: dict = field(default_factory=dict)
 
+    #: round_number -> count of +1 reveal reaction bonuses this team has
+    #: RECEIVED that round, capped per round (#800). The team is the ranked
+    #: participant, so in team mode the bonus has to land here — crediting the
+    #: one member who happened to carry the answer moved a shadow score nobody
+    #: can see. Mirrors ``PlayerSession._reaction_bonuses_received`` field for
+    #: field, including being cleared by ``reset_for_new_game``: round numbers
+    #: restart at 1 each game, so a team at the cap in round N of the old game
+    #: would otherwise be blocked in round N of the new one (#167).
+    _reaction_bonuses_received: dict[int, int] = field(default_factory=dict)
+
     # ------------------------------------------------------------------
     # Membership
     # ------------------------------------------------------------------
@@ -205,6 +215,48 @@ class Team:
         self.round_score_breakdown = {}
         self.submitted = False
 
+    def add_reaction_bonus(self, round_num: int, cap: int) -> bool:
+        """Award a +1 reveal reaction bonus for ``round_num``, respecting ``cap``.
+
+        The team-side twin of ``PlayerSession.add_reaction_bonus`` (#800). A
+        team may receive at most ``cap`` bonuses per round; once at the cap the
+        call is a no-op. Returns ``True`` when a bonus was actually granted.
+        """
+        received = self._reaction_bonuses_received.get(round_num, 0)
+        if received >= cap:
+            return False
+        self._reaction_bonuses_received[round_num] = received + 1
+        self.score += 1
+        self.round_score += 1
+        return True
+
+    # ------------------------------------------------------------------
+    # Game lifecycle
+    # ------------------------------------------------------------------
+
+    def reset_for_new_game(self) -> None:
+        """Clear every game-level tally so a rematch starts this team at zero.
+
+        The twin of ``PlayerSession.reset_for_new_game`` (#799). Teams survive
+        ``reset_to_lobby`` on purpose — the one-tap rematch keeps the room
+        exactly as it stands — but until this existed nothing but the explicit
+        reset-game button cleared their scores, so game 2 opened with game 1's
+        leaderboard, awards counted the old rounds and the streak bonus carried
+        over.
+        """
+        self.score = 0
+        self.streak = 0
+        self.max_streak = 0
+        self.round_history = []
+        self.round_scores = []
+        self.answer_times = []
+        self.hard_score = 0
+        self.freezes_used = 0
+        self.powerups_used = 0
+        self.rounds_played = 0
+        self._reaction_bonuses_received = {}
+        self.reset_round()
+
     def to_dict(self) -> dict:
         """Wire shape. Mirrors a player entry closely on purpose (#365)."""
         return {
@@ -301,6 +353,16 @@ class TeamRegistry:
     def reset_round(self) -> None:
         for team in self._teams.values():
             team.reset_round()
+
+    def reset_for_new_game(self) -> None:
+        """Zero every team's game-level tallies, keeping the teams themselves.
+
+        The registry-level counterpart to the per-player loop in
+        ``start_game`` / ``reset_to_lobby`` (#799). Membership is untouched:
+        the rematch is meant to keep the room, only the scoreboard restarts.
+        """
+        for team in self._teams.values():
+            team.reset_for_new_game()
 
     def to_list(self) -> list[dict]:
         return [t.to_dict() for t in self._teams.values()]

--- a/custom_components/quizify/server/serializers.py
+++ b/custom_components/quizify/server/serializers.py
@@ -320,6 +320,15 @@ def serialize_leaderboard(players: list[PlayerSession]) -> list[dict[str, Any]]:
         last_result = p.round_history[-1] if p.round_history else None
         result.append({
             "rank": rank,
+            # Stable identity of the row, beside the name that gets printed
+            # (#759, the same shape #728 gave the lightning leaderboard). Two
+            # teams may legitimately carry the same name — the name is free
+            # text on purpose — and by name they were one row to every client
+            # that looked one up: the "you" highlight lit both, the FLIP
+            # animation and the rank-delta memo collapsed them into one.
+            # A player's own name is already unique per game, so for a player
+            # the entrant id is simply their name.
+            "entrant_id": getattr(p, "team_id", None) or p.name,
             "name": p.name,
             "score": p.score,
             "streak": p.streak,

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -45,6 +45,7 @@ from custom_components.quizify.game.state import (
 from custom_components.quizify.game.team import (
     ANSWER_CHANGE_LOCK_SECONDS as LIGHTNING_ANSWER_LOCK_SECONDS,
 )
+from custom_components.quizify.game.team import Team
 from custom_components.quizify.server.broadcast_dispatcher import BroadcastDispatcher
 from custom_components.quizify.server.connection import ConnectionManager
 from custom_components.quizify.server.origin import reject_cross_origin
@@ -1613,24 +1614,44 @@ class QuizifyWebSocketHandler:
             return  # already granted a bonus this round
         reactor.reaction_bonuses_given.add(round_num)
 
-        # Award +1 to each player who answered correctly this round,
-        # respecting the per-round incoming cap.
+        # Award +1 for each correct answer this round, respecting the per-round
+        # incoming cap.
+        #
+        # #800: the points go to the *ranked participant*, not to the name on
+        # the AnswerResult. In team mode the results are still per player — the
+        # member whose tap carried the team's answer is the "correct" one — so
+        # crediting them moved a shadow score (#668/#669) that no screen shows,
+        # while the leaderboard this very broadcast carries never budged. The
+        # recipient is therefore the team when there is one, and the player
+        # only when they are solo.
+        reactor_participant = game_state.get_ranked_participant_for(reactor.name)
         bonus_recipients: list[str] = []
+        credited: list[Any] = []
         for result in summary.results:
             if not result.correct:
                 continue
-            recipient = game_state.get_player(result.player_id)
-            if not recipient or recipient.name == reactor.name:
-                continue  # can't tip your own hat
+            recipient = game_state.get_ranked_participant_for(result.player_id)
+            if recipient is None or recipient is reactor_participant:
+                continue  # can't tip your own hat — nor your own team's
+            if any(recipient is seen for seen in credited):
+                continue  # one team, several correct members → one bonus
+            credited.append(recipient)
             # Per-round inbound counter (separate from `reaction_bonuses_given`
-            # which tracks OUTGOING bonuses). Encapsulated on PlayerSession so
+            # which tracks OUTGOING bonuses). Encapsulated on the participant so
             # it is reset per game in reset_for_new_game() (#167) and the cap
             # logic lives with the state it guards (#364).
             if not recipient.add_reaction_bonus(
                 round_num, self._REACTION_BONUS_CAP_PER_ROUND
             ):
                 continue  # recipient already at the per-round cap
-            bonus_recipients.append(recipient.name)
+            # ``to_players`` stays a list of PLAYER names: it is what each
+            # phone matches itself against to raise the "+1 from X" toast. A
+            # credited team hands over its whole roster, so every member is
+            # told about the point their team just earned.
+            if isinstance(recipient, Team):
+                bonus_recipients.extend(recipient.members)
+            else:
+                bonus_recipients.append(recipient.name)
 
         if bonus_recipients:
             # #449: the bonus above mutated recipient scores, but the #414

--- a/custom_components/quizify/www/js/player-end.js
+++ b/custom_components/quizify/www/js/player-end.js
@@ -39,8 +39,14 @@
         window.scrollTo(0, 0);
         var leaderboard = (data.leaderboard || []).slice();
 
+        // Match on the entrant id, not the printed name (#759): two teams may
+        // carry the same name, and by name the "(du)" badge lit up on both of
+        // them. The name is still what the row prints.
+        var team = window.QuizifyPlayerTeam;
+        var mine = team && team.myTeam && team.myTeam();
+        var me = (mine && (mine.team_id || mine.name)) || state.playerName;
         leaderboard.forEach(function (entry) {
-            entry.is_current = (entry.name === state.playerName);
+            entry.is_current = ((entry.entrant_id || entry.name) === me);
         });
         // Defensive: ensure rank order (server sends sorted, but be safe).
         leaderboard.sort(function (a, b) {

--- a/custom_components/quizify/www/js/player-game.js
+++ b/custom_components/quizify/www/js/player-game.js
@@ -1041,7 +1041,26 @@
      * @param {Object} data - State data containing leaderboard
      * @param {string} targetListId - ID of list container
      */
-    var _prevLeaderboardRanks = {}; // name -> rank
+    var _prevLeaderboardRanks = {}; // entrant id -> rank
+
+    /**
+     * The leaderboard row that is mine: my team's when I'm in one, my own
+     * otherwise. Mirrors player-lightning.js's myEntrant() — see #728 there
+     * and #759 here: two teams may carry the same name, so matching rows by
+     * the printed name lit up the "you" badge on both of them, collapsed them
+     * into one entry in the rank-delta memo and made the FLIP animation swap
+     * their positions at random.
+     */
+    function myEntrant() {
+        var team = window.QuizifyPlayerTeam;
+        var mine = team && team.myTeam && team.myTeam();
+        return (mine && (mine.team_id || mine.name)) || state.playerName;
+    }
+
+    /** The stable key of one leaderboard row; falls back to the name. */
+    function entrantKey(entry) {
+        return entry.entrant_id || entry.name;
+    }
 
     // Clear the rank-delta memo (issue #257). Without this a game_reset
     // leaves stale ranks behind, so the first leaderboard of the *next*
@@ -1055,10 +1074,11 @@
         var listEl = document.getElementById(targetListId || 'leaderboard-list');
         if (!listEl) return;
 
+        var me = myEntrant();
         leaderboard.forEach(function (entry) {
-            entry.is_current = (entry.name === state.playerName);
+            entry.is_current = (entrantKey(entry) === me);
             // Calculate rank delta vs previous
-            var prevRank = _prevLeaderboardRanks[entry.name];
+            var prevRank = _prevLeaderboardRanks[entrantKey(entry)];
             if (prevRank !== undefined && prevRank !== entry.rank) {
                 entry.rank_delta = prevRank - entry.rank; // positive = moved up
             } else {
@@ -1066,12 +1086,14 @@
             }
         });
 
-        var displayList = compressLeaderboard(leaderboard, state.playerName);
+        var displayList = compressLeaderboard(leaderboard, me);
 
         // FLIP animation: record old positions before DOM update
         var oldPositions = {};
-        listEl.querySelectorAll('.leaderboard-entry[data-name]').forEach(function(el) {
-            oldPositions[el.dataset.name] = el.getBoundingClientRect().top;
+        // Keyed by the entrant id, not the name (#759): two same-named teams
+        // shared one slot here and the FLIP animation flung them at each other.
+        listEl.querySelectorAll('.leaderboard-entry[data-entrant]').forEach(function(el) {
+            oldPositions[el.dataset.entrant] = el.getBoundingClientRect().top;
         });
 
         var html = '';
@@ -1084,11 +1106,11 @@
         // FLIP: animate from old positions to new
         var prefersReduced = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
         if (!prefersReduced && Object.keys(oldPositions).length > 0) {
-            listEl.querySelectorAll('.leaderboard-entry[data-name]').forEach(function(el) {
-                var name = el.dataset.name;
-                if (oldPositions[name] !== undefined) {
+            listEl.querySelectorAll('.leaderboard-entry[data-entrant]').forEach(function(el) {
+                var key = el.dataset.entrant;
+                if (oldPositions[key] !== undefined) {
                     var newTop = el.getBoundingClientRect().top;
-                    var delta = oldPositions[name] - newTop;
+                    var delta = oldPositions[key] - newTop;
                     if (Math.abs(delta) > 2) {
                         el.style.transform = 'translateY(' + delta + 'px)';
                         el.style.transition = 'none';
@@ -1103,7 +1125,7 @@
 
         // Store current ranks for next update
         leaderboard.forEach(function(entry) {
-            _prevLeaderboardRanks[entry.name] = entry.rank;
+            _prevLeaderboardRanks[entrantKey(entry)] = entry.rank;
         });
 
         if (leaderboard.length > 8) {
@@ -1116,7 +1138,7 @@
     /**
      * Compress leaderboard for display when >10 players
      */
-    function compressLeaderboard(players, currentPlayerName) {
+    function compressLeaderboard(players, currentEntrant) {
         if (players.length <= 10) return players;
 
         var top5 = players.slice(0, 5);
@@ -1124,7 +1146,7 @@
         var currentIdx = -1;
 
         for (var i = 0; i < players.length; i++) {
-            if (players[i].name === currentPlayerName) {
+            if (entrantKey(players[i]) === currentEntrant) {
                 currentIdx = i;
                 break;
             }
@@ -1178,7 +1200,7 @@
             ? '<span class="player-color-dot" style="background:' + entry.color + '"></span>'
             : '';
         var colorBorder = entry.color ? ' style="border-left:3px solid ' + entry.color + '"' : '';
-        return '<div class="leaderboard-entry' + currentClass + disconnectedClass + '"' + colorBorder + ' data-name="' + pu.escapeHtml(entry.name) + '">' +
+        return '<div class="leaderboard-entry' + currentClass + disconnectedClass + '"' + colorBorder + ' data-entrant="' + pu.escapeHtml(entrantKey(entry)) + '">' +
             '<span class="entry-rank' + rankClass + '">' + rank + '</span>' +
             colorDot +
             '<span class="entry-name">' + pu.escapeHtml(entry.name) + youBadge + '</span>' +

--- a/custom_components/quizify/www/js/player.bundle.js
+++ b/custom_components/quizify/www/js/player.bundle.js
@@ -2900,8 +2900,14 @@
         window.scrollTo(0, 0);
         var leaderboard = (data.leaderboard || []).slice();
 
+        // Match on the entrant id, not the printed name (#759): two teams may
+        // carry the same name, and by name the "(du)" badge lit up on both of
+        // them. The name is still what the row prints.
+        var team = window.QuizifyPlayerTeam;
+        var mine = team && team.myTeam && team.myTeam();
+        var me = (mine && (mine.team_id || mine.name)) || state.playerName;
         leaderboard.forEach(function (entry) {
-            entry.is_current = (entry.name === state.playerName);
+            entry.is_current = ((entry.entrant_id || entry.name) === me);
         });
         // Defensive: ensure rank order (server sends sorted, but be safe).
         leaderboard.sort(function (a, b) {
@@ -5306,7 +5312,26 @@
      * @param {Object} data - State data containing leaderboard
      * @param {string} targetListId - ID of list container
      */
-    var _prevLeaderboardRanks = {}; // name -> rank
+    var _prevLeaderboardRanks = {}; // entrant id -> rank
+
+    /**
+     * The leaderboard row that is mine: my team's when I'm in one, my own
+     * otherwise. Mirrors player-lightning.js's myEntrant() — see #728 there
+     * and #759 here: two teams may carry the same name, so matching rows by
+     * the printed name lit up the "you" badge on both of them, collapsed them
+     * into one entry in the rank-delta memo and made the FLIP animation swap
+     * their positions at random.
+     */
+    function myEntrant() {
+        var team = window.QuizifyPlayerTeam;
+        var mine = team && team.myTeam && team.myTeam();
+        return (mine && (mine.team_id || mine.name)) || state.playerName;
+    }
+
+    /** The stable key of one leaderboard row; falls back to the name. */
+    function entrantKey(entry) {
+        return entry.entrant_id || entry.name;
+    }
 
     // Clear the rank-delta memo (issue #257). Without this a game_reset
     // leaves stale ranks behind, so the first leaderboard of the *next*
@@ -5320,10 +5345,11 @@
         var listEl = document.getElementById(targetListId || 'leaderboard-list');
         if (!listEl) return;
 
+        var me = myEntrant();
         leaderboard.forEach(function (entry) {
-            entry.is_current = (entry.name === state.playerName);
+            entry.is_current = (entrantKey(entry) === me);
             // Calculate rank delta vs previous
-            var prevRank = _prevLeaderboardRanks[entry.name];
+            var prevRank = _prevLeaderboardRanks[entrantKey(entry)];
             if (prevRank !== undefined && prevRank !== entry.rank) {
                 entry.rank_delta = prevRank - entry.rank; // positive = moved up
             } else {
@@ -5331,12 +5357,14 @@
             }
         });
 
-        var displayList = compressLeaderboard(leaderboard, state.playerName);
+        var displayList = compressLeaderboard(leaderboard, me);
 
         // FLIP animation: record old positions before DOM update
         var oldPositions = {};
-        listEl.querySelectorAll('.leaderboard-entry[data-name]').forEach(function(el) {
-            oldPositions[el.dataset.name] = el.getBoundingClientRect().top;
+        // Keyed by the entrant id, not the name (#759): two same-named teams
+        // shared one slot here and the FLIP animation flung them at each other.
+        listEl.querySelectorAll('.leaderboard-entry[data-entrant]').forEach(function(el) {
+            oldPositions[el.dataset.entrant] = el.getBoundingClientRect().top;
         });
 
         var html = '';
@@ -5349,11 +5377,11 @@
         // FLIP: animate from old positions to new
         var prefersReduced = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
         if (!prefersReduced && Object.keys(oldPositions).length > 0) {
-            listEl.querySelectorAll('.leaderboard-entry[data-name]').forEach(function(el) {
-                var name = el.dataset.name;
-                if (oldPositions[name] !== undefined) {
+            listEl.querySelectorAll('.leaderboard-entry[data-entrant]').forEach(function(el) {
+                var key = el.dataset.entrant;
+                if (oldPositions[key] !== undefined) {
                     var newTop = el.getBoundingClientRect().top;
-                    var delta = oldPositions[name] - newTop;
+                    var delta = oldPositions[key] - newTop;
                     if (Math.abs(delta) > 2) {
                         el.style.transform = 'translateY(' + delta + 'px)';
                         el.style.transition = 'none';
@@ -5368,7 +5396,7 @@
 
         // Store current ranks for next update
         leaderboard.forEach(function(entry) {
-            _prevLeaderboardRanks[entry.name] = entry.rank;
+            _prevLeaderboardRanks[entrantKey(entry)] = entry.rank;
         });
 
         if (leaderboard.length > 8) {
@@ -5381,7 +5409,7 @@
     /**
      * Compress leaderboard for display when >10 players
      */
-    function compressLeaderboard(players, currentPlayerName) {
+    function compressLeaderboard(players, currentEntrant) {
         if (players.length <= 10) return players;
 
         var top5 = players.slice(0, 5);
@@ -5389,7 +5417,7 @@
         var currentIdx = -1;
 
         for (var i = 0; i < players.length; i++) {
-            if (players[i].name === currentPlayerName) {
+            if (entrantKey(players[i]) === currentEntrant) {
                 currentIdx = i;
                 break;
             }
@@ -5443,7 +5471,7 @@
             ? '<span class="player-color-dot" style="background:' + entry.color + '"></span>'
             : '';
         var colorBorder = entry.color ? ' style="border-left:3px solid ' + entry.color + '"' : '';
-        return '<div class="leaderboard-entry' + currentClass + disconnectedClass + '"' + colorBorder + ' data-name="' + pu.escapeHtml(entry.name) + '">' +
+        return '<div class="leaderboard-entry' + currentClass + disconnectedClass + '"' + colorBorder + ' data-entrant="' + pu.escapeHtml(entrantKey(entry)) + '">' +
             '<span class="entry-rank' + rankClass + '">' + rank + '</span>' +
             colorDot +
             '<span class="entry-name">' + pu.escapeHtml(entry.name) + youBadge + '</span>' +

--- a/tests/test_estimate_round_tail_810.py
+++ b/tests/test_estimate_round_tail_810.py
@@ -1,0 +1,220 @@
+"""One round-closing tail, and estimate rounds feed auto-difficulty (#810).
+
+``_do_evaluate_round`` and ``_evaluate_estimate_round`` each carried their own
+copy of the round-closing sequence — build the ``AnswerResult``s, take the
+leaderboard, construct the ``RoundSummary``, flip to ANSWER_REVEAL, record the
+question stats, clear ``joined_late``, log, broadcast. The estimate copy's
+docstring claimed it mirrored the MC one and did not: the ``GroupCalibrator``
+feed (#40/#302) existed only in the MC branch. Since #566 every pack carries
+estimate questions, so an auto-mode room contributed no signal on those rounds
+and the target never advanced for them.
+
+The tail is now ``_close_round``, called by both. The property worth pinning is
+not "the two agree today" but "there is only one of them".
+
+**The correctness reading, decided here:** an exact hit stays what the reveal
+and the per-question stats mean by correct, and the calibrator gets a different
+reading — whether the guess landed inside
+``ESTIMATE_CALIBRATION_BAND`` of the question's slider span. Distance zero on a
+slider is close to unattainable, so feeding ``exact`` to the calibrator would
+have scored every estimate round 0/N and walked an auto-mode game down to EASY
+and held it there. That would be a worse bug than the missing feed, not a fix
+for it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from custom_components.quizify.game.scoring import (
+    ESTIMATE_CALIBRATION_BAND,
+    estimate_within_calibration_band,
+)
+from custom_components.quizify.game.state import GamePhase, QuizifyGameState
+
+
+class _Runtime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+    def create_task(self, coro):  # noqa: ANN001
+        return asyncio.ensure_future(coro)
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+def _auto_game(tmp_path: Path, category: str) -> QuizifyGameState:
+    """An "auto"-difficulty game, so ``_calibrator`` is live."""
+    gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+    for name in ("Anna", "Mira"):
+        gs.add_player(name, _ws())
+    gs.start_game(
+        category=category,
+        difficulty="auto",
+        num_rounds=5,
+        language="en",
+        lightning_enabled=False,
+        hot_seat_enabled=False,
+    )
+    assert gs._calibrator is not None, "auto mode did not arm the calibrator"
+    gs.start_next_question()
+    return gs
+
+
+class _SpyCalibrator:
+    """Records what it was fed, then delegates nothing — the target holds."""
+
+    def __init__(self, real) -> None:  # noqa: ANN001
+        self._real = real
+        self.rounds: list[tuple[int, int]] = []
+
+    def record_round(self, correct: int, total: int) -> None:
+        self.rounds.append((correct, total))
+        self._real.record_round(correct=correct, total=total)
+
+    def next_target(self):  # noqa: ANN202
+        return self._real.next_target()
+
+    def average_rate(self):  # noqa: ANN202
+        return self._real.average_rate()
+
+    @property
+    def current_target(self):  # noqa: ANN202
+        return self._real.current_target
+
+
+# --------------------------------------------------------------------------
+# The bug: an auto-mode estimate round produced no signal at all
+# --------------------------------------------------------------------------
+
+
+def test_an_auto_mode_estimate_round_feeds_the_calibrator(
+    tmp_path: Path,
+) -> None:
+    game = _auto_game(tmp_path, "estimation-en")
+    spy = _SpyCalibrator(game._calibrator)
+    game._calibrator = spy
+
+    question = game.get_current_question()
+    assert question.is_estimate
+    game.submit_guess("Anna", question.estimate_answer)
+    game.submit_guess("Mira", question.estimate_answer)
+    game.evaluate_round()
+
+    assert spy.rounds, "the estimate round fed the calibrator nothing"
+    assert spy.rounds == [(2, 2)]
+
+
+def test_a_room_missing_by_a_mile_is_a_signal_too(tmp_path: Path) -> None:
+    """Not just "record_round was called" — the number has to mean something."""
+    game = _auto_game(tmp_path, "estimation-en")
+    spy = _SpyCalibrator(game._calibrator)
+    game._calibrator = spy
+
+    question = game.get_current_question()
+    span = question.estimate_max - question.estimate_min
+    game.submit_guess("Anna", question.estimate_min)
+    game.submit_guess("Mira", question.estimate_max)
+    game.evaluate_round()
+
+    # At least one of the two extremes is more than a tenth of the span away
+    # from any answer inside the range, so the room cannot have scored 2/2.
+    assert spy.rounds and spy.rounds[0][1] == 2
+    assert spy.rounds[0][0] < 2, (
+        f"a guess {span:.0f} wide counted as correct: {spy.rounds}"
+    )
+
+
+def test_the_reveal_still_calls_only_an_exact_hit_correct(
+    tmp_path: Path,
+) -> None:
+    """The calibration band is for the calibrator alone; the reveal is unchanged."""
+    game = _auto_game(tmp_path, "estimation-en")
+    question = game.get_current_question()
+    span = question.estimate_max - question.estimate_min
+
+    # Inside the band, but not the value: correct for calibration, wrong on
+    # the number line.
+    close = question.estimate_answer + span * ESTIMATE_CALIBRATION_BAND / 2
+    close = min(close, question.estimate_max)
+    game.submit_guess("Anna", close)
+    game.submit_guess("Mira", question.estimate_min)
+    game.evaluate_round()  # a no-op when the last guess already triggered it
+
+    summary = game.get_round_summary()
+    anna = next(r for r in summary.results if r.player_id == "Anna")
+    assert anna.correct is False
+    assert game.get_player("Anna").round_history[-1] == "wrong"
+
+
+def test_the_calibration_band_is_relative_to_the_slider_span() -> None:
+    assert estimate_within_calibration_band(9.0, 100.0) is True
+    assert estimate_within_calibration_band(11.0, 100.0) is False
+    # No usable span → nothing to judge closeness against, so exact only.
+    assert estimate_within_calibration_band(0.0, None) is True
+    assert estimate_within_calibration_band(1.0, None) is False
+    assert estimate_within_calibration_band(1.0, 0.0) is False
+
+
+# --------------------------------------------------------------------------
+# The structural half: one tail, two callers
+# --------------------------------------------------------------------------
+
+
+def test_both_evaluators_close_the_round_through_the_same_helper(
+    tmp_path: Path,
+) -> None:
+    """Two blocks documented as mirrors drifted anyway. Now there is one."""
+    calls: list[str] = []
+    original = QuizifyGameState._close_round
+
+    for category in ("picture-round-en", "estimation-en"):
+        game = _auto_game(tmp_path, category)
+
+        def _spy(self, *a, _cat=category, **kw):  # noqa: ANN001, ANN002, ANN003
+            calls.append(_cat)
+            return original(self, *a, **kw)
+
+        game._close_round = _spy.__get__(game)
+        before = len(calls)
+
+        question = game.get_current_question()
+        if question.is_estimate:
+            game.submit_guess("Anna", question.estimate_answer)
+        else:
+            correct = next(i for i, a in enumerate(question.answers) if a.correct)
+            game.submit_answer("Anna", correct)
+        game.evaluate_round()
+
+        assert len(calls) == before + 1, f"{category} did not use the helper"
+
+
+def test_the_estimate_round_still_transitions_and_broadcasts(
+    tmp_path: Path,
+) -> None:
+    """The rest of the tail the estimate path already had must survive."""
+    fired: list[str] = []
+    game = _auto_game(tmp_path, "estimation-en")
+    game._fire_broadcast = lambda event, **kw: fired.append(event)  # noqa: ARG005
+
+    question = game.get_current_question()
+    game.get_player("Anna").joined_late = True
+    game.submit_guess("Anna", question.estimate_answer)
+    game.evaluate_round()
+    summary = game.get_round_summary()
+
+    assert game.phase == GamePhase.ANSWER_REVEAL
+    assert "round_evaluated" in fired
+    assert summary.estimate is not None, "the number-line block went missing"
+    assert summary.correct_answer.text
+    assert game.get_player("Anna").joined_late is False
+    assert {r.player_id for r in summary.results} == {"Anna", "Mira"}

--- a/tests/test_leaderboard_duplicate_team_names_759.py
+++ b/tests/test_leaderboard_duplicate_team_names_759.py
@@ -1,0 +1,160 @@
+"""Two teams of the same name are two rows on the normal leaderboard (#759).
+
+``serialize_leaderboard`` identified a row by its name alone. Each ``Team``
+object is scored and paid correctly in a normal round — the scoring half of
+this was fixed for the lightning round in #728 — but two teams called "Sofa"
+produced two rows the client could not tell apart: the name-based "you"
+highlight lit both of them, the rank-delta memo and the FLIP animation shared
+one slot between them.
+
+The fix is the shape #728 introduced in ``game/lightning.py``: a stable
+``entrant_id`` beside the ``name``, with the name still the label. A player's
+name is already unique per game, so for a player the entrant id is their name
+and nothing about solo play changes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from custom_components.quizify.game.state import QuizifyGameState
+from custom_components.quizify.server.serializers import serialize_leaderboard
+
+_JS_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "custom_components"
+    / "quizify"
+    / "www"
+    / "js"
+)
+
+
+class _Runtime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+    def create_task(self, coro):  # noqa: ANN001
+        return asyncio.ensure_future(coro)
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+def _two_sofas(tmp_path: Path) -> QuizifyGameState:
+    """Two teams called "Sofa", plus one solo player."""
+    gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+    for name in ("Anna", "Jan", "Mira"):
+        gs.add_player(name, _ws())
+    gs.create_team("Sofa", "Anna")
+    gs.create_team("Sofa", "Jan")
+    return gs
+
+
+# --------------------------------------------------------------------------
+# The wire: two rows, and they can be told apart
+# --------------------------------------------------------------------------
+
+
+def test_two_same_named_teams_are_two_distinguishable_rows(
+    tmp_path: Path,
+) -> None:
+    gs = _two_sofas(tmp_path)
+    teams = gs.team_registry.all_teams()
+    teams[0].score = 30
+    teams[1].score = 10
+
+    rows = serialize_leaderboard(gs.get_ranked_participants())
+    sofas = [r for r in rows if r["name"] == "Sofa"]
+
+    assert len(sofas) == 2
+    ids = {r["entrant_id"] for r in sofas}
+    assert len(ids) == 2, f"the two Sofas share one identity: {ids}"
+    assert ids == {t.team_id for t in teams}
+
+
+def test_the_row_still_prints_the_team_name(tmp_path: Path) -> None:
+    """The id is for matching; the name is still the label the TV shows."""
+    gs = _two_sofas(tmp_path)
+    rows = serialize_leaderboard(gs.get_ranked_participants())
+    assert [r["name"] for r in rows if r["entrant_id"] != r["name"]] == [
+        "Sofa",
+        "Sofa",
+    ]
+
+
+def test_a_players_entrant_id_is_their_name(tmp_path: Path) -> None:
+    """Names are unique per game, so solo play needs no second identifier."""
+    gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+    for name in ("Bob", "Alice"):
+        gs.add_player(name, _ws())
+
+    rows = serialize_leaderboard(gs.get_ranked_participants())
+    assert {r["entrant_id"] for r in rows} == {"Bob", "Alice"}
+    assert all(r["entrant_id"] == r["name"] for r in rows)
+
+
+def test_a_solo_player_in_a_team_game_keeps_their_own_id(
+    tmp_path: Path,
+) -> None:
+    gs = _two_sofas(tmp_path)
+    rows = serialize_leaderboard(gs.get_ranked_participants())
+    mira = next(r for r in rows if r["name"] == "Mira")
+    assert mira["entrant_id"] == "Mira"
+
+
+# --------------------------------------------------------------------------
+# The client: nothing matches a leaderboard row by its printed name any more
+# --------------------------------------------------------------------------
+
+
+def _src(name: str) -> str:
+    return (_JS_DIR / name).read_text("utf-8")
+
+
+def test_the_player_leaderboard_matches_on_the_entrant_id() -> None:
+    src = _src("player-game.js")
+    assert "function entrantKey(" in src
+    assert "function myEntrant(" in src
+    assert "entry.is_current = (entrantKey(entry) === me)" in src
+    assert "entry.name === state.playerName" not in src, (
+        "a leaderboard row is still identified by its printed name"
+    )
+
+
+def test_the_flip_animation_and_rank_memo_key_on_the_entrant_id() -> None:
+    src = _src("player-game.js")
+    assert "data-entrant=" in src
+    assert "el.dataset.entrant" in src
+    assert "_prevLeaderboardRanks[entrantKey(entry)]" in src
+    assert "dataset.name" not in src
+
+
+def test_the_finale_you_badge_matches_on_the_entrant_id() -> None:
+    src = _src("player-end.js")
+    assert "(entry.entrant_id || entry.name) === me" in src
+    assert "entry.is_current = (entry.name === state.playerName)" not in src
+
+
+def test_the_shipped_bundle_carries_the_change() -> None:
+    """The bundle is committed; a stale one ships the old matching to phones."""
+    bundle = _src("player.bundle.js")
+    for needle in (
+        "function entrantKey(",
+        "data-entrant=",
+        "(entry.entrant_id || entry.name) === me",
+    ):
+        assert needle in bundle, (
+            f"{needle!r} missing — run: python3 scripts/build_bundle.py"
+        )
+    assert not re.search(
+        r"entry\.is_current = \(entry\.name === state\.playerName\)", bundle
+    )

--- a/tests/test_reaction_bonus_team_mode_800.py
+++ b/tests/test_reaction_bonus_team_mode_800.py
@@ -1,0 +1,259 @@
+"""The reveal reaction bonus credits the participant the room can see (#800).
+
+``_handle_reaction`` awarded its +1 to ``game_state.get_player(result.player_id)``.
+In team mode the ``RoundSummary`` results are still per player — the member
+whose tap carried the team's answer is the "correct" one — so the point landed
+on that member's ``player.score``, the shadow value #668/#669 established is
+meaningless in team mode. ``Team.score`` never moved, and the ``reaction_bonus``
+broadcast serializes ``get_ranked_participants()``, i.e. the teams: the
+recipient's phone toasted "+1 from Mira" while the TV, the reveal leaderboard
+and the podium all stayed exactly where they were.
+
+The bonus now goes to the ranked participant — the team when there is one, the
+player when they are solo — and the toast list stays a list of player names so
+every member of a credited team hears about it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.quizify.game.state import GamePhase, QuizifyGameState
+from custom_components.quizify.server.websocket import QuizifyWebSocketHandler
+
+
+class _Runtime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+    def create_task(self, coro):  # noqa: ANN001
+        return asyncio.ensure_future(coro)
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    return ws
+
+
+def _handler(tmp_path: Path, game: QuizifyGameState) -> QuizifyWebSocketHandler:
+    return QuizifyWebSocketHandler(
+        runtime=_Runtime(tmp_path), game_state_provider=lambda: game
+    )
+
+
+def _revealed_team_game(tmp_path: Path) -> QuizifyGameState:
+    """Team Sofa (Anna + Jan) answered correctly; Mira is solo and watching."""
+    gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+    for name in ("Anna", "Jan", "Mira"):
+        gs.add_player(name, _ws())
+    gs.create_team("Sofa", "Anna")
+    gs.join_team(gs.get_team_of("Anna")["team_id"], "Jan")
+    gs.start_game(
+        category="picture-round-en",
+        difficulty="easy",
+        num_rounds=3,
+        language="en",
+        lightning_enabled=False,
+        hot_seat_enabled=False,
+    )
+    gs.start_next_question()
+    q = gs.get_current_question()
+    correct = next(i for i, a in enumerate(q.answers) if a.correct)
+    gs.submit_answer("Anna", correct)
+    gs.evaluate_round()
+    assert gs.phase == GamePhase.ANSWER_REVEAL
+    return gs
+
+
+def _sofa(gs: QuizifyGameState):  # noqa: ANN202
+    return next(t for t in gs.team_registry.all_teams() if t.name == "Sofa")
+
+
+def _row(msg: dict, name: str) -> dict:
+    return next(e for e in msg["leaderboard"] if e["name"] == name)
+
+
+# --------------------------------------------------------------------------
+# The bug: the point landed on a score nobody can see
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_bonus_lands_on_the_team_not_the_carrier(
+    tmp_path: Path,
+) -> None:
+    gs = _revealed_team_game(tmp_path)
+    team = _sofa(gs)
+    team_before = team.score
+    carrier_before = gs.get_player("Anna").score
+
+    h = _handler(tmp_path, gs)
+    h._conn.broadcast = lambda m: asyncio.sleep(0)  # type: ignore[assignment,return-value]
+    await h._handle_reaction(gs.get_player("Mira").ws, {"emoji": "🎉"}, gs)
+
+    assert team.score == team_before + 1, "the team's score never moved"
+    assert gs.get_player("Anna").score == carrier_before, (
+        "the point went to the carrier's shadow score again"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_broadcast_leaderboard_shows_the_point(
+    tmp_path: Path,
+) -> None:
+    """The frame that carries the toast has to carry the changed board too."""
+    gs = _revealed_team_game(tmp_path)
+    before = _sofa(gs).score
+
+    h = _handler(tmp_path, gs)
+    sent: list[dict] = []
+    h._conn.broadcast = lambda m: sent.append(m) or asyncio.sleep(0)  # type: ignore[assignment,return-value]
+    await h._handle_reaction(gs.get_player("Mira").ws, {"emoji": "🎉"}, gs)
+    if h._reaction_flush_task is not None:
+        await h._reaction_flush_task
+
+    frame = next(m for m in sent if m.get("type") == "reaction_bonus")
+    assert _row(frame, "Sofa")["score"] == before + 1
+
+
+@pytest.mark.asyncio
+async def test_every_member_of_the_credited_team_is_toasted(
+    tmp_path: Path,
+) -> None:
+    """``to_players`` stays player names — it is what each phone matches on."""
+    gs = _revealed_team_game(tmp_path)
+
+    h = _handler(tmp_path, gs)
+    sent: list[dict] = []
+    h._conn.broadcast = lambda m: sent.append(m) or asyncio.sleep(0)  # type: ignore[assignment,return-value]
+    await h._handle_reaction(gs.get_player("Mira").ws, {"emoji": "🎉"}, gs)
+    if h._reaction_flush_task is not None:
+        await h._reaction_flush_task
+
+    frame = next(m for m in sent if m.get("type") == "reaction_bonus")
+    assert set(frame["to_players"]) == {"Anna", "Jan"}
+
+
+@pytest.mark.asyncio
+async def test_you_cannot_tip_your_own_team(tmp_path: Path) -> None:
+    """The 'no tipping your own hat' rule follows the participant, not the name."""
+    gs = _revealed_team_game(tmp_path)
+    team = _sofa(gs)
+    before = team.score
+
+    h = _handler(tmp_path, gs)
+    h._conn.broadcast = lambda m: asyncio.sleep(0)  # type: ignore[assignment,return-value]
+    # Jan is on Sofa but is not the carrier, so by player name he looked like
+    # an unrelated tipper.
+    await h._handle_reaction(gs.get_player("Jan").ws, {"emoji": "🎉"}, gs)
+
+    assert team.score == before
+
+
+@pytest.mark.asyncio
+async def test_the_per_round_cap_applies_to_the_team(tmp_path: Path) -> None:
+    """Four reactors, cap of three — the fourth point is refused."""
+    gs = _revealed_team_game(tmp_path)
+    for extra in ("Nils", "Ute", "Timo"):
+        gs.add_player(extra, _ws())
+    team = _sofa(gs)
+    before = team.score
+
+    h = _handler(tmp_path, gs)
+    h._conn.broadcast = lambda m: asyncio.sleep(0)  # type: ignore[assignment,return-value]
+    for reactor in ("Mira", "Nils", "Ute", "Timo"):
+        await h._handle_reaction(gs.get_player(reactor).ws, {"emoji": "🎉"}, gs)
+
+    assert team.score == before + h._REACTION_BONUS_CAP_PER_ROUND
+
+
+@pytest.mark.asyncio
+async def test_the_cap_counter_is_cleared_between_games(
+    tmp_path: Path,
+) -> None:
+    """Round numbers restart at 1, so the received-count must too (#167)."""
+    gs = _revealed_team_game(tmp_path)
+    team = _sofa(gs)
+    for extra in ("Nils", "Ute"):
+        gs.add_player(extra, _ws())
+
+    h = _handler(tmp_path, gs)
+    h._conn.broadcast = lambda m: asyncio.sleep(0)  # type: ignore[assignment,return-value]
+    for reactor in ("Mira", "Nils", "Ute"):
+        await h._handle_reaction(gs.get_player(reactor).ws, {"emoji": "🎉"}, gs)
+    assert team._reaction_bonuses_received
+
+    team.reset_for_new_game()
+    assert team._reaction_bonuses_received == {}
+
+
+# --------------------------------------------------------------------------
+# Solo play is untouched
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_game_without_teams_still_pays_the_player(
+    tmp_path: Path,
+) -> None:
+    gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+    for name in ("Bob", "Alice"):
+        gs.add_player(name, _ws())
+    gs.start_game(
+        category="picture-round-en",
+        difficulty="easy",
+        num_rounds=3,
+        language="en",
+        lightning_enabled=False,
+        hot_seat_enabled=False,
+    )
+    gs.start_next_question()
+    q = gs.get_current_question()
+    gs.submit_answer("Bob", next(i for i, a in enumerate(q.answers) if a.correct))
+    gs.evaluate_round()
+    before = gs.get_player("Bob").score
+
+    h = _handler(tmp_path, gs)
+    h._conn.broadcast = lambda m: asyncio.sleep(0)  # type: ignore[assignment,return-value]
+    await h._handle_reaction(gs.get_player("Alice").ws, {"emoji": "🎉"}, gs)
+
+    assert gs.get_player("Bob").score == before + 1
+
+
+@pytest.mark.asyncio
+async def test_a_solo_player_in_a_team_game_is_paid_directly(
+    tmp_path: Path,
+) -> None:
+    """A player who joined no team keeps their own row, so they keep the point."""
+    gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+    for name in ("Anna", "Mira"):
+        gs.add_player(name, _ws())
+    gs.create_team("Sofa", "Anna")
+    gs.start_game(
+        category="picture-round-en",
+        difficulty="easy",
+        num_rounds=3,
+        language="en",
+        lightning_enabled=False,
+        hot_seat_enabled=False,
+    )
+    gs.start_next_question()
+    q = gs.get_current_question()
+    gs.submit_answer("Mira", next(i for i, a in enumerate(q.answers) if a.correct))
+    gs.evaluate_round()
+    before = gs.get_player("Mira").score
+
+    h = _handler(tmp_path, gs)
+    h._conn.broadcast = lambda m: asyncio.sleep(0)  # type: ignore[assignment,return-value]
+    await h._handle_reaction(gs.get_player("Anna").ws, {"emoji": "🎉"}, gs)
+
+    assert gs.get_player("Mira").score == before + 1

--- a/tests/test_team_reset_for_new_game_799.py
+++ b/tests/test_team_reset_for_new_game_799.py
@@ -1,0 +1,228 @@
+"""A rematch starts every team at zero (#799).
+
+``start_game`` reset every ``PlayerSession`` and the power-up manager, and
+``reset_to_lobby`` did the same — neither touched the ``TeamRegistry``. Only
+``clear_all_players`` (the explicit reset-game button) ever cleared a team's
+score, so the one-tap rematch from the finale opened game 2 on game 1's
+leaderboard: Sofa 120 / Cara 0 before a single question, awards counting the
+old rounds, and the streak bonus carrying on where it left off.
+
+The second half is the same defect one layer down: the stale-player prune in
+``start_game`` called the *registry's* ``remove_player`` rather than the game
+state's, so a player whose phone stayed dark was dropped from the roster but
+left behind in ``Team.members``. A team whose members had all gone dark
+survived as a zombie row that timed out every round.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from custom_components.quizify.game.state import QuizifyGameState
+
+
+class _Runtime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+    def create_task(self, coro):  # noqa: ANN001
+        return asyncio.ensure_future(coro)
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+def _team_game(tmp_path: Path, rounds: int = 3) -> QuizifyGameState:
+    """Two teams — Sofa (Anna, Jan) and Cara (Mira) — mid-game."""
+    st = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="test")
+    for name in ("Anna", "Jan", "Mira"):
+        st.add_player(name, _ws())
+    st.create_team("Sofa", "Anna")
+    st.join_team(st.get_team_of("Anna")["team_id"], "Jan")
+    st.create_team("Cara", "Mira")
+    st.start_game(
+        category="picture-round-en",
+        difficulty="easy",
+        num_rounds=rounds,
+        language="en",
+        lightning_enabled=False,
+        hot_seat_enabled=False,
+    )
+    return st
+
+
+def _by_name(game: QuizifyGameState, name: str):  # noqa: ANN202
+    return next(t for t in game.team_registry.all_teams() if t.name == name)
+
+
+def _dirty(team) -> None:  # noqa: ANN001
+    """Give a team the tallies three played rounds would have left behind."""
+    team.score = 120
+    team.streak = 4
+    team.max_streak = 4
+    team.round_history = ["correct", "correct", "correct"]
+    team.round_scores = [40, 40, 40]
+    team.answer_times = [2.0, 3.0, 1.5]
+    team.hard_score = 80
+    team.freezes_used = 1
+    team.powerups_used = 2
+    team.rounds_played = 3
+
+
+def _assert_clean(team) -> None:  # noqa: ANN001
+    assert team.score == 0, f"{team.name} kept {team.score} points"
+    assert team.streak == 0
+    assert team.max_streak == 0
+    assert team.round_history == []
+    assert team.round_scores == []
+    assert team.answer_times == []
+    assert team.hard_score == 0
+    assert team.freezes_used == 0
+    assert team.powerups_used == 0
+    assert team.rounds_played == 0
+    assert team.round_score == 0
+    assert team.current_answer is None
+
+
+# --------------------------------------------------------------------------
+# The bug as it was reported: Play again keeps the previous game's totals
+# --------------------------------------------------------------------------
+
+
+def test_play_again_starts_every_team_at_zero(tmp_path: Path) -> None:
+    """end_game → reset_to_lobby → start_game is the one-tap rematch path."""
+    game = _team_game(tmp_path)
+    _dirty(_by_name(game, "Sofa"))
+    _dirty(_by_name(game, "Cara"))
+
+    game.end_game()
+    game.reset_to_lobby()
+    game.start_game(
+        category="picture-round-en",
+        difficulty="easy",
+        num_rounds=3,
+        language="en",
+        lightning_enabled=False,
+        hot_seat_enabled=False,
+    )
+
+    for name in ("Sofa", "Cara"):
+        _assert_clean(_by_name(game, name))
+
+
+def test_reset_to_lobby_alone_already_clears_the_teams(tmp_path: Path) -> None:
+    """The finale's leaderboard must not survive into the lobby it returns to."""
+    game = _team_game(tmp_path)
+    _dirty(_by_name(game, "Sofa"))
+
+    game.end_game()
+    game.reset_to_lobby()
+
+    _assert_clean(_by_name(game, "Sofa"))
+
+
+def test_start_game_alone_already_clears_the_teams(tmp_path: Path) -> None:
+    """The second gate, independent of the first.
+
+    Both entry points reset, so a team carrying a score into a lobby — by any
+    route the future invents — still starts the next game at zero.
+    """
+    game = _team_game(tmp_path)
+    game.end_game()
+    game.reset_to_lobby()
+    _dirty(_by_name(game, "Sofa"))
+
+    game.start_game(
+        category="picture-round-en",
+        difficulty="easy",
+        num_rounds=3,
+        language="en",
+        lightning_enabled=False,
+        hot_seat_enabled=False,
+    )
+
+    _assert_clean(_by_name(game, "Sofa"))
+
+
+def test_the_rematch_leaderboard_is_flat(tmp_path: Path) -> None:
+    """What the room actually sees: every row on zero before question one."""
+    game = _team_game(tmp_path)
+    _by_name(game, "Sofa").score = 120
+
+    game.end_game()
+    game.reset_to_lobby()
+    game.start_game(
+        category="picture-round-en",
+        difficulty="easy",
+        num_rounds=3,
+        language="en",
+        lightning_enabled=False,
+        hot_seat_enabled=False,
+    )
+
+    scores = {row["name"]: row["score"] for row in game.get_leaderboard()}
+    assert set(scores) == {"Sofa", "Cara"}
+    assert all(v == 0 for v in scores.values()), scores
+
+
+def test_the_teams_themselves_survive_the_rematch(tmp_path: Path) -> None:
+    """Only the scoreboard restarts — the room stays as it stands."""
+    game = _team_game(tmp_path)
+    game.end_game()
+    game.reset_to_lobby()
+
+    sofa = _by_name(game, "Sofa")
+    assert sofa.members == ["Anna", "Jan"]
+    assert len(game.team_registry.all_teams()) == 2
+
+
+# --------------------------------------------------------------------------
+# The related half: the stale-player prune has to go through remove_player
+# --------------------------------------------------------------------------
+
+
+def test_a_pruned_player_also_leaves_their_team(tmp_path: Path) -> None:
+    game = _team_game(tmp_path)
+    game.get_player("Jan").connected = False
+
+    game.start_game(
+        category="picture-round-en",
+        difficulty="easy",
+        num_rounds=3,
+        language="en",
+        lightning_enabled=False,
+        hot_seat_enabled=False,
+    )
+
+    assert game.get_player("Jan") is None
+    assert _by_name(game, "Sofa").members == ["Anna"]
+
+
+def test_a_team_whose_members_all_went_dark_is_dissolved(
+    tmp_path: Path,
+) -> None:
+    """Otherwise it stands as a zombie row that times out every round."""
+    game = _team_game(tmp_path)
+    for name in ("Anna", "Jan"):
+        game.get_player(name).connected = False
+
+    game.start_game(
+        category="picture-round-en",
+        difficulty="easy",
+        num_rounds=3,
+        language="en",
+        lightning_enabled=False,
+        hot_seat_enabled=False,
+    )
+
+    names = [t.name for t in game.team_registry.all_teams()]
+    assert names == ["Cara"], names
+    assert [row["name"] for row in game.get_leaderboard()] == ["Cara"]


### PR DESCRIPTION
Bundle A2 of the v1.16.0 week. Four issues that all live in `custom_components/quizify/game/` (`state.py`, `team.py`) plus one spot in `server/websocket.py` — separate PRs would have collided on every rebase.

Closes #799
Closes #800
Closes #759
Closes #810

---

## #799 — a rematch started with the previous game's team scores

`start_game()` reset every `PlayerSession` and the power-up manager, `reset_to_lobby()` did the same, and **neither touched the `TeamRegistry`**. Only `clear_all_players()` (the explicit reset-game button) ever cleared a team, so the one-tap rematch — `_handle_play_again` → `reset_to_lobby` → `start_game` — opened game 2 on game 1's leaderboard: Sofa 120 / Cara 0 before a single question, awards counting the old rounds, the streak bonus carrying on.

* `Team.reset_for_new_game()` mirrors `PlayerSession.reset_for_new_game()` field for field (score, streak, max_streak, round_history, round_scores, answer_times, hard_score, freezes_used, powerups_used, rounds_played, the received-reaction map, and `reset_round()`).
* `TeamRegistry.reset_for_new_game()` fans it out; both `start_game()` and `reset_to_lobby()` call it. Membership is untouched — the rematch is meant to keep the room, only the scoreboard restarts.
* The stale-player prune in `start_game()` now goes through the game state's `remove_player()` instead of the registry's, so a player whose phone stayed dark also leaves `Team.members`. A team whose members have all gone dark is dissolved rather than left standing as a zombie row that times out every round.

## #800 — the reveal reaction bonus credited a member's hidden personal score

`_handle_reaction` awarded its +1 to `get_player(result.player_id)`. In team mode the results are still per player — the member whose tap carried the team's answer is the "correct" one — so the point landed on that member's `player.score`, the shadow value #668/#669 established is meaningless in team mode, while the `reaction_bonus` broadcast serializes `get_ranked_participants()` and showed no change at all.

**Chosen approach: credit the Team** (the first of the two the issue lays out), not skip the bonus in team mode. Reasons: the bonus is the room's way of applauding whoever nailed the question, and in team mode the thing that nailed it *is* the team — removing the mechanic would take a working piece of the game away from every team room rather than fix it. And `Team` already answers to every attribute the ranking path reads, so crediting it is the smaller change: one new method, one resolution helper, no mode-specific branch in the flush path.

* New `QuizifyGameState.get_ranked_participant_for(name)` — the team when there is one, the player when they are solo. Anything that pays "whoever answered" should pay the participant the room can see.
* `Team.add_reaction_bonus(round_num, cap)` with its own received-count map, cleared by `reset_for_new_game()` for the #167 reason (round numbers restart each game).
* "Can't tip your own hat" now follows the participant, so a member cannot tip their own team.
* One bonus per team per reactor even if several members show as correct.
* `to_players` stays a list of **player** names — it is what each phone matches itself against for the toast — so a credited team hands over its whole roster and every member hears about the point. No client change needed there.

## #759 — two teams of the same name were one row to the client

`serialize_leaderboard` identified a row by its name alone. The scoring half was already right; this is the display half #728 deliberately left behind. Rows now carry an `entrant_id` beside the `name` — the same shape #728 introduced in `game/lightning.py` — with the name still the printed label. A player's name is unique per game, so their entrant id is simply their name and nothing about solo play changes.

Client side, three things stopped matching on the printed name: the `is_current` / "(du)" highlight (`player-game.js` and `player-end.js`), the rank-delta memo, and the FLIP animation's `data-name` key (now `data-entrant`, which had two same-named teams sharing one slot and flinging them at each other). `player.bundle.js` is rebuilt.

Not done here: `create_team` still accepts a duplicate name. #728 argued against rejecting it (the name is free text on purpose, and an error path mid-lobby costs i18n and client wiring), and now that the display is unambiguous that argument stands again — the reason to reconsider was the ambiguity, and the ambiguity is gone.

## #810 — one round-closing tail, and estimate rounds feed auto-difficulty

`_do_evaluate_round` and `_evaluate_estimate_round` each carried a copy of the closing sequence, and the estimate copy — documented as a mirror — was missing the `GroupCalibrator` feed. Since #566 every pack carries estimate questions, so an auto-mode room contributed no signal on those rounds and the target never advanced for them.

Both evaluators now compute only their scoring and hand off to `_close_round(question, correct_answer, correctness, *, estimate=None, calibration_correctness=None)`, which builds the results, takes the leaderboard, constructs the `RoundSummary`, flips to `ANSWER_REVEAL`, feeds the calibrator, records the question stats, clears `joined_late`, logs and broadcasts.

**The decision the issue asks for: an exact estimate hit is NOT what the calibrator is told about.** `exact` is `distance == 0`, and on a slider that runs, say, 0…1000 that is close to unattainable. Wiring it into the calibrator would have scored every estimate round 0/N — a unanimous "make it easier" vote every time — and walked an auto-mode game down to EASY and held it there. That is a worse bug than the missing feed, not a fix for it.

The calibrator gets a second reading instead: whether the guess landed within `ESTIMATE_CALIBRATION_BAND` (10%) of the question's slider span, via `estimate_within_calibration_band()` in `scoring.py`. It is deterministic, derived from data the question already carries, and it is the judgement the reveal's number line already invites — inside the band you were in the neighbourhood. **The reveal and the per-question stats are unchanged**: they still call only an exact hit correct, so `AnswerResult.correct`, `round_history` and the stats pipeline behave exactly as before. A question with no usable span falls back to the exact test.

---

## Verification

Every fix has a test that fails without it, checked with `git stash` / run / `git stash pop`:

| Issue | Test file | Without the fix |
|---|---|---|
| #799 | `tests/test_team_reset_for_new_game_799.py` | 6 of 7 fail (the 7th asserts teams *survive* the rematch, which held before) |
| #800 | `tests/test_reaction_bonus_team_mode_800.py` | 5 of 8 fail (3 are solo-play and own-team non-regressions) |
| #759 | `tests/test_leaderboard_duplicate_team_names_759.py` | all 8 fail |
| #810 | `tests/test_estimate_round_tail_810.py` | 3 of 6 fail (stashing `state.py` only, so the new `scoring.py` helper still imports) |

* `ruff check custom_components/` — clean. Not run as `ruff format`; the repo is not format-clean.
* `mypy custom_components/quizify` — `Success: no issues found in 48 source files`, i.e. at baseline.
* Full suite: **2811 passed** (2782 before this PR, +29 new).
* `scripts/build_bundle.py` re-run; the committed `player.bundle.js` is in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)