### PR TITLE
Gate the unauthenticated endpoints on Origin, cap WebSocket frames, unify the error fallback text

### DIFF
--- a/custom_components/quizify/const.py
+++ b/custom_components/quizify/const.py
@@ -74,6 +74,45 @@ ERR_ALREADY_JOINED = "ALREADY_JOINED"
 #: told to wait, rather than being shown a generic failure it cannot act on.
 ERR_JOIN_RATE_LIMITED = "JOIN_RATE_LIMITED"
 
+#: English fallback text for every error code above (#812).
+#:
+#: The phone localizes off the structured ``code`` (``t('errors.<CODE>')``) and
+#: only shows this ``message`` when its bundle has no key for the code — a
+#: stale service worker, a language file that has not caught up yet. It used to
+#: be hand-copied into three local ``error_messages`` dicts inside
+#: ``server/websocket.py``, which had already drifted apart from each other and
+#: from ``www/i18n/en.json`` (one map said "Time is up" where the client shows
+#: "Time expired", and only one of the two submit maps carried
+#: ``ERR_INVALID_ACTION`` at all). #729 was exactly that failure mode: a code
+#: missing from one of the copies.
+#:
+#: One map, next to the codes it names, and ``ConnectionManager.send_error``
+#: reads it whenever a caller passes no message. The wording tracks the
+#: ``errors`` block of ``www/i18n/en.json`` — ``tests/test_error_fallback_text_812.py``
+#: pins that agreement, so the two can no longer drift.
+ERROR_FALLBACK_TEXT: dict[str, str] = {
+    ERR_NAME_TAKEN: "Name already taken",
+    ERR_NAME_INVALID: "Please enter a name",
+    ERR_GAME_NOT_STARTED: "No active game",
+    ERR_GAME_ALREADY_STARTED: "Game already running",
+    ERR_GAME_ENDED: "Game ended",
+    ERR_ROUND_EXPIRED: "Time expired",
+    ERR_TEAM_LOCKED: "The team answer just changed — wait a moment",
+    ERR_TEAM_CLOSED: "Teams are set for this game — you play on your own.",
+    ERR_ALREADY_SUBMITTED: "Already answered",
+    ERR_FROZEN: "Frozen — wait for the freeze to end",
+    ERR_NOT_IN_GAME: "Not in game",
+    ERR_INVALID_ACTION: "Invalid action",
+    ERR_ADMIN_REQUIRED: (
+        "This window is not the host — the command was refused. "
+        "Reopen the admin window from Home Assistant."
+    ),
+    ERR_GAME_FULL: "Game is full",
+    ERR_NO_QUESTIONS_REMAINING: "No questions remaining",
+    ERR_ALREADY_JOINED: "Already joined",
+    ERR_JOIN_RATE_LIMITED: "Too many join attempts",
+}
+
 # Question structure
 ANSWERS_PER_QUESTION = 3
 

--- a/custom_components/quizify/manifest.json
+++ b/custom_components/quizify/manifest.json
@@ -1,6 +1,9 @@
 {
   "domain": "quizify",
   "name": "Quizify",
+  "after_dependencies": [
+    "cloud"
+  ],
   "codeowners": [
     "@mholzi"
   ],

--- a/custom_components/quizify/server/connection.py
+++ b/custom_components/quizify/server/connection.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 from aiohttp import web
 
+from ..const import ERROR_FALLBACK_TEXT
 from .token_store import TokenStore
 
 if TYPE_CHECKING:
@@ -467,9 +468,21 @@ class ConnectionManager:
             _LOGGER.warning("Failed to send to WebSocket: %s", err)
 
     async def send_error(
-        self, ws: web.WebSocketResponse, code: str, message: str
+        self, ws: web.WebSocketResponse, code: str, message: str | None = None
     ) -> None:
-        """Send a structured error message to *ws*."""
+        """Send a structured error message to *ws*.
+
+        *message* is the English fallback the phone shows only when its i18n
+        bundle has no ``errors.<code>`` key. Omit it and the shared
+        :data:`~custom_components.quizify.const.ERROR_FALLBACK_TEXT` map
+        supplies it (#812) — that map replaced three hand-copied dicts in
+        ``websocket.py`` that had already drifted apart. Pass one explicitly
+        only where the situation says more than the code does (e.g. *which*
+        team closed, *which* field was malformed). An unknown code falls back
+        to the code itself, as the old local maps did.
+        """
+        if message is None:
+            message = ERROR_FALLBACK_TEXT.get(code, code)
         await self.send(ws, {"type": "error", "code": code, "message": message})
 
     # ------------------------------------------------------------------

--- a/custom_components/quizify/server/origin.py
+++ b/custom_components/quizify/server/origin.py
@@ -1,0 +1,174 @@
+"""Same-origin gate for the unauthenticated Quizify endpoints (#785).
+
+Quizify's WebSocket and its three unauthenticated POST views are registered on
+``hass.http.app.router`` with **no** Home Assistant auth middleware, because the
+players are phones that scanned a QR code and have no HA login. That is the
+intended trade-off — but it left one hole the browser does not close for us:
+
+* Browsers do **not** apply CORS to a WebSocket handshake. Any page open in the
+  victim's browser could open ``ws://homeassistant.local:8123/api/quizify/ws``
+  from the victim's own address, which sails past every per-IP cap, and during
+  the admin-bootstrap window be handed the admin role and the session token.
+* ``request.json()`` does not enforce a Content-Type, so a cross-site form/fetch
+  could POST to flag-question / pack-submit as a CORS *simple* request — no
+  preflight, no consent.
+
+Both holes are shut by the two helpers here:
+
+``is_origin_allowed``
+    Compares the browser-supplied ``Origin`` against the host the request came
+    in on plus the URLs Home Assistant knows itself by. A request with **no**
+    ``Origin`` keeps passing: non-browser clients (the standalone dev server,
+    the tests, a script) never send one, and an attacker cannot make a browser
+    omit it.
+
+``check_unauthenticated_post``
+    The same gate plus a mandatory ``Content-Type: application/json``, which
+    forces a cross-site caller into a preflight that HA will not answer.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from urllib.parse import urlsplit
+
+from aiohttp import web
+
+_LOGGER = logging.getLogger(__name__)
+
+#: The one body type the three unauthenticated POST views accept. Anything
+#: else is refused, so a browser cannot reach them as a CORS simple request.
+JSON_CONTENT_TYPE = "application/json"
+
+#: Ports that carry no information in an origin comparison — a browser omits
+#: them from both ``Origin`` and ``Host``, so a configured URL that spells one
+#: out must still compare equal.
+_DEFAULT_PORTS = {"http": "80", "https": "443"}
+
+
+def _normalize(value: str | None) -> str | None:
+    """Return the lower-cased ``host[:port]`` of *value*, default port dropped.
+
+    Accepts a full URL (``https://ha.example.com:8123/lovelace``), a bare
+    authority (``ha.example.com:8123``) or ``None``.
+    """
+    if not value:
+        return None
+    candidate = value.strip()
+    if not candidate:
+        return None
+    parts = urlsplit(candidate if "//" in candidate else f"//{candidate}")
+    netloc = parts.netloc.lower()
+    if not netloc:
+        return None
+    # Strip credentials should a configured URL carry any.
+    netloc = netloc.rpartition("@")[2]
+    scheme = parts.scheme.lower()
+    default_port = _DEFAULT_PORTS.get(scheme)
+    if default_port and netloc.endswith(f":{default_port}"):
+        netloc = netloc[: -len(default_port) - 1]
+    return netloc or None
+
+
+def _hass_of(runtime: Any) -> Any | None:
+    """Return the Home Assistant instance behind *runtime*, if there is one.
+
+    ``StandaloneRuntime`` (dev server, tests) has no ``hass`` — the gate then
+    falls back to ``request.host`` alone, which is exactly right there.
+    """
+    return getattr(runtime, "hass", None)
+
+
+def _nabu_casa_host(hass: Any) -> str | None:
+    """The Nabu Casa remote UI host, or ``None`` when cloud is not in use.
+
+    Imported lazily and defensively: ``homeassistant.components.cloud`` is not
+    present on every install, and ``async_remote_ui_url`` raises when the
+    instance is not connected to the cloud.
+    """
+    try:
+        from homeassistant.components.cloud import (  # noqa: PLC0415
+            async_remote_ui_url,
+        )
+
+        return _normalize(async_remote_ui_url(hass))
+    except Exception:  # noqa: BLE001 — no cloud, not logged in, older HA
+        return None
+
+
+def allowed_origin_hosts(request: Any, runtime: Any) -> set[str]:
+    """Every ``host[:port]`` a legitimate Quizify page can be served from."""
+    hosts: set[str] = set()
+    own = _normalize(getattr(request, "host", None))
+    if own:
+        hosts.add(own)
+
+    hass = _hass_of(runtime)
+    config = getattr(hass, "config", None)
+    for attr in ("internal_url", "external_url"):
+        configured = _normalize(getattr(config, attr, None))
+        if configured:
+            hosts.add(configured)
+
+    if hass is not None:
+        remote = _nabu_casa_host(hass)
+        if remote:
+            hosts.add(remote)
+
+    return hosts
+
+
+def is_origin_allowed(request: Any, runtime: Any) -> bool:
+    """Whether *request* may be served, judged by its ``Origin`` header.
+
+    ``True`` when no ``Origin`` was sent (non-browser client) or when its host
+    matches one of :func:`allowed_origin_hosts`. ``False`` — the cross-site
+    case — for anything else, ``Origin: null`` (a sandboxed iframe or a
+    ``file://`` page) included.
+    """
+    headers = getattr(request, "headers", None) or {}
+    origin = headers.get("Origin")
+    if origin is None or not origin.strip():
+        return True
+
+    candidate = _normalize(origin)
+    if candidate is None:
+        return False
+    return candidate in allowed_origin_hosts(request, runtime)
+
+
+def reject_cross_origin(request: Any, runtime: Any, what: str) -> bool:
+    """Log-and-report helper: ``True`` when *request* must be refused."""
+    if is_origin_allowed(request, runtime):
+        return False
+    _LOGGER.warning(
+        "Refusing cross-origin %s from %s (Origin=%r, allowed=%s)",
+        what,
+        getattr(request, "remote", None),
+        (getattr(request, "headers", None) or {}).get("Origin"),
+        sorted(allowed_origin_hosts(request, runtime)),
+    )
+    return True
+
+
+def check_unauthenticated_post(request: Any, runtime: Any) -> web.Response | None:
+    """Gate an unauthenticated POST view; ``None`` means "carry on" (#785).
+
+    Refuses a cross-site ``Origin`` with 403 and a body that is not declared
+    ``application/json`` with 415. The Content-Type requirement is the CSRF
+    half: it is not on the CORS simple-request list, so a cross-site page has
+    to send a preflight, and Home Assistant answers no preflight for these
+    routes.
+    """
+    if reject_cross_origin(request, runtime, "POST"):
+        return web.json_response({"error": "forbidden_origin"}, status=403)
+
+    headers = getattr(request, "headers", None) or {}
+    content_type = (headers.get("Content-Type") or "").split(";", 1)[0].strip().lower()
+    if content_type != JSON_CONTENT_TYPE:
+        return web.json_response(
+            {"error": "unsupported_media_type", "expected": JSON_CONTENT_TYPE},
+            status=415,
+        )
+    return None

--- a/custom_components/quizify/server/origin.py
+++ b/custom_components/quizify/server/origin.py
@@ -85,7 +85,10 @@ def _nabu_casa_host(hass: Any) -> str | None:
 
     Imported lazily and defensively: ``homeassistant.components.cloud`` is not
     present on every install, and ``async_remote_ui_url`` raises when the
-    instance is not connected to the cloud.
+    instance is not connected to the cloud. ``cloud`` is declared in
+    ``manifest.json`` as an **after_dependency** (not a dependency) for exactly
+    that reason — Quizify works fine without it, it only wants the remote UI
+    host to be knowable when it does exist. hassfest requires the declaration.
     """
     try:
         from homeassistant.components.cloud import (  # noqa: PLC0415

--- a/custom_components/quizify/server/pack_submission.py
+++ b/custom_components/quizify/server/pack_submission.py
@@ -67,6 +67,7 @@ from ..const import (
     SUBMIT_STATUS_PENDING,
 )
 from .context import APP_CTX_KEY
+from .origin import check_unauthenticated_post
 from .rate_limit import SlidingWindowLimiter
 
 if TYPE_CHECKING:
@@ -441,6 +442,15 @@ def _check_gates(request: web.Request, ctx: AppContext) -> web.Response | None:
     hit the same worker, the same PAT and the same repo, so splitting the budget
     would just hand a caller twice the issue-filing rate.
     """
+    # CSRF gate (#785). Both routes are registered with no HA auth and file a
+    # GitHub issue through the host's worker secret, so a cross-site page must
+    # not be able to reach them: refuse a foreign Origin, and require an
+    # explicit ``application/json`` body so a browser cannot get here as a CORS
+    # simple request.
+    refusal = check_unauthenticated_post(request, ctx.runtime)
+    if refusal is not None:
+        return refusal
+
     if not (ctx.community_submit_url or "").strip():
         return web.json_response(
             {

--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -23,6 +23,7 @@ from aiohttp import web
 from ..game.seasons import is_in_season, parse_season, pick_active_season
 from .context import APP_CTX_KEY
 from .flag_store import FlagStore
+from .origin import check_unauthenticated_post
 from .pack_news import PackNewsStore
 from .pack_submission import (
     request_pack_view,
@@ -1187,6 +1188,16 @@ async def flag_question_view(request: web.Request) -> web.Response:
     is best-effort (clients without an auth model can lie, but that's fine
     for a "raise the maintainer's attention" signal).
     """
+    ctx = _get_ctx(request)
+
+    # CSRF gate (#785). The route carries no HA auth and appends to
+    # ``flagged.jsonl``, so a cross-site page must not be able to reach it:
+    # refuse a foreign Origin, and require an explicit ``application/json``
+    # body so a browser cannot post here as a CORS simple request.
+    refusal = check_unauthenticated_post(request, ctx.runtime)
+    if refusal is not None:
+        return refusal
+
     # Per-IP rate limit (#357). Reject early — before the JSON parse and the
     # executor disk write — so a flood can't pin the loop or grow the file.
     if not _flag_rate_limiter.check(request.remote or ""):

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -15,19 +15,13 @@ from aiohttp import WSMsgType, web
 from custom_components.quizify.const import (
     ERR_ADMIN_REQUIRED,
     ERR_ALREADY_JOINED,
-    ERR_ALREADY_SUBMITTED,
-    ERR_FROZEN,
     ERR_GAME_ALREADY_STARTED,
-    ERR_GAME_ENDED,
-    ERR_GAME_FULL,
     ERR_GAME_NOT_STARTED,
     ERR_INVALID_ACTION,
     ERR_JOIN_RATE_LIMITED,
     ERR_NAME_INVALID,
-    ERR_NAME_TAKEN,
     ERR_NO_QUESTIONS_REMAINING,
     ERR_NOT_IN_GAME,
-    ERR_ROUND_EXPIRED,
     ERR_TEAM_CLOSED,
     LOBBY_DISCONNECT_GRACE_PERIOD,
     MAX_PLAYERS,
@@ -53,6 +47,7 @@ from custom_components.quizify.game.team import (
 )
 from custom_components.quizify.server.broadcast_dispatcher import BroadcastDispatcher
 from custom_components.quizify.server.connection import ConnectionManager
+from custom_components.quizify.server.origin import reject_cross_origin
 from custom_components.quizify.server.rate_limit import SlidingWindowLimiter
 from custom_components.quizify.server.round_message_builder import RoundMessageBuilder
 from custom_components.quizify.server.serializers import (
@@ -305,6 +300,17 @@ class QuizifyWebSocketHandler:
     # this — but that is the uncommon setup for a local party game.) Refused
     # connections get an HTTP 429 before the WebSocket is upgraded.
     MAX_CONNECTIONS_PER_IP = 15
+
+    # Largest WebSocket frame we will buffer, let alone parse (#786). Without
+    # it aiohttp's 4 MiB default applies to every unauthenticated player and
+    # dashboard socket, and the flood guard below counts *frames*, not bytes:
+    # 15 frames/s x 4 MiB is 60 MiB of JSON per second per socket, each
+    # ``msg.json()`` of which runs synchronously on Home Assistant's shared
+    # event loop. Real Quizify frames are a few hundred bytes; the largest
+    # legitimate one is ``start_game`` with its tts/house blocks, comfortably
+    # under a kilobyte. aiohttp closes an oversized frame with 1009 before the
+    # payload is buffered or parsed.
+    MAX_MSG_SIZE = 16 * 1024
 
     # Loopback exception to the cap above (#701). Over Nabu Casa every remote
     # client reaches HA through snitun on 127.0.0.1, and HA's forwarded-header
@@ -648,7 +654,21 @@ class QuizifyWebSocketHandler:
                 status=429, text="Too many connections from this address"
             )
 
-        ws = web.WebSocketResponse(heartbeat=self.HEARTBEAT_INTERVAL)
+        # Same-origin gate (#785): browsers do NOT apply CORS to a WebSocket
+        # handshake, so without this any page open in a player's (or the
+        # host's) browser could open this socket from their own address —
+        # inheriting the per-IP allowances and, inside the admin-bootstrap
+        # window, the admin role and its session token. Checked before
+        # prepare() so a cross-site handshake is answered with a plain HTTP
+        # 403 and never upgraded. A request with no Origin still passes: the
+        # dev server, the tests and non-browser clients send none, and a
+        # browser cannot be made to omit it.
+        if reject_cross_origin(request, self._runtime, "WebSocket handshake"):
+            return web.Response(status=403, text="Cross-origin request refused")
+
+        ws = web.WebSocketResponse(
+            heartbeat=self.HEARTBEAT_INTERVAL, max_msg_size=self.MAX_MSG_SIZE
+        )
         await ws.prepare(request)
         if remote is not None:
             self._ip_connections[remote] = self._ip_connections.get(remote, 0) + 1
@@ -690,7 +710,13 @@ class QuizifyWebSocketHandler:
                     # from handler errors (#20 in logical review).
                     try:
                         data = msg.json()
-                    except ValueError:
+                    except (ValueError, RecursionError):
+                        # RecursionError (#786): a deeply nested frame blows
+                        # the interpreter's stack inside ``json.loads``. It is
+                        # not a ValueError, so it used to escape the read loop
+                        # and tear the connection down with a traceback
+                        # instead of the structured error every other
+                        # malformed frame gets.
                         await self._conn.send_error(
                             ws, ERR_INVALID_ACTION, "Malformed message (invalid JSON)"
                         )
@@ -1211,25 +1237,25 @@ class QuizifyWebSocketHandler:
                 name, bool(player_obj.is_admin) if player_obj else False
             )
         else:
-            # English i18n-fallback strings only — the client localizes off
-            # the structured ``code`` via ``t('join.refused.<CODE>')`` and only
-            # falls back to this ``message`` if the key is missing
-            # (player-core.js).
+            # The client localizes off the structured ``code`` via
+            # ``t('join.refused.<CODE>')``; the wire ``message`` is only the
+            # English fallback for a bundle that has no key for the code.
             #
-            # #729: every code ``add_player`` can return must appear here.
-            # ``ERR_GAME_ENDED`` did not, so a guest who scanned a QR code from
-            # a finished game got the bare "Failed to join" — no hint that the
-            # game was over and the host had to start a new one.
-            error_messages = {
-                ERR_NAME_TAKEN: "Name already taken",
-                ERR_NAME_INVALID: "Please enter a name",
-                ERR_GAME_FULL: "Game is full",
-                ERR_GAME_ENDED: "This game has already finished",
-            }
-            await self._conn.send_error(
-                ws, error_code or ERR_INVALID_ACTION,
-                error_messages.get(error_code or "", "Failed to join"),
-            )
+            # #729: every code ``add_player`` can return must have a fallback.
+            # ``ERR_GAME_ENDED`` had none, so a guest who scanned a QR code
+            # from a finished game got the bare "Failed to join" — no hint that
+            # the game was over and the host had to start a new one. #812
+            # moved that map to ``ERROR_FALLBACK_TEXT`` in const.py, where the
+            # coverage is asserted against ``add_player`` itself rather than
+            # against whichever local dict happened to come first in this file.
+            if error_code:
+                await self._conn.send_error(ws, error_code)
+            else:
+                # A refusal with no code at all: nothing to localize, so say
+                # the one thing that is certainly true.
+                await self._conn.send_error(
+                    ws, ERR_INVALID_ACTION, "Failed to join"
+                )
 
     # ------------------------------------------------------------------
     # Player reconnect (session-based)
@@ -1469,15 +1495,8 @@ class QuizifyWebSocketHandler:
             if err is None:
                 await self._conn.send(ws, {"type": "guess_accepted"})
             else:
-                error_messages = {
-                    ERR_ALREADY_SUBMITTED: "Already answered",
-                    ERR_ROUND_EXPIRED: "Time is up",
-                    ERR_FROZEN: "Frozen — wait for the freeze to end",
-                    ERR_NOT_IN_GAME: "Not in the game",
-                    ERR_GAME_NOT_STARTED: "No active game",
-                    ERR_INVALID_ACTION: "Invalid action",
-                }
-                await self._conn.send_error(ws, err, error_messages.get(err, err))
+                # Fallback text comes from ERROR_FALLBACK_TEXT (#812).
+                await self._conn.send_error(ws, err)
             return
 
         shuffled_index = data.get("answer_index")
@@ -1540,17 +1559,8 @@ class QuizifyWebSocketHandler:
             # Do NOT broadcast here \u2014 that would double-fire when the timer
             # path races with all-submitted (#3 in logical review).
         elif isinstance(result, str):
-            # English i18n-fallback strings only (client localizes off ``code``).
-            error_messages = {
-                ERR_ALREADY_SUBMITTED: "Already answered",
-                ERR_ROUND_EXPIRED: "Time is up",
-                ERR_FROZEN: "Frozen — wait for the freeze to end",
-                ERR_NOT_IN_GAME: "Not in the game",
-                ERR_GAME_NOT_STARTED: "No active game",
-            }
-            await self._conn.send_error(
-                ws, result, error_messages.get(result, result)
-            )
+            # Fallback text comes from ERROR_FALLBACK_TEXT (#812).
+            await self._conn.send_error(ws, result)
 
     # ------------------------------------------------------------------
     # Power-ups

--- a/tests/test_error_fallback_text_812.py
+++ b/tests/test_error_fallback_text_812.py
@@ -1,0 +1,188 @@
+"""Regression tests for issue #812 (code quality).
+
+Three handlers in ``server/websocket.py`` — the join branch, the estimate-guess
+branch and the multiple-choice branch — each declared their own local
+``error_messages`` dict mapping ``ERR_*`` codes to English fallback text. The
+copies had already drifted: one carried ``ERR_INVALID_ACTION`` and the other did
+not, and both said "Time is up" where ``www/i18n/en.json`` — the text the client
+actually shows off the code — says "Time expired".
+
+#729 was exactly that failure mode (a code missing from one of the copies), and
+its regression test located "the join map" as the *first* ``error_messages = {``
+in the file — correct only as long as ``_handle_join`` happened to be defined
+before the two submit handlers.
+
+There is now one module-level ``ERROR_FALLBACK_TEXT`` next to the codes it
+names, and ``ConnectionManager.send_error`` fills the message from it whenever
+the caller passes none.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+import custom_components.quizify.const as const  # noqa: E402
+from custom_components.quizify.const import (  # noqa: E402
+    ERR_ROUND_EXPIRED,
+    ERROR_FALLBACK_TEXT,
+)
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+
+_COMPONENT = _REPO_ROOT / "custom_components" / "quizify"
+_EN_JSON = _COMPONENT / "www" / "i18n" / "en.json"
+
+#: Codes that name a wire error. ``ERR_SUBMIT_*`` lives in the HTTP
+#: pack-submission flow, which answers with its own JSON bodies rather than a
+#: WebSocket error frame, so it is deliberately not part of this map.
+_WIRE_ERROR_NAMES = sorted(
+    name
+    for name in dir(const)
+    if name.startswith("ERR_") and not name.startswith("ERR_SUBMIT_")
+)
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_str = AsyncMock()
+    ws.send_json = AsyncMock()
+    return ws
+
+
+class _Runtime:
+    def __init__(self, data_dir: Path) -> None:
+        self.data_dir = data_dir
+
+    def create_task(self, coro):  # noqa: ANN001, ANN202
+        return asyncio.ensure_future(coro)
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+
+def _conn(tmp_path: Path) -> ConnectionManager:
+    return ConnectionManager(_Runtime(tmp_path), lambda: None)
+
+
+# ---------------------------------------------------------------------------
+# One map, covering every code
+# ---------------------------------------------------------------------------
+
+
+def test_every_wire_error_code_has_fallback_text() -> None:
+    """A code with no entry reaches the phone as the bare code (#729)."""
+    missing = [
+        name
+        for name in _WIRE_ERROR_NAMES
+        if getattr(const, name) not in ERROR_FALLBACK_TEXT
+    ]
+    assert not missing, (
+        f"these error codes have no entry in ERROR_FALLBACK_TEXT: {missing}"
+    )
+
+
+def test_no_entry_is_empty() -> None:
+    for code, text in ERROR_FALLBACK_TEXT.items():
+        assert text.strip(), f"ERROR_FALLBACK_TEXT[{code!r}] is blank"
+
+
+def test_the_map_names_no_code_that_does_not_exist() -> None:
+    known = {getattr(const, name) for name in _WIRE_ERROR_NAMES}
+    assert set(ERROR_FALLBACK_TEXT) <= known
+
+
+def test_the_wording_agrees_with_the_english_bundle() -> None:
+    """The drift the issue is about: "Time is up" vs en.json's "Time expired".
+
+    Only codes the bundle actually carries are compared — ``FROZEN`` and
+    ``TEAM_LOCKED`` have no ``errors.*`` key of their own.
+    """
+    bundle = json.loads(_EN_JSON.read_text(encoding="utf-8")).get("errors", {})
+    drift = {
+        code: (text, bundle[code])
+        for code, text in ERROR_FALLBACK_TEXT.items()
+        if code in bundle and bundle[code] != text
+    }
+    assert not drift, (
+        "ERROR_FALLBACK_TEXT disagrees with www/i18n/en.json — the server "
+        f"fallback and the string the client shows must match: {drift}"
+    )
+
+
+def test_the_expired_round_says_what_the_client_says() -> None:
+    """The exact divergence named in the issue."""
+    assert ERROR_FALLBACK_TEXT[ERR_ROUND_EXPIRED] == "Time expired"
+
+
+# ---------------------------------------------------------------------------
+# send_error defaults from it
+# ---------------------------------------------------------------------------
+
+
+def test_send_error_fills_the_message_from_the_map(tmp_path: Path) -> None:
+    conn = _conn(tmp_path)
+    ws = _ws()
+    sent: list[dict] = []
+
+    async def _send(target, payload) -> None:  # noqa: ANN001
+        sent.append(payload)
+
+    conn.send = _send  # type: ignore[assignment]
+    asyncio.run(conn.send_error(ws, ERR_ROUND_EXPIRED))
+
+    assert sent == [
+        {"type": "error", "code": ERR_ROUND_EXPIRED, "message": "Time expired"}
+    ]
+
+
+def test_an_explicit_message_still_wins(tmp_path: Path) -> None:
+    """Call sites that know more than the code keep saying it."""
+    conn = _conn(tmp_path)
+    sent: list[dict] = []
+
+    async def _send(target, payload) -> None:  # noqa: ANN001
+        sent.append(payload)
+
+    conn.send = _send  # type: ignore[assignment]
+    asyncio.run(conn.send_error(_ws(), ERR_ROUND_EXPIRED, "That team is closed"))
+
+    assert sent[0]["message"] == "That team is closed"
+
+
+def test_an_unknown_code_falls_back_to_itself(tmp_path: Path) -> None:
+    """What the old local maps did with ``.get(err, err)``."""
+    conn = _conn(tmp_path)
+    sent: list[dict] = []
+
+    async def _send(target, payload) -> None:  # noqa: ANN001
+        sent.append(payload)
+
+    conn.send = _send  # type: ignore[assignment]
+    asyncio.run(conn.send_error(_ws(), "SOMETHING_NEW"))
+
+    assert sent[0]["message"] == "SOMETHING_NEW"
+
+
+# ---------------------------------------------------------------------------
+# The copies are gone
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "module", ["server/websocket.py", "server/connection.py"]
+)
+def test_no_module_keeps_a_private_fallback_map(module: str) -> None:
+    source = (_COMPONENT / module).read_text(encoding="utf-8")
+    assert "error_messages = {" not in source, (
+        f"{module} declares a local error-message map again — the fallback "
+        "text belongs in const.ERROR_FALLBACK_TEXT (#812)"
+    )

--- a/tests/test_flag_rate_limit_357.py
+++ b/tests/test_flag_rate_limit_357.py
@@ -40,6 +40,11 @@ class _Req:
         self.app = {APP_CTX_KEY: ctx}
         self.remote = remote
         self._body = body
+        self.host = "homeassistant.local:8123"
+        # #785: the view now requires a declared JSON body (and refuses a
+        # cross-site Origin). A same-origin caller sends both; this fake is
+        # the app's own page, so no Origin at all is the honest shape here.
+        self.headers = {"Content-Type": "application/json"}
 
     async def json(self) -> dict:
         return self._body

--- a/tests/test_join_refusal_visible_729.py
+++ b/tests/test_join_refusal_visible_729.py
@@ -41,6 +41,7 @@ sys.path.insert(0, str(_REPO_ROOT))
 from custom_components.quizify.const import (  # noqa: E402
     ERR_GAME_ENDED,
     ERR_INVALID_ACTION,
+    ERROR_FALLBACK_TEXT,
 )
 
 #: Spelled out rather than imported from const: these are wire values the
@@ -121,10 +122,15 @@ def _handler(game: QuizifyGameState, tmp_path: Path):
     handler._get_game_state = lambda: game  # type: ignore[assignment]
     sent: list[dict] = []
 
-    async def _send_error(ws, code, message) -> None:
-        sent.append({"code": code, "message": message})
+    # Capture one layer lower than ``send_error`` (#812): the fallback text is
+    # no longer passed in by the handler, it is filled in by ``send_error``
+    # itself from ``ERROR_FALLBACK_TEXT``. Stubbing ``send_error`` would step
+    # over the very defaulting these tests are here to check.
+    async def _send(ws, payload) -> None:
+        if payload.get("type") == "error":
+            sent.append(payload)
 
-    handler._conn.send_error = _send_error  # type: ignore[assignment]
+    handler._conn.send = _send  # type: ignore[assignment]
     handler._conn.broadcast = AsyncMock()  # type: ignore[assignment]
     return handler, sent
 
@@ -254,25 +260,46 @@ def test_the_three_languages_stay_in_key_parity() -> None:
 
 
 def test_every_registry_refusal_is_named_on_the_wire() -> None:
-    """The join handler's fallback map must cover all of ``add_player``.
+    """The shared fallback map must cover all of ``add_player``.
 
     ``ERR_GAME_ENDED`` was missing, so a guest scanning the QR code of a
     finished game got the bare "Failed to join".
+
+    #812: this used to locate "the join map" as the *first*
+    ``error_messages = {`` in ``websocket.py`` — correct only as long as
+    ``_handle_join`` happened to be defined before the two submit handlers. A
+    map added to an earlier handler would have silently redirected the test.
+    There is now one module-level map, so the test names it directly.
     """
     registry = REGISTRY_PY.read_text(encoding="utf-8")
     add_player = registry[registry.index("def add_player(") : registry.index(
         "def get_player("
     )]
-    refusals = set(re.findall(r"return False, (ERR_\w+)", add_player))
-    assert refusals, "could not find any refusal in PlayerRegistry.add_player"
+    refusal_names = set(re.findall(r"return False, (ERR_\w+)", add_player))
+    assert refusal_names, "could not find any refusal in PlayerRegistry.add_player"
 
-    handler = WEBSOCKET_PY.read_text(encoding="utf-8")
-    error_map = handler[handler.index("error_messages = {") :][:600]
-    for code in sorted(refusals):
-        assert code in error_map, (
-            f"{code} can refuse a join but has no message in the join "
-            "handler's fallback map — the guest gets 'Failed to join'"
+    import custom_components.quizify.const as const  # noqa: PLC0415
+
+    for name in sorted(refusal_names):
+        code = getattr(const, name)
+        assert code in ERROR_FALLBACK_TEXT, (
+            f"{name} can refuse a join but has no entry in "
+            "ERROR_FALLBACK_TEXT — the guest gets the bare code"
         )
+        assert ERROR_FALLBACK_TEXT[code].strip(), f"{name} maps to empty text"
+
+
+def test_no_handler_keeps_a_private_copy_of_the_map() -> None:
+    """The three hand-copied ``error_messages`` dicts are gone (#812).
+
+    They had already drifted from each other and from ``en.json``; a fourth
+    copy would drift the same way.
+    """
+    handler = WEBSOCKET_PY.read_text(encoding="utf-8")
+    assert "error_messages = {" not in handler, (
+        "websocket.py declares a local error-message map again — the fallback "
+        "text belongs in const.ERROR_FALLBACK_TEXT (#812)"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_pack_request_579.py
+++ b/tests/test_pack_request_579.py
@@ -122,6 +122,9 @@ class _FakeRequest:
         self.app = {ps.APP_CTX_KEY: ctx}
         self.remote = remote
         self._body = body
+        self.host = "homeassistant.local:8123"
+        # #785: the POST views require a declared JSON body.
+        self.headers = {"Content-Type": "application/json"}
 
     async def json(self) -> Any:
         if isinstance(self._body, Exception):

--- a/tests/test_pack_submission_secret_256.py
+++ b/tests/test_pack_submission_secret_256.py
@@ -69,6 +69,9 @@ class _FakeRequest:
         self.app = {ps.APP_CTX_KEY: ctx}
         self.remote = "1.2.3.4"
         self._body = body
+        self.host = "homeassistant.local:8123"
+        # #785: the POST views require a declared JSON body.
+        self.headers = {"Content-Type": "application/json"}
 
     async def json(self) -> dict:
         return self._body

--- a/tests/test_ws_frame_limits_786.py
+++ b/tests/test_ws_frame_limits_786.py
@@ -1,0 +1,157 @@
+"""Regression tests for issue #786 (security).
+
+``web.WebSocketResponse(heartbeat=...)`` was created without ``max_msg_size``,
+so aiohttp's 4 MiB default applied to every unauthenticated player/dashboard
+socket. The flood guard counts **frames**, not bytes (15/s per connection), and
+``msg.json()`` runs synchronously on Home Assistant's shared event loop — so one
+LAN guest could push 15 x 4 MiB of JSON per second through a single socket, and
+hold up to fifteen sockets. Real Quizify frames are a few hundred bytes.
+
+The related edge: a deeply nested frame makes ``msg.json()`` raise
+``RecursionError``, which ``except ValueError`` did not catch, so it escaped the
+read loop and tore the connection down with a traceback instead of answering
+with the structured error every other malformed frame gets.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from aiohttp import WSMessage, WSMsgType, web
+from aiohttp.test_utils import TestClient, TestServer
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.const import ERR_INVALID_ACTION  # noqa: E402
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server import WS_PATH  # noqa: E402
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    def create_task(self, coro):  # noqa: ANN001, ANN202
+        return asyncio.ensure_future(coro)
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func, *args)
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+@pytest.fixture
+def handler(game: QuizifyGameState) -> QuizifyWebSocketHandler:
+    runtime = _FakeRuntime(game._runtime.data_dir)  # type: ignore[attr-defined]
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    h._conn = ConnectionManager(runtime, lambda: game)
+    return h
+
+
+async def _make_client(handler: QuizifyWebSocketHandler) -> TestClient:
+    app = web.Application()
+    app.router.add_get(WS_PATH, handler.handle)
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    return client
+
+
+class TestFrameSizeCap:
+    def test_the_cap_is_far_below_aiohttps_default(self) -> None:
+        """4 MiB is aiohttp's default; the largest real frame is < 1 KiB."""
+        assert QuizifyWebSocketHandler.MAX_MSG_SIZE == 16 * 1024
+
+    @pytest.mark.asyncio
+    async def test_an_oversized_frame_is_closed_not_parsed(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """aiohttp answers 1009 (message too big) before buffering or parsing."""
+        client = await _make_client(handler)
+        try:
+            ws = await client.ws_connect(WS_PATH)
+            oversized = json.dumps(
+                {"type": "join", "name": "x" * (handler.MAX_MSG_SIZE * 2)}
+            )
+            assert len(oversized) > handler.MAX_MSG_SIZE
+            await ws.send_str(oversized)
+
+            msg = await asyncio.wait_for(ws.receive(), timeout=5)
+            assert msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSED, WSMsgType.ERROR), (
+                f"the oversized frame was accepted and processed: {msg!r}"
+            )
+            if msg.type is WSMsgType.CLOSE:
+                assert msg.data == 1009, f"expected close code 1009, got {msg.data}"
+            await ws.close()
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_a_normal_frame_still_gets_through(
+        self, handler: QuizifyWebSocketHandler
+    ) -> None:
+        """The cap must not bite a real message."""
+        client = await _make_client(handler)
+        try:
+            ws = await client.ws_connect(WS_PATH)
+            await ws.send_str(json.dumps({"type": "definitely_not_a_type"}))
+            msg = await asyncio.wait_for(ws.receive_json(), timeout=5)
+            assert msg["type"] == "error"
+            await ws.close()
+        finally:
+            await client.close()
+
+
+class TestRecursionErrorOnParse:
+    @pytest.mark.asyncio
+    async def test_a_recursion_error_answers_instead_of_tearing_down(
+        self,
+        handler: QuizifyWebSocketHandler,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``RecursionError`` is not a ``ValueError``.
+
+        Forced rather than provoked with real nesting: the depth at which
+        ``json.loads`` gives up is a property of the running CPython (and of
+        ``sys.getrecursionlimit()``), so a payload that raises today may parse
+        fine on the next interpreter — and since #786 also caps frames at
+        16 KiB, the deepest payload that fits is right on that boundary. What
+        this pins is the handler's behaviour when the parse *does* raise.
+        """
+
+        def _boom(self, *args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ANN202
+            raise RecursionError("maximum recursion depth exceeded")
+
+        monkeypatch.setattr(WSMessage, "json", _boom)
+
+        client = await _make_client(handler)
+        try:
+            ws = await client.ws_connect(WS_PATH)
+            await ws.send_str('{"type": "join", "name": "Guest"}')
+
+            msg = await asyncio.wait_for(ws.receive(), timeout=5)
+            assert msg.type is WSMsgType.TEXT, (
+                "the RecursionError escaped the read loop and closed the "
+                f"socket instead of answering: {msg!r}"
+            )
+            payload = json.loads(msg.data)
+            assert payload["type"] == "error"
+            assert payload["code"] == ERR_INVALID_ACTION
+
+            # And the socket is still usable afterwards.
+            assert not ws.closed
+            await ws.close()
+        finally:
+            await client.close()

--- a/tests/test_ws_origin_gate_785.py
+++ b/tests/test_ws_origin_gate_785.py
@@ -1,0 +1,310 @@
+"""Regression tests for issue #785 (security).
+
+The WebSocket handshake never looked at ``Origin``. Browsers do not apply CORS
+to a WebSocket upgrade, so any page open in the victim's browser could open
+``ws://homeassistant.local:8123/api/quizify/ws?role=admin`` *from the victim's
+own address* — past every per-IP cap — and, inside the admin-bootstrap window,
+be handed the admin role plus the persisted session token.
+
+The same gap covered the three unauthenticated POST views (flag-question,
+pack-submit, pack-submit/request): ``request.json()`` does not enforce a
+Content-Type, so a cross-site page could reach them as a CORS *simple* request
+with no preflight and no consent.
+
+Both are now gated by ``server/origin.py``: a foreign ``Origin`` is refused
+(403 before the upgrade / before the body is read), the POST views additionally
+require ``Content-Type: application/json``, and a request with **no** Origin
+keeps passing — non-browser clients, the dev server and the tests never send
+one, and a browser cannot be made to omit it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from aiohttp import WSServerHandshakeError, web
+from aiohttp.test_utils import TestClient, TestServer
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server import WS_PATH, views  # noqa: E402
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.context import APP_CTX_KEY  # noqa: E402
+from custom_components.quizify.server.origin import (  # noqa: E402
+    allowed_origin_hosts,
+    is_origin_allowed,
+)
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+EVIL = "http://evil.example"
+
+
+class _FakeRuntime:
+    """Runtime with no ``hass`` — the standalone/dev shape."""
+
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    def create_task(self, coro):  # noqa: ANN001, ANN202
+        return asyncio.ensure_future(coro)
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func, *args)
+
+
+class _HARuntime(_FakeRuntime):
+    """Runtime that carries a hass with configured internal/external URLs."""
+
+    def __init__(
+        self,
+        tmp_path: Path,
+        internal_url: str | None = None,
+        external_url: str | None = None,
+    ) -> None:
+        super().__init__(tmp_path)
+        self.hass = SimpleNamespace(
+            config=SimpleNamespace(
+                internal_url=internal_url, external_url=external_url
+            )
+        )
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+
+
+def _handler(runtime, game: QuizifyGameState) -> QuizifyWebSocketHandler:  # noqa: ANN001
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    h._conn = ConnectionManager(runtime, lambda: game)
+    return h
+
+
+async def _make_client(handler: QuizifyWebSocketHandler) -> TestClient:
+    app = web.Application()
+    app.router.add_get(WS_PATH, handler.handle)
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    return client
+
+
+def _own_origin(client: TestClient) -> str:
+    url = client.make_url(WS_PATH)
+    return f"http://{url.host}:{url.port}"
+
+
+# ---------------------------------------------------------------------------
+# The WebSocket handshake
+# ---------------------------------------------------------------------------
+
+
+class TestWebSocketOriginGate:
+    @pytest.mark.asyncio
+    async def test_a_foreign_origin_is_refused_before_the_upgrade(
+        self, game: QuizifyGameState, tmp_path: Path
+    ) -> None:
+        """This is the CSWSH itself: a page on another site, the victim's IP."""
+        handler = _handler(_FakeRuntime(tmp_path), game)
+        client = await _make_client(handler)
+        try:
+            with pytest.raises(WSServerHandshakeError) as exc:
+                await client.ws_connect(WS_PATH, headers={"Origin": EVIL})
+            assert exc.value.status == 403
+            # Nothing was upgraded, so nothing was registered.
+            assert len(handler._conn.connections) == 0
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_the_refused_handshake_never_reaches_the_admin_bootstrap(
+        self, game: QuizifyGameState, tmp_path: Path
+    ) -> None:
+        """``?role=admin`` is exactly the request the issue is about."""
+        handler = _handler(_FakeRuntime(tmp_path), game)
+        client = await _make_client(handler)
+        try:
+            with pytest.raises(WSServerHandshakeError) as exc:
+                await client.ws_connect(
+                    f"{WS_PATH}?role=admin", headers={"Origin": EVIL}
+                )
+            assert exc.value.status == 403
+            assert not handler._conn.has_admin_connections()
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_a_request_without_an_origin_still_connects(
+        self, game: QuizifyGameState, tmp_path: Path
+    ) -> None:
+        """Non-browser clients (and every existing test) send no Origin."""
+        handler = _handler(_FakeRuntime(tmp_path), game)
+        client = await _make_client(handler)
+        try:
+            ws = await client.ws_connect(WS_PATH)
+            await ws.close()
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_the_pages_own_origin_connects(
+        self, game: QuizifyGameState, tmp_path: Path
+    ) -> None:
+        """A real phone sends the host it loaded the page from."""
+        handler = _handler(_FakeRuntime(tmp_path), game)
+        client = await _make_client(handler)
+        try:
+            ws = await client.ws_connect(
+                WS_PATH, headers={"Origin": _own_origin(client)}
+            )
+            await ws.close()
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_a_configured_external_url_is_accepted(
+        self, game: QuizifyGameState, tmp_path: Path
+    ) -> None:
+        """HA behind a proxy: the browser's Origin is not ``request.host``."""
+        runtime = _HARuntime(tmp_path, external_url="https://quiz.example.com")
+        handler = _handler(runtime, game)
+        client = await _make_client(handler)
+        try:
+            ws = await client.ws_connect(
+                WS_PATH, headers={"Origin": "https://quiz.example.com"}
+            )
+            await ws.close()
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_a_sandboxed_origin_is_refused(
+        self, game: QuizifyGameState, tmp_path: Path
+    ) -> None:
+        """``Origin: null`` is a sandboxed iframe or a file:// page."""
+        handler = _handler(_FakeRuntime(tmp_path), game)
+        client = await _make_client(handler)
+        try:
+            with pytest.raises(WSServerHandshakeError) as exc:
+                await client.ws_connect(WS_PATH, headers={"Origin": "null"})
+            assert exc.value.status == 403
+        finally:
+            await client.close()
+
+
+# ---------------------------------------------------------------------------
+# The helper itself
+# ---------------------------------------------------------------------------
+
+
+class _Req:
+    def __init__(self, host: str, headers: dict | None = None) -> None:
+        self.host = host
+        self.headers = headers or {}
+        self.remote = "203.0.113.9"
+
+
+class TestOriginHelper:
+    def test_no_origin_passes(self, tmp_path: Path) -> None:
+        assert is_origin_allowed(_Req("ha.local:8123"), _FakeRuntime(tmp_path))
+
+    def test_matching_host_passes(self, tmp_path: Path) -> None:
+        req = _Req("ha.local:8123", {"Origin": "http://ha.local:8123"})
+        assert is_origin_allowed(req, _FakeRuntime(tmp_path))
+
+    def test_a_different_port_on_the_same_host_is_foreign(
+        self, tmp_path: Path
+    ) -> None:
+        """Another service on the LAN box is not Quizify."""
+        req = _Req("ha.local:8123", {"Origin": "http://ha.local:9000"})
+        assert not is_origin_allowed(req, _FakeRuntime(tmp_path))
+
+    def test_default_ports_compare_equal(self, tmp_path: Path) -> None:
+        """Browsers omit :443; a configured URL may spell it out."""
+        runtime = _HARuntime(tmp_path, external_url="https://quiz.example.com:443")
+        req = _Req("127.0.0.1:8123", {"Origin": "https://quiz.example.com"})
+        assert is_origin_allowed(req, runtime)
+
+    def test_internal_url_is_honoured(self, tmp_path: Path) -> None:
+        runtime = _HARuntime(tmp_path, internal_url="http://192.168.1.5:8123")
+        req = _Req("127.0.0.1:8123", {"Origin": "http://192.168.1.5:8123"})
+        assert is_origin_allowed(req, runtime)
+
+    def test_the_allowed_set_never_leaks_an_unset_url(self, tmp_path: Path) -> None:
+        runtime = _HARuntime(tmp_path)  # both URLs None
+        hosts = allowed_origin_hosts(_Req("ha.local:8123"), runtime)
+        assert hosts == {"ha.local:8123"}
+
+
+# ---------------------------------------------------------------------------
+# The unauthenticated POST views
+# ---------------------------------------------------------------------------
+
+
+class _PostRuntime:
+    def __init__(self, data_dir: Path) -> None:
+        self.data_dir = data_dir
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+
+class _PostReq:
+    def __init__(self, ctx, headers: dict, body: dict) -> None:  # noqa: ANN001
+        self.app = {APP_CTX_KEY: ctx}
+        self.remote = "203.0.113.55"
+        self.host = "ha.local:8123"
+        self.headers = headers
+        self._body = body
+
+    async def json(self) -> dict:
+        return self._body
+
+
+def _flag(tmp_path: Path, headers: dict):  # noqa: ANN001, ANN202
+    ctx = SimpleNamespace(runtime=_PostRuntime(tmp_path))
+    views._flag_rate_limiter.forget("203.0.113.55")
+    req = _PostReq(ctx, headers, {"question_id": "geo_037"})
+    return asyncio.run(views.flag_question_view(req))  # type: ignore[arg-type]
+
+
+class TestUnauthenticatedPostGate:
+    def test_a_cross_site_origin_is_refused(self, tmp_path: Path) -> None:
+        resp = _flag(
+            tmp_path, {"Origin": EVIL, "Content-Type": "application/json"}
+        )
+        assert resp.status == 403
+        assert not (tmp_path / views._FLAG_FILE).exists(), (
+            "the cross-site POST still appended to flagged.jsonl"
+        )
+
+    def test_a_form_content_type_is_refused(self, tmp_path: Path) -> None:
+        """The CSRF half: no simple request may reach this view."""
+        resp = _flag(
+            tmp_path, {"Content-Type": "application/x-www-form-urlencoded"}
+        )
+        assert resp.status == 415
+        assert not (tmp_path / views._FLAG_FILE).exists()
+
+    def test_a_missing_content_type_is_refused(self, tmp_path: Path) -> None:
+        resp = _flag(tmp_path, {})
+        assert resp.status == 415
+
+    def test_the_apps_own_post_still_works(self, tmp_path: Path) -> None:
+        resp = _flag(
+            tmp_path,
+            {
+                "Origin": "http://ha.local:8123",
+                "Content-Type": "application/json; charset=utf-8",
+            },
+        )
+        assert resp.status == 200
+        assert (tmp_path / views._FLAG_FILE).exists()

--- a/tests/test_ws_origin_gate_785.py
+++ b/tests/test_ws_origin_gate_785.py
@@ -36,6 +36,9 @@ from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
 from custom_components.quizify.server import WS_PATH, views  # noqa: E402
 from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
 from custom_components.quizify.server.context import APP_CTX_KEY  # noqa: E402
+from custom_components.quizify.server.flag_store import (  # noqa: E402
+    FILENAME as FLAG_FILE,
+)
 from custom_components.quizify.server.origin import (  # noqa: E402
     allowed_origin_hosts,
     is_origin_allowed,
@@ -282,7 +285,7 @@ class TestUnauthenticatedPostGate:
             tmp_path, {"Origin": EVIL, "Content-Type": "application/json"}
         )
         assert resp.status == 403
-        assert not (tmp_path / views._FLAG_FILE).exists(), (
+        assert not (tmp_path / FLAG_FILE).exists(), (
             "the cross-site POST still appended to flagged.jsonl"
         )
 
@@ -292,7 +295,7 @@ class TestUnauthenticatedPostGate:
             tmp_path, {"Content-Type": "application/x-www-form-urlencoded"}
         )
         assert resp.status == 415
-        assert not (tmp_path / views._FLAG_FILE).exists()
+        assert not (tmp_path / FLAG_FILE).exists()
 
     def test_a_missing_content_type_is_refused(self, tmp_path: Path) -> None:
         resp = _flag(tmp_path, {})
@@ -307,4 +310,4 @@ class TestUnauthenticatedPostGate:
             },
         )
         assert resp.status == 200
-        assert (tmp_path / views._FLAG_FILE).exists()
+        assert (tmp_path / FLAG_FILE).exists()


### PR DESCRIPTION
Bundle A1 of the v1.16.0 week plan. All three issues live in `server/websocket.py` (and #785 also in `server/views.py`), so they are one branch — separate PRs on the same function would collide on rebase.

## #785 — the WebSocket handshake never validated `Origin`

Browsers do not apply CORS to a WebSocket upgrade, and the route is registered on `hass.http.app.router` with no HA auth middleware. Any page open in the victim's browser could therefore open `ws://homeassistant.local:8123/api/quizify/ws?role=admin` **from the victim's own address** — past every per-IP cap — and, inside the admin-bootstrap window, be handed the admin role plus the persisted session token.

New `custom_components/quizify/server/origin.py` compares the browser-supplied `Origin` against `request.host`, `hass.config.internal_url`, `hass.config.external_url` and the Nabu Casa remote UI host. `handle()` answers a plain HTTP **403 before `ws.prepare()`** when it matches none, so nothing is upgraded and nothing is registered.

A request with **no** `Origin` keeps passing — non-browser clients, the standalone dev server and the existing tests never send one, and a browser cannot be made to omit it. `Origin: null` (sandboxed iframe, `file://` page) is treated as foreign and refused. Default ports are normalised, so a configured `https://host:443` still matches a browser's `https://host`.

The same helper now gates the three unauthenticated POST views — `flag-question` (`views.py`) and `pack-submit` / `pack-submit/request` (both via `_check_gates` in `pack_submission.py`) — which additionally require `Content-Type: application/json`. That is not a CORS simple-request content type, so a cross-site page is forced into a preflight Home Assistant does not answer. Anything else gets 415.

## #786 — frames accepted aiohttp's 4 MiB default and parsed on the HA loop

`web.WebSocketResponse` now takes `max_msg_size=16 * 1024`. aiohttp closes an oversized frame with 1009 before the payload is buffered or parsed, which is what the frame-counting flood guard could not do — 15 frames/s × 4 MiB was 60 MiB of `json.loads` per second per socket, on Home Assistant's shared event loop. The largest legitimate Quizify frame (`start_game` with its tts/house blocks) is comfortably under a kilobyte.

`RecursionError` is now caught alongside `ValueError` around `msg.json()`, so a deeply nested frame answers with the same structured `INVALID_ACTION` error as any other malformed frame instead of escaping the read loop and tearing the connection down with a traceback.

## #812 — three hand-copied `ERR_*` fallback-text maps

The join branch, the estimate-guess branch and the multiple-choice branch each declared a local `error_messages` dict. They had already drifted: only one carried `ERR_INVALID_ACTION`, and both submit maps said "Time is up" where `www/i18n/en.json` — the text the client actually shows off the code — says "Time expired".

One module-level `ERROR_FALLBACK_TEXT` now sits next to the `ERR_*` constants in `const.py`, covering every wire error code, and `ConnectionManager.send_error` fills the message from it when the caller passes none. Explicit messages still win where a call site knows more than the code does. The three local copies are gone.

`tests/test_join_refusal_visible_729.py` no longer locates "the join map" as the **first** `error_messages = {` in the file (which was only correct as long as `_handle_join` happened to be defined before the submit handlers) — it imports the dict and asserts coverage of every `add_player` refusal directly. A new test fails if any module grows a private copy again.

## Tests

New: `tests/test_ws_origin_gate_785.py` (16), `tests/test_ws_frame_limits_786.py` (4), `tests/test_error_fallback_text_812.py` (10), plus one added to `test_join_refusal_visible_729.py`.

Each fix was verified to be load-bearing by reverting only that production change and re-running its tests:

| Issue | Failures without the fix |
|---|---|
| #785 | 6 (WS 403 for foreign/`null`/admin-role Origin; POST 403 cross-site, 415 form/absent Content-Type) |
| #786 | 2 (oversized frame accepted and parsed; `RecursionError` escapes the loop) |
| #812 | 4 (`send_error` does not default; unknown code; private map re-appears in `websocket.py` and in the 729 test) |

Suite: **2813 passed** (baseline on `main` was 2782). `ruff check custom_components/` clean, `mypy` clean (49 source files).

Four existing test files' fake requests gained `host` + `headers` so they express what a same-origin caller actually sends.

Closes #785
Closes #786
Closes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)