### PR TITLE
One HouseSettings for the house consumers, and a start that honours the host

### DIFF
--- a/custom_components/quizify/__init__.py
+++ b/custom_components/quizify/__init__.py
@@ -87,30 +87,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         async_register_built_in_panel,
     )
     from homeassistant.components.http import StaticPathConfig  # noqa: PLC0415
-    from homeassistant.core import ServiceCall  # noqa: PLC0415
 
     from .analytics import QuizifyAnalytics  # noqa: PLC0415
     from .const import (  # noqa: PLC0415
         CONF_AVOID_RECENT_REPEATS,
         CONF_COMMUNITY_SUBMIT_SECRET,
         CONF_COMMUNITY_SUBMIT_URL,
-        CONF_FINALE_SCENE,
-        CONF_HOUSE_EVENTS_ENABLED,
         CONF_LOBBY_MUSIC_URL,
-        CONF_MEDIA_PLAYER_ENTITY,
-        CONF_PARTY_LIGHT_ENTITIES,
-        CONF_SFX_CORRECT_URL,
-        CONF_SFX_STREAK_URL,
-        CONF_SFX_WINNER_URL,
-        CONF_SFX_WRONG_URL,
-        CONF_TTS_ENTITY,
         DEFAULT_AVOID_RECENT_REPEATS,
-        DEFAULT_HOUSE_EVENTS_ENABLED,
     )
     from .game.state import QuizifyGameState  # noqa: PLC0415
-    from .game_events import QuizifyEventEmitter  # noqa: PLC0415
-    from .lights import QuizifyPartyLights  # noqa: PLC0415
-    from .lobby_music import QuizifyLobbyMusic  # noqa: PLC0415
+    from .house import build_house_consumers  # noqa: PLC0415
     from .question_stats import QuestionStatsService  # noqa: PLC0415
     from .runtime import HARuntime  # noqa: PLC0415
     from .server import STATIC_URL_PREFIX, WS_PATH, WWW_DIR  # noqa: PLC0415
@@ -125,8 +112,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         register_routes,
     )
     from .server.websocket import QuizifyWebSocketHandler  # noqa: PLC0415
-    from .sound_effects import QuizifySoundEffects  # noqa: PLC0415
-    from .tts import QuizifyTTSAnnouncer  # noqa: PLC0415
+    from .services import async_register_services  # noqa: PLC0415
 
     _LOGGER.debug("Setting up Quizify integration")
 
@@ -307,131 +293,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     _LOGGER.debug("Quizify sidebar panel registered")
 
-    # Register HA service to reset the persisted admin session token.
-    async def reset_admin_session(call: ServiceCall) -> None:  # noqa: ARG001
-        domain_data = hass.data.get(DOMAIN)
-        if domain_data:
-            handler = domain_data.get("ws_handler")
-            if handler:
-                await handler.conn.async_clear_admin_token()
-                _LOGGER.warning(
-                    "Quizify admin session token RESET via HA service. "
-                    "Next admin connection will bootstrap a fresh token."
-                )
-
-    hass.services.async_register(DOMAIN, "reset_admin_session", reset_admin_session)
-    _LOGGER.debug("Quizify reset_admin_session service registered")
-
-    # Game-control services (#367). Expose a safe subset of the admin game
-    # controls as HA services so hosts can drive the game via Assist voice
-    # ("Hey Nabu, next question"), a Zigbee remote, a dashboard button or an
-    # automation — instead of only the admin WebSocket UI. Each delegates to
-    # the SAME socket-independent core the admin WS handler now uses (the
-    # ``admin_action_*`` methods), so there is one implementation and the
-    # broadcast that refreshes entities + connected clients always fires.
-    from homeassistant.exceptions import (  # noqa: PLC0415
-        ServiceValidationError,
-    )
-
-    from .game.state import GamePhase  # noqa: PLC0415
-
-    def _require_runtime() -> tuple[QuizifyWebSocketHandler, QuizifyGameState]:
-        """Return (ws_handler, game_state) or raise if setup isn't complete.
-
-        Guards against a raw ``KeyError`` when a service fires before/without a
-        loaded config entry (e.g. during teardown): the host sees a clear
-        message in the HA UI / voice response instead of an opaque crash.
-        """
-        domain_data = hass.data.get(DOMAIN)
-        if not domain_data:
-            raise ServiceValidationError(
-                "Quizify is not set up. Add the Quizify integration first."
-            )
-        handler = domain_data.get("ws_handler")
-        game = domain_data.get("game")
-        if handler is None or game is None:
-            raise ServiceValidationError(
-                "Quizify is not ready yet. Try again in a moment."
-            )
-        return handler, game
-
-    async def start_game_service(call: ServiceCall) -> None:  # noqa: ARG001
-        handler, game = _require_runtime()
-        try:
-            await handler.admin_action_start_game(game)
-        except ValueError as err:
-            raise ServiceValidationError(
-                "Cannot start a new quiz right now — a game is already in "
-                "progress. End it first, then start a new one."
-            ) from err
-
-    async def next_round_service(call: ServiceCall) -> None:  # noqa: ARG001
-        handler, game = _require_runtime()
-        try:
-            await handler.admin_action_next_round(game)
-        except ValueError as err:
-            raise ServiceValidationError(
-                "Cannot advance to the next question right now. Start a game "
-                "first, or wait until the current question has been revealed."
-            ) from err
-
-    async def pause_service(call: ServiceCall) -> None:  # noqa: ARG001
-        handler, game = _require_runtime()
-        if not await handler.admin_action_pause(game):
-            raise ServiceValidationError(
-                "There is no active question to pause right now."
-            )
-
-    async def resume_service(call: ServiceCall) -> None:  # noqa: ARG001
-        handler, game = _require_runtime()
-        if not await handler.admin_action_resume(game):
-            raise ServiceValidationError(
-                "The game is not paused, so there is nothing to resume."
-            )
-
-    async def end_game_service(call: ServiceCall) -> None:  # noqa: ARG001
-        handler, game = _require_runtime()
-        if game.phase == GamePhase.LOBBY:
-            raise ServiceValidationError(
-                "No game is currently running, so there is nothing to end."
-            )
-        await handler.admin_action_end_game(game)
-
-    async def reload_packs_service(call: ServiceCall) -> None:  # noqa: ARG001
-        """Re-read the question packs from disk (#743).
-
-        The host-owned drop-in folder is ``<config>/quizify/packs``; a pack
-        added there used to need a full Home Assistant restart, because
-        ``reload_categories`` had no caller and no service. Reloading is
-        refused outside the lobby: the running game's queue was built from the
-        packs as they were, and swapping the bank underneath it would leave
-        the round the players are answering pointing at questions that are no
-        longer loaded.
-        """
-        _handler, game = _require_runtime()
-        if game.phase != GamePhase.LOBBY:
-            raise ServiceValidationError(
-                "Packs can only be reloaded from the lobby. End the running "
-                "game first, then reload."
-            )
-        # Blocking disk I/O (glob + JSON parse of every pack) — off the loop.
-        categories = await runtime.run_in_executor(
-            game.question_bank.reload_categories
-        )
-        _LOGGER.info(
-            "Quizify packs reloaded via service: %d packs available",
-            len(categories),
-        )
-
-    hass.services.async_register(DOMAIN, "start_game", start_game_service)
-    hass.services.async_register(DOMAIN, "next_round", next_round_service)
-    hass.services.async_register(DOMAIN, "pause", pause_service)
-    hass.services.async_register(DOMAIN, "resume", resume_service)
-    hass.services.async_register(DOMAIN, "end_game", end_game_service)
-    _LOGGER.debug("Quizify game-control services registered (#367)")
-
-    hass.services.async_register(DOMAIN, "reload_packs", reload_packs_service)
-    _LOGGER.debug("Quizify reload_packs service registered (#743)")
+    # HA services (#367 / #743 / #744): the admin-session reset plus a safe
+    # subset of the game controls, so hosts can drive the game from Assist
+    # voice, a Zigbee remote, a dashboard button or an automation. They live in
+    # ``services.py`` rather than as closures here (#789) — they close over
+    # nothing but ``hass`` and look their entry-scoped state up per call.
+    async_register_services(hass)
 
     # Forward to sensor/binary_sensor platforms so HA exposes Quizify game
     # state as entities (sensor.quizify_current_round, etc.).
@@ -454,90 +321,35 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     game_state.question_bank.set_avoid_recent_repeats(
         bool(options.get(CONF_AVOID_RECENT_REPEATS, DEFAULT_AVOID_RECENT_REPEATS))
     )
-    # The house-lights master defaults to the CONF_HOUSE_EVENTS_ENABLED option
-    # (off out of the box) — the admin "House Plays Along" panel overrides it per
-    # game via configure() (#494 P4). Only the event-driven ACCENTS are gated by
-    # it; the phase-driven ambient glow always follows the game.
-    house_enabled = bool(
-        options.get(CONF_HOUSE_EVENTS_ENABLED, DEFAULT_HOUSE_EVENTS_ENABLED)
-    )
-    party_lights = QuizifyPartyLights(
-        hass=hass,
-        entity_ids=list(options.get(CONF_PARTY_LIGHT_ENTITIES) or []),
-        game_state=game_state,
-        finale_scene=options.get(CONF_FINALE_SCENE),
-        enabled=house_enabled,
-    )
-    party_lights.attach()
-    # Accent choreography (#494 Phase 2): react to the quizify_* bus events on
-    # top of the phase-driven ambient glow. No-op unless lights are configured.
-    party_lights.attach_events()
+    # The five "House Plays Along" consumers (#494): TTS announcer, party
+    # lights, lobby music, event emitter, room SFX. Built ONCE, here, off one
+    # shared HouseSettings holding the config-entry defaults (#789) — the
+    # options-reload listener below refreshes that object in place, so nothing
+    # is torn down, rebuilt or snapshotted and every reference taken here stays
+    # valid for the life of the entry.
+    house = build_house_consumers(hass, options, game_state)
+    house.attach()
 
-    tts_announcer = QuizifyTTSAnnouncer(
-        hass=hass,
-        tts_entity_id=options.get(CONF_TTS_ENTITY) or None,
-        media_player_entity_id=options.get(CONF_MEDIA_PLAYER_ENTITY) or None,
-        game_state=game_state,
-    )
-    tts_announcer.attach()
     # Let the WS handler push milestone announcements directly — the
-    # state-callback path only sees phase transitions.
-    ws_handler.set_tts_announcer(tts_announcer)
-
-    # Lobby music shares the TTS media_player entity (no separate field).
-    lobby_music = QuizifyLobbyMusic(
-        hass=hass,
-        media_player_entity_id=options.get(CONF_MEDIA_PLAYER_ENTITY) or None,
-        game_state=game_state,
-    )
-    lobby_music.attach()
-
-    # HA event backbone (#366) — fires quizify_* bus events at game milestones
-    # so the host can drive their own automations. Attaches a state callback for
-    # phase-driven events; the WS handler pushes the richer per-event ones.
-    # Gated behind the CONF_HOUSE_EVENTS_ENABLED master toggle (default off, like
-    # TTS/lights): stays a no-op until the host opts in, and always on the
-    # standalone dev server (no bus).
-    event_emitter = QuizifyEventEmitter(
-        hass=hass,
-        game_state=game_state,
-        enabled=house_enabled,
-    )
-    event_emitter.attach()
-    ws_handler.set_event_emitter(event_emitter)
-
-    # Room SFX (#494 Phase 3): one-shot stings on the shared media_player at game
-    # milestones, driven off the quizify_* bus events. Hybrid source — per-cue
-    # override URLs from the options flow, else the bundled CC0 default at
-    # www/sfx/<cue>.mp3 (if the host installed one). No phase callback, so only
-    # attach_events() (which also does the one-time bundled-default disk stat).
-    sound_effects = QuizifySoundEffects(
-        hass=hass,
-        media_player_entity_id=options.get(CONF_MEDIA_PLAYER_ENTITY) or None,
-        game_state=game_state,
-        cue_urls={
-            "correct": options.get(CONF_SFX_CORRECT_URL) or None,
-            "wrong": options.get(CONF_SFX_WRONG_URL) or None,
-            "streak": options.get(CONF_SFX_STREAK_URL) or None,
-            "winner": options.get(CONF_SFX_WINNER_URL) or None,
-        },
-        enabled=house_enabled,
-    )
-    sound_effects.attach_events()
-
-    # Hand the house consumers to the WS layer so the admin panel's
+    # state-callback path only sees phase transitions — and give it the live
+    # house consumers so the admin "House Plays Along" panel's
     # ``configure_house`` message (and start_game) can drive them per game
-    # (#494 P4). Guarded: the setters live in the WS slice, so this stays inert
-    # if the handler predates them.
-    _wire_house_consumers(ws_handler, party_lights, sound_effects)
+    # (#494 P4). Wired once: the consumers outlive an options reload now, so
+    # there is no second wiring pass to keep in step with this one.
+    ws_handler.set_tts_announcer(house.tts_announcer)
+    ws_handler.set_event_emitter(house.event_emitter)
+    _wire_house_consumers(ws_handler, house.party_lights, house.sound_effects)
 
-    hass.data[DOMAIN]["party_lights"] = party_lights
-    hass.data[DOMAIN]["tts_announcer"] = tts_announcer
-    hass.data[DOMAIN]["lobby_music"] = lobby_music
-    hass.data[DOMAIN]["event_emitter"] = event_emitter
-    hass.data[DOMAIN]["sound_effects"] = sound_effects
+    # The consumers live on the AppContext, which is what "the views and
+    # websocket handlers need to do their job" already means (#789). The
+    # hass.data mirror below is kept because services.yaml lookups and a dozen
+    # tests read it; it aliases the same objects, and since nothing is ever
+    # rebuilt the two can no longer drift.
+    ctx.house = house
+    for key, consumer in house.as_pairs():
+        hass.data[DOMAIN][key] = consumer
 
-    # Re-attach on options change so toggling lights/TTS in the UI takes
+    # Re-apply the options live so toggling lights/TTS/SFX in the UI takes
     # effect without an HA restart.
     async def _update_listener(
         _hass: HomeAssistant, updated_entry: ConfigEntry
@@ -558,113 +370,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ctx.community_submit_secret = (
             opts.get(CONF_COMMUNITY_SUBMIT_SECRET) or ""
         ).strip() or None
-        domain_data = _hass.data.get(DOMAIN, {})
-        pl: QuizifyPartyLights | None = domain_data.get("party_lights")
-        tts: QuizifyTTSAnnouncer | None = domain_data.get("tts_announcer")
-        lm: QuizifyLobbyMusic | None = domain_data.get("lobby_music")
-        ev: QuizifyEventEmitter | None = domain_data.get("event_emitter")
-        sfx: QuizifySoundEffects | None = domain_data.get("sound_effects")
-        # Snapshot the old announcer's live per-game narration config BEFORE we
-        # tear it down (#411). Rebuilding from the config entry resets
-        # ``_enabled`` to False and drops the admin's per-game entity overrides,
-        # which would silently kill narration mid-game until the next start_game.
-        tts_snapshot = tts.export_runtime_config() if tts is not None else None
-        # Snapshot the emitter's phase tracking + master toggle so a reload
-        # landing on round 1 doesn't re-fire quizify_game_started (#366, same
-        # #411 rationale) and doesn't discard the panel's master override (#494).
-        ev_snapshot = ev.export_runtime_state() if ev is not None else None
-        # Same #411 hazard for the two "House Plays Along" consumers (#494 P4):
-        # rebuilding them from the config entry resets every per-accent/per-cue
-        # toggle to its default and drops the admin panel's entity overrides,
-        # silently wiping the host's mid-game settings. Snapshot before teardown,
-        # restore onto the fresh instances below.
-        pl_snapshot = pl.export_runtime_config() if pl is not None else None
-        sfx_snapshot = sfx.export_runtime_config() if sfx is not None else None
-        if pl is not None:
-            pl.detach()
-        if tts is not None:
-            tts.detach()
-        if lm is not None:
-            lm.detach()
-        if ev is not None:
-            ev.detach()
-        if sfx is not None:
-            sfx.detach()
-        new_house_enabled = bool(
-            opts.get(CONF_HOUSE_EVENTS_ENABLED, DEFAULT_HOUSE_EVENTS_ENABLED)
-        )
-        new_pl = QuizifyPartyLights(
-            hass=_hass,
-            entity_ids=list(opts.get(CONF_PARTY_LIGHT_ENTITIES) or []),
-            game_state=game_state,
-            finale_scene=opts.get(CONF_FINALE_SCENE),
-            enabled=new_house_enabled,
-        )
-        # Carry the panel's house-lights config across the reload BEFORE
-        # attaching, so the restored entity override is already in place when
-        # attach_events() evaluates is_configured (#411 / #494 P4).
-        new_pl.restore_runtime_config(pl_snapshot)
-        new_pl.attach()
-        # Re-subscribe the accent choreography (#494) symmetrically — the old
-        # pl.detach() above already dropped its listeners + cancelled any pulse.
-        new_pl.attach_events()
-        new_tts = QuizifyTTSAnnouncer(
-            hass=_hass,
-            tts_entity_id=opts.get(CONF_TTS_ENTITY) or None,
-            media_player_entity_id=opts.get(CONF_MEDIA_PLAYER_ENTITY) or None,
-            game_state=game_state,
-        )
-        # Carry the runtime narration config across the reload so an in-flight
-        # game keeps narrating (#411).
-        new_tts.restore_runtime_config(tts_snapshot)
-        new_tts.attach()
-        new_lm = QuizifyLobbyMusic(
-            hass=_hass,
-            media_player_entity_id=opts.get(CONF_MEDIA_PLAYER_ENTITY) or None,
-            game_state=game_state,
-        )
-        new_lm.attach()
-        new_ev = QuizifyEventEmitter(
-            hass=_hass,
-            game_state=game_state,
-            enabled=new_house_enabled,
-        )
-        # Carry the phase tracking + the panel's master override across the
-        # reload so an in-flight game keeps its game_started dedupe (#366) and
-        # its house master (#494 P4). Toggling the master switch in the options
-        # UI still takes effect immediately when the panel never overrode it.
-        new_ev.restore_runtime_state(ev_snapshot)
-        new_ev.attach()
-        # Rebuild room SFX from the fresh options (new override URLs, new
-        # media_player). attach_events() re-stats the bundled defaults and
-        # re-subscribes; the old sfx.detach() above already dropped its
-        # listeners. No phase callback, so no attach() — but the panel's cue
-        # toggles + speaker override DO need to survive the rebuild (#494 P4).
-        new_sfx = QuizifySoundEffects(
-            hass=_hass,
-            media_player_entity_id=opts.get(CONF_MEDIA_PLAYER_ENTITY) or None,
-            game_state=game_state,
-            cue_urls={
-                "correct": opts.get(CONF_SFX_CORRECT_URL) or None,
-                "wrong": opts.get(CONF_SFX_WRONG_URL) or None,
-                "streak": opts.get(CONF_SFX_STREAK_URL) or None,
-                "winner": opts.get(CONF_SFX_WINNER_URL) or None,
-            },
-            enabled=new_house_enabled,
-        )
-        new_sfx.restore_runtime_config(sfx_snapshot)
-        new_sfx.attach_events()
-        domain_data["party_lights"] = new_pl
-        domain_data["tts_announcer"] = new_tts
-        domain_data["lobby_music"] = new_lm
-        domain_data["event_emitter"] = new_ev
-        domain_data["sound_effects"] = new_sfx
-        handler = domain_data.get("ws_handler")
-        if handler is not None:
-            handler.set_tts_announcer(new_tts)
-            handler.set_event_emitter(new_ev)
-            # Re-point the WS layer at the fresh house consumers (#494 P4).
-            _wire_house_consumers(handler, new_pl, new_sfx)
+        # The whole house-consumer reload path (#789). This used to be 100
+        # lines: export each consumer's runtime config, detach it, rebuild it
+        # from the fresh options with a duplicate of every constructor call
+        # above, restore the snapshot, re-attach it, re-stash it under a string
+        # key and re-point the WS handler at it — a sequence #411 had to be
+        # re-fixed in once per consumer as they were added. The consumers read
+        # their config-entry defaults through the shared settings object, so
+        # updating it in place is the entire operation, and every panel
+        # override survives because nothing touches it.
+        house.apply_options(opts)
         _LOGGER.info("Quizify options reloaded")
 
     entry.async_on_unload(entry.add_update_listener(_update_listener))
@@ -700,8 +415,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if ws_handler:
             await ws_handler.cleanup_game_tasks()
 
-        # Unsubscribe the five house consumers (#605), same sequence as
-        # ``_update_listener`` uses on an options change.
+        # Unsubscribe the five house consumers (#605). This is the ONLY
+        # teardown path left: an options change no longer detaches anything,
+        # because it no longer rebuilds anything (#789).
         #
         # Popping ``hass.data`` below does NOT unsubscribe anything: the party
         # lights hold five ``hass.bus.async_listen`` handles and the sound
@@ -715,20 +431,17 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Each detach is guarded on its own: a consumer that raises must not
         # stop the other four from unsubscribing, or a single bad teardown
         # leaves exactly the leak this fixes.
-        for key in (
-            "party_lights",
-            "tts_announcer",
-            "lobby_music",
-            "event_emitter",
-            "sound_effects",
-        ):
-            consumer = domain_data.get(key)
-            if consumer is None:
-                continue
-            try:
-                consumer.detach()
-            except Exception:  # noqa: BLE001
-                _LOGGER.exception("Failed to detach %s on unload", key)
+        #
+        # Read off the AppContext (#789), which is where the consumers live; the
+        # ``hass.data`` keys are only a mirror, and an entry that never finished
+        # setup has neither.
+        house = getattr(ctx, "house", None)
+        if house is not None:
+            for key, consumer in house.as_pairs():
+                try:
+                    consumer.detach()
+                except Exception:  # noqa: BLE001
+                    _LOGGER.exception("Failed to detach %s on unload", key)
 
     try:
         async_remove_panel(hass, "quizify")

--- a/custom_components/quizify/game_events.py
+++ b/custom_components/quizify/game_events.py
@@ -42,6 +42,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from .game.state import GamePhase, QuizifyGameState
+from .house_settings import HouseSettings
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -80,25 +81,25 @@ class QuizifyEventEmitter:
         hass: HomeAssistant | None,
         game_state: QuizifyGameState,
         enabled: bool = True,
+        settings: HouseSettings | None = None,
     ) -> None:
+        """Build the event backbone.
+
+        ``settings`` is the shared :class:`HouseSettings` (#789) — the master
+        toggle for the whole backbone lives there in two layers: the
+        config-entry value (``CONF_HOUSE_EVENTS_ENABLED``, default off, so the
+        integration stays silent on the bus until the host opts in) and the
+        admin panel's tri-state runtime override. ``enabled`` is the standalone
+        form used by the dev server and the unit tests; it seeds a private
+        settings object that behaves identically.
+        """
         self._hass = hass
         self._game = game_state
-        # Master toggle for the whole event backbone (#366). Off => every fire
-        # is a no-op, so the integration stays silent on the bus until the host
-        # opts in via the options flow (CONF_HOUSE_EVENTS_ENABLED, default off).
-        # The constructor default is True because the sole production caller
-        # (__init__) always passes the resolved option explicitly; the product
-        # "off by default" lives at the config layer, not here.
-        self._enabled = enabled
-        # The admin "House Plays Along" panel's runtime master (#494 P4).
-        # ``None`` means the panel never touched it, so the config-entry value
-        # above still wins — which is what keeps a host toggling
-        # CONF_HOUSE_EVENTS_ENABLED in the options UI working after a reload,
-        # while a panel-set master survives an unrelated options change (#411).
-        self._enabled_override: bool | None = None
+        self._settings = settings or HouseSettings(house_enabled=bool(enabled))
         # Track the last phase we observed so phase-driven events fire only on
         # transitions, not on every state_callback flap. Mirrors the lights /
-        # TTS observers. Survives an options reload via export/restore below.
+        # TTS observers. Survives an options reload because the reload no longer
+        # rebuilds this object (#789).
         self._last_phase: GamePhase | None = None
         # One-shot guard so the "time running out" event fires at most once per
         # round. Reset at every question start (see ``notify_question_shown``),
@@ -106,11 +107,19 @@ class QuizifyEventEmitter:
         self._time_running_out_fired: bool = False
 
     @property
+    def _enabled(self) -> bool:
+        """The config-entry master (CONF_HOUSE_EVENTS_ENABLED), read live."""
+        return self._settings.house_enabled
+
+    @property
+    def _enabled_override(self) -> bool | None:
+        """The panel's tri-state master; ``None`` = the panel never set one."""
+        return self._settings.enabled_override
+
+    @property
     def _master_enabled(self) -> bool:
         """The effective master: panel override if set, else the config entry."""
-        if self._enabled_override is None:
-            return self._enabled
-        return self._enabled_override
+        return self._settings.master_enabled
 
     @property
     def is_configured(self) -> bool:
@@ -145,57 +154,17 @@ class QuizifyEventEmitter:
         preset: master on, every light/SFX toggle off → the bus stays live, the
         house stays quiet.
         """
-        self._enabled_override = bool(enabled)
+        # The master is the one panel value shared with the party lights and the
+        # SFX player, so it is written to the shared settings (#789).
+        self._settings.enabled_override = bool(enabled)
 
-    # ------------------------------------------------------------------
-    # Options-reload lifecycle (#411 pattern)
-    # ------------------------------------------------------------------
-
-    def export_runtime_state(self) -> dict[str, Any]:
-        """Snapshot the transient phase-tracking state + master toggle (#411).
-
-        An options reload rebuilds this emitter from scratch, which would reset
-        ``_last_phase`` to ``None``. On its own that is mostly harmless (the
-        game_started/finale detectors are further gated on ``round``), but a
-        reload landing exactly on the first active round could otherwise re-fire
-        ``quizify_game_started``. Snapshotting the last phase across the reload
-        closes that gap, matching how the TTS announcer preserves its runtime
-        config (#411).
-
-        ``enabled_override`` rides along for the same reason (#494 P4): the
-        rebuild reads the master from the config entry, which would silently
-        discard the admin panel's runtime master mid-game. Note it is the
-        OVERRIDE that is snapshotted, not the effective master — a ``None``
-        override means the panel never set one, so the rebuilt emitter correctly
-        picks up the (possibly just changed) CONF_HOUSE_EVENTS_ENABLED value
-        rather than being pinned to the old one.
-        """
-        return {
-            "last_phase": self._last_phase.value
-            if self._last_phase is not None
-            else None,
-            "enabled_override": self._enabled_override,
-        }
-
-    def restore_runtime_state(self, snapshot: dict[str, Any] | None) -> None:
-        """Restore a snapshot from :meth:`export_runtime_state` (#411 pattern).
-
-        Defensive: a falsy/empty snapshot is a no-op, an absent key falls back to
-        the current value, and an unknown phase value is ignored so a stale
-        snapshot can never crash the rebuild. ``enabled_override`` is tri-state
-        (True/False/None) so it is NOT coerced through ``bool()`` — that would
-        turn "the panel never set a master" into a hard False.
-        """
-        if not snapshot:
-            return
-        value = snapshot.get("last_phase")
-        if value:
-            try:
-                self._last_phase = GamePhase(value)
-            except ValueError:
-                _LOGGER.debug("Ignoring unknown phase in snapshot: %s", value)
-        override = snapshot.get("enabled_override", self._enabled_override)
-        self._enabled_override = None if override is None else bool(override)
+    # There is deliberately no export/restore_runtime_state pair any more
+    # (#789). It carried ``_last_phase`` and the panel's master across the
+    # rebuild an options reload used to perform, so that a reload landing on
+    # round 1 could not re-fire ``quizify_game_started`` and could not discard
+    # the panel's master mid-game. Both now hold by construction: the emitter
+    # itself outlives the reload, and only the config-entry defaults it reads
+    # through :class:`HouseSettings` are refreshed.
 
     # ------------------------------------------------------------------
     # Phase-driven milestones (state-callback path)

--- a/custom_components/quizify/house.py
+++ b/custom_components/quizify/house.py
@@ -1,0 +1,142 @@
+"""One place that builds the five "House Plays Along" consumers (#789).
+
+``async_setup_entry`` used to construct the TTS announcer, the party lights, the
+lobby music, the event emitter and the room SFX inline — and then the nested
+``_update_listener`` closure repeated every one of those constructor calls with
+identical keyword arguments, so any new option had to be added in two places
+with nothing forcing the pairing.
+
+There is now one construction site, here, and no second one: the reload path
+updates the shared :class:`~custom_components.quizify.house_settings.HouseSettings`
+in place (:meth:`HouseConsumers.apply_options`) and the consumers read the new
+values through it. Nothing is torn down, rebuilt or snapshotted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .game_events import QuizifyEventEmitter
+from .house_settings import HouseSettings
+from .lights import QuizifyPartyLights
+from .lobby_music import QuizifyLobbyMusic
+from .sound_effects import QuizifySoundEffects
+from .tts import QuizifyTTSAnnouncer
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from typing import Any
+
+    from homeassistant.core import HomeAssistant
+
+    from .game.state import QuizifyGameState
+
+
+@dataclass
+class HouseConsumers:
+    """The five long-lived house consumers plus the settings they share.
+
+    Held on the :class:`~custom_components.quizify.server.context.AppContext`
+    for the lifetime of the config entry. Every member outlives an options
+    reload — that is the point of the settings object — so a reference taken at
+    setup stays valid, and the WS handler never has to be re-pointed.
+    """
+
+    settings: HouseSettings
+    party_lights: QuizifyPartyLights
+    tts_announcer: QuizifyTTSAnnouncer
+    lobby_music: QuizifyLobbyMusic
+    event_emitter: QuizifyEventEmitter
+    sound_effects: QuizifySoundEffects
+
+    # Order matters only for the detach sweep on unload (#605); the pairs are
+    # (label, consumer) so a failure can be logged against a readable name.
+    def as_pairs(self) -> tuple[tuple[str, object], ...]:
+        """The five consumers with their ``hass.data`` labels."""
+        return (
+            ("party_lights", self.party_lights),
+            ("tts_announcer", self.tts_announcer),
+            ("lobby_music", self.lobby_music),
+            ("event_emitter", self.event_emitter),
+            ("sound_effects", self.sound_effects),
+        )
+
+    def attach(self) -> None:
+        """Subscribe every consumer to the game state and the event bus.
+
+        Exactly the sequence ``async_setup_entry`` ran inline: the lights take
+        both the phase callback and the accent listeners, the SFX take only the
+        bus listeners (they have no phase behaviour), and the rest take the
+        phase callback.
+        """
+        self.party_lights.attach()
+        # Accent choreography (#494 Phase 2): react to the quizify_* bus events
+        # on top of the phase-driven ambient glow. No-op unless configured.
+        self.party_lights.attach_events()
+        self.tts_announcer.attach()
+        self.lobby_music.attach()
+        self.event_emitter.attach()
+        # No phase callback for SFX, so only attach_events() — which also does
+        # the one-time bundled-default disk stat.
+        self.sound_effects.attach_events()
+
+    def apply_options(self, options: Mapping[str, Any]) -> None:
+        """Push a fresh set of config-entry options onto the live consumers.
+
+        The whole of the options-reload path (#789). ``update_from_options``
+        rewrites the shared defaults, which every consumer reads lazily, so the
+        new values are live immediately; the three ``refresh_from_settings``
+        calls only reproduce the *side effects* the old rebuild had — arming
+        listeners for a host who just configured their first entity, re-syncing
+        the bulbs, restarting lobby music on a changed speaker.
+        """
+        self.settings.update_from_options(options)
+        self.party_lights.refresh_from_settings()
+        self.sound_effects.refresh_from_settings()
+        self.lobby_music.refresh_from_settings()
+
+
+def build_house_consumers(
+    hass: HomeAssistant | None,
+    options: Mapping[str, Any],
+    game_state: QuizifyGameState,
+) -> HouseConsumers:
+    """Build all five house consumers off one config entry's options.
+
+    Nothing is attached here — the caller does that via
+    :meth:`HouseConsumers.attach` once it has also wired the WS handler, so the
+    ordering stays visible at the setup site.
+    """
+    settings = HouseSettings.from_options(options)
+    return HouseConsumers(
+        settings=settings,
+        # The house-lights master defaults to CONF_HOUSE_EVENTS_ENABLED (off out
+        # of the box) — the admin "House Plays Along" panel overrides it per game
+        # via configure() (#494 P4). Only the event-driven ACCENTS are gated by
+        # it; the phase-driven ambient glow always follows the game.
+        party_lights=QuizifyPartyLights(
+            hass=hass, game_state=game_state, settings=settings
+        ),
+        tts_announcer=QuizifyTTSAnnouncer(
+            hass=hass, game_state=game_state, settings=settings
+        ),
+        # Lobby music shares the TTS media_player entity (no separate field).
+        lobby_music=QuizifyLobbyMusic(
+            hass=hass, game_state=game_state, settings=settings
+        ),
+        # HA event backbone (#366) — fires quizify_* bus events at game
+        # milestones so the host can drive their own automations. Gated behind
+        # the same master toggle, and always inert on the standalone dev server
+        # (no bus).
+        event_emitter=QuizifyEventEmitter(
+            hass=hass, game_state=game_state, settings=settings
+        ),
+        # Room SFX (#494 Phase 3): one-shot stings on the shared media_player,
+        # driven off the quizify_* bus events. Hybrid source — per-cue override
+        # URLs from the options flow, else the bundled CC0 default at
+        # www/sfx/<cue>.mp3 (if the host installed one).
+        sound_effects=QuizifySoundEffects(
+            hass=hass, game_state=game_state, settings=settings
+        ),
+    )

--- a/custom_components/quizify/house_settings.py
+++ b/custom_components/quizify/house_settings.py
@@ -1,0 +1,162 @@
+"""The config-entry side of "The House Plays Along" (#789).
+
+Every house consumer — TTS announcer, party lights, lobby music, event emitter,
+room SFX — is fed from two sources that used to be fused inside each object:
+
+* the **config entry** (the options flow: which lights, which speaker, which TTS
+  engine, the per-cue override URLs, the ``CONF_HOUSE_EVENTS_ENABLED`` master),
+  which changes when the host edits the integration options; and
+* the admin **panel**, which overrides some of those per game over the socket.
+
+Fusing them is what made an options reload expensive. The listener had to tear
+every consumer down, rebuild it from the fresh options, and then restore the
+panel's runtime state onto the new instance — which is why four classes carried
+an ``export_runtime_config`` / ``restore_runtime_config`` pair that existed for
+no other reason, and why #411 ("a reload silently kills narration mid-game") had
+to be re-fixed once per consumer as they were added.
+
+:class:`HouseSettings` splits the two apart. It holds the config-entry defaults
+in one mutable object that every consumer keeps a **reference** to and reads
+lazily, so :func:`HouseSettings.update_from_options` is the whole of the reload
+path: no teardown, no rebuild, no snapshot. The panel's own per-consumer
+overrides simply stay where they always were — on the consumer instances, which
+now outlive the reload.
+
+The one panel override that lives here rather than on a consumer is
+``enabled_override``, the house master. It is a single switch the admin panel
+pushes to three consumers at once (lights, SFX, event emitter); keeping three
+private copies of one value in sync was duplication, not encapsulation.
+
+Nothing in this module imports Home Assistant or the consumers themselves, so it
+is safe to import from any of them (and from the standalone dev server).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from .const import (
+    CONF_FINALE_SCENE,
+    CONF_HOUSE_EVENTS_ENABLED,
+    CONF_MEDIA_PLAYER_ENTITY,
+    CONF_PARTY_LIGHT_ENTITIES,
+    CONF_SFX_CORRECT_URL,
+    CONF_SFX_STREAK_URL,
+    CONF_SFX_WINNER_URL,
+    CONF_SFX_WRONG_URL,
+    CONF_TTS_ENTITY,
+    DEFAULT_HOUSE_EVENTS_ENABLED,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+#: The four SFX cue keys. Each maps to an optional override URL from the options
+#: flow and a bundled default at ``www/sfx/<cue>.mp3``. Declared here rather than
+#: in :mod:`sound_effects` so the options-reading code and the player agree on
+#: the key set without the settings module importing the consumer.
+CUE_KEYS = ("correct", "wrong", "streak", "winner")
+
+#: Option key per cue, in ``CUE_KEYS`` order.
+_CUE_OPTION_KEYS = {
+    "correct": CONF_SFX_CORRECT_URL,
+    "wrong": CONF_SFX_WRONG_URL,
+    "streak": CONF_SFX_STREAK_URL,
+    "winner": CONF_SFX_WINNER_URL,
+}
+
+
+def clean_entity_ids(entity_ids: list[str] | None) -> list[str]:
+    """Strip whitespace, drop empties, dedupe while keeping order."""
+    seen: set[str] = set()
+    cleaned: list[str] = []
+    for raw in entity_ids or []:
+        entity = (raw or "").strip()
+        if entity and entity not in seen:
+            seen.add(entity)
+            cleaned.append(entity)
+    return cleaned
+
+
+def _clean_str(value: Any) -> str | None:
+    """Normalize a free-text/entity option to a non-empty string or ``None``."""
+    return (str(value).strip() or None) if value else None
+
+
+@dataclass
+class HouseSettings:
+    """Config-entry defaults for the house consumers, plus the shared master.
+
+    Mutable and shared **by reference**: the consumers built in
+    :mod:`custom_components.quizify.house` all hold the same instance, so
+    :meth:`update_from_options` on an options reload is immediately visible to
+    every one of them without anything being rebuilt.
+
+    The construction defaults describe a bare, unconfigured house (no entities,
+    no cue overrides). ``house_enabled`` defaults to ``True`` for the same reason
+    the consumers' own ``enabled=`` arguments did: the product's "off out of the
+    box" lives at the config layer — :meth:`from_options` resolves it from
+    ``CONF_HOUSE_EVENTS_ENABLED``, whose default is off.
+    """
+
+    # --- config-entry defaults, rewritten in place by an options reload -----
+    house_enabled: bool = True
+    light_entities: list[str] = field(default_factory=list)
+    finale_scene: str | None = None
+    media_player: str | None = None
+    tts_entity: str | None = None
+    cue_urls: dict[str, str | None] = field(
+        default_factory=lambda: dict.fromkeys(CUE_KEYS)
+    )
+
+    # --- the admin panel's shared master override ---------------------------
+    # ``None`` means "the panel never touched it", so the config-entry value
+    # above still wins. Tri-state on purpose: coercing it to a hard ``False``
+    # would pin the master off and make the options-flow switch inert for a host
+    # who never opened the panel.
+    enabled_override: bool | None = None
+
+    # ------------------------------------------------------------------
+    # Construction / refresh from the config entry
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_options(cls, options: Mapping[str, Any]) -> HouseSettings:
+        """Build the defaults from a config entry's ``options`` mapping."""
+        settings = cls()
+        settings.update_from_options(options)
+        return settings
+
+    def update_from_options(self, options: Mapping[str, Any]) -> None:
+        """Re-read every config-entry default IN PLACE (the whole reload path).
+
+        Deliberately does not touch :attr:`enabled_override` or any consumer's
+        own per-game overrides: an options change must not discard what the
+        admin panel set for the game currently in progress (#411). Because the
+        consumers read through this object, the new values are live the moment
+        this returns.
+        """
+        self.house_enabled = bool(
+            options.get(CONF_HOUSE_EVENTS_ENABLED, DEFAULT_HOUSE_EVENTS_ENABLED)
+        )
+        self.light_entities = clean_entity_ids(
+            list(options.get(CONF_PARTY_LIGHT_ENTITIES) or [])
+        )
+        self.finale_scene = _clean_str(options.get(CONF_FINALE_SCENE))
+        self.media_player = _clean_str(options.get(CONF_MEDIA_PLAYER_ENTITY))
+        self.tts_entity = _clean_str(options.get(CONF_TTS_ENTITY))
+        self.cue_urls = {
+            cue: _clean_str(options.get(_CUE_OPTION_KEYS[cue])) for cue in CUE_KEYS
+        }
+
+    # ------------------------------------------------------------------
+    # Resolved values
+    # ------------------------------------------------------------------
+
+    @property
+    def master_enabled(self) -> bool:
+        """The effective house master: panel override if set, else the entry."""
+        if self.enabled_override is None:
+            return self.house_enabled
+        return self.enabled_override

--- a/custom_components/quizify/lights.py
+++ b/custom_components/quizify/lights.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from .game.state import GamePhase, QuizifyGameState
 from .game_events import (
@@ -40,6 +40,7 @@ from .game_events import (
     EVENT_WINNER_DECIDED,
 )
 from .ha_service import fire_and_forget_service
+from .house_settings import HouseSettings, clean_entity_ids
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -167,16 +168,10 @@ _ACCENT_WINNER: list[tuple[object, float]] = [
 # sweep (above) is the finale's celebration instead.
 
 
-def _clean_entity_ids(entity_ids: list[str] | None) -> list[str]:
-    """Strip whitespace, drop empties, dedupe while keeping order."""
-    seen: set[str] = set()
-    cleaned: list[str] = []
-    for raw in entity_ids or []:
-        entity = (raw or "").strip()
-        if entity and entity not in seen:
-            seen.add(entity)
-            cleaned.append(entity)
-    return cleaned
+# Kept as a module-local alias: the cleaning rule now lives with the config-entry
+# defaults it normalises (:mod:`house_settings`), but this name is referenced from
+# the domain-allowlist notes in the WS layer and the #724 tests.
+_clean_entity_ids = clean_entity_ids
 
 
 class QuizifyPartyLights:
@@ -185,17 +180,30 @@ class QuizifyPartyLights:
     def __init__(
         self,
         hass: HomeAssistant | None,
-        entity_ids: list[str],
         game_state: QuizifyGameState,
+        entity_ids: list[str] | None = None,
         finale_scene: str | None = None,
         enabled: bool = True,
+        settings: HouseSettings | None = None,
     ) -> None:
+        """Build the light choreography.
+
+        ``settings`` is the shared :class:`HouseSettings` the integration builds
+        once per config entry (#789); the lights read the configured entities,
+        finale scene and house master through it, so an options reload updates
+        them in place instead of rebuilding this object. The ``entity_ids`` /
+        ``finale_scene`` / ``enabled`` arguments are the standalone form used by
+        the dev server and the unit tests — they seed a private settings object
+        that behaves identically. Passing both ignores the loose arguments.
+        """
         self._hass = hass
-        self._entity_ids = _clean_entity_ids(entity_ids)
-        # Optional finale scene (#280). Activated alongside the winner sweep so
-        # the host can drive a whole-room "victory" look (their own scene) on top
-        # of the party lights. Cleaned: empty/whitespace → None (no-op).
-        self._finale_scene = (finale_scene or "").strip() or None
+        # Config-entry values (entities, the optional #280 finale scene, the
+        # CONF_HOUSE_EVENTS_ENABLED master) are read lazily off this object.
+        self._settings = settings or HouseSettings(
+            house_enabled=bool(enabled),
+            light_entities=clean_entity_ids(entity_ids),
+            finale_scene=(finale_scene or "").strip() or None,
+        )
         self._game = game_state
         self._last_phase: GamePhase | None = None
         # Accent choreography (#494). Unsub handles for the four bus listeners
@@ -205,22 +213,13 @@ class QuizifyPartyLights:
         self._pulse_task: asyncio.Task | None = None
 
         # --- "House Plays Along" runtime config (#494 Phase 4) ---------------
-        # Master switch for the EVENT-DRIVEN ACCENTS only, in two layers:
+        # The master switch for the EVENT-DRIVEN ACCENTS lives on the shared
+        # settings object in two layers (the config-entry value plus the admin
+        # panel's tri-state override) so a host toggling
+        # CONF_HOUSE_EVENTS_ENABLED in the options UI takes effect immediately
+        # on a never-panelled install, while a panel-set master survives an
+        # unrelated options change (#411). See :attr:`_master_enabled`.
         #
-        # * ``_enabled`` — the config-entry value (CONF_HOUSE_EVENTS_ENABLED).
-        #   The constructor default is True because the sole production caller
-        #   (__init__) always passes the resolved option explicitly; the product
-        #   "off by default" lives at the config layer, not here — exactly the
-        #   posture QuizifyEventEmitter takes.
-        # * ``_enabled_override`` — the admin panel's runtime master. ``None``
-        #   means "the panel never touched it", so the config entry still wins.
-        #
-        # Two layers rather than one so BOTH survive an options reload: the
-        # panel's master is preserved across an unrelated options change (#411),
-        # while a host toggling CONF_HOUSE_EVENTS_ENABLED in the options UI on a
-        # never-panelled install still takes effect immediately.
-        self._enabled: bool = bool(enabled)
-        self._enabled_override: bool | None = None
         # Per-accent toggles, all default ON so flipping the master on gives the
         # full choreography out of the box (the TTS posture, #281).
         self._light_question: bool = True
@@ -269,7 +268,9 @@ class QuizifyPartyLights:
         options flow, lights picked in the panel) still gets its accent
         listeners.
         """
-        self._enabled_override = bool(enabled)
+        # The master is the one panel value shared with the SFX player and the
+        # event emitter, so it is written to the shared settings (#789).
+        self._settings.enabled_override = bool(enabled)
         self._light_question = bool(light_question)
         self._light_countdown = bool(light_countdown)
         self._light_reveal = bool(light_reveal)
@@ -281,82 +282,40 @@ class QuizifyPartyLights:
         # Idempotent; a no-op when already attached or still unconfigured.
         self.attach_events()
 
-    def export_runtime_config(self) -> dict[str, Any]:
-        """Snapshot the mutable per-game house-lights config (#411 pattern).
-
-        An options reload rebuilds this instance from the config entry, which
-        would reset every toggle back to its default and drop the admin's entity
-        overrides — silently wiping the panel's settings mid-game until the next
-        ``start_game``. ``__init__._update_listener`` snapshots the live config
-        here and restores it onto the fresh instance via
-        :meth:`restore_runtime_config`, exactly as it already does for the TTS
-        announcer (#411).
-
-        Note it snapshots ``_enabled_override`` — the PANEL's master — not the
-        effective one. A ``None`` override means the panel never touched the
-        master, so the rebuilt instance correctly picks up the (possibly just
-        changed) CONF_HOUSE_EVENTS_ENABLED value from the config entry instead of
-        being pinned to the old one.
-
-        ``_last_phase`` is deliberately NOT snapshotted: letting it reset to
-        ``None`` makes the next state change re-apply the ambient recipe, which
-        re-syncs the bulbs after a reload. Carrying it over would suppress that.
-        """
-        return {
-            "enabled_override": self._enabled_override,
-            "light_question": self._light_question,
-            "light_countdown": self._light_countdown,
-            "light_reveal": self._light_reveal,
-            "light_streak": self._light_streak,
-            "light_winner": self._light_winner,
-            "winner_scene": self._winner_scene,
-            "entity_ids_override": self._entity_ids_override,
-            "finale_scene_override": self._finale_scene_override,
-        }
-
-    def restore_runtime_config(self, snapshot: dict[str, Any] | None) -> None:
-        """Restore a snapshot from :meth:`export_runtime_config` (#411 pattern).
-
-        Defensive: a falsy/empty snapshot is a no-op, and each field falls back
-        to the current value when absent, so a partial snapshot never clobbers
-        an unrelated default. ``enabled_override`` is tri-state (True/False/None)
-        so it is NOT coerced through ``bool()`` — that would turn "the panel never
-        set a master" into a hard False and pin the master off.
-        """
-        if not snapshot:
-            return
-        override = snapshot.get("enabled_override", self._enabled_override)
-        self._enabled_override = None if override is None else bool(override)
-        self._light_question = bool(
-            snapshot.get("light_question", self._light_question)
-        )
-        self._light_countdown = bool(
-            snapshot.get("light_countdown", self._light_countdown)
-        )
-        self._light_reveal = bool(snapshot.get("light_reveal", self._light_reveal))
-        self._light_streak = bool(snapshot.get("light_streak", self._light_streak))
-        self._light_winner = bool(snapshot.get("light_winner", self._light_winner))
-        self._winner_scene = bool(snapshot.get("winner_scene", self._winner_scene))
-        self._entity_ids_override = (
-            _clean_entity_ids(
-                snapshot.get("entity_ids_override", self._entity_ids_override)
-            )
-            or None
-        )
-        self._finale_scene_override = (
-            snapshot.get("finale_scene_override", self._finale_scene_override) or None
-        )
-
     # ------------------------------------------------------------------
     # Entity resolution — override wins, else the config-entry value
     # ------------------------------------------------------------------
+    #
+    # There is deliberately no export/restore_runtime_config pair any more
+    # (#789). It existed only because an options reload tore this object down
+    # and built a new one from the fresh config entry; the settings object is
+    # now updated in place, this instance outlives the reload, and every panel
+    # override below survives simply by not being touched.
+
+    @property
+    def _enabled(self) -> bool:
+        """The config-entry master (CONF_HOUSE_EVENTS_ENABLED), read live."""
+        return self._settings.house_enabled
+
+    @property
+    def _enabled_override(self) -> bool | None:
+        """The panel's tri-state master; ``None`` = the panel never set one."""
+        return self._settings.enabled_override
+
+    @property
+    def _entity_ids(self) -> list[str]:
+        """The config-entry light entities, read live off the settings."""
+        return self._settings.light_entities
+
+    @property
+    def _finale_scene(self) -> str | None:
+        """The config-entry finale scene (#280), read live off the settings."""
+        return self._settings.finale_scene
 
     @property
     def _master_enabled(self) -> bool:
         """The effective accent master: panel override if set, else the entry."""
-        if self._enabled_override is None:
-            return self._enabled
-        return self._enabled_override
+        return self._settings.master_enabled
 
     @property
     def _active_entity_ids(self) -> list[str]:
@@ -377,6 +336,19 @@ class QuizifyPartyLights:
 
     def attach(self) -> None:
         self._game.register_state_callback(self._on_state_changed)
+
+    def refresh_from_settings(self) -> None:
+        """Re-sync after the config entry's options changed (#789).
+
+        The old reload path rebuilt this object, which had two side effects
+        worth keeping now that it does not: a fresh instance started with
+        ``_last_phase = None``, so the next state change re-applied the ambient
+        recipe and re-synced the bulbs; and it ran ``attach_events()``, which is
+        what arms the accent listeners for a host who just configured their
+        first light entity. Both are reproduced here, and both are idempotent.
+        """
+        self._last_phase = None
+        self.attach_events()
 
     def attach_events(self) -> None:
         """Subscribe to the ``quizify_*`` bus events for accent choreography.

--- a/custom_components/quizify/lobby_music.py
+++ b/custom_components/quizify/lobby_music.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING
 
 from .game.state import GamePhase, QuizifyGameState
 from .ha_service import fire_and_forget_service
+from .house_settings import HouseSettings
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -37,16 +38,36 @@ class QuizifyLobbyMusic:
     def __init__(
         self,
         hass: HomeAssistant | None,
-        media_player_entity_id: str | None,
         game_state: QuizifyGameState,
+        media_player_entity_id: str | None = None,
+        settings: HouseSettings | None = None,
     ) -> None:
+        """Build the lobby-music player.
+
+        ``settings`` is the shared :class:`HouseSettings` (#789): the speaker is
+        read through it, so an options reload updates it in place rather than
+        rebuilding this object. ``media_player_entity_id`` is the standalone form
+        used by the dev server and the unit tests.
+        """
         self._hass = hass
-        self._media_player_entity_id = (media_player_entity_id or "").strip() or None
+        self._settings = settings or HouseSettings(
+            media_player=(media_player_entity_id or "").strip() or None
+        )
         self._game = game_state
         self._last_phase: GamePhase | None = None
         # Track whether we currently believe music is playing so we only
-        # issue one stop on leaving the lobby (not on every state push).
+        # issue one stop on leaving the lobby (not on every state push), and on
+        # WHICH speaker — the configured entity can change under us now that an
+        # options reload updates the settings in place instead of rebuilding
+        # this object (#789), and the stop has to reach the speaker that is
+        # actually playing, not the one just configured.
         self._playing = False
+        self._playing_entity: str | None = None
+
+    @property
+    def _media_player_entity_id(self) -> str | None:
+        """The config-entry speaker, read live off the settings."""
+        return self._settings.media_player
 
     @property
     def is_configured(self) -> bool:
@@ -63,6 +84,22 @@ class QuizifyLobbyMusic:
         # start the music until the phase moved away and back. Reusing
         # ``_on_state_changed`` (with ``_last_phase is None``) resumes LOBBY
         # music immediately and is a safe no-op for any non-lobby phase.
+        self._on_state_changed()
+
+    def refresh_from_settings(self) -> None:
+        """Re-evaluate after the config entry's options changed (#789).
+
+        The old reload path stopped this player, threw it away and attached a
+        fresh one, whose ``attach()`` re-evaluated the current phase and so
+        resumed LOBBY music under the new speaker/URL (#411). The instance now
+        survives the reload, so the same stop-then-re-evaluate has to be done
+        explicitly — otherwise a host who changes the speaker mid-lobby keeps
+        hearing the old one, and a host who sets the URL for the first time
+        hears nothing until the phase moves away and back.
+        """
+        if self._playing:
+            self._stop()
+        self._last_phase = None
         self._on_state_changed()
 
     def detach(self) -> None:
@@ -94,6 +131,7 @@ class QuizifyLobbyMusic:
         if not url:
             return
         self._playing = True
+        self._playing_entity = self._media_player_entity_id
         # play_media starts the file; repeat_set with "all" loops it. The
         # repeat call is best-effort — players that don't support repeat
         # just ignore it (single play-through).
@@ -116,11 +154,13 @@ class QuizifyLobbyMusic:
         )
 
     def _stop(self) -> None:
+        entity_id = self._playing_entity or self._media_player_entity_id
         self._playing = False
+        self._playing_entity = None
         self._call(
             "media_player",
             "media_stop",
-            {"entity_id": self._media_player_entity_id},
+            {"entity_id": entity_id},
         )
 
     def _call(self, domain: str, service: str, data: dict[str, object]) -> None:

--- a/custom_components/quizify/server/context.py
+++ b/custom_components/quizify/server/context.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from ..analytics import QuizifyAnalytics
     from ..game.state import QuizifyGameState
+    from ..house import HouseConsumers
     from ..question_stats import QuestionStatsService
     from ..runtime import Runtime
     from .websocket import QuizifyWebSocketHandler
@@ -88,3 +89,9 @@ class AppContext:
     # back-compatible. Mutable so an options-flow change applies without an HA
     # restart, mirroring ``community_submit_url``.
     community_submit_secret: str | None = None
+    # The five "House Plays Along" consumers plus the config-entry settings they
+    # share (#789). ``None`` on the standalone dev server, which has no config
+    # entry and no Home Assistant to drive. They used to be reachable only via
+    # ``hass.data[DOMAIN]``, which this class exists to replace; the unload path
+    # detaches them from here.
+    house: HouseConsumers | None = None

--- a/custom_components/quizify/server/views.py
+++ b/custom_components/quizify/server/views.py
@@ -933,19 +933,29 @@ def _pack_news_store(request: web.Request) -> PackNewsStore:
     return store
 
 
-def _preset_store(request: web.Request) -> PresetStore:
+def get_preset_store(app: web.Application) -> PresetStore:
     """Return the per-app preset store, creating it once.
 
     Cached on the aiohttp application rather than rebuilt per request: the
     store owns an ``asyncio.Lock`` that serialises read-modify-write, and a
     fresh instance per request would lock nothing. Stashing it here (instead
     of on ``AppContext``) keeps the HA and standalone entry points untouched.
+
+    Takes the application rather than a request so the ``quizify.start_game``
+    service can reach the SAME instance (#744) — a preset started by voice and a
+    preset saved in the admin UI have to be the same list, and a second store
+    with its own lock would not serialise against the first.
     """
-    store = request.app.get(_PRESET_STORE_KEY)
+    store = app.get(_PRESET_STORE_KEY)
     if store is None:
-        store = PresetStore(_get_ctx(request).runtime)
-        request.app[_PRESET_STORE_KEY] = store
+        store = PresetStore(app[APP_CTX_KEY].runtime)
+        app[_PRESET_STORE_KEY] = store
     return store
+
+
+def _preset_store(request: web.Request) -> PresetStore:
+    """The request-scoped form of :func:`get_preset_store`."""
+    return get_preset_store(request.app)
 
 
 async def presets_view(request: web.Request) -> web.Response:

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -179,6 +179,114 @@ def _coerce_toggle(value: Any, *, default: bool) -> bool:
     return default
 
 
+# --- socket-less start_game settings (#744) ----------------------------------
+#
+# The keyword arguments ``QuizifyGameState.start_game`` accepts and that a
+# service call / preset / last-used snapshot may fill in. The two seed
+# arguments are deliberately absent: they exist for tests to pin the random
+# draws and must never be reachable from a host-facing surface.
+_START_GAME_FIELDS = frozenset(
+    {
+        "category",
+        "categories",
+        "difficulty",
+        "num_rounds",
+        "language",
+        "timer_duration",
+        "lightning_enabled",
+        "hot_seat_enabled",
+        "powerups_enabled",
+        "wager_enabled",
+    }
+)
+
+# The admin UI's sentinel for "no pick" in the pack and difficulty choosers. It
+# is stored verbatim in a saved preset and typed verbatim into a service call,
+# and ``start_game`` spells the same thing ``None``.
+_MIXED = "mixed"
+
+#: Saved-preset field name -> ``start_game`` keyword. ``packs`` and ``category``
+#: are handled separately because they resolve to two different keywords.
+_PRESET_FIELD_MAP = {
+    "rounds": "num_rounds",
+    "timer": "timer_duration",
+    "difficulty": "difficulty",
+    "lightning": "lightning_enabled",
+    "hot_seat": "hot_seat_enabled",
+    "powerups": "powerups_enabled",
+    "wager": "wager_enabled",
+}
+
+
+def _coerce_category(raw: Any) -> dict[str, Any]:
+    """Resolve a pack selection to ``category`` / ``categories`` kwargs.
+
+    Accepts the three shapes every Quizify surface already uses: a list of
+    slugs (multi-pack), a single slug, or the ``"mixed"`` sentinel / empty value
+    meaning "all packs". Always returns BOTH keys so a narrower pick from a
+    later layer fully replaces a broader one instead of merging with it.
+    """
+    if isinstance(raw, (list, tuple)):
+        slugs = [str(s).strip() for s in raw if str(s).strip()]
+        if slugs:
+            return {"category": None, "categories": slugs}
+        return {"category": None, "categories": None}
+    value = str(raw or "").strip()
+    if not value or value == _MIXED:
+        return {"category": None, "categories": None}
+    return {"category": value, "categories": None}
+
+
+def _preset_to_start_settings(preset: dict[str, Any]) -> dict[str, Any]:
+    """Translate a saved preset record into ``start_game`` keywords (#744).
+
+    Presets are stored in the admin UI's vocabulary (``rounds``, ``timer``,
+    ``packs``, ``hot_seat``); this is the one place that knows the mapping.
+    Fields the preset does not carry are left out entirely so the layer below
+    keeps owning them.
+    """
+    settings: dict[str, Any] = {}
+    if "packs" in preset:
+        settings.update(_coerce_category(preset.get("packs")))
+    elif "category" in preset:
+        settings.update(_coerce_category(preset.get("category")))
+    for field, keyword in _PRESET_FIELD_MAP.items():
+        if preset.get(field) is None:
+            continue
+        value = preset[field]
+        if keyword == "difficulty":
+            settings["difficulty"] = (
+                None if str(value).strip() in ("", _MIXED) else str(value).strip()
+            )
+        elif keyword in ("num_rounds", "timer_duration"):
+            try:
+                settings[keyword] = int(value)
+            except (TypeError, ValueError):
+                continue
+        else:
+            settings[keyword] = bool(value)
+    return settings
+
+
+def _overrides_to_start_settings(overrides: dict[str, Any]) -> dict[str, Any]:
+    """Translate the explicit ``quizify.start_game`` fields into keywords.
+
+    The service schema has already coerced and range-checked the numbers, so
+    this only has to resolve the pack selection and the ``"mixed"`` difficulty
+    sentinel. Absent fields stay absent.
+    """
+    settings: dict[str, Any] = {}
+    if "category" in overrides:
+        settings.update(_coerce_category(overrides["category"]))
+    if "difficulty" in overrides:
+        raw = str(overrides["difficulty"] or "").strip()
+        settings["difficulty"] = None if raw in ("", _MIXED) else raw
+    for key in ("num_rounds", "language", "timer_duration"):
+        if overrides.get(key) is not None:
+            settings[key] = overrides[key]
+    return settings
+
+
 class QuizifyWebSocketHandler:
     """Handle WebSocket connections for Quizify."""
 
@@ -1422,12 +1530,9 @@ class QuizifyWebSocketHandler:
             # off ``new_streak`` in the answer_result above. A message with no
             # reader is worse than no message: it reads like a contract.
             if result.milestone_bonus:
-                # Speak it if TTS is configured. Cheap to look up; the
-                # announcer no-ops if no TTS entity is set.
-                self._notify_tts_milestone(player.name, result.milestone_streak)
-                # Fire the HA bus event so the host can automate on a streak
-                # (#366).
-                self._notify_house_milestone(
+                # ONE milestone from the dispatch point (#789); the fan-out to
+                # the announcer and the HA bus lives in _notify_milestone.
+                self._notify_milestone(
                     player.name, result.milestone_streak, result.milestone_bonus
                 )
             # NB: round-summary broadcast is fired exclusively by
@@ -2077,14 +2182,14 @@ class QuizifyWebSocketHandler:
         # the service path drive one implementation (#367).
         await self._after_start_game(
             game_state,
-            data.get("tts") or {},
+            data.get("tts"),
             house_config=data.get("house"),
         )
 
     async def _after_start_game(
         self,
         game_state: QuizifyGameState,
-        tts_config: dict,
+        tts_config: dict | None = None,
         house_config: dict | None = None,
     ) -> None:
         """Continue a just-started game: TTS + house config, grace, first question.
@@ -2098,24 +2203,24 @@ class QuizifyWebSocketHandler:
         # Apply per-game TTS narration settings (#281). The toggles ride the
         # start_game payload (like lightning_enabled), persisted in admin
         # localStorage — not config-entry options. No-op when no announcer is
-        # wired (standalone dev server, HA without a TTS entity). The service
-        # path passes an empty dict (no per-game overrides).
-        self._apply_tts_config(tts_config)
+        # wired (standalone dev server, HA without a TTS entity).
+        #
+        # An ABSENT block is SKIPPED, exactly like the house block below (#744).
+        # ``_apply_tts_config`` reads the master as ``bool(tts.get("enabled"))``,
+        # so feeding it ``{}`` turns narration OFF — which is what starting the
+        # game by voice or from the Lovelace card used to do: the host set the
+        # narrator up in the lobby over ``configure_tts``, said "Hey Nabu, start
+        # the quiz", and the quizmaster went silent for the whole game. Skipping
+        # leaves whatever the lobby-time push installed, which is the only
+        # non-destructive reading of "no per-game override".
+        if tts_config:
+            self._apply_tts_config(tts_config)
 
         # Apply the "House Plays Along" settings the same way (#494 Phase 4) —
         # the admin panel rides them on the start_game payload under ``house``,
-        # alongside ``tts``.
-        #
-        # Deliberately NOT symmetric with the TTS line above: an ABSENT block is
-        # skipped rather than applied as an empty dict. ``_apply_house_config``
-        # reads the master as ``bool(house.get("enabled"))`` (default off, like
-        # TTS), so feeding it ``{}`` would silently disarm lights/SFX/events that
-        # the host had switched on in the config-entry options. Two callers hit
-        # that case: ``admin_action_start_game`` (the HA-service path, which has
-        # no panel and passes nothing) and any admin client that omits the block.
-        # Skipping leaves whatever is already in force — the config-entry options
-        # plus whatever the lobby-time ``configure_house`` push installed — which
-        # is the only non-destructive reading of "no per-game override".
+        # alongside ``tts``. Same absent-means-leave-alone rule, for the same
+        # reason: ``{}`` would silently disarm lights/SFX/events that the host
+        # had switched on in the config-entry options.
         if house_config:
             self._apply_house_config(house_config)
 
@@ -2156,8 +2261,13 @@ class QuizifyWebSocketHandler:
         # Start the first question
         await self._start_next_question(game_state)
 
-    async def admin_action_start_game(self, game_state: QuizifyGameState) -> None:
-        """Start a game with default settings — HA-service entry point (#367).
+    async def admin_action_start_game(
+        self,
+        game_state: QuizifyGameState,
+        preset: dict[str, Any] | None = None,
+        overrides: dict[str, Any] | None = None,
+    ) -> None:
+        """Start a game from outside the socket — HA-service entry point (#367).
 
         Callable without an admin WebSocket connection so hosts can start the
         quiz via Assist voice, a Zigbee remote or a dashboard button. Only valid
@@ -2168,14 +2278,57 @@ class QuizifyWebSocketHandler:
         Raises ``ValueError`` (game already started / no questions) for the
         caller to translate; on success runs the same continuation as the admin
         path.
+
+        ``preset`` is a record from :class:`~server.preset_store.PresetStore`
+        and ``overrides`` the explicit service fields; both are optional and
+        both are resolved by :meth:`resolve_start_settings` on top of the host's
+        last-used settings (#744). It used to call the bare
+        ``game_state.start_game()`` and hand the host the factory game — mixed
+        packs, medium, 10 rounds, German — no matter what they had set up.
         """
         if game_state.phase != GamePhase.LOBBY:
             raise ValueError(ERR_GAME_ALREADY_STARTED)
-        # Default settings: mixed packs, default difficulty, 10 rounds, HA
-        # language default. start_game() re-raises ERR_GAME_ALREADY_STARTED /
+        settings = self.resolve_start_settings(game_state, preset, overrides)
+        # start_game() re-raises ERR_GAME_ALREADY_STARTED /
         # ERR_NO_QUESTIONS_REMAINING which the service surfaces to the host.
-        game_state.start_game()
-        await self._after_start_game(game_state, {})
+        game_state.start_game(**settings)
+        # No ``tts`` block: the narration config the host set up in the lobby
+        # over ``configure_tts`` is left exactly as it is (#744).
+        await self._after_start_game(game_state)
+
+    @staticmethod
+    def resolve_start_settings(
+        game_state: QuizifyGameState,
+        preset: dict[str, Any] | None = None,
+        overrides: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Resolve the ``start_game`` kwargs for a socket-less start (#744).
+
+        Four layers, each beating the one before it:
+
+        1. ``start_game``'s own defaults — nothing is passed for a field no
+           layer below mentions, so the game-state defaults keep owning them;
+        2. the host's **last-used settings** (``game_state.last_settings``, the
+           same snapshot the one-tap rematch replays). This is what makes "Hey
+           Nabu, start the quiz" replay the evening the host actually set up
+           rather than the factory one;
+        3. a **saved preset**, matched by name in the service layer;
+        4. the **explicit service fields**.
+
+        Kept static and pure so the layering can be unit-tested without a
+        handler, a socket or a Home Assistant instance.
+        """
+        settings: dict[str, Any] = dict(game_state.last_settings or {})
+        # A preset never carries a language: it is a shape-of-the-evening, and
+        # the language belongs to the room. Left to layer 2/4.
+        if preset:
+            settings.update(_preset_to_start_settings(preset))
+        if overrides:
+            settings.update(_overrides_to_start_settings(overrides))
+        # ``last_settings`` is written by start_game itself and can carry keys a
+        # future version adds; filter to what start_game actually accepts so a
+        # stale snapshot can never raise TypeError on the host's voice command.
+        return {k: v for k, v in settings.items() if k in _START_GAME_FIELDS}
 
     # ------------------------------------------------------------------
     # Admin: next question
@@ -3422,17 +3575,11 @@ class QuizifyWebSocketHandler:
             admin_msg, dashboard_message=strip_answer_for_dashboard(admin_msg)
         )
 
-        # Narrate the question text (+ options) at round start (#281). The
-        # canonical shuffled order matches the TV grid so spoken letters line
-        # up. Guarded like the milestone hook so a bad config can't break the
-        # question fan-out.
-        self._notify_tts_question(
+        # ONE question milestone from the dispatch point (#789): narration
+        # (#281, with the canonical shuffled order so spoken letters match the
+        # TV grid) plus the HA bus event (#366) fan out inside _notify_question.
+        self._notify_question(
             question, game_state.round, game_state.total_rounds, shuffled_texts
-        )
-        # Fire the HA bus event (round + type only; no text/answers) so the host
-        # can automate on each question start (#366).
-        self._notify_house_question(
-            question, game_state.round, game_state.total_rounds
         )
 
         # Cache players to avoid redundant calls
@@ -3522,11 +3669,11 @@ class QuizifyWebSocketHandler:
                     # out via the broadcast string path (admin-as-player already
                     # excluded there) instead of a per-socket send_json (#413/#258).
                     min_remaining = tick.dashboard_remaining
-                    # Spoken "time running out" warning (#281), once per round.
-                    self._notify_tts_countdown(min_remaining)
-                    # House "time running out" bus event (#280), once per round —
-                    # drives the faster countdown light pulse.
-                    self._notify_house_time_running_out(min_remaining)
+                    # ONE countdown milestone per tick (#789): the spoken
+                    # warning (#281) and the bus event that drives the faster
+                    # light pulse (#280) fan out inside _notify_countdown, each
+                    # with its own once-per-round guard.
+                    self._notify_countdown(min_remaining)
                     dash_shown = math.ceil(max(0.0, min_remaining))
                     if dash_shown != last_dashboard_shown:
                         last_dashboard_shown = dash_shown
@@ -4211,6 +4358,61 @@ class QuizifyWebSocketHandler:
         game_state.language = language
         await self._broadcast_state_projected(game_state)
 
+    # ------------------------------------------------------------------
+    # Milestone fan-out (#789)
+    # ------------------------------------------------------------------
+    #
+    # Four game moments — question shown, countdown, reveal, streak milestone —
+    # are interesting to BOTH the narrator and the HA event bus. Each dispatch
+    # point used to carry a twin call, one to a ``_notify_tts_*`` hook and one to
+    # its ``_notify_house_*`` sibling, so adding a consumer meant editing every
+    # site. The dispatch points now fire ONE milestone and the fan-out lives
+    # here, in the four methods below.
+    #
+    # The narrator is deliberately NOT wired up as a subscriber of
+    # ``QuizifyEventEmitter``, which is the shape the lights and the SFX use.
+    # The emitter's fires are gated on the house master (``CONF_HOUSE_EVENTS_
+    # ENABLED``, off out of the box), while narration has its own independent
+    # master in the TTS panel — routing speech through the bus would silence the
+    # quizmaster on every install that has narration on and house events off.
+
+    def _notify_milestone(self, player_name: str, streak: int, bonus: int) -> None:
+        """Announce a streak milestone and put it on the HA bus (#789)."""
+        self._notify_tts_milestone(player_name, streak)
+        self._notify_house_milestone(player_name, streak, bonus)
+
+    def _notify_question(
+        self,
+        question: Any,
+        round_no: int,
+        total_rounds: int,
+        options: list[str] | None = None,
+    ) -> None:
+        """Announce a question start and put it on the HA bus (#789).
+
+        The announcer gets the shuffled option texts (so spoken letters match
+        the TV grid); the bus event deliberately gets only the round and the
+        question type, never the text or answers, which would leak the question
+        to automations before the players see it.
+        """
+        self._notify_tts_question(question, round_no, total_rounds, options)
+        self._notify_house_question(question, round_no, total_rounds)
+
+    def _notify_countdown(self, seconds_remaining: float) -> None:
+        """Push the per-tick remaining time to both consumers (#789).
+
+        Called every timer tick. Each side keeps its own once-per-round guard
+        and its own threshold — the spoken warning at 10s, the light pulse at
+        5s — so this stays a plain fan-out.
+        """
+        self._notify_tts_countdown(seconds_remaining)
+        self._notify_house_time_running_out(seconds_remaining)
+
+    def _notify_reveal(self, game_state: QuizifyGameState) -> None:
+        """Announce the reveal and put it on the HA bus (#789)."""
+        self._notify_tts_reveal(game_state)
+        self._notify_house_reveal(game_state)
+
     def _notify_tts_milestone(self, player_name: str, streak: int) -> None:
         """Forward a milestone hit to the TTS announcer if one is wired.
 
@@ -4454,12 +4656,11 @@ class QuizifyWebSocketHandler:
         game_state = self._get_game_state()
         if game_state:
             await self._broadcast_round_summary(game_state)
-            # Narrate the reveal (correct answer + who got it + standings) as
-            # a single combined utterance (#281), after the summary broadcast.
-            self._notify_tts_reveal(game_state)
-            # Fire the HA bus event with the correct answer + how many got it
-            # (#366), off the same round summary.
-            self._notify_house_reveal(game_state)
+            # ONE reveal milestone (#789), after the summary broadcast: the
+            # combined spoken utterance (#281) and the bus event carrying the
+            # correct answer + how many got it (#366) fan out inside
+            # _notify_reveal, both off the same round summary.
+            self._notify_reveal(game_state)
 
     async def _dispatch_game_ended(self) -> None:
         """Handler for the ``game_ended`` state event."""

--- a/custom_components/quizify/services.py
+++ b/custom_components/quizify/services.py
@@ -1,0 +1,213 @@
+"""Quizify's Home Assistant services (#367, #743, #744, #789).
+
+A safe subset of the admin game controls, exposed as HA services so hosts can
+drive the game from Assist voice ("Hey Nabu, start the quiz"), a Zigbee remote,
+a dashboard button or an automation — instead of only the admin WebSocket UI.
+Each delegates to the SAME socket-independent core the admin WS handler uses
+(the ``admin_action_*`` methods), so there is one implementation and the
+broadcast that refreshes entities + connected clients always fires.
+
+These handlers used to be seven nested closures inside ``async_setup_entry``
+(#789). They close over nothing but ``hass``, which is what let them move out
+whole; the entry-scoped state they need is looked up per call, which is also
+what makes the "Quizify is not set up" guard below possible at all.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import config_validation as cv
+
+from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant, ServiceCall
+
+    from .game.state import QuizifyGameState
+    from .server.websocket import QuizifyWebSocketHandler
+
+_LOGGER = logging.getLogger(__name__)
+
+#: Everything ``quizify.start_game`` accepts (#744). Every field is optional —
+#: the service with no data at all still starts a game, it just starts the one
+#: the host last configured instead of a hard-coded default one.
+START_GAME_SCHEMA = vol.Schema(
+    {
+        vol.Optional("preset"): cv.string,
+        # A single pack slug, a list of them, or the literal "mixed" to clear
+        # the pack selection. The admin UI sends exactly these three shapes.
+        vol.Optional("category"): vol.Any(cv.string, [cv.string]),
+        vol.Optional("difficulty"): cv.string,
+        vol.Optional("num_rounds"): vol.All(vol.Coerce(int), vol.Range(min=1, max=50)),
+        vol.Optional("language"): cv.string,
+        vol.Optional("timer_duration"): vol.All(
+            vol.Coerce(int), vol.Range(min=5, max=300)
+        ),
+    }
+)
+
+
+def _require_runtime(
+    hass: HomeAssistant,
+) -> tuple[QuizifyWebSocketHandler, QuizifyGameState]:
+    """Return (ws_handler, game_state) or raise if setup isn't complete.
+
+    Guards against a raw ``KeyError`` when a service fires before/without a
+    loaded config entry (e.g. during teardown): the host sees a clear message
+    in the HA UI / voice response instead of an opaque crash.
+    """
+    domain_data = hass.data.get(DOMAIN)
+    if not domain_data:
+        raise ServiceValidationError(
+            "Quizify is not set up. Add the Quizify integration first."
+        )
+    handler = domain_data.get("ws_handler")
+    game = domain_data.get("game")
+    if handler is None or game is None:
+        raise ServiceValidationError("Quizify is not ready yet. Try again in a moment.")
+    return handler, game
+
+
+async def _resolve_preset(hass: HomeAssistant, name: str) -> dict[str, Any]:
+    """Look a saved preset up by name (case-insensitive) — #744.
+
+    Saved presets (:mod:`server.preset_store`) were reachable only from the
+    admin UI, so "start my Friday setup" by voice was impossible. Matching is on
+    the host-visible NAME rather than the generated id, because the name is the
+    only part of a preset a voice sentence or a dashboard button can carry.
+
+    Raises :class:`ServiceValidationError` naming the presets that do exist, so
+    a typo is self-correcting instead of silently starting the wrong game.
+    """
+    from .server.views import get_preset_store  # noqa: PLC0415
+
+    presets = await get_preset_store(hass.http.app).list()
+    wanted = name.strip().casefold()
+    for preset in presets:
+        if str(preset.get("name", "")).strip().casefold() == wanted:
+            return preset
+    known = ", ".join(str(p.get("name", "")) for p in presets) or "none saved yet"
+    raise ServiceValidationError(
+        f"No saved Quizify preset called {name!r}. Available presets: {known}."
+    )
+
+
+def async_register_services(hass: HomeAssistant) -> None:
+    """Register every ``quizify.*`` service on ``hass``.
+
+    Called from ``async_setup_entry``. ``hass.services.async_register`` is
+    idempotent per (domain, service) name, so a second config entry — or a
+    reload — simply re-points the same names at equivalent handlers.
+    """
+    from .game.state import GamePhase  # noqa: PLC0415
+
+    async def reset_admin_session(call: ServiceCall) -> None:  # noqa: ARG001
+        domain_data = hass.data.get(DOMAIN)
+        if domain_data:
+            handler = domain_data.get("ws_handler")
+            if handler:
+                await handler.conn.async_clear_admin_token()
+                _LOGGER.warning(
+                    "Quizify admin session token RESET via HA service. "
+                    "Next admin connection will bootstrap a fresh token."
+                )
+
+    async def start_game_service(call: ServiceCall) -> None:
+        """Start a game honouring the host's settings (#744).
+
+        Before this, the service and the Lovelace card both landed on a bare
+        ``game_state.start_game()`` — mixed packs, medium, 10 rounds, German —
+        and muted the narrator on the way. Now an optional saved ``preset`` and
+        the five explicit fields ride the call, and anything still unspecified
+        falls back to the settings of the host's last game rather than to the
+        factory defaults.
+        """
+        handler, game = _require_runtime(hass)
+        overrides = dict(call.data)
+        preset_name = str(overrides.pop("preset", "") or "").strip()
+        preset = await _resolve_preset(hass, preset_name) if preset_name else None
+        try:
+            await handler.admin_action_start_game(
+                game, preset=preset, overrides=overrides
+            )
+        except ValueError as err:
+            raise ServiceValidationError(
+                "Cannot start a new quiz right now — a game is already in "
+                "progress. End it first, then start a new one."
+            ) from err
+
+    async def next_round_service(call: ServiceCall) -> None:  # noqa: ARG001
+        handler, game = _require_runtime(hass)
+        try:
+            await handler.admin_action_next_round(game)
+        except ValueError as err:
+            raise ServiceValidationError(
+                "Cannot advance to the next question right now. Start a game "
+                "first, or wait until the current question has been revealed."
+            ) from err
+
+    async def pause_service(call: ServiceCall) -> None:  # noqa: ARG001
+        handler, game = _require_runtime(hass)
+        if not await handler.admin_action_pause(game):
+            raise ServiceValidationError(
+                "There is no active question to pause right now."
+            )
+
+    async def resume_service(call: ServiceCall) -> None:  # noqa: ARG001
+        handler, game = _require_runtime(hass)
+        if not await handler.admin_action_resume(game):
+            raise ServiceValidationError(
+                "The game is not paused, so there is nothing to resume."
+            )
+
+    async def end_game_service(call: ServiceCall) -> None:  # noqa: ARG001
+        handler, game = _require_runtime(hass)
+        if game.phase == GamePhase.LOBBY:
+            raise ServiceValidationError(
+                "No game is currently running, so there is nothing to end."
+            )
+        await handler.admin_action_end_game(game)
+
+    async def reload_packs_service(call: ServiceCall) -> None:  # noqa: ARG001
+        """Re-read the question packs from disk (#743).
+
+        The host-owned drop-in folder is ``<config>/quizify/packs``; a pack
+        added there used to need a full Home Assistant restart, because
+        ``reload_categories`` had no caller and no service. Reloading is
+        refused outside the lobby: the running game's queue was built from the
+        packs as they were, and swapping the bank underneath it would leave
+        the round the players are answering pointing at questions that are no
+        longer loaded.
+        """
+        _handler, game = _require_runtime(hass)
+        if game.phase != GamePhase.LOBBY:
+            raise ServiceValidationError(
+                "Packs can only be reloaded from the lobby. End the running "
+                "game first, then reload."
+            )
+        # Blocking disk I/O (glob + JSON parse of every pack) — off the loop.
+        # ``HARuntime.run_in_executor`` is exactly this call, so going straight
+        # to hass keeps the handler free of an entry-scoped dependency it would
+        # otherwise have to look up and guard.
+        categories = await hass.async_add_executor_job(
+            game.question_bank.reload_categories
+        )
+        _LOGGER.info(
+            "Quizify packs reloaded via service: %d packs available",
+            len(categories),
+        )
+
+    hass.services.async_register(DOMAIN, "reset_admin_session", reset_admin_session)
+    hass.services.async_register(
+        DOMAIN, "start_game", start_game_service, schema=START_GAME_SCHEMA
+    )
+    hass.services.async_register(DOMAIN, "next_round", next_round_service)
+    hass.services.async_register(DOMAIN, "pause", pause_service)
+    hass.services.async_register(DOMAIN, "resume", resume_service)
+    hass.services.async_register(DOMAIN, "end_game", end_game_service)
+    hass.services.async_register(DOMAIN, "reload_packs", reload_packs_service)
+    _LOGGER.debug("Quizify services registered (#367 / #743 / #744)")

--- a/custom_components/quizify/services.yaml
+++ b/custom_components/quizify/services.yaml
@@ -10,12 +10,79 @@ reset_admin_session:
 start_game:
   name: Start game
   description: >-
-    Start a new Quizify game with the default settings (mixed packs, default
-    difficulty, 10 rounds). Wire it to an Assist sentence ("Hey Nabu, start the
-    quiz"), a Zigbee remote button or a dashboard button so the host can kick
-    off the game without reaching for the admin panel. Only works from the
-    lobby — it will not interrupt a game already in progress.
-  fields: {}
+    Start a new Quizify game. Wire it to an Assist sentence ("Hey Nabu, start
+    the quiz"), a Zigbee remote button or a dashboard button so the host can
+    kick off the game without reaching for the admin panel. With no fields set
+    it repeats the settings of your last game; name a saved preset, or set the
+    individual fields, to start a different one. Only works from the lobby —
+    it will not interrupt a game already in progress.
+  fields:
+    preset:
+      name: Preset
+      description: >-
+        The name of a preset saved in the Quizify setup screen. Its packs,
+        difficulty, rounds, timer and game-mode toggles are applied; the fields
+        below still win over it.
+      required: false
+      example: Friday night
+      selector:
+        text:
+    category:
+      name: Packs
+      description: >-
+        One question pack, a list of them, or "mixed" for all packs.
+      required: false
+      example: geography
+      selector:
+        text:
+          multiple: true
+    difficulty:
+      name: Difficulty
+      description: >-
+        Fixed difficulty for the whole game, or "auto" to let Quizify calibrate
+        it to the group. Leave empty to keep your last setting.
+      required: false
+      selector:
+        select:
+          options:
+            - easy
+            - medium
+            - hard
+            - auto
+            - mixed
+          custom_value: true
+    num_rounds:
+      name: Rounds
+      description: How many questions the game runs for.
+      required: false
+      example: 15
+      selector:
+        number:
+          min: 1
+          max: 50
+          mode: box
+    language:
+      name: Language
+      description: >-
+        Language code for the questions and the player screens, e.g. "de",
+        "en" or "es".
+      required: false
+      example: de
+      selector:
+        text:
+    timer_duration:
+      name: Timer
+      description: >-
+        Seconds each question stays open. Leave empty for the difficulty's
+        default.
+      required: false
+      example: 30
+      selector:
+        number:
+          min: 5
+          max: 300
+          unit_of_measurement: seconds
+          mode: box
 
 next_round:
   name: Next question

--- a/custom_components/quizify/sound_effects.py
+++ b/custom_components/quizify/sound_effects.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 import contextlib
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from .game_events import (
     EVENT_ANSWER_REVEALED,
@@ -44,6 +44,7 @@ from .game_events import (
     EVENT_WINNER_DECIDED,
 )
 from .ha_service import fire_and_forget_service
+from .house_settings import CUE_KEYS, HouseSettings
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -63,8 +64,10 @@ WWW_DIR = Path(__file__).parent / "www"
 STATIC_URL_PREFIX = "/quizify/static"
 
 # The four cue keys. Each maps to an optional override URL (from the options
-# flow) and a bundled default at ``www/sfx/<cue>.mp3``.
-_CUE_KEYS = ("correct", "wrong", "streak", "winner")
+# flow) and a bundled default at ``www/sfx/<cue>.mp3``. The list now lives with
+# the config-entry defaults that carry the override URLs (:mod:`house_settings`);
+# this alias keeps the established module-local name.
+_CUE_KEYS = CUE_KEYS
 
 # Best-effort HA base-URL helper. Imported lazily/guarded so the module still
 # imports on the standalone dev server (no ``homeassistant`` package) and so
@@ -82,19 +85,35 @@ class QuizifySoundEffects:
     def __init__(
         self,
         hass: HomeAssistant | None,
-        media_player_entity_id: str | None,
         game_state: QuizifyGameState,
-        cue_urls: dict[str, str | None],
+        media_player_entity_id: str | None = None,
+        cue_urls: dict[str, str | None] | None = None,
         enabled: bool = True,
+        settings: HouseSettings | None = None,
     ) -> None:
+        """Build the room-SFX player.
+
+        ``settings`` is the shared :class:`HouseSettings` (#789): the speaker,
+        the per-cue override URLs and the house master are read through it, so
+        an options reload updates them in place rather than rebuilding this
+        object. ``media_player_entity_id`` / ``cue_urls`` / ``enabled`` are the
+        standalone form used by the dev server and the unit tests; they seed a
+        private settings object that behaves identically.
+        """
         self._hass = hass
-        self._media_player_entity_id = (media_player_entity_id or "").strip() or None
+        # Config-entry values (the shared speaker, the four per-cue override
+        # URLs, the CONF_HOUSE_EVENTS_ENABLED master) are read lazily off this.
+        # Per-cue URLs are normalized there: blank/whitespace => None (no
+        # override); unknown keys are ignored and missing keys default to None.
+        self._settings = settings or HouseSettings(
+            house_enabled=bool(enabled),
+            media_player=(media_player_entity_id or "").strip() or None,
+            cue_urls={
+                cue: ((cue_urls or {}).get(cue) or "").strip() or None
+                for cue in _CUE_KEYS
+            },
+        )
         self._game = game_state
-        # Per-cue override URLs. Normalized: blank/whitespace => None (no
-        # override). Unknown keys are ignored; missing keys default to None.
-        self._cue_urls: dict[str, str | None] = {
-            cue: ((cue_urls.get(cue) or "").strip() or None) for cue in _CUE_KEYS
-        }
         # Resolved bundled-default URLs, computed ONCE at attach_events() time so
         # we never stat the disk on the event hot path (#475). Cue key -> URL for
         # every cue whose default file exists AND for which we could build a base
@@ -103,22 +122,12 @@ class QuizifySoundEffects:
         self._event_unsubs: list[Callable[[], None]] = []
 
         # --- "House Plays Along" runtime config (#494 Phase 4) ---------------
-        # Master switch in two layers:
+        # The master switch lives on the shared settings object in two layers
+        # (the config-entry value plus the admin panel's tri-state override), so
+        # a host toggling CONF_HOUSE_EVENTS_ENABLED in the options UI on a
+        # never-panelled install takes effect immediately, while a panel-set
+        # master survives an unrelated options change (#411).
         #
-        # * ``_enabled`` — the config-entry value (CONF_HOUSE_EVENTS_ENABLED).
-        #   The constructor default is True because the sole production caller
-        #   (__init__) always passes the resolved option explicitly; the product
-        #   "off by default" lives at the config layer, not here — the same
-        #   posture QuizifyEventEmitter takes.
-        # * ``_enabled_override`` — the admin panel's runtime master. ``None``
-        #   means "the panel never touched it", so the config entry still wins.
-        #
-        # Two layers rather than one so BOTH survive an options reload: the
-        # panel's master is preserved across an unrelated options change (#411),
-        # while a host toggling CONF_HOUSE_EVENTS_ENABLED in the options UI on a
-        # never-panelled install still takes effect immediately.
-        self._enabled: bool = bool(enabled)
-        self._enabled_override: bool | None = None
         # Per-cue toggles, all default ON so flipping the master on gives the
         # full soundtrack out of the box (the TTS posture, #281).
         self._cue_enabled: dict[str, bool] = dict.fromkeys(_CUE_KEYS, True)
@@ -150,7 +159,9 @@ class QuizifySoundEffects:
         the first time (no speaker in the options flow, one picked in the panel)
         still gets its cue listeners — and its one-time bundled-default stat.
         """
-        self._enabled_override = bool(enabled)
+        # The master is the one panel value shared with the party lights and the
+        # event emitter, so it is written to the shared settings (#789).
+        self._settings.enabled_override = bool(enabled)
         self._cue_enabled = {
             "correct": bool(sfx_correct),
             "wrong": bool(sfx_wrong),
@@ -161,53 +172,36 @@ class QuizifySoundEffects:
         # Idempotent; a no-op when already attached or still unconfigured.
         self.attach_events()
 
-    def export_runtime_config(self) -> dict[str, Any]:
-        """Snapshot the mutable per-game house-SFX config (#411 pattern).
+    # There is deliberately no export/restore_runtime_config pair any more
+    # (#789): it existed only so the panel's toggles could survive the rebuild
+    # an options reload used to perform. The settings object is now updated in
+    # place, this instance outlives the reload, and the overrides below survive
+    # simply by not being touched.
 
-        An options reload rebuilds this instance from the config entry, which
-        would reset every cue toggle back to its default and drop the admin's
-        speaker override — silently wiping the panel's settings mid-game until
-        the next ``start_game``. ``__init__._update_listener`` snapshots the live
-        config here and restores it onto the fresh instance via
-        :meth:`restore_runtime_config`, exactly as it already does for the TTS
-        announcer (#411).
-        """
-        return {
-            "enabled_override": self._enabled_override,
-            "sfx_correct": self._cue_enabled["correct"],
-            "sfx_wrong": self._cue_enabled["wrong"],
-            "sfx_streak": self._cue_enabled["streak"],
-            "sfx_winner": self._cue_enabled["winner"],
-            "media_player_override": self._media_player_override,
-        }
+    @property
+    def _enabled(self) -> bool:
+        """The config-entry master (CONF_HOUSE_EVENTS_ENABLED), read live."""
+        return self._settings.house_enabled
 
-    def restore_runtime_config(self, snapshot: dict[str, Any] | None) -> None:
-        """Restore a snapshot from :meth:`export_runtime_config` (#411 pattern).
+    @property
+    def _enabled_override(self) -> bool | None:
+        """The panel's tri-state master; ``None`` = the panel never set one."""
+        return self._settings.enabled_override
 
-        Defensive: a falsy/empty snapshot is a no-op, and each field falls back
-        to the current value when absent, so a partial snapshot never clobbers
-        an unrelated default. ``enabled_override`` is tri-state
-        (True/False/None) so it is NOT coerced through ``bool()`` — that would
-        turn "the panel never set a master" into a hard False.
-        """
-        if not snapshot:
-            return
-        override = snapshot.get("enabled_override", self._enabled_override)
-        self._enabled_override = None if override is None else bool(override)
-        self._cue_enabled = {
-            cue: bool(snapshot.get(f"sfx_{cue}", self._cue_enabled[cue]))
-            for cue in _CUE_KEYS
-        }
-        self._media_player_override = (
-            snapshot.get("media_player_override", self._media_player_override) or None
-        )
+    @property
+    def _media_player_entity_id(self) -> str | None:
+        """The config-entry speaker, read live off the settings."""
+        return self._settings.media_player
+
+    @property
+    def _cue_urls(self) -> dict[str, str | None]:
+        """The four config-entry per-cue override URLs, read live."""
+        return self._settings.cue_urls
 
     @property
     def _master_enabled(self) -> bool:
         """The effective master: panel override if set, else the config entry."""
-        if self._enabled_override is None:
-            return self._enabled
-        return self._enabled_override
+        return self._settings.master_enabled
 
     @property
     def _active_media_player(self) -> str | None:
@@ -243,6 +237,18 @@ class QuizifySoundEffects:
             hass.bus.async_listen(EVENT_STREAK_MILESTONE, self._on_streak_milestone),
             hass.bus.async_listen(EVENT_WINNER_DECIDED, self._on_winner_decided),
         ]
+
+    def refresh_from_settings(self) -> None:
+        """Re-sync after the config entry's options changed (#789).
+
+        The old reload path rebuilt this object, which re-stat'd the bundled
+        defaults and re-ran ``attach_events()``. Both are reproduced here so a
+        host who just configured their first speaker gets the cue listeners
+        armed, and both are idempotent.
+        """
+        if self._event_unsubs:
+            self._resolve_default_urls()
+        self.attach_events()
 
     def detach(self) -> None:
         """Drop the bus listeners. Suppresses unsub errors (reload/unload safe)."""

--- a/custom_components/quizify/tts.py
+++ b/custom_components/quizify/tts.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any
 from .game import tts_phrases
 from .game.state import GamePhase, QuizifyGameState
 from .ha_service import fire_and_forget_service
+from .house_settings import HouseSettings
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -67,13 +68,24 @@ class QuizifyTTSAnnouncer:
     def __init__(
         self,
         hass: HomeAssistant | None,
-        tts_entity_id: str | None,
-        media_player_entity_id: str | None,
         game_state: QuizifyGameState,
+        tts_entity_id: str | None = None,
+        media_player_entity_id: str | None = None,
+        settings: HouseSettings | None = None,
     ) -> None:
+        """Build the announcer.
+
+        ``settings`` is the shared :class:`HouseSettings` (#789): the config-entry
+        TTS engine and speaker are read through it, so an options reload updates
+        them in place rather than rebuilding this object and resetting the live
+        narration config (which is exactly what #411 was). The two explicit id
+        arguments are the standalone form used by the dev server and the unit
+        tests; they seed a private settings object that behaves identically.
+        """
         self._hass = hass
-        self._tts_entity_id = tts_entity_id
-        self._media_player_entity_id = media_player_entity_id
+        self._settings = settings or HouseSettings(
+            tts_entity=tts_entity_id, media_player=media_player_entity_id
+        )
         self._game = game_state
         # None means "never spoken yet" so the first call always passes
         # the throttle. (Initializing to 0.0 would block when
@@ -156,67 +168,22 @@ class QuizifyTTSAnnouncer:
         self._media_player_override = (media_player or "").strip() or None
         self._previous_leader = None
 
-    def export_runtime_config(self) -> dict[str, Any]:
-        """Snapshot the mutable per-game narration config (#411).
+    # There is deliberately no export/restore_runtime_config pair any more
+    # (#789). It existed only because an options reload rebuilt this announcer
+    # from the config entry, resetting ``_enabled`` back to ``False`` and
+    # dropping the per-game entity overrides — the #411 bug. The reload now
+    # refreshes the shared :class:`HouseSettings` in place and leaves this
+    # instance (and everything ``configure`` set on it) alone.
 
-        An options reload rebuilds this announcer from the config entry, which
-        would otherwise reset ``_enabled`` back to ``False`` and drop the admin's
-        per-game entity overrides — silently killing narration mid-game until the
-        next ``start_game``. The listener snapshots the live config here and
-        restores it onto the fresh instance via :meth:`restore_runtime_config`.
-        """
-        return {
-            "enabled": self._enabled,
-            "announce_question": self._announce_question,
-            "announce_options": self._announce_options,
-            "announce_reveal": self._announce_reveal,
-            "announce_standings": self._announce_standings,
-            "announce_join": self._announce_join,
-            "announce_countdown": self._announce_countdown,
-            "announce_milestone": self._announce_milestone,
-            "tts_entity_override": self._tts_entity_override,
-            "media_player_override": self._media_player_override,
-        }
+    @property
+    def _tts_entity_id(self) -> str | None:
+        """The config-entry TTS engine, read live off the settings."""
+        return self._settings.tts_entity
 
-    def restore_runtime_config(self, snapshot: dict[str, Any] | None) -> None:
-        """Restore a config snapshot from :meth:`export_runtime_config` (#411).
-
-        Defensive: a falsy/empty snapshot is a no-op, and each field falls back
-        to the current value when absent, so a partial snapshot never clobbers
-        an unrelated default.
-        """
-        if not snapshot:
-            return
-        self._enabled = bool(snapshot.get("enabled", self._enabled))
-        self._announce_question = bool(
-            snapshot.get("announce_question", self._announce_question)
-        )
-        self._announce_options = bool(
-            snapshot.get("announce_options", self._announce_options)
-        )
-        self._announce_reveal = bool(
-            snapshot.get("announce_reveal", self._announce_reveal)
-        )
-        self._announce_standings = bool(
-            snapshot.get("announce_standings", self._announce_standings)
-        )
-        self._announce_join = bool(
-            snapshot.get("announce_join", self._announce_join)
-        )
-        self._announce_countdown = bool(
-            snapshot.get("announce_countdown", self._announce_countdown)
-        )
-        self._announce_milestone = bool(
-            snapshot.get("announce_milestone", self._announce_milestone)
-        )
-        self._tts_entity_override = (
-            snapshot.get("tts_entity_override", self._tts_entity_override)
-            or None
-        )
-        self._media_player_override = (
-            snapshot.get("media_player_override", self._media_player_override)
-            or None
-        )
+    @property
+    def _media_player_entity_id(self) -> str | None:
+        """The config-entry speaker, read live off the settings."""
+        return self._settings.media_player
 
     @property
     def _active_tts_entity(self) -> str | None:

--- a/custom_components/quizify/www/cards/quizify-host-card.js
+++ b/custom_components/quizify/www/cards/quizify-host-card.js
@@ -190,8 +190,11 @@
         }
 
         set hass(hass) {
-            // Only the display language is taken from hass; the game state comes
-            // from Quizify's own socket, which is the authority on the game.
+            // The game state comes from Quizify's own socket, which is the
+            // authority on the game. hass is kept for exactly two things: the
+            // display language, and calling the quizify.start_game SERVICE
+            // (#744) — see _startGame.
+            this._hass = hass;
             var lang = (hass && (hass.language || (hass.locale && hass.locale.language))) || 'en';
             lang = String(lang).slice(0, 2);
             if (LABELS[lang] && lang !== this._lang) {
@@ -293,6 +296,30 @@
             var payload = data || {};
             payload.type = type;
             this._ws.send(JSON.stringify(payload));
+        }
+
+        /*
+         * Starting goes through the quizify.start_game SERVICE, not the socket
+         * (#744).
+         *
+         * The card has no setup screen, so its start_game frame carried no
+         * settings at all — and the admin path reads an absent field and an
+         * explicit null the same way, so the server could only answer it with
+         * the factory game: mixed packs, medium, 10 rounds, German, narrator
+         * off. The service is the surface that knows what "no settings given"
+         * means: it replays the host's last game. Falls back to the socket when
+         * hass is not available (the card can be rendered outside a Lovelace
+         * view), so the button is never dead.
+         */
+        _startGame() {
+            var hass = this._hass;
+            if (hass && typeof hass.callService === 'function') {
+                try {
+                    hass.callService('quizify', 'start_game', {});
+                    return;
+                } catch (e) { /* fall through to the socket */ }
+            }
+            this._send('start_game');
         }
 
         // ---- Rendering ---------------------------------------------------
@@ -397,17 +424,24 @@
             if (expanded) this._drawQr(joinUrl);
         }
 
+        // One place decides socket vs service, so every button reaches start_game
+        // the same way no matter which control fired it (#744).
+        _dispatch(msg) {
+            if (msg === 'start_game') { this._startGame(); return; }
+            this._send(msg);
+        }
+
         _bind(primary) {
             var self = this;
             var t = this._t;
             var btn = this.shadowRoot.getElementById('primary');
             if (btn && primary.msg) {
-                btn.addEventListener('click', function () { self._send(primary.msg); });
+                btn.addEventListener('click', function () { self._dispatch(primary.msg); });
             }
             var others = this.shadowRoot.querySelectorAll('[data-msg]');
             for (var i = 0; i < others.length; i++) {
                 (function (el) {
-                    el.addEventListener('click', function () { self._send(el.dataset.msg); });
+                    el.addEventListener('click', function () { self._dispatch(el.dataset.msg); });
                 })(others[i]);
             }
             var reset = this.shadowRoot.querySelector('[data-reset]');

--- a/tests/test_game_events.py
+++ b/tests/test_game_events.py
@@ -37,6 +37,7 @@ from custom_components.quizify.game_events import (  # noqa: E402
     EVENT_WINNER_DECIDED,
     QuizifyEventEmitter,
 )
+from custom_components.quizify.house_settings import HouseSettings  # noqa: E402
 
 
 class _FakeBus:
@@ -401,38 +402,55 @@ def test_attach_detach_registers_callback():
     assert t._on_state_changed not in game.callbacks
 
 
-def test_runtime_state_snapshot_roundtrip():
+def test_options_reload_does_not_re_fire_game_started():
+    """An options reload must not replay ``quizify_game_started`` (#411/#789).
+
+    The emitter used to be rebuilt from the config entry on every options
+    change, which reset ``_last_phase`` — so a reload landing exactly on the
+    first active round could fire the start event a second time. It carried an
+    ``export/restore_runtime_state`` pair purely to close that gap. The emitter
+    now survives the reload (only the settings it reads are refreshed), so the
+    phase tracking is simply never lost.
+    """
+    hass = _FakeHass()
     game = _FakeGame()
-    t = _emitter(_FakeHass(), game)
+    settings = HouseSettings(house_enabled=True)
+    t = QuizifyEventEmitter(hass=hass, game_state=game, settings=settings)
     game.round = 1
     game.phase = GamePhase.QUESTION_ACTIVE
     t._on_state_changed()  # sets _last_phase, fires game_started
-    snap = t.export_runtime_state()
-    # ``enabled_override`` rides along since #494 P4 (the admin panel's runtime
-    # master). None here — this emitter was never configure()d by the panel, so
-    # the rebuilt instance still follows CONF_HOUSE_EVENTS_ENABLED.
-    assert snap == {"last_phase": "QUESTION_ACTIVE", "enabled_override": None}
+    assert [e for e, _ in hass.bus.fired] == ["quizify_game_started"]
 
-    # A fresh emitter (options reload) that restores the snapshot must NOT
-    # re-fire game_started when it sees the same active round again.
-    hass2 = _FakeHass()
-    game2 = _FakeGame()
-    game2.round = 1
-    game2.phase = GamePhase.QUESTION_ACTIVE
-    t2 = QuizifyEventEmitter(hass=hass2, game_state=game2)
-    t2.restore_runtime_state(snap)
-    t2._on_state_changed()
-    assert hass2.bus.fired == []
+    # The options reload: the shared settings are updated in place.
+    hass.bus.fired.clear()
+    settings.update_from_options({"house_events_enabled": True})
+
+    t._on_state_changed()
+    assert hass.bus.fired == []
 
 
-def test_restore_ignores_empty_and_bad_snapshot():
-    t = _emitter(_FakeHass(), _FakeGame())
-    t.restore_runtime_state(None)
-    assert t._last_phase is None
-    t.restore_runtime_state({})
-    assert t._last_phase is None
-    t.restore_runtime_state({"last_phase": "NOT_A_PHASE"})
-    assert t._last_phase is None
+def test_options_reload_keeps_the_panel_master():
+    """A panel master set mid-game outlives an options change, and an untouched
+    one leaves the config-entry switch in charge (#494 P4 / #789)."""
+    settings = HouseSettings(house_enabled=False)
+    t = QuizifyEventEmitter(
+        hass=_FakeHass(), game_state=_FakeGame(), settings=settings
+    )
+    assert t._master_enabled is False
+
+    t.configure(enabled=True)  # the panel turns the house on mid-game
+    settings.update_from_options({})  # an unrelated options change
+    assert t._master_enabled is True
+    assert t._enabled_override is True
+
+    # A never-panelled emitter follows the options switch immediately.
+    fresh_settings = HouseSettings(house_enabled=False)
+    fresh = QuizifyEventEmitter(
+        hass=_FakeHass(), game_state=_FakeGame(), settings=fresh_settings
+    )
+    assert fresh._enabled_override is None
+    fresh_settings.update_from_options({"house_events_enabled": True})
+    assert fresh._master_enabled is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_house_reload_494.py
+++ b/tests/test_house_reload_494.py
@@ -192,12 +192,14 @@ async def test_reload_preserves_house_panel_config(http_hass: HomeAssistant) -> 
     new_sfx = hass.data[DOMAIN]["sound_effects"]
     new_ev = hass.data[DOMAIN]["event_emitter"]
 
-    # Fresh instances (a real rebuild, not a lucky reuse) …
-    assert new_pl is not old_pl
-    assert new_sfx is not old_sfx
-    assert new_ev is not old_ev
+    # The SAME instances (#789): the reload refreshes the shared config-entry
+    # settings they read rather than rebuilding them, which is what makes the
+    # panel config below survive without a snapshot protocol.
+    assert new_pl is old_pl
+    assert new_sfx is old_sfx
+    assert new_ev is old_ev
 
-    # … whose panel config survived intact.
+    # Their panel config is intact.
     assert new_pl._master_enabled is True
     assert new_pl._light_question is False
     assert new_pl._light_streak is False
@@ -219,10 +221,10 @@ async def test_reload_preserves_house_panel_config(http_hass: HomeAssistant) -> 
     assert new_ev._master_enabled is True
     assert new_ev.is_configured is True
 
-    # The WS handler is re-pointed at the FRESH consumers, mirroring how it is
-    # re-pointed at the new TTS announcer. Without this, the next
-    # ``configure_house`` frame from the panel would reconfigure the orphaned
-    # pre-reload instances and the host's toggles would appear to do nothing.
+    # The WS handler still points at the live consumers. It used to have to be
+    # re-pointed after every reload — miss that, and the next ``configure_house``
+    # frame reconfigured the orphaned pre-reload instances while the host's
+    # toggles appeared to do nothing. There is nothing to re-point any more.
     handler = hass.data[DOMAIN]["ws_handler"]
     assert handler._party_lights is new_pl
     assert handler._sound_effects is new_sfx

--- a/tests/test_house_runtime_494.py
+++ b/tests/test_house_runtime_494.py
@@ -51,6 +51,7 @@ from custom_components.quizify.game_events import (  # noqa: E402
     EVENT_WINNER_DECIDED,
     QuizifyEventEmitter,
 )
+from custom_components.quizify.house_settings import HouseSettings  # noqa: E402
 from custom_components.quizify.lights import QuizifyPartyLights  # noqa: E402
 from custom_components.quizify.sound_effects import (  # noqa: E402
     QuizifySoundEffects,
@@ -712,13 +713,33 @@ def test_emitter_has_no_per_event_toggles():
 
 
 # ---------------------------------------------------------------------------
-# Snapshot round-trip (#411 pattern) — the unit half
+# Options-reload continuity — the unit half (#411 / #494 P4, rebuilt for #789)
 # ---------------------------------------------------------------------------
+#
+# These used to drive an export/restore_runtime_config pair on each consumer:
+# an options reload rebuilt every house consumer from the config entry, so the
+# panel's toggles and entity overrides had to be snapshotted onto the fresh
+# instance or they were silently wiped mid-game. There is no rebuild any more —
+# the consumers read their config-entry defaults through a shared HouseSettings
+# that the listener refreshes in place — so the same guarantees are asserted
+# against the real mechanism: change the options, and the LIVE consumer must
+# see the new defaults while keeping every panel override.
 
 
-def test_lights_snapshot_roundtrip_preserves_panel_config():
+def _reload(settings, **options):
+    """Do what ``__init__._update_listener`` does: refresh the shared defaults."""
+    settings.update_from_options(options)
+
+
+def test_reload_keeps_the_panel_config_on_the_live_lights():
     hass = _FakeHass()
-    pl = _lights(hass, entities=("light.entry",), finale_scene="scene.entry")
+    settings = HouseSettings.from_options(
+        {
+            "party_light_entities": ["light.entry"],
+            "finale_scene": "scene.entry",
+        }
+    )
+    pl = QuizifyPartyLights(hass=hass, game_state=_FakeGame(), settings=settings)
     _configure_lights(
         pl,
         enabled=True,
@@ -728,30 +749,31 @@ def test_lights_snapshot_roundtrip_preserves_panel_config():
         light_entities=["light.panel"],
         winner_scene_entity="scene.panel",
     )
-    snapshot = pl.export_runtime_config()
 
-    # An options reload rebuilds from the config entry (master back to False).
-    fresh = QuizifyPartyLights(
-        hass=hass,
-        entity_ids=["light.entry"],
-        game_state=_FakeGame(),
+    # An unrelated options change — house events are still off at the entry.
+    _reload(
+        settings,
+        party_light_entities=["light.entry"],
         finale_scene="scene.entry",
-        enabled=False,
+        lobby_music_url="http://a.test/x.mp3",
     )
-    fresh.restore_runtime_config(snapshot)
 
-    assert fresh._master_enabled is True
-    assert fresh._light_question is False
-    assert fresh._light_streak is False
-    assert fresh._light_countdown is True  # untouched toggles keep their value
-    assert fresh._winner_scene is False
-    assert fresh._active_entity_ids == ["light.panel"]
-    assert fresh._active_finale_scene == "scene.panel"
+    assert pl._master_enabled is True
+    assert pl._light_question is False
+    assert pl._light_streak is False
+    assert pl._light_countdown is True  # untouched toggles keep their value
+    assert pl._winner_scene is False
+    assert pl._active_entity_ids == ["light.panel"]
+    assert pl._active_finale_scene == "scene.panel"
 
 
-def test_sfx_snapshot_roundtrip_preserves_panel_config():
+def test_reload_keeps_the_panel_config_on_the_live_sfx():
     hass = _FakeHass()
-    sfx = _sfx(hass, media_player="media_player.entry")
+    settings = HouseSettings.from_options(
+        {"media_player_entity": "media_player.entry"}
+    )
+    sfx = QuizifySoundEffects(hass=hass, game_state=_FakeGame(), settings=settings)
+    sfx.attach_events()
     _configure_sfx(
         sfx,
         enabled=True,
@@ -759,141 +781,122 @@ def test_sfx_snapshot_roundtrip_preserves_panel_config():
         sfx_winner=False,
         media_player="media_player.panel",
     )
-    snapshot = sfx.export_runtime_config()
 
-    fresh = QuizifySoundEffects(
-        hass=hass,
-        media_player_entity_id="media_player.entry",
-        game_state=_FakeGame(),
-        cue_urls={},
-        enabled=False,
-    )
-    fresh.restore_runtime_config(snapshot)
+    _reload(settings, media_player_entity="media_player.entry")
 
-    assert fresh._master_enabled is True
-    assert fresh._cue_enabled == {
+    assert sfx._master_enabled is True
+    assert sfx._cue_enabled == {
         "correct": False,
         "wrong": True,
         "streak": True,
         "winner": False,
     }
-    assert fresh._active_media_player == "media_player.panel"
+    assert sfx._active_media_player == "media_player.panel"
 
 
-def test_emitter_snapshot_roundtrip_preserves_master_and_phase():
+def test_reload_keeps_the_emitter_master_and_its_phase_dedupe():
     hass = _FakeHass()
     game = _FakeGame()
-    emitter = QuizifyEventEmitter(hass=hass, game_state=game, enabled=False)
+    settings = HouseSettings(house_enabled=False)
+    emitter = QuizifyEventEmitter(hass=hass, game_state=game, settings=settings)
     emitter.configure(enabled=True)
     game.round = 1
     game.phase = GamePhase.QUESTION_ACTIVE
     emitter._on_state_changed()  # sets _last_phase, fires game_started
     assert [t for t, _ in hass.bus.fired] == [EVENT_GAME_STARTED]
 
-    snapshot = emitter.export_runtime_state()
-    fresh = QuizifyEventEmitter(hass=hass, game_state=game, enabled=False)
-    fresh.restore_runtime_state(snapshot)
+    _reload(settings)
 
-    # The panel's master survived the rebuild…
-    assert fresh._master_enabled is True
+    # The panel's master survived…
+    assert emitter._master_enabled is True
     # …and so did the phase dedupe (no duplicate game_started).
     hass.bus.fired.clear()
-    fresh._on_state_changed()
+    emitter._on_state_changed()
     assert hass.bus.fired == []
 
 
-@pytest.mark.parametrize("snapshot", [None, {}])
-def test_restore_is_defensive_against_empty_snapshots(snapshot):
-    """A falsy snapshot must never clobber the live config."""
+def test_reload_refreshes_the_config_entry_defaults_underneath():
+    """The other half: the NEW options genuinely land on the live consumers."""
     hass = _FakeHass()
-    pl = _lights(hass)
-    _configure_lights(pl, enabled=True, light_reveal=False)
-    pl.restore_runtime_config(snapshot)
-    assert pl._master_enabled is True
-    assert pl._light_reveal is False
+    settings = HouseSettings.from_options(
+        {"party_light_entities": ["light.old"], "media_player_entity": "mp.old"}
+    )
+    pl = QuizifyPartyLights(hass=hass, game_state=_FakeGame(), settings=settings)
+    sfx = QuizifySoundEffects(hass=hass, game_state=_FakeGame(), settings=settings)
+    assert pl._active_entity_ids == ["light.old"]
+    assert sfx._active_media_player == "mp.old"
 
-    sfx = _sfx(hass)
-    _configure_sfx(sfx, enabled=True, sfx_wrong=False)
-    sfx.restore_runtime_config(snapshot)
-    assert sfx._master_enabled is True
-    assert sfx._cue_enabled["wrong"] is False
+    _reload(
+        settings,
+        party_light_entities=["light.new"],
+        media_player_entity="mp.new",
+        finale_scene="scene.new",
+        sfx_correct_url="http://a.test/correct.mp3",
+    )
 
-
-def test_partial_snapshot_only_touches_the_keys_it_carries():
-    hass = _FakeHass()
-    pl = _lights(hass)
-    _configure_lights(pl, enabled=True)
-
-    pl.restore_runtime_config({"light_streak": False})
-
-    assert pl._master_enabled is True  # untouched
-    assert pl._light_streak is False  # applied
-    assert pl._light_reveal is True  # untouched
+    assert pl._active_entity_ids == ["light.new"]
+    assert pl._active_finale_scene == "scene.new"
+    assert sfx._active_media_player == "mp.new"
+    assert sfx._cue_urls["correct"] == "http://a.test/correct.mp3"
 
 
-def test_untouched_master_snapshots_as_none_so_the_config_entry_still_wins():
+def test_untouched_master_stays_none_so_the_config_entry_still_wins():
     """The tri-state master is the subtle bit (#494 P4 + #411).
 
-    ``export`` snapshots the panel's OVERRIDE, not the effective master. When the
-    panel never set one it stays ``None``, so a host who flips
-    CONF_HOUSE_EVENTS_ENABLED in the options UI still sees it take effect after
-    the reload. Coercing that ``None`` through ``bool()`` would pin the master
-    off forever.
+    An unset panel override means the config-entry switch is still in charge, so
+    a host who flips CONF_HOUSE_EVENTS_ENABLED in the options UI sees it take
+    effect immediately. Coercing that ``None`` to ``False`` anywhere on the path
+    would pin the master off forever.
     """
     hass = _FakeHass()
+    settings = HouseSettings.from_options({"party_light_entities": ["light.x"]})
+    pl = QuizifyPartyLights(hass=hass, game_state=_FakeGame(), settings=settings)
+    ev = QuizifyEventEmitter(hass=hass, game_state=_FakeGame(), settings=settings)
+    sfx = QuizifySoundEffects(hass=hass, game_state=_FakeGame(), settings=settings)
     # Never configure()d — the panel was never opened.
-    pl = QuizifyPartyLights(
-        hass=hass, entity_ids=["light.x"], game_state=_FakeGame(), enabled=False
-    )
-    snapshot = pl.export_runtime_config()
-    assert snapshot["enabled_override"] is None
+    assert pl._enabled_override is None
+    assert pl._master_enabled is False
 
-    # The options UI just turned house events ON → the rebuild passes enabled=True.
-    fresh = QuizifyPartyLights(
-        hass=hass, entity_ids=["light.x"], game_state=_FakeGame(), enabled=True
-    )
-    fresh.restore_runtime_config(snapshot)
-    assert fresh._enabled_override is None
-    assert fresh._master_enabled is True  # the config-entry change landed
+    _reload(settings, party_light_entities=["light.x"], house_events_enabled=True)
 
-    # Same for the emitter and the SFX.
-    ev = QuizifyEventEmitter(hass=hass, game_state=_FakeGame(), enabled=False)
-    assert ev.export_runtime_state()["enabled_override"] is None
-    fresh_ev = QuizifyEventEmitter(hass=hass, game_state=_FakeGame(), enabled=True)
-    fresh_ev.restore_runtime_state(ev.export_runtime_state())
-    assert fresh_ev._master_enabled is True
-
-    sfx = QuizifySoundEffects(
-        hass=hass,
-        media_player_entity_id="media_player.x",
-        game_state=_FakeGame(),
-        cue_urls={},
-        enabled=False,
-    )
-    assert sfx.export_runtime_config()["enabled_override"] is None
-    fresh_sfx = QuizifySoundEffects(
-        hass=hass,
-        media_player_entity_id="media_player.x",
-        game_state=_FakeGame(),
-        cue_urls={},
-        enabled=True,
-    )
-    fresh_sfx.restore_runtime_config(sfx.export_runtime_config())
-    assert fresh_sfx._master_enabled is True
+    assert pl._enabled_override is None
+    assert pl._master_enabled is True
+    assert ev._master_enabled is True
+    assert sfx._master_enabled is True
 
 
 def test_panel_master_off_survives_a_config_entry_master_on():
     """The mirror case: an explicit panel OFF must not be undone by a reload."""
     hass = _FakeHass()
-    pl = QuizifyPartyLights(
-        hass=hass, entity_ids=["light.x"], game_state=_FakeGame(), enabled=True
+    settings = HouseSettings.from_options(
+        {"party_light_entities": ["light.x"], "house_events_enabled": True}
     )
+    pl = QuizifyPartyLights(hass=hass, game_state=_FakeGame(), settings=settings)
     _configure_lights(pl, enabled=False)  # host switched the house off mid-game
-    snapshot = pl.export_runtime_config()
-    assert snapshot["enabled_override"] is False
+    assert pl._enabled_override is False
 
-    fresh = QuizifyPartyLights(
-        hass=hass, entity_ids=["light.x"], game_state=_FakeGame(), enabled=True
+    _reload(settings, party_light_entities=["light.x"], house_events_enabled=True)
+
+    assert pl._master_enabled is False
+
+
+def test_the_house_master_is_one_switch_across_the_three_consumers():
+    """The panel presents one master over three subsystems (#789).
+
+    It used to be three private copies kept in sync by three separate
+    ``configure()`` calls in the same frame; it is now one field on the shared
+    settings, so a partial fan-out can no longer leave them disagreeing.
+    """
+    hass = _FakeHass()
+    settings = HouseSettings.from_options({"party_light_entities": ["light.x"]})
+    pl = QuizifyPartyLights(hass=hass, game_state=_FakeGame(), settings=settings)
+    ev = QuizifyEventEmitter(hass=hass, game_state=_FakeGame(), settings=settings)
+    sfx = QuizifySoundEffects(hass=hass, game_state=_FakeGame(), settings=settings)
+
+    ev.configure(enabled=True)
+
+    assert (pl._master_enabled, ev._master_enabled, sfx._master_enabled) == (
+        True,
+        True,
+        True,
     )
-    fresh.restore_runtime_config(snapshot)
-    assert fresh._master_enabled is False

--- a/tests/test_house_settings_789.py
+++ b/tests/test_house_settings_789.py
@@ -1,0 +1,394 @@
+"""One settings object, one construction site, one milestone (#789).
+
+The five house consumers used to be built twice from the same options — once in
+``async_setup_entry`` and once, with identical keyword arguments, in the nested
+``_update_listener`` closure. Because each object fused its config-entry values
+with the admin panel's runtime overrides, the reload had to snapshot every
+consumer, detach it, rebuild it, restore the snapshot, re-stash it under a
+string key and re-point the WS handler at it. Four classes carried an
+``export/restore_runtime_config`` pair that existed for no other reason.
+
+What replaces it:
+
+* :class:`HouseSettings` — the config-entry defaults in one mutable object every
+  consumer holds a reference to and reads lazily;
+* :func:`build_house_consumers` — the single construction site;
+* :class:`~custom_components.quizify.server.context.AppContext` — where the
+  consumers now live;
+* ``services.py`` — the seven HA service handlers, out of ``async_setup_entry``.
+
+The reload assertions that matter are at the bottom, driven through the REAL
+config-entries state machine: change an option and the running consumers must
+see the new value *and* keep their runtime overrides.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.const import (  # noqa: E402
+    CONF_FINALE_SCENE,
+    CONF_HOUSE_EVENTS_ENABLED,
+    CONF_LOBBY_MUSIC_URL,
+    CONF_MEDIA_PLAYER_ENTITY,
+    CONF_PARTY_LIGHT_ENTITIES,
+    CONF_SFX_CORRECT_URL,
+    CONF_TTS_ENTITY,
+    DOMAIN,
+)
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.house import (  # noqa: E402
+    build_house_consumers,
+)
+from custom_components.quizify.house_settings import HouseSettings  # noqa: E402
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="t")
+
+
+# ---------------------------------------------------------------------------
+# HouseSettings
+# ---------------------------------------------------------------------------
+
+
+def test_options_are_normalised_once_for_every_consumer() -> None:
+    """Whitespace, empties and duplicates are cleaned in ONE place — the five
+    consumers used to each carry their own copy of this."""
+    settings = HouseSettings.from_options(
+        {
+            CONF_PARTY_LIGHT_ENTITIES: [" light.a ", "", "light.a", "light.b"],
+            CONF_FINALE_SCENE: "  ",
+            CONF_MEDIA_PLAYER_ENTITY: " media_player.tv ",
+            CONF_TTS_ENTITY: "",
+            CONF_SFX_CORRECT_URL: " http://a.test/c.mp3 ",
+        }
+    )
+
+    assert settings.light_entities == ["light.a", "light.b"]
+    assert settings.finale_scene is None
+    assert settings.media_player == "media_player.tv"
+    assert settings.tts_entity is None
+    assert settings.cue_urls == {
+        "correct": "http://a.test/c.mp3",
+        "wrong": None,
+        "streak": None,
+        "winner": None,
+    }
+
+
+def test_house_events_default_off_at_the_config_layer() -> None:
+    assert HouseSettings.from_options({}).house_enabled is False
+    assert HouseSettings.from_options({CONF_HOUSE_EVENTS_ENABLED: True}).master_enabled
+
+
+def test_update_never_touches_the_panel_master() -> None:
+    """The whole point of splitting the two sources apart (#411)."""
+    settings = HouseSettings.from_options({CONF_HOUSE_EVENTS_ENABLED: True})
+    settings.enabled_override = False  # the panel silenced the house mid-game
+
+    settings.update_from_options({CONF_HOUSE_EVENTS_ENABLED: True})
+
+    assert settings.enabled_override is False
+    assert settings.master_enabled is False
+
+
+# ---------------------------------------------------------------------------
+# The single construction site
+# ---------------------------------------------------------------------------
+
+
+def test_the_five_consumers_share_one_settings_object(game) -> None:
+    """A second construction site is what made a new option need two edits."""
+    house = build_house_consumers(
+        None, {CONF_PARTY_LIGHT_ENTITIES: ["light.a"]}, game
+    )
+
+    for _name, consumer in house.as_pairs():
+        assert consumer._settings is house.settings
+
+    # And updating that one object is visible on every one of them.
+    house.settings.update_from_options(
+        {
+            CONF_PARTY_LIGHT_ENTITIES: ["light.b"],
+            CONF_MEDIA_PLAYER_ENTITY: "media_player.new",
+            CONF_TTS_ENTITY: "tts.new",
+        }
+    )
+    assert house.party_lights._active_entity_ids == ["light.b"]
+    assert house.tts_announcer._active_tts_entity == "tts.new"
+    assert house.sound_effects._active_media_player == "media_player.new"
+    assert house.lobby_music._media_player_entity_id == "media_player.new"
+
+
+def test_as_pairs_covers_every_consumer(game) -> None:
+    """The unload sweep (#605) iterates this — a consumer missing from it is a
+    listener leak that survives removing the integration."""
+    house = build_house_consumers(None, {}, game)
+    assert [name for name, _ in house.as_pairs()] == [
+        "party_lights",
+        "tts_announcer",
+        "lobby_music",
+        "event_emitter",
+        "sound_effects",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# The milestone fan-out
+# ---------------------------------------------------------------------------
+
+
+def test_narration_is_not_gated_behind_the_house_master(game) -> None:
+    """The deliberate asymmetry in the fan-out (#789).
+
+    Lights and SFX subscribe to the event emitter, whose fires are gated on the
+    house master (``CONF_HOUSE_EVENTS_ENABLED``, off out of the box). Narration
+    has its own master in the TTS panel, so it is fanned out directly instead —
+    routing it through the bus would silence the quizmaster on every install
+    that has narration on and house events off, which is the default shape.
+    """
+    house = build_house_consumers(None, {}, game)
+    assert house.event_emitter._master_enabled is False
+
+    house.tts_announcer.configure(
+        enabled=True,
+        announce_question=True,
+        announce_reveal=True,
+        announce_standings=True,
+    )
+
+    assert house.tts_announcer._enabled is True
+
+
+# ---------------------------------------------------------------------------
+# Through the real config-entries state machine
+# ---------------------------------------------------------------------------
+
+pytest.importorskip("homeassistant")
+pytest.importorskip("pytest_homeassistant_custom_component")
+
+from homeassistant.core import HomeAssistant  # noqa: E402
+from homeassistant.setup import async_setup_component  # noqa: E402
+from pytest_homeassistant_custom_component.common import (  # noqa: E402
+    MockConfigEntry,
+)
+
+pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+#: Every service ``async_register_services`` is responsible for. They used to be
+#: seven closures inside ``async_setup_entry``.
+_SERVICES = (
+    "reset_admin_session",
+    "start_game",
+    "next_round",
+    "pause",
+    "resume",
+    "end_game",
+    "reload_packs",
+)
+
+
+@pytest.fixture(autouse=True)
+def _stub_frontend_panel():
+    """Stub the frontend panel helpers (no hass_frontend wheel under test)."""
+    panels: dict = {}
+
+    def _register_panel(_hass, *, frontend_url_path, **_kw):
+        panels[frontend_url_path] = True
+
+    def _remove_panel(_hass, path):
+        if path not in panels:
+            raise KeyError(path)
+        del panels[path]
+
+    with (
+        patch(
+            "homeassistant.components.frontend.async_register_built_in_panel",
+            side_effect=_register_panel,
+        ),
+        patch(
+            "homeassistant.components.frontend.async_remove_panel",
+            side_effect=_remove_panel,
+        ),
+    ):
+        yield panels
+
+
+@pytest.fixture
+async def http_hass(hass: HomeAssistant) -> HomeAssistant:
+    assert await async_setup_component(hass, "http", {"http": {}})
+    await hass.async_block_till_done()
+    return hass
+
+
+async def _setup(hass: HomeAssistant, **options) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, options=options or {})
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id) is True
+    await hass.async_block_till_done()
+    return entry
+
+
+async def test_the_services_are_registered_from_their_own_module(
+    http_hass: HomeAssistant,
+) -> None:
+    hass = http_hass
+    await _setup(hass)
+    for service in _SERVICES:
+        assert hass.services.has_service(DOMAIN, service), service
+
+
+async def test_the_consumers_live_on_the_app_context(
+    http_hass: HomeAssistant,
+) -> None:
+    """``context.py`` says AppContext replaced the ``hass.data[DOMAIN]`` service
+    locator; the house consumers were the part that had not moved (#789)."""
+    hass = http_hass
+    await _setup(hass)
+    ctx = hass.data[DOMAIN]["ctx"]
+
+    assert ctx.house is not None
+    # The hass.data keys are a mirror of the same objects, kept for the existing
+    # lookups — since nothing is rebuilt they can no longer drift apart.
+    for name, consumer in ctx.house.as_pairs():
+        assert hass.data[DOMAIN][name] is consumer
+
+
+async def test_unload_detaches_the_consumers_off_the_context(
+    http_hass: HomeAssistant,
+) -> None:
+    """The #605 listener-leak guard, now reading from the AppContext."""
+    hass = http_hass
+    entry = await _setup(
+        hass,
+        **{
+            CONF_PARTY_LIGHT_ENTITIES: ["light.a"],
+            CONF_MEDIA_PLAYER_ENTITY: "media_player.tv",
+            CONF_HOUSE_EVENTS_ENABLED: True,
+        },
+    )
+    house = hass.data[DOMAIN]["ctx"].house
+    assert house.party_lights._event_unsubs
+    assert house.sound_effects._event_unsubs
+
+    assert await hass.config_entries.async_unload(entry.entry_id) is True
+    await hass.async_block_till_done()
+
+    assert house.party_lights._event_unsubs == []
+    assert house.sound_effects._event_unsubs == []
+
+
+async def test_a_reload_lands_new_options_without_dropping_panel_overrides(
+    http_hass: HomeAssistant,
+) -> None:
+    """THE #789 test: change an option, reload, and the RUNNING consumers must
+    see the new value while keeping every runtime override.
+
+    Both halves used to be one mechanism fighting itself. Rebuilding from the
+    fresh options is what made the new values land — and is exactly what wiped
+    the panel's settings, which is why four classes grew a snapshot protocol to
+    put them back. Nothing is rebuilt now, so the two halves are independent.
+    """
+    hass = http_hass
+    entry = await _setup(
+        hass,
+        **{
+            CONF_PARTY_LIGHT_ENTITIES: ["light.old"],
+            CONF_MEDIA_PLAYER_ENTITY: "media_player.old",
+            CONF_TTS_ENTITY: "tts.old",
+            CONF_FINALE_SCENE: "scene.old",
+        },
+    )
+    house = hass.data[DOMAIN]["ctx"].house
+
+    # The admin panels set their per-game overrides mid-game.
+    house.tts_announcer.configure(
+        enabled=True,
+        announce_question=True,
+        announce_reveal=False,
+        announce_standings=True,
+        tts_entity="tts.from_panel",
+    )
+    house.party_lights.configure(
+        enabled=True, light_streak=False, light_entities=["light.from_panel"]
+    )
+    house.sound_effects.configure(enabled=True, sfx_winner=False)
+
+    # The host now edits the integration options.
+    hass.config_entries.async_update_entry(
+        entry,
+        options={
+            CONF_PARTY_LIGHT_ENTITIES: ["light.new"],
+            CONF_MEDIA_PLAYER_ENTITY: "media_player.new",
+            CONF_TTS_ENTITY: "tts.new",
+            CONF_FINALE_SCENE: "scene.new",
+            CONF_SFX_CORRECT_URL: "http://a.test/correct.mp3",
+            CONF_LOBBY_MUSIC_URL: "http://a.test/lobby.mp3",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert hass.data[DOMAIN]["ctx"].house is house  # same live consumers
+
+    # Half one — the NEW config-entry values are live on the running objects.
+    assert house.party_lights._entity_ids == ["light.new"]
+    assert house.party_lights._finale_scene == "scene.new"
+    assert house.tts_announcer._tts_entity_id == "tts.new"
+    assert house.sound_effects._media_player_entity_id == "media_player.new"
+    assert house.sound_effects._cue_urls["correct"] == "http://a.test/correct.mp3"
+    assert house.lobby_music._media_player_entity_id == "media_player.new"
+
+    # Half two — every runtime override survived, so the game in progress keeps
+    # narrating and keeps the choreography the host picked.
+    assert house.tts_announcer._enabled is True
+    assert house.tts_announcer._announce_reveal is False
+    assert house.tts_announcer._active_tts_entity == "tts.from_panel"
+    assert house.party_lights._master_enabled is True
+    assert house.party_lights._light_streak is False
+    assert house.party_lights._active_entity_ids == ["light.from_panel"]
+    assert house.sound_effects._cue_enabled["winner"] is False
+    assert house.event_emitter._master_enabled is True
+
+    # …and the announcer's fallback, where the panel set no override, followed
+    # the options change instead.
+    assert house.tts_announcer._active_media_player == "media_player.new"
+
+
+async def test_a_first_time_speaker_arms_the_sfx_listeners_on_reload(
+    http_hass: HomeAssistant,
+) -> None:
+    """The side effect the rebuild used to have for free: a host who configures
+    their first speaker/light has to get the bus listeners armed."""
+    hass = http_hass
+    entry = await _setup(hass, **{CONF_HOUSE_EVENTS_ENABLED: True})
+    house = hass.data[DOMAIN]["ctx"].house
+    assert house.sound_effects._event_unsubs == []
+    assert house.party_lights._event_unsubs == []
+
+    hass.config_entries.async_update_entry(
+        entry,
+        options={
+            CONF_HOUSE_EVENTS_ENABLED: True,
+            CONF_MEDIA_PLAYER_ENTITY: "media_player.new",
+            CONF_PARTY_LIGHT_ENTITIES: ["light.new"],
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert house.sound_effects._event_unsubs
+    assert house.party_lights._event_unsubs

--- a/tests/test_init_reattach_328.py
+++ b/tests/test_init_reattach_328.py
@@ -109,12 +109,19 @@ async def _setup(hass: HomeAssistant) -> MockConfigEntry:
     return entry
 
 
-async def test_options_update_reattaches_optional_integrations(
+async def test_options_update_reaches_the_live_optional_integrations(
     http_hass: HomeAssistant,
 ) -> None:
-    """Updating the entry options fires ``_update_listener``, which detaches the
-    old optional-integration helpers and re-attaches fresh ones wired to the new
-    options — without an HA restart."""
+    """Updating the entry options fires ``_update_listener``, and the new
+    entities are live on the optional-integration helpers — without an HA
+    restart.
+
+    The helpers used to be REPLACED here: torn down, rebuilt from the fresh
+    options, re-stashed and re-wired. Since #789 they are long-lived and read
+    their config-entry defaults through the shared ``HouseSettings`` the
+    listener refreshes, so the assertion that matters is that the same objects
+    now see the new options — a rebuild would be the bug, not the mechanism.
+    """
     hass = http_hass
     entry = await _setup(hass)
     data = hass.data[DOMAIN]
@@ -137,20 +144,25 @@ async def test_options_update_reattaches_optional_integrations(
     await hass.async_block_till_done()
 
     data = hass.data[DOMAIN]
-    # The helpers were replaced with brand-new instances (re-attach, not reuse).
-    assert data["party_lights"] is not old_pl
-    assert data["tts_announcer"] is not old_tts
-    assert data["lobby_music"] is not old_lm
+    # Same instances — nothing was rebuilt, so nothing can be left orphaned
+    # subscribed to the bus or pointed at by a stale reference.
+    assert data["party_lights"] is old_pl
+    assert data["tts_announcer"] is old_tts
+    assert data["lobby_music"] is old_lm
 
-    # The new party-lights helper reflects the freshly-configured entity ids…
+    # The party-lights helper reflects the freshly-configured entity ids…
     assert data["party_lights"]._entity_ids == new_lights
     assert data["party_lights"].is_configured is True
-    # …and the new TTS announcer is now fully configured too.
+    # …and the TTS announcer is now fully configured too.
     assert data["tts_announcer"].is_configured is True
 
-    # The ws handler is re-pointed at the new TTS announcer (so milestone
-    # announcements use the live instance, not the stale one).
+    # The ws handler still points at the live announcer.
     assert hass.data[DOMAIN]["ws_handler"]._tts_announcer is data["tts_announcer"]
+    # The AppContext is where the consumers actually live (#789); hass.data
+    # only mirrors it, and the two can no longer drift.
+    house = hass.data[DOMAIN]["ctx"].house
+    assert house.party_lights is data["party_lights"]
+    assert house.tts_announcer is data["tts_announcer"]
 
 
 async def test_options_update_propagates_url_and_community_fields(
@@ -211,7 +223,7 @@ async def test_options_update_clears_fields_when_emptied(
     data = hass.data[DOMAIN]
     assert data["game"].lobby_music_url is None
     assert data["ctx"].community_submit_url is None
-    # An unconfigured party-lights helper is re-attached (no entity ids given).
+    # The party-lights helper reads the cleared option and reports unconfigured.
     assert data["party_lights"].is_configured is False
 
 
@@ -224,7 +236,8 @@ async def test_options_reload_preserves_live_narration_config(
     switch on and stores per-game entity overrides. Before the fix, the reload
     rebuilt the announcer from the config entry, resetting ``_enabled`` back to
     ``False`` — so narration went silent until the next game. The listener now
-    snapshots + restores the live runtime config onto the fresh instance.
+    refreshes only the config-entry defaults the announcer reads (#789), so
+    there is nothing left that could reset the live narration config.
     """
     hass = http_hass
     entry = await _setup(hass)
@@ -250,7 +263,7 @@ async def test_options_reload_preserves_live_narration_config(
     await hass.async_block_till_done()
 
     new_tts = hass.data[DOMAIN]["tts_announcer"]
-    assert new_tts is not old_tts
+    assert new_tts is old_tts
     # Master switch and per-event toggles survived the reload…
     assert new_tts._enabled is True
     assert new_tts._announce_reveal is False

--- a/tests/test_service_start_settings_744.py
+++ b/tests/test_service_start_settings_744.py
@@ -1,0 +1,452 @@
+"""Starting by voice or button must honour the host's settings (#744).
+
+``quizify.start_game`` had ``fields: {}`` and ``admin_action_start_game`` called
+the bare ``game_state.start_game()``: mixed packs, medium, 10 rounds, German,
+Lightning and Hot Seat on — whatever the host had actually set up in the lobby.
+It then ran ``_apply_tts_config({})``, and ``bool({}.get("enabled"))`` is
+``False``, so the quizmaster the host had just switched on went silent for the
+whole game. Saved presets were unreachable from every one of these paths.
+
+Three seams are covered here:
+
+* the settings layering (``resolve_start_settings``) — a pure function, so the
+  precedence can be asserted without a socket or a Home Assistant;
+* the narrator: a socket-less start must LEAVE the lobby-time TTS config alone,
+  the way a missing ``house`` block has always been left alone;
+* the service itself, through the real HA service registry, including a saved
+  preset looked up by name.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import voluptuous as vol
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.const import DOMAIN  # noqa: E402
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+from custom_components.quizify.server.connection import (  # noqa: E402
+    ConnectionManager,
+)
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+from custom_components.quizify.tts import QuizifyTTSAnnouncer  # noqa: E402
+
+
+class _Runtime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+    def create_task(self, coro):  # noqa: ANN001
+        import asyncio  # noqa: PLC0415
+
+        return asyncio.ensure_future(coro)
+
+
+def _fake_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    ws.close = AsyncMock()
+    return ws
+
+
+def _make_handler(game: QuizifyGameState, tmp_path: Path) -> QuizifyWebSocketHandler:
+    runtime = _Runtime(tmp_path)
+    h = QuizifyWebSocketHandler(runtime=runtime, game_state_provider=lambda: game)
+    h._conn = ConnectionManager(runtime, lambda: game)
+    h._conn.broadcast = AsyncMock()
+    h.START_REDIRECT_GRACE = 0.0
+    return h
+
+
+def _game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="test")
+
+
+# ---------------------------------------------------------------------------
+# The settings layering
+# ---------------------------------------------------------------------------
+
+
+def test_last_used_settings_are_the_fallback(tmp_path: Path) -> None:
+    """THE #744 case: the host set the evening up, played it, and now says
+    "Hey Nabu, start the quiz" from the couch."""
+    gs = _game(tmp_path)
+    gs.start_game(
+        categories=["geographie"],
+        difficulty="hard",
+        num_rounds=15,
+        language="de",
+        lightning_enabled=False,
+    )
+    gs.reset_to_lobby()
+
+    resolved = QuizifyWebSocketHandler.resolve_start_settings(gs)
+
+    assert resolved["categories"] == ["geographie"]
+    assert resolved["difficulty"] == "hard"
+    assert resolved["num_rounds"] == 15
+    assert resolved["lightning_enabled"] is False
+
+
+def test_a_first_ever_start_falls_through_to_the_game_defaults(
+    tmp_path: Path,
+) -> None:
+    """Nothing played yet → nothing to carry over, and start_game's own
+    defaults keep owning every field."""
+    assert QuizifyWebSocketHandler.resolve_start_settings(_game(tmp_path)) == {}
+
+
+def test_the_preset_beats_the_last_game(tmp_path: Path) -> None:
+    gs = _game(tmp_path)
+    gs.start_game(categories=["geographie"], difficulty="hard", num_rounds=15)
+    gs.reset_to_lobby()
+
+    resolved = QuizifyWebSocketHandler.resolve_start_settings(
+        gs,
+        preset={
+            "name": "With kids",
+            "packs": ["tiere-natur"],
+            "rounds": 8,
+            "timer": 45,
+            "difficulty": "easy",
+            "lightning": False,
+            "hot_seat": False,
+            "powerups": False,
+            "wager": False,
+        },
+    )
+
+    assert resolved["categories"] == ["tiere-natur"]
+    assert resolved["category"] is None
+    assert resolved["difficulty"] == "easy"
+    assert resolved["num_rounds"] == 8
+    assert resolved["timer_duration"] == 45
+    assert resolved["powerups_enabled"] is False
+    assert resolved["wager_enabled"] is False
+
+
+def test_the_explicit_fields_beat_the_preset(tmp_path: Path) -> None:
+    resolved = QuizifyWebSocketHandler.resolve_start_settings(
+        _game(tmp_path),
+        preset={"packs": ["tiere-natur"], "rounds": 8, "difficulty": "easy"},
+        overrides={"num_rounds": 20, "category": "geographie", "language": "es"},
+    )
+
+    assert resolved["num_rounds"] == 20
+    assert resolved["category"] == "geographie"
+    # The narrower single-pack pick fully replaces the preset's list — it does
+    # not merge with it.
+    assert resolved["categories"] is None
+    assert resolved["language"] == "es"
+    assert resolved["difficulty"] == "easy"  # untouched by the overrides
+
+
+def test_mixed_clears_the_pack_and_difficulty_picks(tmp_path: Path) -> None:
+    gs = _game(tmp_path)
+    gs.start_game(categories=["geographie"], difficulty="hard")
+    gs.reset_to_lobby()
+
+    resolved = QuizifyWebSocketHandler.resolve_start_settings(
+        gs, overrides={"category": "mixed", "difficulty": "mixed"}
+    )
+
+    assert resolved["category"] is None
+    assert resolved["categories"] is None
+    assert resolved["difficulty"] is None
+
+
+def test_a_stale_last_settings_key_can_never_wedge_the_voice_command(
+    tmp_path: Path,
+) -> None:
+    """``last_settings`` is written by ``start_game`` itself, so a future
+    version can add a key this one does not accept. Filtering it out here keeps
+    "start the quiz" working across an update instead of raising TypeError."""
+    gs = _game(tmp_path)
+    gs.start_game(num_rounds=12)
+    gs.reset_to_lobby()
+    gs._last_settings["some_future_field"] = "boom"
+
+    resolved = QuizifyWebSocketHandler.resolve_start_settings(gs)
+
+    assert "some_future_field" not in resolved
+    gs.start_game(**resolved)  # would raise TypeError if it leaked through
+    assert gs.total_rounds == 12
+
+
+# ---------------------------------------------------------------------------
+# The narrator
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_socketless_start_does_not_mute_the_narrator(
+    tmp_path: Path,
+) -> None:
+    """THE #744 bug. The host switches narration on in the lobby (which reaches
+    the announcer over ``configure_tts``, before any ``start_game``), then starts
+    the game by voice. The start carries no ``tts`` block, and an absent block
+    must mean "leave as configured" — exactly as an absent ``house`` block
+    already did — not "narration off"."""
+    gs = _game(tmp_path)
+    handler = _make_handler(gs, tmp_path)
+    announcer = QuizifyTTSAnnouncer(
+        hass=None,
+        game_state=gs,
+        tts_entity_id="tts.cloud",
+        media_player_entity_id="media_player.kitchen",
+    )
+    handler.set_tts_announcer(announcer)
+    # The lobby-time push from admin.js.
+    handler._apply_tts_config({"enabled": True, "announce_reveal": False})
+    assert announcer._enabled is True
+
+    await handler.admin_action_start_game(gs)
+
+    assert gs.phase != GamePhase.LOBBY
+    assert announcer._enabled is True
+    assert announcer._announce_reveal is False
+
+
+@pytest.mark.asyncio
+async def test_an_admin_start_with_a_tts_block_still_applies_it(
+    tmp_path: Path,
+) -> None:
+    """The counter-regression: the admin panel always sends the block, and it
+    must still be able to switch narration OFF for a game."""
+    gs = _game(tmp_path)
+    handler = _make_handler(gs, tmp_path)
+    announcer = QuizifyTTSAnnouncer(
+        hass=None,
+        game_state=gs,
+        tts_entity_id="tts.cloud",
+        media_player_entity_id="media_player.kitchen",
+    )
+    handler.set_tts_announcer(announcer)
+    handler._apply_tts_config({"enabled": True})
+    assert announcer._enabled is True
+
+    await handler._after_start_game(gs, {"enabled": False})
+
+    assert announcer._enabled is False
+
+
+@pytest.mark.asyncio
+async def test_the_service_core_starts_the_last_used_game(
+    tmp_path: Path,
+) -> None:
+    """End to end on the socket-less core: the game that actually starts is the
+    one the host last configured."""
+    gs = _game(tmp_path)
+    handler = _make_handler(gs, tmp_path)
+    gs.start_game(categories=["geographie"], difficulty="hard", num_rounds=15)
+    gs.reset_to_lobby()
+
+    await handler.admin_action_start_game(gs)
+
+    assert gs.categories == ["geographie"]
+    assert gs.difficulty == "hard"
+    assert gs.total_rounds == 15
+
+
+# ---------------------------------------------------------------------------
+# The Lovelace card
+# ---------------------------------------------------------------------------
+
+_CARD = (
+    _REPO_ROOT
+    / "custom_components"
+    / "quizify"
+    / "www"
+    / "cards"
+    / "quizify-host-card.js"
+)
+
+
+def test_the_card_starts_through_the_service_not_the_socket() -> None:
+    """The card has no setup screen, so its ``start_game`` frame carried no
+    settings — and the admin path cannot tell an absent field from an explicit
+    null, so it could only answer with the factory game. The service is the
+    surface that knows what "no settings given" means (#744)."""
+    source = _CARD.read_text(encoding="utf-8")
+    assert "callService('quizify', 'start_game'" in source
+    # Every control routes through the one dispatcher, so a second start button
+    # cannot quietly go back to the socket.
+    assert "self._dispatch(primary.msg)" in source
+    assert "self._dispatch(el.dataset.msg)" in source
+    # …and the socket stays the fallback, so the button is never dead when the
+    # card is rendered without a hass.
+    assert "this._send('start_game')" in source
+
+
+# ---------------------------------------------------------------------------
+# The service, through the real HA registry
+# ---------------------------------------------------------------------------
+
+pytest.importorskip("homeassistant")
+pytest.importorskip("pytest_homeassistant_custom_component")
+
+from homeassistant.core import HomeAssistant  # noqa: E402
+from homeassistant.exceptions import ServiceValidationError  # noqa: E402
+from homeassistant.setup import async_setup_component  # noqa: E402
+from pytest_homeassistant_custom_component.common import (  # noqa: E402
+    MockConfigEntry,
+)
+
+pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+
+@pytest.fixture(autouse=True)
+def _stub_frontend_panel():
+    """Stub the frontend panel helpers (no hass_frontend wheel under test)."""
+    panels: dict = {}
+
+    def _register_panel(_hass, *, frontend_url_path, **_kw):
+        panels[frontend_url_path] = True
+
+    def _remove_panel(_hass, path):
+        if path not in panels:
+            raise KeyError(path)
+        del panels[path]
+
+    with (
+        patch(
+            "homeassistant.components.frontend.async_register_built_in_panel",
+            side_effect=_register_panel,
+        ),
+        patch(
+            "homeassistant.components.frontend.async_remove_panel",
+            side_effect=_remove_panel,
+        ),
+    ):
+        yield panels
+
+
+@pytest.fixture
+async def http_hass(hass: HomeAssistant) -> HomeAssistant:
+    assert await async_setup_component(hass, "http", {"http": {}})
+    await hass.async_block_till_done()
+    return hass
+
+
+async def _setup(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN)
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id) is True
+    await hass.async_block_till_done()
+    # Drop the start-redirect grace so these don't sleep 2.5s each.
+    hass.data[DOMAIN]["ws_handler"].START_REDIRECT_GRACE = 0.0
+    return entry
+
+
+async def test_the_service_accepts_the_hosts_settings(
+    http_hass: HomeAssistant,
+) -> None:
+    """The fields #744 asked for actually reach the game."""
+    hass = http_hass
+    await _setup(hass)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "start_game",
+        {
+            "category": ["geographie"],
+            "difficulty": "hard",
+            "num_rounds": 15,
+            "language": "de",
+            "timer_duration": 45,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    game = hass.data[DOMAIN]["game"]
+    assert game.categories == ["geographie"]
+    assert game.difficulty == "hard"
+    assert game.total_rounds == 15
+    assert game.language == "de"
+
+
+async def test_the_service_starts_a_saved_preset_by_name(
+    http_hass: HomeAssistant,
+) -> None:
+    """Saved presets were unreachable from the service path (#744). They are
+    matched on the host-visible NAME — the only part of a preset a voice
+    sentence or a dashboard button can carry."""
+    hass = http_hass
+    await _setup(hass)
+
+    from custom_components.quizify.server.views import (  # noqa: PLC0415
+        get_preset_store,
+    )
+
+    await get_preset_store(hass.http.app).save(
+        {
+            "name": "With kids",
+            "packs": ["tiere-natur"],
+            "rounds": 8,
+            "difficulty": "easy",
+            "lightning": False,
+            "powerups": False,
+        }
+    )
+
+    await hass.services.async_call(
+        DOMAIN, "start_game", {"preset": "with kids"}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    game = hass.data[DOMAIN]["game"]
+    assert game.categories == ["tiere-natur"]
+    assert game.difficulty == "easy"
+    assert game.total_rounds == 8
+
+
+async def test_an_unknown_preset_names_the_ones_that_exist(
+    http_hass: HomeAssistant,
+) -> None:
+    """A typo has to be self-correcting, not silently start the wrong game."""
+    hass = http_hass
+    await _setup(hass)
+
+    from custom_components.quizify.server.views import (  # noqa: PLC0415
+        get_preset_store,
+    )
+
+    await get_preset_store(hass.http.app).save({"name": "With kids", "rounds": 8})
+
+    with pytest.raises(ServiceValidationError, match="With kids"):
+        await hass.services.async_call(
+            DOMAIN, "start_game", {"preset": "with kidz"}, blocking=True
+        )
+    assert hass.data[DOMAIN]["game"].phase == GamePhase.LOBBY
+
+
+async def test_the_service_rejects_an_out_of_range_round_count(
+    http_hass: HomeAssistant,
+) -> None:
+    """The schema is the guard: ``total_rounds`` drives the round comparison, so
+    a 0 or a 500 must never reach the game state."""
+    hass = http_hass
+    await _setup(hass)
+
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN, "start_game", {"num_rounds": 0}, blocking=True
+        )
+    assert hass.data[DOMAIN]["game"].phase == GamePhase.LOBBY

--- a/tests/test_spanish_narration_745.py
+++ b/tests/test_spanish_narration_745.py
@@ -30,6 +30,7 @@ from custom_components.quizify.game.state import (  # noqa: E402
     GamePhase,
     QuizifyGameState,
 )
+from custom_components.quizify.house_settings import HouseSettings  # noqa: E402
 from custom_components.quizify.tts import QuizifyTTSAnnouncer  # noqa: E402
 
 _WWW = _REPO_ROOT / "custom_components" / "quizify" / "www"
@@ -316,15 +317,15 @@ class TestMilestoneIsLocalizedAndToggleable:
         assert len(hass.calls) == 1
 
     def test_the_toggle_survives_an_options_reload(self, game) -> None:
-        """Same export/restore round-trip the six siblings get (#411)."""
+        """Same reload continuity the six siblings get (#411 / #789)."""
         hass = _FakeHass()
-        t = _announcer(hass, game)
+        settings = HouseSettings(
+            tts_entity="tts.cloud", media_player="media_player.kitchen"
+        )
+        t = QuizifyTTSAnnouncer(hass=hass, game_state=game, settings=settings)
         _configure(t, announce_milestone=False)
-        snapshot = t.export_runtime_config()
-        assert snapshot["announce_milestone"] is False
-        fresh = _announcer(hass, game)
-        fresh.restore_runtime_config(snapshot)
-        assert fresh._announce_milestone is False
+        settings.update_from_options({"tts_entity": "tts.cloud"})
+        assert t._announce_milestone is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tts_lobby_reload_411.py
+++ b/tests/test_tts_lobby_reload_411.py
@@ -31,6 +31,7 @@ from custom_components.quizify.game.state import (  # noqa: E402
     GamePhase,
     QuizifyGameState,
 )
+from custom_components.quizify.house_settings import HouseSettings  # noqa: E402
 from custom_components.quizify.lobby_music import QuizifyLobbyMusic  # noqa: E402
 from custom_components.quizify.tts import QuizifyTTSAnnouncer  # noqa: E402
 
@@ -63,33 +64,22 @@ def game(tmp_path):
     return QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="t")
 
 
-def _reload_announcer(
-    old: QuizifyTTSAnnouncer, hass, game
-) -> QuizifyTTSAnnouncer:
-    """Mimic the __init__ listener: snapshot old → rebuild → restore."""
-    snapshot = old.export_runtime_config()
-    old.detach()
-    new = QuizifyTTSAnnouncer(
-        hass=hass,
-        tts_entity_id="tts.cloud",
-        media_player_entity_id="media_player.kitchen",
-        game_state=game,
-    )
-    new.restore_runtime_config(snapshot)
-    new.attach()
-    return new
-
-
 def test_reload_preserves_enabled_and_overrides(game):
+    """The #411 regression guard, against the #789 mechanism.
+
+    The listener used to snapshot the announcer, tear it down, rebuild it from
+    the config entry and restore the snapshot. It now refreshes the shared
+    settings in place and leaves the announcer alone — so the master switch and
+    the per-game entity overrides survive by construction, and the NEW
+    config-entry entities are visible to the same live instance.
+    """
     hass = _FakeHass()
-    old = QuizifyTTSAnnouncer(
-        hass=hass,
-        tts_entity_id="tts.cloud",
-        media_player_entity_id="media_player.kitchen",
-        game_state=game,
+    settings = HouseSettings(
+        tts_entity="tts.cloud", media_player="media_player.kitchen"
     )
-    old.attach()
-    old.configure(
+    announcer = QuizifyTTSAnnouncer(hass=hass, game_state=game, settings=settings)
+    announcer.attach()
+    announcer.configure(
         enabled=True,
         announce_question=True,
         announce_reveal=False,
@@ -101,34 +91,49 @@ def test_reload_preserves_enabled_and_overrides(game):
         media_player="media_player.party",
     )
 
-    new = _reload_announcer(old, hass, game)
-
-    assert new is not old
-    assert new._enabled is True
-    assert new._announce_reveal is False
-    assert new._announce_options is False
-    assert new._announce_countdown is False
-    assert new._active_tts_entity == "tts.game_engine"
-    assert new._active_media_player == "media_player.party"
-
-
-def test_restore_runtime_config_is_defensive(game):
-    hass = _FakeHass()
-    tts = QuizifyTTSAnnouncer(
-        hass=hass,
-        tts_entity_id="tts.cloud",
-        media_player_entity_id="media_player.kitchen",
-        game_state=game,
+    # The options reload: only the config-entry defaults are rewritten.
+    settings.update_from_options(
+        {
+            "tts_entity": "tts.cloud_new",
+            "media_player_entity": "media_player.kitchen_new",
+        }
     )
-    tts._enabled = True
-    # An empty / None snapshot must never clobber the current config.
-    tts.restore_runtime_config(None)
-    tts.restore_runtime_config({})
-    assert tts._enabled is True
-    # A partial snapshot only touches the keys it carries.
-    tts.restore_runtime_config({"announce_join": False})
-    assert tts._enabled is True
-    assert tts._announce_join is False
+
+    assert announcer._enabled is True
+    assert announcer._announce_reveal is False
+    assert announcer._announce_options is False
+    assert announcer._announce_countdown is False
+    # The panel's per-game overrides still win…
+    assert announcer._active_tts_entity == "tts.game_engine"
+    assert announcer._active_media_player == "media_player.party"
+    # …over the freshly-read config-entry values underneath them.
+    assert announcer._tts_entity_id == "tts.cloud_new"
+    assert announcer._media_player_entity_id == "media_player.kitchen_new"
+
+
+def test_reload_lands_new_entities_when_the_panel_set_no_override(game):
+    """The counter-case: with no per-game override, the options change is what
+    the announcer speaks through."""
+    hass = _FakeHass()
+    settings = HouseSettings(
+        tts_entity="tts.cloud", media_player="media_player.kitchen"
+    )
+    announcer = QuizifyTTSAnnouncer(hass=hass, game_state=game, settings=settings)
+    announcer.configure(
+        enabled=True,
+        announce_question=True,
+        announce_reveal=True,
+        announce_standings=True,
+    )
+    assert announcer._active_tts_entity == "tts.cloud"
+
+    settings.update_from_options(
+        {"tts_entity": "tts.piper", "media_player_entity": "media_player.den"}
+    )
+
+    assert announcer._active_tts_entity == "tts.piper"
+    assert announcer._active_media_player == "media_player.den"
+    assert announcer._enabled is True  # narration was NOT silently killed
 
 
 async def test_lobby_music_resumes_on_attach_in_lobby(game):


### PR DESCRIPTION
## #789 — the house consumers were built twice, and carried a snapshot protocol to survive it

The five "House Plays Along" consumers (TTS announcer, party lights, lobby music, event emitter, room SFX) were constructed from the same options in two places: `async_setup_entry`, and again in the nested 127-line `_update_listener` closure with identical kwargs. Because each object fused its config-entry values with the admin panel's runtime overrides, an options reload had to, per consumer: export its runtime config, detach it, rebuild it, restore the snapshot, re-attach it, re-stash it under a string key and re-point the WS handler at it. Four classes carried an `export`/`restore_runtime_config` pair that existed for no other reason, and #411 had been re-fixed once per consumer as they were added.

What replaces it:

- **`house_settings.py` — `HouseSettings`.** The config-entry defaults (lights, finale scene, speaker, TTS engine, the four cue URLs, the `CONF_HOUSE_EVENTS_ENABLED` master) in one mutable object every consumer keeps a reference to and reads lazily. The reload path is now `settings.update_from_options(opts)` — nothing is torn down, rebuilt or snapshotted, and every panel override survives because nothing touches it. The panel's shared master moves here too: it was three private copies of one value kept in sync by three `configure()` calls in the same frame.
- **`house.py` — `build_house_consumers()` + `HouseConsumers`.** The single construction site. `apply_options()` is the whole reload; the three `refresh_from_settings()` calls in it only reproduce the *side effects* the old rebuild had for free (arming listeners for a host who just configured their first entity, re-syncing the bulbs, restarting lobby music on a changed speaker).
- **`export`/`restore_runtime_config` deleted** from `tts.py`, `lights.py`, `sound_effects.py` and `game_events.py`.
- **`AppContext.house`** holds the consumers; the unload sweep (#605) reads them from there. The `hass.data[DOMAIN]` keys stay as a mirror for the existing lookups — since nothing is ever rebuilt, the two can no longer drift.
- **`services.py` — `async_register_services(hass)`.** The seven HA service handlers move out of `async_setup_entry`, which loses ~300 lines.
- **The four twin `_notify_tts_*` / `_notify_house_*` call sites** collapse to one milestone each (`_notify_milestone`, `_notify_question`, `_notify_countdown`, `_notify_reveal`).

Behaviour is unchanged. See "Left undone" for the one part of the issue that is not in here.

## #744 — starting by voice or button ignored every setting and muted the narrator

`quizify.start_game` had `fields: {}` and `admin_action_start_game` called the bare `game_state.start_game()`, then `_apply_tts_config({})` — and `bool({}.get("enabled"))` is `False`, so the narrator the host had just switched on in the lobby went silent for the whole game.

- An **absent `tts` block is now left alone**, exactly as an absent `house` block already was. The admin panel always sends the block, so it can still switch narration off for a game.
- `quizify.start_game` accepts an optional **`preset`** (matched by its host-visible name in `PresetStore`, which was unreachable from every one of these paths) plus **`category` / `difficulty` / `num_rounds` / `language` / `timer_duration`**, with a voluptuous schema and full `services.yaml` selectors.
- `resolve_start_settings` layers them: `start_game`'s own defaults → the host's **last-used settings** (`game_state.last_settings`, the snapshot the one-tap rematch already replays) → the preset → the explicit fields. So "Hey Nabu, start the quiz" replays the evening the host actually set up.
- The **Lovelace card** calls that service instead of sending a settings-less socket frame — the admin path cannot tell an absent field from an explicit `null`, so only the service can know what "no settings given" means.

## Tests

`git stash`-verified per issue, against the pre-change tree:

- **#744** — 12 of the 14 new tests in `test_service_start_settings_744.py` fail without the fix, including the core one: `test_a_socketless_start_does_not_mute_the_narrator` fails with `assert False is True` on `announcer._enabled` after a socket-less start. The two that pass are the deliberate counter-regressions (an admin start *with* a `tts` block still applies it).
- **#789** — 7 of the 11 new tests in `test_house_settings_789.py` fail without the change; the seams do not exist there (`AttributeError: 'AppContext' object has no attribute 'house'`). The behavioural contract is guarded by the pre-existing #411/#494 tests, which stay green — that is the point of a refactor.

The existing #411/#494/#328 reload tests keep their behavioural assertions. Their **identity** assertions are inverted (`is not old_pl` → `is old_pl`): they were asserting the rebuild, which is the mechanism being removed. The snapshot round-trip unit tests in `test_house_runtime_494.py` and `test_game_events.py` are rewritten to drive the real mechanism — change an option, and the live consumer must see the new value *and* keep its overrides.

Full suite: **2806 passed**. `ruff check custom_components/` clean, `mypy` clean (51 files).

## Left undone

The issue also asks to "route TTS through `QuizifyEventEmitter` as a subscriber so a milestone fires once, not twice". **I did not do that, deliberately.** The emitter's fires are gated on the house master (`CONF_HOUSE_EVENTS_ENABLED`, off out of the box), while narration has its own independent master in the TTS panel — so subscribing the announcer to the bus would silence the quizmaster on every install that has narration on and house events off, which is the default shape. That is a behaviour change, and the issue's own constraint is that behaviour must not change.

What the four dispatch points *did* carry — a twin call to a `_notify_tts_*` hook and its `_notify_house_*` sibling, so adding a consumer meant editing every site — is fixed: they fire one milestone and the fan-out lives in one place, with the asymmetry documented there and covered by a test.

Closes #789
Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)
