### PR TITLE
Give the host card a real button in the wager window and the Hot Seat

### DIFF
--- a/custom_components/quizify/www/cards/quizify-host-card.js
+++ b/custom_components/quizify/www/cards/quizify-host-card.js
@@ -36,25 +36,62 @@
     var MAX_RECONNECT = 10;
 
     /*
-     * Phase -> primary action. Phase strings are GamePhase in game/state.py;
-     * every message here is one admin.js already sends for the same phase. The
-     * card must not invent transitions — an unknown phase falls through to a
-     * disabled button rather than guessing.
+     * Phase -> primary action. Phase strings are GamePhase in
+     * game/phase_controller.py; every message here is one admin.js already
+     * sends for the same phase. The card must not invent transitions.
+     *
+     * EVERY phase gets an entry, including the ones the host cannot act on
+     * (#801). An absent phase used to fall through to a disabled button
+     * reading 'Connecting…', so a host on a wall tablet watched a lie for the
+     * whole wager window and the whole Hot Seat auction while the game was
+     * running perfectly well. A phase with `msg: null` is the honest version
+     * of the same button: still disabled, but it says what the room is doing.
+     * tests/test_host_card_278.py asserts the map covers GamePhase, so the
+     * next phase added to the game cannot silently reintroduce 'Connecting…'.
+     *
+     * What each `msg` costs on the server (server/websocket.py):
+     *   admin_skip  — WAGER_ACTIVE closes the betting window and asks the
+     *                 question; QUESTION_ACTIVE evaluates the round now.
+     *                 Anywhere else it falls through to _handle_next_question.
+     *   next_question — accepted in LOBBY (started), ANSWER_REVEAL,
+     *                 LIGHTNING_RECAP and HOT_SEAT_REVEAL; refused with
+     *                 ERR_INVALID_ACTION everywhere else.
      */
     var PHASE_ACTIONS = {
         LOBBY: { labelKey: 'start', msg: 'start_game' },
+        // #656: the question has not been asked yet, so "skip" here means
+        // stop waiting for bets — anyone who has not bet has no bet.
+        WAGER_ACTIVE: { labelKey: 'closeBets', msg: 'admin_skip' },
         QUESTION_ACTIVE: { labelKey: 'skip', msg: 'admin_skip' },
         ANSWER_REVEAL: { labelKey: 'next', msg: 'next_question' },
         PAUSED: { labelKey: 'resume', msg: 'resume_game' },
         FINALE: { labelKey: 'again', msg: 'play_again' },
-        LIGHTNING: { labelKey: 'skip', msg: 'admin_skip' },
-        LIGHTNING_RECAP: { labelKey: 'next', msg: 'next_question' }
+        // The lightning loop is server-driven and has no host step: admin_skip
+        // reaches _handle_next_question, which refuses LIGHTNING with
+        // ERR_INVALID_ACTION. Say so rather than offering a button that errors.
+        LIGHTNING: { labelKey: 'lightningRunning', msg: null },
+        LIGHTNING_RECAP: { labelKey: 'next', msg: 'next_question' },
+        // #616: the auction and the seat question run themselves to a close;
+        // only the reveal hands the game back to the host.
+        HOT_SEAT_AUCTION: { labelKey: 'auctionRunning', msg: null },
+        HOT_SEAT: { labelKey: 'seatAnswering', msg: null },
+        HOT_SEAT_REVEAL: { labelKey: 'next', msg: 'next_question' }
     };
+
+    /*
+     * Phases in which the expanded card's extra 'Reveal' button (admin_skip)
+     * actually does something. Outside these two the server answers it with
+     * ERR_INVALID_ACTION, so the button is hidden rather than shown dead
+     * (#801) — during the Hot Seat auction it was pure noise.
+     */
+    var SKIPPABLE_PHASES = { QUESTION_ACTIVE: true, WAGER_ACTIVE: true };
 
     var LABELS = {
         en: {
             title: 'Quizify', start: 'Start game', skip: 'Skip to answer',
             next: 'Next question', resume: 'Resume', again: 'Play again',
+            closeBets: 'Close betting', lightningRunning: 'Lightning round running',
+            auctionRunning: 'Bidding for the hot seat', seatAnswering: 'The hot seat is answering',
             reveal: 'Reveal', end: 'End game', reset: 'Reset', kick: 'Kick',
             players: 'players', round: 'Round', join: 'Join',
             waiting: 'Waiting for players', connecting: 'Connecting…',
@@ -65,6 +102,8 @@
         de: {
             title: 'Quizify', start: 'Spiel starten', skip: 'Zur Auflösung',
             next: 'Nächste Frage', resume: 'Weiter', again: 'Nochmal spielen',
+            closeBets: 'Wetten schließen', lightningRunning: 'Blitzrunde läuft',
+            auctionRunning: 'Gebote für den Hot Seat', seatAnswering: 'Der Hot Seat antwortet',
             reveal: 'Auflösen', end: 'Spiel beenden', reset: 'Zurücksetzen', kick: 'Rauswerfen',
             players: 'Spieler', round: 'Runde', join: 'Beitreten',
             waiting: 'Warte auf Spieler', connecting: 'Verbinde…',
@@ -75,6 +114,8 @@
         es: {
             title: 'Quizify', start: 'Empezar partida', skip: 'Ir a la respuesta',
             next: 'Siguiente pregunta', resume: 'Continuar', again: 'Jugar otra vez',
+            closeBets: 'Cerrar apuestas', lightningRunning: 'Ronda relámpago en curso',
+            auctionRunning: 'Pujas por la silla caliente', seatAnswering: 'La silla caliente responde',
             reveal: 'Revelar', end: 'Terminar partida', reset: 'Reiniciar', kick: 'Expulsar',
             players: 'jugadores', round: 'Ronda', join: 'Unirse',
             waiting: 'Esperando jugadores', connecting: 'Conectando…',
@@ -324,6 +365,17 @@
 
         // ---- Rendering ---------------------------------------------------
 
+        /*
+         * The one morphing button.
+         *
+         * Three outcomes, and the middle one is the point of #801:
+         *   - a known phase with a message  -> live button
+         *   - a known phase without one     -> disabled button naming the
+         *     phase ("Bidding for the hot seat"), because the game is running
+         *     and the host is simply not the one who advances it
+         *   - genuinely no state yet        -> 'Connecting…', which is now
+         *     only ever true when it is true
+         */
         _primary() {
             var phase = this._state && this._state.phase;
             var action = PHASE_ACTIONS[phase] || null;
@@ -331,10 +383,11 @@
             // An empty lobby has nothing to start; say why rather than letting
             // the host tap a button that refuses.
             var blocked = phase === 'LOBBY' && players.length === 0;
+            var msg = (action && action.msg) || null;
             return {
                 label: action ? this._t[action.labelKey] : this._t.connecting,
-                msg: action ? action.msg : null,
-                disabled: !action || blocked || this._status !== 'online',
+                msg: msg,
+                disabled: !msg || blocked || this._status !== 'online',
                 blockedReason: blocked ? this._t.waiting : null
             };
         }
@@ -395,11 +448,15 @@
                     esc(primary.label) + '</button>';
 
             if (expanded) {
-                html += '<div class="row">' +
-                    // Reveal is admin_skip: it cuts the timer short and shows the
-                    // answer, which is what admin.js does behind the same label.
-                    '<button data-msg="admin_skip">' + esc(t.reveal) + '</button>' +
-                    '<button data-msg="end_game">' + esc(t.end) + '</button>' +
+                html += '<div class="row">';
+                // Reveal is admin_skip: it cuts the timer short and shows the
+                // answer, which is what admin.js does behind the same label.
+                // Only two phases accept it (#801) — elsewhere the server
+                // answers ERR_INVALID_ACTION, so the button is not offered.
+                if (s && SKIPPABLE_PHASES[s.phase]) {
+                    html += '<button data-msg="admin_skip">' + esc(t.reveal) + '</button>';
+                }
+                html += '<button data-msg="end_game">' + esc(t.end) + '</button>' +
                     '<button data-reset="1">' + esc(t.reset) + '</button>' +
                     '</div>';
             }

--- a/tests/test_host_card_278.py
+++ b/tests/test_host_card_278.py
@@ -13,6 +13,12 @@ Two things are worth pinning, and they are the two that would fail silently:
 2. **The no-token fallback.** #530 shipped a control surface that silently did
    nothing because a credential was missing. The card must always name that
    state and link out of it.
+3. **Coverage of the whole phase enum (#801).** A phase missing from
+   ``PHASE_ACTIONS`` used to fall through to a disabled 'Connecting…' button,
+   so the host of a running game read a connection error for the entire wager
+   window and the entire Hot Seat detour. Every ``GamePhase`` must now resolve
+   to either an action or a deliberate status label, which is what stops the
+   next phase added to the game from reintroducing that silence.
 
 ``cards.py`` is tested for the promise it makes to setup: never raise.
 """
@@ -29,15 +35,69 @@ CARD_JS = COMPONENT / "www" / "cards" / "quizify-host-card.js"
 PHASES_PY = COMPONENT / "game" / "phase_controller.py"
 CARDS_PY = COMPONENT / "cards.py"
 
-# Phase -> the message the card must send. Keep in step with PHASE_ACTIONS in
-# the card and with what admin.js does for the same phase.
-EXPECTED_ACTIONS = {
+# Phase -> the message the card must send, or ``None`` where the host has no
+# move and the button is a status label instead (#801). Keep in step with
+# PHASE_ACTIONS in the card and with what admin.js does for the same phase.
+#
+# The ``None`` rows are not gaps: the server refuses ``admin_skip`` and
+# ``next_question`` in those phases (``_handle_admin_skip`` special-cases only
+# WAGER_ACTIVE and QUESTION_ACTIVE, and ``_advance_round`` accepts only LOBBY,
+# ANSWER_REVEAL, LIGHTNING_RECAP and HOT_SEAT_REVEAL), so a button there would
+# do nothing but raise ERR_INVALID_ACTION.
+EXPECTED_ACTIONS: dict[str, str | None] = {
     "LOBBY": "start_game",
+    "WAGER_ACTIVE": "admin_skip",
     "QUESTION_ACTIVE": "admin_skip",
     "ANSWER_REVEAL": "next_question",
     "PAUSED": "resume_game",
     "FINALE": "play_again",
+    "LIGHTNING": None,
+    "LIGHTNING_RECAP": "next_question",
+    "HOT_SEAT_AUCTION": None,
+    "HOT_SEAT": None,
+    "HOT_SEAT_REVEAL": "next_question",
 }
+
+#: Phases in which the server actually acts on ``admin_skip``. The expanded
+#: card's extra "Reveal" button sends it, so it may only be rendered here.
+SKIPPABLE = {"QUESTION_ACTIVE", "WAGER_ACTIVE"}
+
+
+def _phase_actions() -> dict[str, tuple[str, str | None]]:
+    """Parse PHASE_ACTIONS out of the card: phase -> (labelKey, msg|None)."""
+    text = _card_text()
+    block = re.search(r"var PHASE_ACTIONS = \{(.*?)\n    \};", text, re.S)
+    assert block, "could not find PHASE_ACTIONS in the card"
+    entries = re.findall(
+        r"^\s+([A-Z_]+): \{ labelKey: '(\w+)', msg: (?:'(\w+)'|(null)) \}",
+        block.group(1),
+        re.M,
+    )
+    assert entries, "PHASE_ACTIONS parsed as empty — the entry shape changed"
+    return {phase: (label, msg or None) for phase, label, msg, _null in entries}
+
+
+def _card_labels() -> dict[str, set[str]]:
+    """Parse the card's inline LABELS: language code -> the keys it defines."""
+    text = _card_text()
+    block = re.search(r"var LABELS = \{(.*?)\n    \};", text, re.S)
+    assert block, "could not find LABELS in the card"
+    out: dict[str, set[str]] = {}
+    for lang, body in re.findall(
+        r"\n        (\w+): \{(.*?)\n        \}", block.group(1), re.S
+    ):
+        # Drop the quoted values first, so a colon or a word inside a
+        # translated string cannot be mistaken for a key.
+        stripped = re.sub(r"'[^']*'", "''", body)
+        out[lang] = set(re.findall(r"(\w+):", stripped))
+    assert out, "LABELS parsed as empty — the bundle shape changed"
+    return out
+
+
+def _game_phases() -> set[str]:
+    phases = set(re.findall(r"^\s+([A-Z_]+) = \"", PHASES_PY.read_text(), re.M))
+    assert phases, "could not read GamePhase from game/phase_controller.py"
+    return phases
 
 
 def _card_text() -> str:
@@ -49,28 +109,111 @@ def test_card_file_ships() -> None:
 
 
 def test_every_phase_maps_to_the_expected_message() -> None:
-    text = _card_text()
+    actions = _phase_actions()
     for phase, message in EXPECTED_ACTIONS.items():
-        pattern = re.compile(
-            re.escape(phase) + r"\s*:\s*\{[^}]*msg\s*:\s*'" + re.escape(message) + r"'"
+        assert phase in actions, (
+            f"{phase} is missing from PHASE_ACTIONS — a phase whose mapping is "
+            "absent leaves the host with a dead button."
         )
-        assert pattern.search(text), (
-            f"{phase} must trigger {message!r} in PHASE_ACTIONS — a phase whose "
-            "mapping is missing or wrong leaves the host with a dead button."
+        assert actions[phase][1] == message, (
+            f"{phase} must trigger {message!r} in PHASE_ACTIONS, not "
+            f"{actions[phase][1]!r} — a wrong mapping is a button the server "
+            "answers with ERR_INVALID_ACTION."
         )
 
 
 def test_card_phases_exist_in_the_game() -> None:
     """A phase the card knows must still exist in GamePhase."""
-    game_phases = set(re.findall(r"^\s+([A-Z_]+) = \"", PHASES_PY.read_text(), re.M))
-    assert game_phases, "could not read GamePhase from game/phase_controller.py"
-
-    card_phases = set(re.findall(r"^\s+([A-Z_]+): \{ labelKey", _card_text(), re.M))
-    assert card_phases, "could not read PHASE_ACTIONS from the card"
-
-    unknown = card_phases - game_phases
+    card_phases = set(_phase_actions())
+    unknown = card_phases - _game_phases()
     assert not unknown, (
         f"the card handles phases the game no longer has: {sorted(unknown)}"
+    )
+
+
+def test_every_game_phase_is_covered_by_the_card() -> None:
+    """#801: no phase may fall through to the disabled 'Connecting…' button.
+
+    ``_primary()`` labels an unknown phase with ``connecting``, which reads as
+    a broken connection. It shipped that way for WAGER_ACTIVE, HOT_SEAT_AUCTION,
+    HOT_SEAT and HOT_SEAT_REVEAL, so a host running the evening from a wall
+    tablet was told the card was still connecting through the whole betting
+    window and the whole Hot Seat detour — and at HOT_SEAT_REVEAL, the one
+    phase where the server does accept ``next_question``, the card offered
+    nothing and the game could not be resumed from it at all.
+
+    This test is the reason the same thing cannot happen to the next phase
+    somebody adds to ``GamePhase``: coverage is asserted against the enum, not
+    against a hand-kept list.
+    """
+    missing = _game_phases() - set(_phase_actions())
+    assert not missing, (
+        "every GamePhase needs a PHASE_ACTIONS entry — either an action or a "
+        "deliberate status label with msg: null. Missing: "
+        f"{sorted(missing)}. Without one the card tells the host it is "
+        "'Connecting…' while the game is running fine."
+    )
+
+
+def test_phases_the_host_cannot_advance_carry_a_real_status_label() -> None:
+    """A msg-less entry has to say something other than 'Connecting…'."""
+    labels = _card_labels()
+    for phase, (label_key, message) in _phase_actions().items():
+        if message is not None:
+            continue
+        assert label_key != "connecting", (
+            f"{phase} must name what the room is doing, not claim the card is "
+            "still connecting"
+        )
+        for lang, keys in labels.items():
+            assert label_key in keys, (
+                f"the {phase} status label {label_key!r} is missing from the "
+                f"{lang} bundle — the card would render `undefined`"
+            )
+
+
+def test_every_label_key_the_map_uses_exists_in_all_three_languages() -> None:
+    labels = _card_labels()
+    assert set(labels) == {"en", "de", "es"}, (
+        f"the card must carry exactly en/de/es; got {sorted(labels)}"
+    )
+    for phase, (label_key, _msg) in _phase_actions().items():
+        for lang, keys in labels.items():
+            assert label_key in keys, (
+                f"{phase} uses label {label_key!r}, absent from the {lang} bundle"
+            )
+
+
+def test_lightning_does_not_send_a_message_the_server_refuses() -> None:
+    """LIGHTNING sent ``admin_skip``, which ERR_INVALID_ACTIONs (#801).
+
+    ``_handle_admin_skip`` special-cases WAGER_ACTIVE and QUESTION_ACTIVE only;
+    in LIGHTNING it falls through to ``_handle_next_question``, whose phase
+    gate rejects it. The lightning loop is server-driven and has no host step,
+    so the honest card offers none.
+    """
+    label_key, message = _phase_actions()["LIGHTNING"]
+    assert message is None, (
+        "the lightning loop has no host-driven step — offering one gives the "
+        f"host a button that errors; got {message!r}"
+    )
+    assert label_key != "connecting"
+
+
+def test_reveal_button_is_offered_only_where_admin_skip_works() -> None:
+    """The expanded card's extra Reveal button is gated to two phases (#801)."""
+    text = _card_text()
+    gate = re.search(r"var SKIPPABLE_PHASES = \{([^}]*)\}", text)
+    assert gate, (
+        "the expanded Reveal button sends admin_skip, which the server refuses "
+        "outside QUESTION_ACTIVE/WAGER_ACTIVE — it needs an explicit phase gate"
+    )
+    assert set(re.findall(r"([A-Z_]+):", gate.group(1))) == SKIPPABLE
+
+    reveal_at = text.index("esc(t.reveal)")
+    window = text[max(0, reveal_at - 400) : reveal_at]
+    assert "SKIPPABLE_PHASES" in window, (
+        "the Reveal button must be rendered behind the phase gate, not always"
     )
 
 


### PR DESCRIPTION
`PHASE_ACTIONS` in `www/cards/quizify-host-card.js` covered seven of the eleven `GamePhase` values. The four it missed — `WAGER_ACTIVE`, `HOT_SEAT_AUCTION`, `HOT_SEAT` and `HOT_SEAT_REVEAL` — fell through `_primary()` to a disabled button labelled "Connecting…", so a host driving the evening from a wall tablet read a connection error for the whole betting window and the whole Hot Seat detour while the game was running perfectly well. At `HOT_SEAT_REVEAL`, the one detour phase where the server does accept `next_question`, the card offered nothing at all and the game could not be resumed from it.

## What changed

Every phase now has an entry, mirroring what `admin.js` does for the same phase:

| Phase | Card |
|---|---|
| `WAGER_ACTIVE` | **Close betting** → `admin_skip` (closes the window and asks the question) |
| `HOT_SEAT_AUCTION` | disabled — "Bidding for the hot seat" |
| `HOT_SEAT` | disabled — "The hot seat is answering" |
| `HOT_SEAT_REVEAL` | **Next question** → `next_question` |
| `LIGHTNING` | disabled — "Lightning round running" (was `admin_skip`) |

A `msg: null` entry is the honest version of the disabled button: still not tappable, but it names what the room is doing instead of claiming the card is offline. `connecting` is now only rendered when there really is no state yet.

Two related refusals go with it:

- `LIGHTNING` sent `admin_skip`, which reaches `_handle_next_question` and is rejected with `ERR_INVALID_ACTION` — the lightning loop is server-driven and has no host step.
- The expanded card's extra **Reveal** button sends the same message and failed the same way during the auction. It is now gated behind `SKIPPABLE_PHASES` and rendered only in `QUESTION_ACTIVE` and `WAGER_ACTIVE`.

## Why it cannot come back

`test_every_game_phase_is_covered_by_the_card` reads `GamePhase` out of `game/phase_controller.py` and fails if any member has no `PHASE_ACTIONS` entry — coverage is asserted against the enum, not against a hand-kept list, so the next phase added to the game cannot silently fall back to "Connecting…". Two further tests pin that a `msg: null` entry never uses the `connecting` label and that every label key it does use exists in all three of the card's inline bundles (en/de/es).

## Verification

- `tests/test_host_card_278.py`: 16 passed. With the card change stashed and the tests kept, 4 fail — `test_every_phase_maps_to_the_expected_message`, `test_every_game_phase_is_covered_by_the_card`, `test_lightning_does_not_send_a_message_the_server_refuses`, `test_reveal_button_is_offered_only_where_admin_skip_works`.
- Full suite: 3181 passed, 11 xfailed. The two failures in `tests/test_service_start_settings_744.py` are the pre-existing local preset-cap problem tracked as #823, unrelated to this change.
- `ruff check custom_components/` clean; `mypy` clean (54 files).
- `scripts/build_gzip.py` run — `www/cards/` is not in `GZIP_TARGETS`, so no sibling changed.

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)