### PR TITLE
Give every game mode its own driver, and build the wire format in one layer

### DIFF
--- a/custom_components/quizify/game/drivers/__init__.py
+++ b/custom_components/quizify/game/drivers/__init__.py
@@ -1,0 +1,47 @@
+"""One driver per game mode (#788).
+
+Before this package, four complete game loops lived inside
+``QuizifyWebSocketHandler``: lightning, the hot-seat auction/question loop, the
+normal-round tick loop and the wager window. They were not I/O adapters — they
+encoded rules ("cut the window short once every connected player answered",
+"hold the bid reveal four seconds", "settle even when unanswered") interleaved
+with socket sends and a hand-rolled phase re-check after every sleep. The
+handler's own teardown comment records that the resulting matrix broke five
+times (#362, #407, #656, #671, #746), each time because a new loop was a fresh
+copy of poll / tick / re-check / settle / cancel.
+
+Each driver here owns exactly that: timing, the phase re-checks and the
+settlement. It talks to the outside world through the two narrow protocols in
+:mod:`.protocols` — a per-mode ``Broadcaster`` for the fan-out points and a
+``MilestoneSink`` for the house beats — and builds no wire payloads itself,
+which is what keeps the game layer clear of the server layer (#747).
+
+The asyncio tasks themselves stay on the handler, where the #746 registry can
+see them; a driver is the coroutine, not its lifetime.
+"""
+
+from __future__ import annotations
+
+from .hot_seat import HotSeatDriver
+from .lightning import LightningDriver
+from .normal_round import NormalRoundDriver
+from .protocols import (
+    HotSeatBroadcaster,
+    LightningBroadcaster,
+    MilestoneSink,
+    RoundBroadcaster,
+    WagerBroadcaster,
+)
+from .wager import WagerWindowDriver
+
+__all__ = [
+    "HotSeatBroadcaster",
+    "HotSeatDriver",
+    "LightningBroadcaster",
+    "LightningDriver",
+    "MilestoneSink",
+    "NormalRoundDriver",
+    "RoundBroadcaster",
+    "WagerBroadcaster",
+    "WagerWindowDriver",
+]

--- a/custom_components/quizify/game/drivers/hot_seat.py
+++ b/custom_components/quizify/game/drivers/hot_seat.py
@@ -1,0 +1,184 @@
+"""The Hot Seat's control loop (#616/#804), lifted out of the transport
+handler by #788.
+
+Auction → sealed reveal → one question for the chair → settlement. Four rules
+are worth naming, because they are the reason this is a driver and not an
+adapter: the auction closes early once every connected player has bid; the bid
+reveal is held for a beat so the room can read it; an auction nobody bid on is
+not a failure but a round that does not happen; and the chair is settled even
+when nothing was answered, because it was bought either way (#653).
+
+The phase re-checks after each wait are #671: a reset or an end_game that lands
+inside the last poll interval must not be followed by a ghost round or a
+settlement against a game that no longer exists.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+from typing import Any
+
+from ..state import GamePhase
+from .protocols import HotSeatBroadcaster, MilestoneSink
+
+_LOGGER = logging.getLogger(__name__)
+
+__all__ = ["HotSeatDriver"]
+
+
+class HotSeatDriver:
+    """Drive auction → reveal → question → settlement for the Hot Seat."""
+
+    #: Poll cadence for both windows. Ticks go out on the ceil() change.
+    POLL_INTERVAL = 0.25
+
+    def __init__(
+        self,
+        broadcaster: HotSeatBroadcaster,
+        *,
+        milestones: MilestoneSink | None = None,
+        reveal_hold: float = 4.0,
+    ) -> None:
+        self._out = broadcaster
+        self._milestones = milestones
+        self._reveal_hold = reveal_hold
+
+    async def run(self, game_state: Any) -> None:
+        try:
+            await self._run(game_state)
+        except asyncio.CancelledError:
+            pass
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("Hot seat loop crashed")
+
+    async def _run(self, game_state: Any) -> None:
+        hs = game_state.hot_seat
+        if hs is None:
+            return
+
+        # --- bidding window ---------------------------------------------
+        await self._wait_out(
+            game_state,
+            hs,
+            phase=GamePhase.HOT_SEAT_AUCTION,
+            stage="auction",
+            done=lambda: hs.all_bid(
+                [p.name for p in game_state.get_players() if p.connected]
+            ),
+        )
+        # #671: the wait above only checks the phase INSIDE it. Leaving it
+        # (expired, or everyone bid) and acting without a re-check lets a reset
+        # that landed in the last poll interval be followed by a ghost round in
+        # the fresh lobby.
+        if game_state.phase != GamePhase.HOT_SEAT_AUCTION:
+            return
+
+        winner = game_state.close_hot_seat_auction()
+        if winner is None:
+            # Nobody wanted the chair. Not a failure — just a round that does
+            # not happen. Fall back to the normal question so the game keeps
+            # moving.
+            await self._out.send_hot_seat_no_bids()
+            game_state.abort_hot_seat()
+            await self._out.resume_normal_question(game_state)
+            return
+
+        # --- simultaneous reveal ----------------------------------------
+        await self._out.send_hot_seat_awarded(game_state, hs)
+        await asyncio.sleep(self._reveal_hold)
+        if game_state.phase != GamePhase.HOT_SEAT:
+            return
+
+        # --- the question ------------------------------------------------
+        await self._out.send_hot_seat_question(game_state, hs)
+        # #708: the chair's question is an ordinary question as far as the
+        # house is concerned — the narrator reads it and the bus event fires,
+        # exactly as in a normal round. Before #788 these hooks were reachable
+        # from the normal-round path only, so the room went quiet for the whole
+        # detour. Fired after the fan-out for the same reason the normal round
+        # does it there: the players see it before the room hears it. The
+        # spoken options are deliberately withheld — only the seat holder has
+        # answer buttons, and reading the options to the room would hand the
+        # spectators a board the mode does not give them.
+        self._milestone(
+            "question_shown",
+            hs.question,
+            game_state.round,
+            game_state.total_rounds,
+            None,
+        )
+        hs.start_answer_clock()
+        await self._wait_out(
+            game_state,
+            hs,
+            phase=GamePhase.HOT_SEAT,
+            stage="question",
+            done=lambda: hs.answered is not None,
+            countdown=True,
+        )
+        # #671: same re-check as after the auction wait — a teardown that lands
+        # in the last poll interval must not be followed by a settlement
+        # against a game that no longer exists.
+        if game_state.phase != GamePhase.HOT_SEAT:
+            return
+
+        # Settle even when nothing was answered: the chair was bought either
+        # way (#653). This is the one place the mode parts ways with the
+        # finale's forgiving timeout.
+        game_state.finish_hot_seat()
+        await self._out.send_hot_seat_result(game_state, hs)
+        # #708: and the reveal beat, so the lights and the narrator close the
+        # detour the way they close an ordinary round.
+        self._milestone("reveal", game_state)
+
+    async def _wait_out(
+        self,
+        game_state: Any,
+        hs: Any,
+        *,
+        phase: GamePhase,
+        stage: str,
+        done: Any,
+        countdown: bool = False,
+    ) -> None:
+        """Poll one of the two windows until it expires or ``done()``.
+
+        Emits a tick only when the displayed whole second changes, and returns
+        early (without settling anything) as soon as the phase moves on — the
+        caller re-checks, because leaving the wait is not the same as the wait
+        having finished.
+        """
+        last_shown = None
+        while not hs.is_expired():
+            if game_state.phase != phase:
+                return
+            remaining = hs.time_remaining()
+            shown = math.ceil(remaining)
+            if shown != last_shown:
+                await self._out.send_hot_seat_tick(stage, shown)
+                last_shown = shown
+            if countdown:
+                # #708: the same per-tick beat the normal round pushes, so the
+                # "time running out" warning and the faster light pulse reach
+                # the chair's window too. The consumers keep their own
+                # once-per-window guards.
+                self._milestone("time_running_out", remaining)
+            if done():
+                return
+            await asyncio.sleep(self.POLL_INTERVAL)
+
+    def _milestone(self, name: str, *args: Any) -> None:
+        """Fire one house beat, if a sink is wired.
+
+        Guarded here as well as in the sink: a driver must never lose a game
+        loop to a misbehaving consumer.
+        """
+        sink = self._milestones
+        if sink is None:
+            return
+        try:
+            getattr(sink, name)(*args)
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("Hot seat milestone %s raised", name)

--- a/custom_components/quizify/game/drivers/lightning.py
+++ b/custom_components/quizify/game/drivers/lightning.py
@@ -1,0 +1,130 @@
+"""The Lightning Round's control loop (#42/#201/#285), lifted out of the
+transport handler by #788.
+
+Five questions, a fixed window each, no reveal in between; the window is cut
+short the moment every connected player has answered. All of that is a *rule*,
+which is why it lives here now and not next to the socket sends. The scoring
+and the question queue stay in :mod:`custom_components.quizify.game.lightning`;
+this only decides when things happen and asks the broadcaster to fan them out.
+
+It deliberately takes no ``MilestoneSink``. The house *should* play along here
+(#708), but not by reusing the normal round's beats: ``announce_question``
+reads a question aloud, and five of those inside seventy-five seconds would
+talk over the mode it is meant to accompany. Lightning needs its own phrases,
+its own light recipe and its own bus event, which is #708's remaining half.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+from typing import Any
+
+from ..state import GamePhase
+from .protocols import LightningBroadcaster
+
+_LOGGER = logging.getLogger(__name__)
+
+__all__ = ["LightningDriver"]
+
+
+class LightningDriver:
+    """Drive splash → question → advance → recap for the fast mode."""
+
+    #: How often the wait polls for "everybody answered". The display shows
+    #: whole seconds, so ticks are emitted on the ceil() change, not per poll.
+    POLL_INTERVAL = 0.25
+
+    def __init__(
+        self,
+        broadcaster: LightningBroadcaster,
+        *,
+        splash_grace: float = 1.0,
+        splash_hold: float = 3.0,
+    ) -> None:
+        self._out = broadcaster
+        self._splash_grace = splash_grace
+        self._splash_hold = splash_hold
+
+    async def run(
+        self, game_state: Any, *, auto_dismiss_splash: bool = False
+    ) -> None:
+        """Run the whole mode to its recap.
+
+        With ``auto_dismiss_splash`` (the #285 auto flow) the loop first holds
+        the intro splash for ``splash_hold`` seconds and dismisses it itself —
+        there is no host "Start" tap any more.
+        """
+        try:
+            await self._run(game_state, auto_dismiss_splash=auto_dismiss_splash)
+        except asyncio.CancelledError:
+            pass
+        except Exception:  # noqa: BLE001
+            # #307: an unexpected exception here used to kill the lightning
+            # task silently, hanging the round on the current question with a
+            # frozen clock. Log it so the failure surfaces.
+            _LOGGER.exception("Lightning loop crashed")
+
+    async def _run(
+        self, game_state: Any, *, auto_dismiss_splash: bool
+    ) -> None:
+        if auto_dismiss_splash:
+            # Hold the intro splash on its own, then advance out of it.
+            await asyncio.sleep(self._splash_hold)
+            if game_state.phase != GamePhase.LIGHTNING:
+                return
+            game_state.begin_lightning_questions()
+        # Brief grace so clients swap from the intro splash (#201) to the
+        # question view before the first clock starts ticking.
+        await asyncio.sleep(self._splash_grace)
+
+        while game_state.phase == GamePhase.LIGHTNING:
+            lr = game_state.lightning
+            if lr is None:
+                return
+            await self._out.send_lightning_question(game_state, lr)
+            # Re-arm the question clock now (after the broadcast) so the
+            # countdown the players see matches the server window.
+            lr.restart_clock()
+            if not await self._wait_out_question(game_state, lr):
+                return
+            # #746, the re-check the hot-seat loop got in #671 and this one did
+            # not: the wait only tests the phase AFTER a sleep, so the
+            # all-answered ``break`` leaves it untested. An end_game landing in
+            # that gap was still followed by ``lr.advance()`` — a lightning
+            # question scored, and a recap frame broadcast, after the finale.
+            if game_state.phase != GamePhase.LIGHTNING:
+                return
+            # No reveal — score silently and arm the next question.
+            if not lr.advance():
+                game_state.finish_lightning_round()
+                await self._out.send_lightning_recap(game_state)
+                return
+
+    async def _wait_out_question(self, game_state: Any, lr: Any) -> bool:
+        """Wait for the fixed window or for everyone to answer.
+
+        Returns False when the phase left LIGHTNING mid-wait, i.e. the caller
+        must not settle anything.
+        """
+        deadline = lr.seconds_per_question
+        waited = 0.0
+        step = self.POLL_INTERVAL
+        # The display shows whole seconds (1 Hz), so only push a tick when the
+        # ceil(remaining) actually changes — no point broadcasting at the 4 Hz
+        # poll cadence (#258).
+        last_shown = None
+        while waited < deadline:
+            shown = math.ceil(lr.time_remaining())
+            if shown != last_shown:
+                await self._out.send_lightning_tick(game_state, lr)
+                last_shown = shown
+            connected = [p.name for p in game_state.get_players() if p.connected]
+            if lr.all_connected_answered(connected):
+                return True
+            await asyncio.sleep(step)
+            waited += step
+            if game_state.phase != GamePhase.LIGHTNING:
+                return False
+        return True

--- a/custom_components/quizify/game/drivers/normal_round.py
+++ b/custom_components/quizify/game/drivers/normal_round.py
@@ -1,0 +1,139 @@
+"""The normal round's countdown loop (#203/#413), lifted out of the transport
+handler by #788.
+
+The *timing* — which players have a live timer, each one's authoritative
+remaining time (so time-boost / freeze power-ups are reflected, #4), the
+dashboard minimum and the all-expired stop condition — already lived in the
+PhaseController. What lived in the WebSocket handler was everything around it:
+the tick cadence, the per-recipient coalescing, the two stop conditions and the
+auto-evaluate. Those are the round's rules over time, so they live here now.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+from typing import Any
+
+from ..phase_controller import TICK_INTERVAL
+from ..state import GamePhase
+from .protocols import MilestoneSink, RoundBroadcaster
+
+_LOGGER = logging.getLogger(__name__)
+
+__all__ = ["NormalRoundDriver"]
+
+
+class NormalRoundDriver:
+    """Tick a live question down and evaluate the round when it runs out."""
+
+    def __init__(
+        self,
+        broadcaster: RoundBroadcaster,
+        *,
+        milestones: MilestoneSink | None = None,
+        tick_interval: float = TICK_INTERVAL,
+    ) -> None:
+        self._out = broadcaster
+        self._milestones = milestones
+        self._tick_interval = tick_interval
+
+    async def run(self, game_state: Any) -> None:
+        try:
+            await self._run(game_state)
+        except asyncio.CancelledError:
+            pass
+        except Exception:  # noqa: BLE001
+            # #307: any other exception used to kill the tick task silently,
+            # leaving the game frozen in QUESTION_ACTIVE with a stuck
+            # countdown. Log it loudly so the failure is diagnosable instead of
+            # presenting as a mysterious hang.
+            _LOGGER.exception("Timer tick loop crashed")
+
+    async def _run(self, game_state: Any) -> None:
+        # #413: the client renders ``Math.ceil(remaining)`` WHOLE seconds, but
+        # the loop ticks every ~0.5s — so half the frames redraw the same
+        # number and are pure waste (at the 20-player cap: 20 sockets × the
+        # dead frame, every tick). Remember the last displayed second per
+        # recipient and only emit when that second actually changes. The sleep
+        # cadence is unchanged, so countdown accuracy and the auto-evaluate
+        # timing are unaffected — only the redundant frames are dropped.
+        last_shown_by_name: dict[str, int] = {}
+        last_dashboard_shown: int | None = None
+
+        while game_state.phase == GamePhase.QUESTION_ACTIVE:
+            players = game_state.get_players()
+            by_name = {p.name: p for p in players}
+            # Ask the timing unit for this tick's per-player remaining plus the
+            # shared dashboard minimum (one timer read each).
+            tick = game_state.resolve_tick([p.name for p in players])
+
+            changed: dict[str, float] = {}
+            for name, remaining in tick.per_player:
+                p = by_name.get(name)
+                if p is None or not p.connected:
+                    continue
+                shown = math.ceil(max(0.0, remaining))
+                if last_shown_by_name.get(name) == shown:
+                    continue
+                last_shown_by_name[name] = shown
+                changed[name] = remaining
+
+            min_remaining = tick.dashboard_remaining
+            # ONE countdown milestone per tick (#789): the spoken warning
+            # (#281) and the bus event that drives the faster light pulse
+            # (#280) fan out inside the sink, each with its own
+            # once-per-round guard.
+            self._milestone("time_running_out", min_remaining)
+            dash_shown = math.ceil(max(0.0, min_remaining))
+            dashboard_remaining: float | None = None
+            if dash_shown != last_dashboard_shown:
+                last_dashboard_shown = dash_shown
+                dashboard_remaining = min_remaining
+
+            if changed or dashboard_remaining is not None:
+                await self._out.send_timer_tick(
+                    game_state, changed, dashboard_remaining
+                )
+            await asyncio.sleep(self._tick_interval)
+
+            # Stop if everyone's timer hit zero and the phase is still active.
+            # Re-read fresh timers (state can change during the sleep) for the
+            # CONNECTED players only; the all-expired decision itself lives in
+            # the PhaseController, which ignores players without a timer so a
+            # late-joining connected player (e.g. the admin's own
+            # /quizify/player tab) can't end the round before their per-player
+            # timer exists.
+            connected = [p.name for p in players if p.connected]
+            if connected and game_state.all_timers_expired(connected):
+                break
+            # Fallback: all_timers_expired needs at least one live timer to
+            # break on, so the loop hangs in every state where the connected
+            # players have none. That covers the original case — everyone
+            # disconnected mid-question (#255) — and the one it missed:
+            # connected players who never got a timer, where NEITHER condition
+            # could fire and the loop spun forever with the countdown frozen at
+            # 0 (#586). Keying the fallback on "no live timers" instead of "no
+            # connected players" covers both with one condition.
+            if (
+                not game_state.has_live_timers(connected)
+                and game_state.round_wall_clock_expired()
+            ):
+                break
+
+        # Timer expired globally. The state machine's
+        # _fire_broadcast("round_evaluated") handles the summary broadcast — do
+        # NOT broadcast here.
+        if game_state.phase == GamePhase.QUESTION_ACTIVE:
+            game_state.evaluate_round()
+
+    def _milestone(self, name: str, *args: Any) -> None:
+        """Fire one house beat, if a sink is wired."""
+        sink = self._milestones
+        if sink is None:
+            return
+        try:
+            getattr(sink, name)(*args)
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("Round milestone %s raised", name)

--- a/custom_components/quizify/game/drivers/protocols.py
+++ b/custom_components/quizify/game/drivers/protocols.py
@@ -1,0 +1,125 @@
+"""The two narrow contracts a game-mode driver is allowed to know about (#788).
+
+A driver owns a mode's *rules over time*: how long a window stays open, what
+cuts it short, which phase re-check has to happen after every sleep, and what
+settles when the window closes. It must not own the wire format — that is the
+server layer's job, and mixing the two is what #747 is about. So a driver never
+builds a payload dict and never touches a WebSocket. It calls the two protocols
+below, and ``server.websocket.QuizifyWebSocketHandler`` implements them.
+
+``Broadcaster`` (one per mode, because the moments differ per mode)
+    Semantic fan-out points — "the question is on", "the clock moved", "here is
+    the recap". The implementation decides who receives what and in which
+    shape; the driver only decides *when*.
+
+``MilestoneSink``
+    The house hooks: narration (#281), the HA event bus (#366) and everything
+    that hangs off them (lights, SFX). Before #788 these were called from the
+    normal-round path only, which is why the house sat out the detour modes
+    (#708). Putting the sink on the driver is what makes "every mode walks
+    every path" expressible rather than remembered.
+
+Both are :class:`typing.Protocol` s, so the handler satisfies them structurally
+— no base class, no import from ``server`` into ``game``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+__all__ = [
+    "HotSeatBroadcaster",
+    "LightningBroadcaster",
+    "MilestoneSink",
+    "RoundBroadcaster",
+    "WagerBroadcaster",
+]
+
+
+class MilestoneSink(Protocol):
+    """Where a driver reports the beats the house reacts to (#789/#708).
+
+    Every method is fire-and-forget and must never raise: the implementation
+    guards each consumer, because a broken TTS entity is not a reason to stall
+    a game loop.
+    """
+
+    def question_shown(
+        self,
+        question: Any,
+        round_no: int,
+        total_rounds: int,
+        options: list[str] | None = None,
+    ) -> None:
+        """A question just went out to the room."""
+
+    def time_running_out(self, seconds_remaining: float) -> None:
+        """The current answer window is running down. Called on every tick;
+        each consumer keeps its own once-per-round guard and threshold."""
+
+    def reveal(self, game_state: Any) -> None:
+        """The answer is out and the round has been scored."""
+
+
+class LightningBroadcaster(Protocol):
+    """The Lightning Round's fan-out points (#42/#201)."""
+
+    async def send_lightning_question(self, game_state: Any, lr: Any) -> None:
+        """Push the current lightning question (own shuffle per phone)."""
+
+    async def send_lightning_tick(self, game_state: Any, lr: Any) -> None:
+        """Push the shared lightning countdown."""
+
+    async def send_lightning_recap(self, game_state: Any) -> None:
+        """Push the end-of-mode recap."""
+
+
+class HotSeatBroadcaster(Protocol):
+    """The Hot Seat's fan-out points (#616/#804)."""
+
+    async def send_hot_seat_tick(self, stage: str, remaining: int) -> None:
+        """Push the countdown for ``"auction"`` or ``"question"``."""
+
+    async def send_hot_seat_no_bids(self) -> None:
+        """Tell the room nobody wanted the chair."""
+
+    async def send_hot_seat_awarded(self, game_state: Any, hs: Any) -> None:
+        """Break the seal: who paid what, and who is sitting down."""
+
+    async def send_hot_seat_question(self, game_state: Any, hs: Any) -> None:
+        """Push the seat holder's question (answers only to the chair)."""
+
+    async def send_hot_seat_result(self, game_state: Any, hs: Any) -> None:
+        """Push the settlement."""
+
+    async def resume_normal_question(self, game_state: Any) -> None:
+        """Leave the detour and start an ordinary question instead.
+
+        The mode's escape hatch, not a broadcast: an auction nobody bid on is
+        a round that does not happen, and the main game has to keep moving.
+        """
+
+
+class RoundBroadcaster(Protocol):
+    """The normal round's fan-out points (#203/#413)."""
+
+    async def send_timer_tick(
+        self,
+        game_state: Any,
+        remaining_by_player: dict[str, float],
+        dashboard_remaining: float | None,
+    ) -> None:
+        """Push one tick.
+
+        ``remaining_by_player`` holds only the players whose *displayed* second
+        actually changed, and ``dashboard_remaining`` is ``None`` when the
+        shared countdown's second did not — the coalescing (#413) is the
+        driver's, the addressing is the implementation's.
+        """
+
+
+class WagerBroadcaster(Protocol):
+    """The betting window's single fan-out point (#656)."""
+
+    async def close_wager_window(self, game_state: Any) -> None:
+        """The deadline passed: arm the round timers and send the question."""

--- a/custom_components/quizify/game/drivers/wager.py
+++ b/custom_components/quizify/game/drivers/wager.py
@@ -1,0 +1,39 @@
+"""The final round's betting window (#656), lifted out of the transport handler
+by #788.
+
+One rule, and it is the whole point of the object: the window ends at its
+deadline whether or not the players cooperate. An AFK phone — or a room that
+all walked out — used to hang the final round on the betting screen forever,
+the same class of hang as #586, so this gets an unconditional timer rather than
+a condition that depends on clients behaving.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from .protocols import WagerBroadcaster
+
+_LOGGER = logging.getLogger(__name__)
+
+__all__ = ["WagerWindowDriver"]
+
+
+class WagerWindowDriver:
+    """Hold the betting window open for its duration, then close it."""
+
+    def __init__(self, broadcaster: WagerBroadcaster, *, duration: float) -> None:
+        self._out = broadcaster
+        self._duration = duration
+
+    async def run(self, game_state: Any) -> None:
+        try:
+            await asyncio.sleep(self._duration)
+        except asyncio.CancelledError:
+            return
+        try:
+            await self._out.close_wager_window(game_state)
+        except Exception:  # noqa: BLE001 — a stuck window strands the game
+            _LOGGER.exception("Wager window failed to close")

--- a/custom_components/quizify/game/lightning.py
+++ b/custom_components/quizify/game/lightning.py
@@ -168,7 +168,7 @@ class LightningRound:
         self._recaps: list[LightningQuestionRecap] = []
 
         # Memoized end-screen payload (#455). Once the round is finished the
-        # recap is immutable, but get_state_snapshot() rebuilds it on EVERY
+        # recap is immutable, but the state snapshot rebuilds it on EVERY
         # join / reconnect / get_state while the phase is LIGHTNING_RECAP.
         # Cache the built dict the first time build_recap() runs post-finish
         # and reuse it thereafter. A fresh LightningRound instance (each detour

--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -122,7 +122,11 @@ class RoundSummary:
     correct_answer: Answer
     fun_fact: str
     results: list[AnswerResult] = field(default_factory=list)
-    leaderboard: list[dict[str, Any]] = field(default_factory=list)
+    #: The standings after this round, in rank order — TEAMS in team mode,
+    #: players otherwise. Domain objects, not wire rows (#747): the only
+    #: consumer inside the process is the narrator, and every client-facing
+    #: leaderboard is serialized at the edge by ``serialize_leaderboard``.
+    leaderboard: list[Any] = field(default_factory=list)
     # Estimate-round reveal data (#275). None for multiple-choice rounds.
     # When set, carries the true value, range/unit, and every player's guess +
     # distance + awarded points so the number-line reveal can be rendered on
@@ -1572,7 +1576,7 @@ class QuizifyGameState:
                 )
             )
 
-        leaderboard = self.get_leaderboard()
+        leaderboard = self.get_standings()
 
         self._round_summary = RoundSummary(
             question=question,
@@ -1893,7 +1897,7 @@ class QuizifyGameState:
         self.phase = GamePhase.FINALE
         self._current_question = None
 
-        # Cache podium and superlatives once so get_state_snapshot() can reuse
+        # Cache podium and superlatives once so the state snapshot can reuse
         # them. In team mode the participants are the teams (#365) — the podium
         # and the awards are computed by the same code, one rung up.
         self._collect_team_powerup_stats()
@@ -1905,7 +1909,10 @@ class QuizifyGameState:
 
         finale_data = {
             "phase": GamePhase.FINALE.value,
-            "leaderboard": self.get_leaderboard(),
+            # Domain objects (#747). ``end_game``'s return never reaches a
+            # client — it is the idempotency cache — so it holds the standings
+            # rather than a second, drift-prone copy of the wire format.
+            "leaderboard": self.get_standings(),
             "podium": [
                 {"name": p.name, "score": p.score, "rank": i + 1}
                 for i, p in enumerate(podium)
@@ -2884,28 +2891,20 @@ class QuizifyGameState:
             return None
         return question.image_url or None
 
-    def get_leaderboard(self) -> list[dict[str, Any]]:
-        """Return sorted leaderboard data — wire-identical to the live broadcast.
+    def get_standings(self) -> list[Any]:
+        """The participants in rank order, highest score first.
 
-        Delegates to :func:`serialize_leaderboard` (the same helper the live
-        ``game_state`` / ``round_summary`` broadcasts use) so the snapshot
-        leaderboard carries the FULL client contract — ``submitted``,
-        ``best_streak``, ``rounds_played``, ``powerups_used``, ``round_score``,
-        ``correct`` — not just rank/name/score/streak (#297). Without those
-        keys a reconnect-after-submit never re-locked the answer buttons
-        (player-core.js reads ``leaderboard[].submitted``) and a FINALE
-        reconnect showed 0 for BESTE SERIE / GESPIELTE RUNDEN / POWER-UPS.
-
-        ``is_admin`` is likewise required so the reconnect client can show the
-        admin "Start New Game" / "Next Round" controls; ``serialize_leaderboard``
-        emits it. (Earlier hand-rolled versions of this method dropped fields
-        and caused a chronic FINALE admin-lockout — see v1.1.4 notes.)
+        Domain objects, deliberately. Until #747 this method returned the
+        client wire rows instead, by reaching into ``server.serializers`` from
+        a function-local import — the game layer building the server layer's
+        format, which is exactly the drift that cost #297, #434, #521 and #253.
+        Every client-facing leaderboard is now serialized at the edge with
+        :func:`~custom_components.quizify.server.serializers.serialize_leaderboard`,
+        which is also where the tie-sharing rank (#308) lives.
         """
-        # Local import keeps the game-layer free of a module-level dependency
-        # on the server layer (serializers only TYPE_CHECKING-imports game).
-        from ..server.serializers import serialize_leaderboard
-
-        return serialize_leaderboard(self.get_ranked_participants())
+        return sorted(
+            self.get_ranked_participants(), key=lambda p: p.score, reverse=True
+        )
 
     def get_ranked_participants(self) -> list[Any]:
         """Whoever the ranking is about: teams in team mode, else players (#365).
@@ -2993,6 +2992,27 @@ class QuizifyGameState:
         """Return the last round summary."""
         return self._round_summary
 
+    def get_players_state(self) -> list[dict[str, Any]]:
+        """The roster rows, as the registry keeps them.
+
+        A read-only accessor so the snapshot serializer (#747) does not have to
+        reach into ``_player_registry``.
+        """
+        return self._player_registry.get_players_state()
+
+    @property
+    def wager_window_duration(self) -> float:
+        """How long a betting window stays open (#656)."""
+        return self._phase_controller.wager_window_duration
+
+    def question_time_remaining_for_snapshot(self) -> float:
+        """Seconds left on the current question, for a mid-round joiner.
+
+        Deliberately not the per-player remaining: someone who has no timer yet
+        needs the room's clock, not their own missing one.
+        """
+        return self._phase_controller.time_remaining_for_snapshot()
+
     def all_submitted(self) -> bool:
         """Whether every active, non-late participant has submitted (#412).
 
@@ -3053,281 +3073,6 @@ class QuizifyGameState:
         """Return the finale superlatives cached by ``end_game`` (#415)."""
         return self._finale_superlatives
 
-    def get_state_snapshot(self) -> dict[str, Any]:
-        """Build a full state snapshot for WebSocket serialization."""
-        snapshot: dict[str, Any] = {
-            "phase": self.phase.value,
-            "game_id": self.game_id,
-            "round": self.round,
-            "total_rounds": self.total_rounds,
-            "category": self.category,
-            "difficulty": self.difficulty,
-            # The player client uses this to sync its UI locale with the
-            # game language (player-core.js handleGameState). Without it
-            # the UI stayed at the browser locale (e.g., German chrome
-            # over English questions if the host picked EN but the guest's
-            # phone is DE). Live-test Mai-27.
-            "language": self.language,
-            "players": self._player_registry.get_players_state(),
-            "leaderboard": self.get_leaderboard(),
-            # Always present, empty in an ordinary game (#365). A reconnecting
-            # phone has to be able to tell "no teams" from "teams not sent" —
-            # otherwise a member who drops mid-game comes back without their
-            # team indicator and believes they are playing alone.
-            "teams": self._team_registry.to_list(),
-        }
-
-        if self.phase == GamePhase.WAGER_ACTIVE and self._current_question:
-            q = self._current_question
-            # #656: the betting window carries category and difficulty and
-            # NOTHING else. A phone that reconnects here must not be handed
-            # the question text — that text has not been sent to anyone yet,
-            # and a player who could read it while betting would be betting
-            # on a certainty. The remaining seconds are the room's, not a
-            # fresh window, so a reconnect can't buy extra thinking time.
-            connected = [p for p in self.get_players() if p.connected]
-            snapshot["wager"] = {
-                "category": q.category,
-                "difficulty": q.difficulty,
-                "window_remaining": round(self.wager_window_remaining(), 1),
-                "window_duration": self._phase_controller.wager_window_duration,
-                # The tally, so a TV reconnecting mid-window shows the bets
-                # already in rather than restarting the count at zero.
-                "locked_in": len(connected) - len(self.players_missing_wager()),
-                "player_count": len(connected),
-            }
-
-        if self.phase == GamePhase.QUESTION_ACTIVE and self._current_question:
-            q = self._current_question
-            # Calculate time remaining for mid-round joiners
-            remaining = self._phase_controller.time_remaining_for_snapshot()
-            # Canonical-shuffle order (#521), matching the live
-            # ``question_started`` payload. Emitting question-JSON order here
-            # meant a dashboard reconnecting mid-question rebuilt its grid
-            # unshuffled — and most packs keep the correct answer first in the
-            # file. ``shuffled_answers`` is empty only before the first
-            # question of a game, where the fallback is the same list anyway.
-            snapshot["question"] = {
-                "id": q.id,
-                "text": q.question,
-                "answers": (
-                    list(self.shuffled_answers)
-                    if len(self.shuffled_answers) == len(q.answers)
-                    else [a.text for a in q.answers]
-                ),
-                "difficulty": q.difficulty,
-                "category": q.category,
-                "image_url": q.image_url,
-                # #434: a dashboard that reconnects mid-question needs both the
-                # style and the remaining time below to resume the blur at the
-                # right point instead of snapping to sharp.
-                "reveal_style": q.reveal_style,
-                # #730/#731: unconditionally, not only for estimates. The live
-                # ``question_started`` always carries the type, so a snapshot
-                # that only carries it sometimes is a field the restore path
-                # cannot forward without knowing which case it is in — exactly
-                # the asymmetry the parity test now forbids.
-                "question_type": q.type,
-                "time_limit": self._round_duration,
-                "time_remaining": round(remaining, 1),
-            }
-            # Estimate questions (#275) carry slider metadata instead of
-            # answers so a reconnecting player rebuilds the slider, not the
-            # 3-answer grid.
-            if q.is_estimate:
-                snapshot["question"]["estimate"] = {
-                    "min": q.estimate_min,
-                    "max": q.estimate_max,
-                    "unit": q.estimate_unit,
-                    "step": q.estimate_step,
-                }
-
-        if self.phase == GamePhase.ANSWER_REVEAL and self._round_summary:
-            s = self._round_summary
-            q = s.question
-            # Round-shuffle answer order, mirroring the QUESTION_ACTIVE
-            # snapshot's ``question.answers``. A TV/dashboard that (re)connects
-            # during the reveal has no live ``question`` block to render, so
-            # without these fields its question view was blank (#296).
-            # Both the order and the highlight index moved from question-JSON
-            # order to the round shuffle in #521 — in JSON order most packs
-            # keep the correct answer first, which put it on tile A every
-            # round. ``correct_answer_index_original`` stays in the payload for
-            # clients cached from before that change.
-            correct_idx_original = next(
-                (i for i, a in enumerate(q.answers) if a.correct), -1
-            )
-            order = self.shuffle_map
-            if len(order) == len(q.answers) and sorted(order) == list(
-                range(len(q.answers))
-            ):
-                reveal_answers = [q.answers[i].text for i in order]
-                if correct_idx_original >= 0:
-                    correct_idx_display = order.index(correct_idx_original)
-                else:
-                    correct_idx_display = -1
-            else:
-                # No usable shuffle (pre-first-question, or a malformed map):
-                # a mis-ordered grid is worse than an unshuffled one.
-                reveal_answers = [a.text for a in q.answers]
-                correct_idx_display = correct_idx_original
-            snapshot["round_summary"] = {
-                "question_text": q.question,
-                "category": q.category,
-                "image_url": q.image_url,
-                "answers": reveal_answers,
-                "correct_answer_index": correct_idx_display,
-                "correct_answer_index_original": correct_idx_original,
-                "correct_answer": s.correct_answer.text,
-                "fun_fact": s.fun_fact,
-                "results": [
-                    {
-                        "player_id": r.player_id,
-                        "correct": r.correct,
-                        "points_earned": r.points_earned,
-                        "new_streak": r.new_streak,
-                        "new_total": r.new_total,
-                    }
-                    for r in s.results
-                ],
-            }
-            # Estimate reveal data (#275) so a reconnect during the reveal
-            # rebuilds the number line instead of an empty answer grid.
-            if s.estimate is not None:
-                snapshot["round_summary"]["question_type"] = q.type
-                snapshot["round_summary"]["estimate"] = s.estimate
-
-        if self.phase == GamePhase.FINALE:
-            # Use cached values computed once in end_game()
-            podium = self._finale_podium or calculate_podium(
-                self.get_ranked_participants()
-            )
-            snapshot["podium"] = [
-                {"name": p.name, "score": p.score, "rank": i + 1}
-                for i, p in enumerate(podium)
-            ]
-            awards = (
-                self._finale_superlatives
-                if self._finale_superlatives is not None
-                else compute_superlatives(self.get_ranked_participants())
-            )
-            if awards:
-                snapshot["superlatives"] = [s.to_dict() for s in awards]
-
-        if self.phase == GamePhase.LIGHTNING and self._lightning is not None:
-            lr = self._lightning
-            lq = lr.current_question
-            snapshot["lightning"] = {
-                "index": lr.index,
-                "num_questions": lr.num_questions,
-                "time_remaining": round(lr.time_remaining(), 1),
-                "seconds_per_question": lr.seconds_per_question,
-                "leaderboard": lr.leaderboard(),
-                # True while the intro splash ("Bolt Burst", #201) is still
-                # showing and the first question hasn't been broadcast.
-                "splash_pending": self._lightning_splash_pending,
-            }
-            if lq is not None:
-                # Canonical (admin/TV) answer order; players get their own
-                # shuffle pushed via the lightning_question event.
-                snapshot["lightning"]["question"] = {
-                    "text": lq.question,
-                    "answers": [a.text for a in lq.answers],
-                    "category": lq.category,
-                    "image_url": lq.image_url,
-                }
-
-        if self.phase == GamePhase.LIGHTNING_RECAP and self._lightning is not None:
-            snapshot["lightning_recap"] = self._lightning.build_recap()
-
-        # #664: the Hot Seat detour belongs in the contract like every other
-        # phase. Without this block a reconnecting phone got a snapshot naming
-        # a HOT_SEAT phase and no hot-seat data, fell through the client's
-        # default case onto the lobby, and — if it belonged to the seat holder
-        # — could never get back to the question, which #653 then charges as a
-        # lost stake. The TV had the same hole, with the previous round's
-        # reveal frozen on it for the whole detour.
-        if (
-            self.phase
-            in (
-                GamePhase.HOT_SEAT_AUCTION,
-                GamePhase.HOT_SEAT,
-                GamePhase.HOT_SEAT_REVEAL,
-            )
-            and self._hot_seat is not None
-        ):
-            hs = self._hot_seat
-            if self.phase == GamePhase.HOT_SEAT_AUCTION:
-                stage = "auction"
-            elif self.phase == GamePhase.HOT_SEAT_REVEAL:
-                stage = "result"
-            else:
-                # There is deliberately no separate "the bids are landing"
-                # stage. ``resolve_auction`` starts the answer clock at the
-                # moment the chair is awarded, so the live flow's four-second
-                # bid reveal is already being paid for out of the seat
-                # holder's window. Someone who reconnects during that hold is
-                # better served by the question than by a reveal they are
-                # being charged for — and worse, without a question to look
-                # at they would burn the clock reading a scoreboard.
-                stage = "question"
-            block: dict[str, Any] = {
-                "stage": stage,
-                "time_remaining": round(hs.time_remaining(), 1),
-                "auction_seconds": hs.auction_seconds,
-                "answer_seconds": hs.answer_seconds,
-                # The banks the bids are percentages of — a snapshot taken when
-                # the auction opened, not the live scores. Keyed by ENTRANT
-                # (#804), which is what the per-player projection in
-                # ``round_message_builder`` reads it by; it never leaves the
-                # server in this shape.
-                "banks": dict(hs.scores),
-                # Count only. The auction is sealed until it closes, and a
-                # reconnect must not be a way to read it early.
-                "bid_count": len(hs.bids),
-                "bidder_count": len(hs.scores),
-                # The person in the chair, matching the live ``hot_seat_awarded``
-                # frame so the phone's restore path and the live path agree.
-                "winner": hs.seat_holder,
-                "entrant": hs.winner_name,
-            }
-            if hs.winner is not None:
-                block["pct"] = hs.winning_pct
-                block["stake"] = hs.winning_stake
-                block["bids"] = hs.reveal()
-            # The question is withheld during the auction on purpose: bidding
-            # is meant to be a bet on yourself, not on a question you have
-            # already read.
-            if stage in ("question", "result") and hs.question is not None:
-                block["question"] = {
-                    "text": hs.question.question,
-                    # Canonical order — admin and TV. The seat holder's own
-                    # shuffle is projected in round_message_builder.
-                    "answers": [a.text for a in hs.question.answers],
-                    "category": hs.question.category,
-                    # #730: the live ``hot_seat_question`` sends this to every
-                    # phone already, so withholding it here bought no secrecy
-                    # — it only left the restore path with one more field it
-                    # could never forward.
-                    "difficulty": hs.question.difficulty,
-                    "image_url": hs.question.image_url,
-                }
-            if stage == "result":
-                block["summary"] = hs.summary()
-            snapshot["hot_seat"] = block
-
-        if self.phase == GamePhase.PAUSED:
-            # #703: the reason used to be attached by the two pause
-            # *broadcasts* only, so any phone that reconnected (or joined, or
-            # asked for state) during a pause got a snapshot without it. The
-            # client derives both the title and the 60s reset affordance from
-            # this field, so a guest who reloaded during a host-gone pause was
-            # told "the host will resume" and lost the only way out (#299) —
-            # on exactly the phones that had just reconnected.
-            snapshot["pause_reason"] = self.get_pause_reason()
-
-        return snapshot
-
     # ------------------------------------------------------------------
     # Broadcast / event dispatch
     # ------------------------------------------------------------------
@@ -3348,7 +3093,7 @@ class QuizifyGameState:
         # Named events (round_evaluated / game_ended) route to dedicated
         # broadcast handlers that build their own messages and re-fetch the
         # live state — they never read this payload's snapshot fields, so
-        # building a full ``get_state_snapshot()`` (O(P log P) + a heavy dict)
+        # building a full state snapshot (O(P log P) + a heavy dict)
         # here only to discard it is wasted work on every round/game end (#304).
         # Pass just the event marker; the default full-state handler fetches the
         # snapshot itself when it actually needs one.

--- a/custom_components/quizify/game_events.py
+++ b/custom_components/quizify/game_events.py
@@ -322,12 +322,13 @@ class QuizifyEventEmitter:
         Emitted from the ``game_ended`` dispatch point (richer than the FINALE
         phase transition, which only knows the single leader). The leaderboard
         is trimmed to ``{name, score}`` per entry — the stable, PII-minimal
-        subset a blueprint needs — not the full wire contract.
+        subset a blueprint needs — not the full wire contract. Built from the
+        standings (domain objects) rather than the client rows since #747, so
+        the bus payload no longer depends on the WebSocket wire format.
         """
         leaderboard = [
-            {"name": entry.get("name"), "score": entry.get("score")}
-            for entry in game_state.get_leaderboard()
-            if isinstance(entry, dict)
+            {"name": participant.name, "score": participant.score}
+            for participant in game_state.get_standings()
         ]
         self._fire(EVENT_GAME_ENDED, {"leaderboard": leaderboard})
 

--- a/custom_components/quizify/server/protocol.py
+++ b/custom_components/quizify/server/protocol.py
@@ -17,7 +17,8 @@ What is NOT covered, so nobody reads more into a green run than is there:
   literal ``"type"`` key, plus the ``d["k"] = v`` lines that add to the same
   local afterwards. A frame assembled some other way is invisible here.
   ``game_state`` is the live example: the snapshot in
-  ``game/state.py::get_state_snapshot`` gets its ``type`` stamped on by the
+  ``server/serializers.py::serialize_state_snapshot`` gets its ``type``
+  stamped on by the
   caller, so the entry below describes only the leaderboard-refresh literal in
   ``round_message_builder.py``.
 * Field *names*, not value types. Nothing here catches an int that turned into
@@ -239,7 +240,8 @@ SERVER_FRAMES: dict[str, FrameSpec] = {
         note=(
             "Declared for the leaderboard-refresh literal in "
             "``round_message_builder``. The full snapshot sent on connect and "
-            "reconnect is built in ``game/state.py::get_state_snapshot`` and "
+            "reconnect is built in "
+            "``server/serializers.py::serialize_state_snapshot`` and "
             "typed by its caller, so it is outside what this file can check."
         ),
     ),

--- a/custom_components/quizify/server/round_message_builder.py
+++ b/custom_components/quizify/server/round_message_builder.py
@@ -192,7 +192,7 @@ class RoundMessageBuilder:
         # must carry the lightning sub-state, or the client's LIGHTNING case
         # (player-core.js ~437) falls through to an empty ``lightning-view`` —
         # i.e. a blank player screen (#221). Mirror the canonical shape built
-        # by ``QuizifyGameState.get_state_snapshot()`` so reconnect snapshots
+        # by ``serialize_state_snapshot()`` so reconnect snapshots
         # and live refreshes are wire-identical.
         lightning = self._build_lightning_substate(game_state)
         if lightning is not None:
@@ -206,7 +206,7 @@ class RoundMessageBuilder:
 
         Returns ``None`` outside a lightning round. The shape is byte-for-byte
         identical to the lightning branch of
-        ``QuizifyGameState.get_state_snapshot()`` so the player client reads
+        ``serialize_state_snapshot()`` so the player client reads
         the same keys regardless of which builder produced the message:
 
         * ``splash_pending`` — True while the intro splash (#201) is up and no
@@ -248,7 +248,7 @@ class RoundMessageBuilder:
     ) -> dict[str, Any]:
         """Re-shape a canonical state snapshot for one reconnecting PLAYER.
 
-        ``QuizifyGameState.get_state_snapshot()`` is player-agnostic — it
+        ``serialize_state_snapshot()`` is player-agnostic — it
         emits answers in canonical order and nests the reveal under
         ``round_summary`` (issue #253). That is correct for the admin and the
         TV dashboard, but a player rebuilds their answer buttons from this

--- a/custom_components/quizify/server/serializers.py
+++ b/custom_components/quizify/server/serializers.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from custom_components.quizify.game.highlights import compute_superlatives
+from custom_components.quizify.game.phase_controller import GamePhase
+from custom_components.quizify.game.scoring import calculate_podium
+
 if TYPE_CHECKING:
     from custom_components.quizify.game.player import PlayerSession
     from custom_components.quizify.game.questions import Question
@@ -351,6 +355,311 @@ def serialize_leaderboard(players: list[PlayerSession]) -> list[dict[str, Any]]:
             "powerups_used": p.powerups_used,
         })
     return result
+
+
+def serialize_state_snapshot(game_state: QuizifyGameState) -> dict[str, Any]:
+    """Build the full client state snapshot (#747).
+
+    This is what a phone, a television or the admin page is handed on join, on
+    reconnect, on ``get_state`` and after a resume — the one payload that has to
+    agree with every live broadcast, because a client that reconnects mid-round
+    renders from this instead of from the frame it missed.
+
+    It used to live on ``QuizifyGameState`` as ``get_state_snapshot``, which put
+    the client wire format inside the domain object and duplicated keys the
+    per-player serializers in this module already emitted — ``image_url``,
+    ``reveal_style``, ``question_type``, ``estimate``, ``time_remaining``. Every
+    drift between the two builders cost a bug: #297 (the snapshot leaderboard
+    had fewer fields than the live broadcast, so a FINALE reconnect locked the
+    admin out), #434 (``reveal_style`` missing, so a reconnecting dashboard
+    snapped a progressive-reveal picture to sharp), #521 (snapshot answers
+    unshuffled, so the correct tile sat first), #253 (nested vs flat
+    ``round_summary``). Two builders in two layers is the shape those share, so
+    there is one now, here, next to the serializers it has to agree with — and
+    ``game/state.py`` no longer imports the server layer to build a payload.
+
+    ``RoundMessageBuilder.project_snapshot_for_player`` still re-shapes the
+    result per recipient (own shuffle, own timer); this is the canonical frame
+    it projects from.
+    """
+    snapshot: dict[str, Any] = {
+        "phase": game_state.phase.value,
+        "game_id": game_state.game_id,
+        "round": game_state.round,
+        "total_rounds": game_state.total_rounds,
+        "category": game_state.category,
+        "difficulty": game_state.difficulty,
+        # The player client uses this to sync its UI locale with the
+        # game language (player-core.js handleGameState). Without it
+        # the UI stayed at the browser locale (e.g., German chrome
+        # over English questions if the host picked EN but the guest's
+        # phone is DE). Live-test Mai-27.
+        "language": game_state.language,
+        "players": game_state.get_players_state(),
+        "leaderboard": serialize_leaderboard(game_state.get_ranked_participants()),
+        # Always present, empty in an ordinary game (#365). A reconnecting
+        # phone has to be able to tell "no teams" from "teams not sent" —
+        # otherwise a member who drops mid-game comes back without their
+        # team indicator and believes they are playing alone.
+        "teams": game_state.team_registry.to_list(),
+    }
+
+    question = game_state.get_current_question()
+
+    if game_state.phase == GamePhase.WAGER_ACTIVE and question:
+        q = question
+        # #656: the betting window carries category and difficulty and
+        # NOTHING else. A phone that reconnects here must not be handed
+        # the question text — that text has not been sent to anyone yet,
+        # and a player who could read it while betting would be betting
+        # on a certainty. The remaining seconds are the room's, not a
+        # fresh window, so a reconnect can't buy extra thinking time.
+        connected = [p for p in game_state.get_players() if p.connected]
+        snapshot["wager"] = {
+            "category": q.category,
+            "difficulty": q.difficulty,
+            "window_remaining": round(game_state.wager_window_remaining(), 1),
+            "window_duration": game_state.wager_window_duration,
+            # The tally, so a TV reconnecting mid-window shows the bets
+            # already in rather than restarting the count at zero.
+            "locked_in": len(connected) - len(game_state.players_missing_wager()),
+            "player_count": len(connected),
+        }
+
+    if game_state.phase == GamePhase.QUESTION_ACTIVE and question:
+        q = question
+        # Calculate time remaining for mid-round joiners
+        remaining = game_state.question_time_remaining_for_snapshot()
+        # Canonical-shuffle order (#521), matching the live
+        # ``question_started`` payload. Emitting question-JSON order here
+        # meant a dashboard reconnecting mid-question rebuilt its grid
+        # unshuffled — and most packs keep the correct answer first in the
+        # file. ``shuffled_answers`` is empty only before the first
+        # question of a game, where the fallback is the same list anyway.
+        snapshot["question"] = {
+            "id": q.id,
+            "text": q.question,
+            "answers": (
+                list(game_state.shuffled_answers)
+                if len(game_state.shuffled_answers) == len(q.answers)
+                else [a.text for a in q.answers]
+            ),
+            "difficulty": q.difficulty,
+            "category": q.category,
+            "image_url": q.image_url,
+            # #434: a dashboard that reconnects mid-question needs both the
+            # style and the remaining time below to resume the blur at the
+            # right point instead of snapping to sharp.
+            "reveal_style": q.reveal_style,
+            # #730/#731: unconditionally, not only for estimates. The live
+            # ``question_started`` always carries the type, so a snapshot
+            # that only carries it sometimes is a field the restore path
+            # cannot forward without knowing which case it is in — exactly
+            # the asymmetry the parity test now forbids.
+            "question_type": q.type,
+            "time_limit": game_state.round_duration,
+            "time_remaining": round(remaining, 1),
+        }
+        # Estimate questions (#275) carry slider metadata instead of
+        # answers so a reconnecting player rebuilds the slider, not the
+        # 3-answer grid.
+        if q.is_estimate:
+            snapshot["question"]["estimate"] = {
+                "min": q.estimate_min,
+                "max": q.estimate_max,
+                "unit": q.estimate_unit,
+                "step": q.estimate_step,
+            }
+
+    round_summary = game_state.get_round_summary()
+    if game_state.phase == GamePhase.ANSWER_REVEAL and round_summary:
+        s = round_summary
+        q = s.question
+        # Round-shuffle answer order, mirroring the QUESTION_ACTIVE
+        # snapshot's ``question.answers``. A TV/dashboard that (re)connects
+        # during the reveal has no live ``question`` block to render, so
+        # without these fields its question view was blank (#296).
+        # Both the order and the highlight index moved from question-JSON
+        # order to the round shuffle in #521 — in JSON order most packs
+        # keep the correct answer first, which put it on tile A every
+        # round. ``correct_answer_index_original`` stays in the payload for
+        # clients cached from before that change.
+        correct_idx_original = next(
+            (i for i, a in enumerate(q.answers) if a.correct), -1
+        )
+        order = game_state.shuffle_map
+        if len(order) == len(q.answers) and sorted(order) == list(
+            range(len(q.answers))
+        ):
+            reveal_answers = [q.answers[i].text for i in order]
+            if correct_idx_original >= 0:
+                correct_idx_display = order.index(correct_idx_original)
+            else:
+                correct_idx_display = -1
+        else:
+            # No usable shuffle (pre-first-question, or a malformed map):
+            # a mis-ordered grid is worse than an unshuffled one.
+            reveal_answers = [a.text for a in q.answers]
+            correct_idx_display = correct_idx_original
+        snapshot["round_summary"] = {
+            "question_text": q.question,
+            "category": q.category,
+            "image_url": q.image_url,
+            "answers": reveal_answers,
+            "correct_answer_index": correct_idx_display,
+            "correct_answer_index_original": correct_idx_original,
+            "correct_answer": s.correct_answer.text,
+            "fun_fact": s.fun_fact,
+            "results": [
+                {
+                    "player_id": r.player_id,
+                    "correct": r.correct,
+                    "points_earned": r.points_earned,
+                    "new_streak": r.new_streak,
+                    "new_total": r.new_total,
+                }
+                for r in s.results
+            ],
+        }
+        # Estimate reveal data (#275) so a reconnect during the reveal
+        # rebuilds the number line instead of an empty answer grid.
+        if s.estimate is not None:
+            snapshot["round_summary"]["question_type"] = q.type
+            snapshot["round_summary"]["estimate"] = s.estimate
+
+    if game_state.phase == GamePhase.FINALE:
+        # Use cached values computed once in end_game()
+        podium = game_state.get_finale_podium() or calculate_podium(
+            game_state.get_ranked_participants()
+        )
+        snapshot["podium"] = [
+            {"name": p.name, "score": p.score, "rank": i + 1}
+            for i, p in enumerate(podium)
+        ]
+        cached_awards = game_state.get_finale_superlatives()
+        awards = (
+            cached_awards
+            if cached_awards is not None
+            else compute_superlatives(game_state.get_ranked_participants())
+        )
+        if awards:
+            snapshot["superlatives"] = [s.to_dict() for s in awards]
+
+    lightning = game_state.lightning
+    if game_state.phase == GamePhase.LIGHTNING and lightning is not None:
+        lr = lightning
+        lq = lr.current_question
+        snapshot["lightning"] = {
+            "index": lr.index,
+            "num_questions": lr.num_questions,
+            "time_remaining": round(lr.time_remaining(), 1),
+            "seconds_per_question": lr.seconds_per_question,
+            "leaderboard": lr.leaderboard(),
+            # True while the intro splash ("Bolt Burst", #201) is still
+            # showing and the first question hasn't been broadcast.
+            "splash_pending": game_state.lightning_splash_pending,
+        }
+        if lq is not None:
+            # Canonical (admin/TV) answer order; players get their own
+            # shuffle pushed via the lightning_question event.
+            snapshot["lightning"]["question"] = {
+                "text": lq.question,
+                "answers": [a.text for a in lq.answers],
+                "category": lq.category,
+                "image_url": lq.image_url,
+            }
+
+    if game_state.phase == GamePhase.LIGHTNING_RECAP and lightning is not None:
+        snapshot["lightning_recap"] = lightning.build_recap()
+
+    hot_seat = game_state.hot_seat
+    # #664: the Hot Seat detour belongs in the contract like every other
+    # phase. Without this block a reconnecting phone got a snapshot naming
+    # a HOT_SEAT phase and no hot-seat data, fell through the client's
+    # default case onto the lobby, and — if it belonged to the seat holder
+    # — could never get back to the question, which #653 then charges as a
+    # lost stake. The TV had the same hole, with the previous round's
+    # reveal frozen on it for the whole detour.
+    if (
+        game_state.phase
+        in (
+            GamePhase.HOT_SEAT_AUCTION,
+            GamePhase.HOT_SEAT,
+            GamePhase.HOT_SEAT_REVEAL,
+        )
+        and hot_seat is not None
+    ):
+        hs = hot_seat
+        if game_state.phase == GamePhase.HOT_SEAT_AUCTION:
+            stage = "auction"
+        elif game_state.phase == GamePhase.HOT_SEAT_REVEAL:
+            stage = "result"
+        else:
+            # There is deliberately no separate "the bids are landing"
+            # stage. ``resolve_auction`` starts the answer clock at the
+            # moment the chair is awarded, so the live flow's four-second
+            # bid reveal is already being paid for out of the seat
+            # holder's window. Someone who reconnects during that hold is
+            # better served by the question than by a reveal they are
+            # being charged for — and worse, without a question to look
+            # at they would burn the clock reading a scoreboard.
+            stage = "question"
+        block: dict[str, Any] = {
+            "stage": stage,
+            "time_remaining": round(hs.time_remaining(), 1),
+            "auction_seconds": hs.auction_seconds,
+            "answer_seconds": hs.answer_seconds,
+            # The banks the bids are percentages of — a snapshot taken when
+            # the auction opened, not the live scores. Keyed by ENTRANT
+            # (#804), which is what the per-player projection in
+            # ``round_message_builder`` reads it by; it never leaves the
+            # server in this shape.
+            "banks": dict(hs.scores),
+            # Count only. The auction is sealed until it closes, and a
+            # reconnect must not be a way to read it early.
+            "bid_count": len(hs.bids),
+            "bidder_count": len(hs.scores),
+            # The person in the chair, matching the live ``hot_seat_awarded``
+            # frame so the phone's restore path and the live path agree.
+            "winner": hs.seat_holder,
+            "entrant": hs.winner_name,
+        }
+        if hs.winner is not None:
+            block["pct"] = hs.winning_pct
+            block["stake"] = hs.winning_stake
+            block["bids"] = hs.reveal()
+        # The question is withheld during the auction on purpose: bidding
+        # is meant to be a bet on yourself, not on a question you have
+        # already read.
+        if stage in ("question", "result") and hs.question is not None:
+            block["question"] = {
+                "text": hs.question.question,
+                # Canonical order — admin and TV. The seat holder's own
+                # shuffle is projected in round_message_builder.
+                "answers": [a.text for a in hs.question.answers],
+                "category": hs.question.category,
+                # #730: the live ``hot_seat_question`` sends this to every
+                # phone already, so withholding it here bought no secrecy
+                # — it only left the restore path with one more field it
+                # could never forward.
+                "difficulty": hs.question.difficulty,
+                "image_url": hs.question.image_url,
+            }
+        if stage == "result":
+            block["summary"] = hs.summary()
+        snapshot["hot_seat"] = block
+
+    if game_state.phase == GamePhase.PAUSED:
+        # #703: the reason used to be attached by the two pause
+        # *broadcasts* only, so any phone that reconnected (or joined, or
+        # asked for state) during a pause got a snapshot without it. The
+        # client derives both the title and the 60s reset affordance from
+        # this field, so a guest who reloaded during a host-gone pause was
+        # told "the host will resume" and lost the only way out (#299) —
+        # on exactly the phones that had just reconnected.
+        snapshot["pause_reason"] = game_state.get_pause_reason()
+
+    return snapshot
 
 
 def serialize_player_list(players: list[PlayerSession]) -> list[dict[str, Any]]:

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -61,6 +61,7 @@ from custom_components.quizify.server.serializers import (
     serialize_finale,
     serialize_leaderboard,
     serialize_player_list,
+    serialize_state_snapshot,
     snapshot_house_entities,
     snapshot_tts_entities,
     strip_answer_for_dashboard,
@@ -920,7 +921,7 @@ class QuizifyWebSocketHandler:
         self, ws: web.WebSocketResponse, data: dict, game_state: QuizifyGameState
     ) -> None:
         """Handle a ``get_state`` request (#286)."""
-        state_msg = game_state.get_state_snapshot()
+        state_msg = serialize_state_snapshot(game_state)
         # Project into the requesting PLAYER's frame (#286): the raw
         # snapshot carries canonical answer order, but ``submit_answer``
         # maps the tapped index through the player's OWN shuffle — sending
@@ -950,7 +951,7 @@ class QuizifyWebSocketHandler:
 
         admin_token = self._conn.get_or_create_admin_token()
 
-        state = game_state.get_state_snapshot()
+        state = serialize_state_snapshot(game_state)
         state["type"] = "game_state"
         state["join_url"] = "/quizify/player"
         state["admin_session_token"] = admin_token
@@ -1224,7 +1225,7 @@ class QuizifyWebSocketHandler:
             # shuffle order for the answer buttons, own timer, flat reveal —
             # otherwise a mid-round joiner mis-scores their taps and sees an
             # empty reveal.
-            state = game_state.get_state_snapshot()
+            state = serialize_state_snapshot(game_state)
             if player_obj is not None:
                 state = self._round_messages.project_snapshot_for_player(
                     game_state, snapshot=state, player=player_obj
@@ -1344,7 +1345,7 @@ class QuizifyWebSocketHandler:
         # Send full game state, projected into THIS player's frame (#253):
         # the reconnect snapshot otherwise carries canonical answer order
         # (mis-scoring taps) and a nested round_summary the reveal can't read.
-        state = game_state.get_state_snapshot()
+        state = serialize_state_snapshot(game_state)
         state = self._round_messages.project_snapshot_for_player(
             game_state, snapshot=state, player=player
         )
@@ -2534,7 +2535,7 @@ class QuizifyWebSocketHandler:
         self._cancel_timer_tick()
         # pause_reason rides along in the snapshot itself since #703, so it
         # is identical here and on every reconnect.
-        state = game_state.get_state_snapshot()
+        state = serialize_state_snapshot(game_state)
         state["type"] = "game_state"
         await self._conn.broadcast(state)
         return True
@@ -2655,7 +2656,7 @@ class QuizifyWebSocketHandler:
         # while the sockets are still open.
         await self._conn.broadcast({"type": "game_reset"})
 
-        state = game_state.get_state_snapshot()
+        state = serialize_state_snapshot(game_state)
         state["type"] = "game_state"
         await self._conn.broadcast(state)
 
@@ -2765,7 +2766,7 @@ class QuizifyWebSocketHandler:
 
         # Broadcast a phase-entry state so every client switches to the
         # lightning view, then the intro splash ("Bolt Burst", #201).
-        state = game_state.get_state_snapshot()
+        state = serialize_state_snapshot(game_state)
         state["type"] = "game_state"
         await self._conn.broadcast(state)
         await self._broadcast_lightning_splash(game_state)
@@ -3077,7 +3078,7 @@ class QuizifyWebSocketHandler:
         if hs is None:
             return False
 
-        state = game_state.get_state_snapshot()
+        state = serialize_state_snapshot(game_state)
         state["type"] = "game_state"
         await self._conn.broadcast(state)
         await self._conn.broadcast({
@@ -3311,7 +3312,7 @@ class QuizifyWebSocketHandler:
         message. Used by the resume path (#286 #287) so a resumed game reaches
         every screen with correctly-ordered answer buttons.
         """
-        base = game_state.get_state_snapshot()
+        base = serialize_state_snapshot(game_state)
 
         # Per-player projected sends.
         player_ws: set[Any] = set()
@@ -3885,7 +3886,7 @@ class QuizifyWebSocketHandler:
                 if not gs.pause(reason="admin_disconnected"):
                     return
                 self._cancel_timer_tick()
-                state = gs.get_state_snapshot()
+                state = serialize_state_snapshot(gs)
                 state["type"] = "game_state"
                 await self._conn.broadcast(state)
                 _LOGGER.info(
@@ -4608,7 +4609,7 @@ class QuizifyWebSocketHandler:
         """Default handler: broadcast a full game-state snapshot."""
         game_state = self._get_game_state()
         if game_state:
-            state = game_state.get_state_snapshot()
+            state = serialize_state_snapshot(game_state)
             state["type"] = "game_state"
             await self._conn.broadcast(state)
 

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -6,7 +6,6 @@ import asyncio
 import contextlib
 import ipaddress
 import logging
-import math
 import random
 from typing import TYPE_CHECKING, Any
 
@@ -26,6 +25,12 @@ from custom_components.quizify.const import (
     LOBBY_DISCONNECT_GRACE_PERIOD,
     MAX_PLAYERS,
     WAGER_WINDOW_DURATION,
+)
+from custom_components.quizify.game.drivers import (
+    HotSeatDriver,
+    LightningDriver,
+    NormalRoundDriver,
+    WagerWindowDriver,
 )
 from custom_components.quizify.game.highlights import compute_superlatives
 from custom_components.quizify.game.hot_seat import stake_of as hot_seat_stake
@@ -2888,81 +2893,39 @@ class QuizifyWebSocketHandler:
         *,
         auto_dismiss_splash: bool = False,
     ) -> None:
-        """Drive the fast lightning loop: broadcast question, wait for the
-        fixed window or all-answered, advance with no reveal, repeat.
+        """Arm the Lightning Round driver (#42/#788).
 
-        With ``auto_dismiss_splash`` (the #285 auto flow) the loop first holds
-        the intro splash for ``AUTO_LIGHTNING_SPLASH_HOLD`` seconds and then
-        dismisses it itself — there is no host "Start" tap any more.
+        The loop itself — the fixed window, the all-answered short-circuit, the
+        phase re-checks and the recap — lives in
+        :class:`~custom_components.quizify.game.drivers.LightningDriver`. What
+        stays here is the task: creating it, parking it on the attribute the
+        #746 registry tears down, and surfacing its exceptions.
         """
         self._cancel_lightning_loop()
-
-        async def loop() -> None:
-            try:
-                if auto_dismiss_splash:
-                    # Hold the intro splash on its own, then advance out of it.
-                    await asyncio.sleep(self.AUTO_LIGHTNING_SPLASH_HOLD)
-                    if game_state.phase != GamePhase.LIGHTNING:
-                        return
-                    game_state.begin_lightning_questions()
-                # Brief grace so clients swap from the intro splash (#201) to
-                # the question view before the first clock starts ticking.
-                await asyncio.sleep(self.LIGHTNING_SPLASH_GRACE)
-                while game_state.phase == GamePhase.LIGHTNING:
-                    lr = game_state.lightning
-                    if lr is None:
-                        break
-                    await self._broadcast_lightning_question(game_state, lr)
-                    # Re-arm the question clock now (after the broadcast) so the
-                    # countdown the players see matches the server window.
-                    lr.restart_clock()
-                    # Wait out the fixed window, but cut short once every
-                    # connected player has answered.
-                    deadline = lr.seconds_per_question
-                    waited = 0.0
-                    step = 0.25
-                    # The display shows whole seconds (1 Hz), so only push a
-                    # tick when the ceil(remaining) actually changes — no point
-                    # broadcasting at the 4 Hz poll cadence (#258).
-                    last_shown = None
-                    while waited < deadline:
-                        shown = math.ceil(lr.time_remaining())
-                        if shown != last_shown:
-                            await self._broadcast_lightning_tick(game_state, lr)
-                            last_shown = shown
-                        connected = [
-                            p.name for p in game_state.get_players() if p.connected
-                        ]
-                        if lr.all_connected_answered(connected):
-                            break
-                        await asyncio.sleep(step)
-                        waited += step
-                        if game_state.phase != GamePhase.LIGHTNING:
-                            return
-                    # #746, the re-check the hot-seat loop got in #671 and
-                    # this one did not: the wait above only tests the phase
-                    # AFTER a sleep, so the all-answered ``break`` leaves it
-                    # untested. An end_game landing in that gap was still
-                    # followed by ``lr.advance()`` — a lightning question
-                    # scored, and a recap frame broadcast, after the finale.
-                    if game_state.phase != GamePhase.LIGHTNING:
-                        return
-                    # No reveal — score silently and arm the next question.
-                    has_more = lr.advance()
-                    if not has_more:
-                        game_state.finish_lightning_round()
-                        await self._broadcast_lightning_recap(game_state)
-                        return
-            except asyncio.CancelledError:
-                pass
-            except Exception:  # noqa: BLE001
-                # #307: an unexpected exception here used to kill the lightning
-                # task silently, hanging the round on the current question with
-                # a frozen clock. Log it so the failure surfaces.
-                _LOGGER.exception("Lightning loop crashed")
-
-        self._lightning_task = asyncio.ensure_future(loop())
+        driver = LightningDriver(
+            self,
+            splash_grace=self.LIGHTNING_SPLASH_GRACE,
+            splash_hold=self.AUTO_LIGHTNING_SPLASH_HOLD,
+        )
+        self._lightning_task = asyncio.ensure_future(
+            driver.run(game_state, auto_dismiss_splash=auto_dismiss_splash)
+        )
         self._lightning_task.add_done_callback(self._log_task_exception)
+
+    # -- LightningBroadcaster (game/drivers/protocols.py) ---------------
+
+    async def send_lightning_question(
+        self, game_state: QuizifyGameState, lr: Any
+    ) -> None:
+        await self._broadcast_lightning_question(game_state, lr)
+
+    async def send_lightning_tick(
+        self, game_state: QuizifyGameState, lr: Any
+    ) -> None:
+        await self._broadcast_lightning_tick(game_state, lr)
+
+    async def send_lightning_recap(self, game_state: QuizifyGameState) -> None:
+        await self._broadcast_lightning_recap(game_state)
 
     def _cancel_lightning_loop(self) -> None:
         if self._lightning_task is not None:
@@ -3148,117 +3111,70 @@ class QuizifyWebSocketHandler:
         return True
 
     def _start_hot_seat_loop(self, game_state: QuizifyGameState) -> None:
-        """Drive auction → reveal → question → settlement (#616)."""
+        """Arm the Hot Seat driver (#616/#788).
+
+        Auction → reveal → question → settlement is
+        :class:`~custom_components.quizify.game.drivers.HotSeatDriver`; the task
+        and the #746 attribute stay here.
+        """
         self._cancel_hot_seat_loop()
-
-        async def loop() -> None:
-            try:
-                hs = game_state.hot_seat
-                if hs is None:
-                    return
-
-                # --- bidding window -----------------------------------
-                last_shown = None
-                while not hs.is_expired():
-                    if game_state.phase != GamePhase.HOT_SEAT_AUCTION:
-                        return
-                    shown = math.ceil(hs.time_remaining())
-                    if shown != last_shown:
-                        await self._conn.broadcast({
-                            "type": "hot_seat_tick",
-                            "phase": "auction",
-                            "remaining": shown,
-                        })
-                        last_shown = shown
-                    connected = [
-                        p.name for p in game_state.get_players() if p.connected
-                    ]
-                    if hs.all_bid(connected):
-                        break
-                    await asyncio.sleep(0.25)
-
-                # #671: the loop above only checks the phase INSIDE the wait.
-                # Leaving it (expired, or everyone bid) and acting without a
-                # re-check lets a reset that landed in the last poll interval
-                # be followed by a ghost round in the fresh lobby.
-                if game_state.phase != GamePhase.HOT_SEAT_AUCTION:
-                    return
-
-                winner = game_state.close_hot_seat_auction()
-                if winner is None:
-                    # Nobody wanted the chair. Not a failure — just a round
-                    # that does not happen. Fall back to the normal question
-                    # so the game keeps moving.
-                    await self._conn.broadcast({"type": "hot_seat_no_bids"})
-                    game_state.abort_hot_seat()
-                    await self._continue_normal_question(game_state)
-                    return
-
-                # --- simultaneous reveal ------------------------------
-                await self._conn.broadcast({
-                    "type": "hot_seat_awarded",
-                    # The PERSON taking the chair. Outside team mode that is
-                    # also the entrant, so this field keeps its old meaning for
-                    # every client; ``entrant`` names who pays (#804).
-                    "winner": hs.seat_holder,
-                    "entrant": hs.winner_name,
-                    "pct": hs.winning_pct,
-                    "stake": hs.winning_stake,
-                    "bids": hs.reveal(),
-                })
-                await asyncio.sleep(self.HOT_SEAT_REVEAL_HOLD)
-                if game_state.phase != GamePhase.HOT_SEAT:
-                    return
-
-                # --- the question -------------------------------------
-                await self._broadcast_hot_seat_question(game_state, hs)
-                hs.start_answer_clock()
-                last_shown = None
-                while not hs.is_expired():
-                    if game_state.phase != GamePhase.HOT_SEAT:
-                        return
-                    shown = math.ceil(hs.time_remaining())
-                    if shown != last_shown:
-                        await self._conn.broadcast({
-                            "type": "hot_seat_tick",
-                            "phase": "question",
-                            "remaining": shown,
-                        })
-                        last_shown = shown
-                    if hs.answered is not None:
-                        break
-                    await asyncio.sleep(0.25)
-
-                # #671: same re-check as after the auction wait — a teardown
-                # that lands in the last poll interval must not be followed by
-                # a settlement against a game that no longer exists.
-                if game_state.phase != GamePhase.HOT_SEAT:
-                    return
-
-                # Settle even when nothing was answered: the chair was bought
-                # either way (#653). This is the one place the mode parts ways
-                # with the finale's forgiving timeout.
-                game_state.finish_hot_seat()
-                await self._conn.broadcast({
-                    "type": "hot_seat_result",
-                    "round_num": game_state.round,
-                    "total_rounds": game_state.total_rounds,
-                    **hs.summary(),
-                    # The rows the room can see (#804): teams in team mode,
-                    # players otherwise. Keyed by ``player.name`` this reported
-                    # the shadow scores the settlement no longer writes to.
-                    "scores": {
-                        participant.name: participant.score
-                        for participant in game_state.get_ranked_participants()
-                    },
-                })
-            except asyncio.CancelledError:
-                pass
-            except Exception:  # noqa: BLE001
-                _LOGGER.exception("Hot seat loop crashed")
-
-        self._hot_seat_task = asyncio.ensure_future(loop())
+        driver = HotSeatDriver(
+            self, milestones=self, reveal_hold=self.HOT_SEAT_REVEAL_HOLD
+        )
+        self._hot_seat_task = asyncio.ensure_future(driver.run(game_state))
         self._hot_seat_task.add_done_callback(self._log_task_exception)
+
+    # -- HotSeatBroadcaster (game/drivers/protocols.py) -----------------
+
+    async def send_hot_seat_tick(self, stage: str, remaining: int) -> None:
+        await self._conn.broadcast({
+            "type": "hot_seat_tick",
+            "phase": stage,
+            "remaining": remaining,
+        })
+
+    async def send_hot_seat_no_bids(self) -> None:
+        await self._conn.broadcast({"type": "hot_seat_no_bids"})
+
+    async def send_hot_seat_awarded(
+        self, game_state: QuizifyGameState, hs: Any
+    ) -> None:
+        await self._conn.broadcast({
+            "type": "hot_seat_awarded",
+            # The PERSON taking the chair. Outside team mode that is also the
+            # entrant, so this field keeps its old meaning for every client;
+            # ``entrant`` names who pays (#804).
+            "winner": hs.seat_holder,
+            "entrant": hs.winner_name,
+            "pct": hs.winning_pct,
+            "stake": hs.winning_stake,
+            "bids": hs.reveal(),
+        })
+
+    async def send_hot_seat_question(
+        self, game_state: QuizifyGameState, hs: Any
+    ) -> None:
+        await self._broadcast_hot_seat_question(game_state, hs)
+
+    async def send_hot_seat_result(
+        self, game_state: QuizifyGameState, hs: Any
+    ) -> None:
+        await self._conn.broadcast({
+            "type": "hot_seat_result",
+            "round_num": game_state.round,
+            "total_rounds": game_state.total_rounds,
+            **hs.summary(),
+            # The rows the room can see (#804): teams in team mode, players
+            # otherwise. Keyed by ``player.name`` this reported the shadow
+            # scores the settlement no longer writes to.
+            "scores": {
+                participant.name: participant.score
+                for participant in game_state.get_ranked_participants()
+            },
+        })
+
+    async def resume_normal_question(self, game_state: QuizifyGameState) -> None:
+        await self._continue_normal_question(game_state)
 
     async def _broadcast_hot_seat_question(
         self, game_state: QuizifyGameState, hs: Any
@@ -3523,24 +3439,20 @@ class QuizifyWebSocketHandler:
     def _start_wager_window(self, game_state: QuizifyGameState) -> None:
         """Arm the task that closes the betting window at the deadline (#656).
 
-        The deadline is what keeps the final round from hanging on a player
-        who never bets — an AFK phone, or a room that all walked out. It is
-        the same class of hang as #586, so it gets an unconditional timer
-        rather than a condition that depends on clients behaving.
+        The deadline is what keeps the final round from hanging on a player who
+        never bets — an AFK phone, or a room that all walked out. It is the
+        same class of hang as #586, so it gets an unconditional timer rather
+        than a condition that depends on clients behaving. The wait itself is
+        :class:`~custom_components.quizify.game.drivers.WagerWindowDriver`.
         """
         self._cancel_wager_window()
+        driver = WagerWindowDriver(self, duration=WAGER_WINDOW_DURATION)
+        self._wager_window_task = asyncio.create_task(driver.run(game_state))
 
-        async def window() -> None:
-            try:
-                await asyncio.sleep(WAGER_WINDOW_DURATION)
-            except asyncio.CancelledError:
-                return
-            try:
-                await self._close_wager_window(game_state)
-            except Exception:  # noqa: BLE001 — a stuck window strands the game
-                _LOGGER.exception("Wager window failed to close")
+    # -- WagerBroadcaster (game/drivers/protocols.py) -------------------
 
-        self._wager_window_task = asyncio.create_task(window())
+    async def close_wager_window(self, game_state: QuizifyGameState) -> None:
+        await self._close_wager_window(game_state)
 
     def _cancel_wager_window(self) -> None:
         """Cancel the pending betting-window deadline, if any.
@@ -3673,122 +3585,60 @@ class QuizifyWebSocketHandler:
     # ------------------------------------------------------------------
 
     def _start_timer_tick(self, game_state: QuizifyGameState) -> None:
-        """Start async task that broadcasts the countdown every tick.
+        """Arm the normal round's countdown driver (#203/#413/#788).
 
-        The *timing* — which players have a live timer, each one's
-        authoritative remaining time (so time-boost / freeze power-ups are
-        reflected, #4), the dashboard minimum and the all-expired stop
-        condition — lives in the PhaseController (#203). This loop owns only
-        the I/O: turning that timing into ``timer_tick`` wire messages for
-        players, pure-admins and dashboards, the sleep cadence and the
-        auto-evaluate when the round runs out.
+        The cadence, the per-recipient coalescing, the two stop conditions and
+        the auto-evaluate live in
+        :class:`~custom_components.quizify.game.drivers.NormalRoundDriver`. This
+        loop owns only the task and the wire messages it asks for.
         """
         self._cancel_timer_tick()
-
-        # #413: the client renders ``Math.ceil(remaining)`` WHOLE seconds, but
-        # the loop ticks every ~0.5s — so half the frames redraw the same
-        # number and are pure waste (at the 20-player cap: 20 sockets × the
-        # dead frame, every tick). Coalesce like the lightning loop already
-        # does: remember the last displayed second per recipient and only emit
-        # a ``timer_tick`` when that second actually changes. The sleep cadence
-        # is unchanged, so the countdown accuracy and the auto-evaluate timing
-        # are unaffected — only the redundant frames are dropped.
-        last_shown_by_name: dict[str, int] = {}
-        last_dashboard_shown: int | None = None
-
-        async def tick_loop() -> None:
-            nonlocal last_dashboard_shown
-            try:
-                while game_state.phase == GamePhase.QUESTION_ACTIVE:
-                    players = game_state.get_players()
-                    by_name = {p.name: p for p in players}
-                    # Ask the timing unit for this tick's per-player remaining
-                    # plus the shared dashboard minimum (one timer read each).
-                    tick = game_state.resolve_tick([p.name for p in players])
-                    # Build the full (ws, payload) fan-out, then deliver it in
-                    # parallel via gather (#258). A single stalled client no
-                    # longer delays the whole room — ConnectionManager.send
-                    # swallows errors so a plain gather is safe.
-                    sends = []
-                    # Each connected player gets their authoritative remaining,
-                    # but only when their displayed second changed (#413).
-                    for name, remaining in tick.per_player:
-                        p = by_name.get(name)
-                        if p is None or not p.connected:
-                            continue
-                        shown = math.ceil(max(0.0, remaining))
-                        if last_shown_by_name.get(name) == shown:
-                            continue
-                        last_shown_by_name[name] = shown
-                        sends.append(self._conn.send(p.ws, {
-                            "type": "timer_tick",
-                            "remaining": round(remaining, 1),
-                        }))
-                    # Broadcast the minimum remaining to dashboards/admins so
-                    # the TV view shows a consistent countdown — again only when
-                    # its displayed second changes. Pre-serialized ONCE and fanned
-                    # out via the broadcast string path (admin-as-player already
-                    # excluded there) instead of a per-socket send_json (#413/#258).
-                    min_remaining = tick.dashboard_remaining
-                    # ONE countdown milestone per tick (#789): the spoken
-                    # warning (#281) and the bus event that drives the faster
-                    # light pulse (#280) fan out inside _notify_countdown, each
-                    # with its own once-per-round guard.
-                    self._notify_countdown(min_remaining)
-                    dash_shown = math.ceil(max(0.0, min_remaining))
-                    if dash_shown != last_dashboard_shown:
-                        last_dashboard_shown = dash_shown
-                        sends.append(
-                            self._conn.broadcast_to_admins_and_dashboards({
-                                "type": "timer_tick",
-                                "remaining": round(min_remaining, 1),
-                            })
-                        )
-                    if sends:
-                        await asyncio.gather(*sends)
-                    await asyncio.sleep(TICK_INTERVAL)
-
-                    # Stop if everyone's timer hit zero and phase is still
-                    # active. Re-read fresh timers (state can change during the
-                    # sleep) for the CONNECTED players only; the all-expired
-                    # decision itself lives in the PhaseController, which ignores
-                    # players without a timer so a late-joining connected player
-                    # (e.g. the admin's own /quizify/player tab) can't end the
-                    # round before their per-player timer exists.
-                    connected = [p.name for p in players if p.connected]
-                    if connected and game_state.all_timers_expired(connected):
-                        break
-                    # Fallback: all_timers_expired needs at least one live
-                    # timer to break on, so the loop hangs in every state where
-                    # the connected players have none. That covers the original
-                    # case — everyone disconnected mid-question (#255) — and
-                    # the one it missed: connected players who never got a
-                    # timer, where NEITHER condition could fire and the loop
-                    # spun forever with the countdown frozen at 0 (#586).
-                    # Keying the fallback on "no live timers" instead of "no
-                    # connected players" covers both with one condition.
-                    if not game_state.has_live_timers(
-                        connected
-                    ) and game_state.round_wall_clock_expired():
-                        break
-
-                # Timer expired globally
-                if game_state.phase == GamePhase.QUESTION_ACTIVE:
-                    # Auto-evaluate round. The state machine's
-                    # _fire_broadcast("round_evaluated") handles the summary
-                    # broadcast \u2014 do NOT broadcast here (#3 in review).
-                    game_state.evaluate_round()
-            except asyncio.CancelledError:
-                pass
-            except Exception:  # noqa: BLE001
-                # #307: any other exception used to kill the tick task
-                # silently, leaving the game frozen in QUESTION_ACTIVE with a
-                # stuck countdown. Log it loudly so the failure is diagnosable
-                # instead of presenting as a mysterious hang.
-                _LOGGER.exception("Timer tick loop crashed")
-
-        self._timer_tick_task = asyncio.ensure_future(tick_loop())
+        # ``TICK_INTERVAL`` is read here rather than defaulted inside the
+        # driver so the module-level name stays the single knob a test (or a
+        # future runtime setting) can turn.
+        driver = NormalRoundDriver(
+            self, milestones=self, tick_interval=TICK_INTERVAL
+        )
+        self._timer_tick_task = asyncio.ensure_future(driver.run(game_state))
         self._timer_tick_task.add_done_callback(self._log_task_exception)
+
+    # -- RoundBroadcaster (game/drivers/protocols.py) -------------------
+
+    async def send_timer_tick(
+        self,
+        game_state: QuizifyGameState,
+        remaining_by_player: dict[str, float],
+        dashboard_remaining: float | None,
+    ) -> None:
+        """Turn one driver tick into ``timer_tick`` frames.
+
+        The driver has already dropped every recipient whose displayed second
+        did not change (#413) and every disconnected player, so this only has
+        to address what is left. Built as one fan-out and delivered in parallel
+        (#258) so a single stalled client can't delay the room; the dashboard
+        copy is pre-serialized ONCE and goes out over the broadcast string path
+        (admin-as-player is already excluded there).
+        """
+        sends = []
+        if remaining_by_player:
+            by_name = {p.name: p for p in game_state.get_players()}
+            for name, remaining in remaining_by_player.items():
+                player = by_name.get(name)
+                if player is None:
+                    continue
+                sends.append(self._conn.send(player.ws, {
+                    "type": "timer_tick",
+                    "remaining": round(remaining, 1),
+                }))
+        if dashboard_remaining is not None:
+            sends.append(
+                self._conn.broadcast_to_admins_and_dashboards({
+                    "type": "timer_tick",
+                    "remaining": round(dashboard_remaining, 1),
+                })
+            )
+        if sends:
+            await asyncio.gather(*sends)
 
     def _cancel_timer_tick(self) -> None:
         """Cancel the timer tick task — and the betting window with it.
@@ -4473,6 +4323,28 @@ class QuizifyWebSocketHandler:
         """Announce the reveal and put it on the HA bus (#789)."""
         self._notify_tts_reveal(game_state)
         self._notify_house_reveal(game_state)
+
+    # -- MilestoneSink (game/drivers/protocols.py) ----------------------
+    #
+    # The three beats a mode driver reports. Before #788 the fan-out above was
+    # reachable from the normal-round path only, which is exactly why the house
+    # sat out the detour modes (#708); a driver holding this contract can walk
+    # the same path without knowing who is listening.
+
+    def question_shown(
+        self,
+        question: Any,
+        round_no: int,
+        total_rounds: int,
+        options: list[str] | None = None,
+    ) -> None:
+        self._notify_question(question, round_no, total_rounds, options)
+
+    def time_running_out(self, seconds_remaining: float) -> None:
+        self._notify_countdown(seconds_remaining)
+
+    def reveal(self, game_state: QuizifyGameState) -> None:
+        self._notify_reveal(game_state)
 
     def _notify_tts_milestone(self, player_name: str, streak: int) -> None:
         """Forward a milestone hit to the TTS announcer if one is wired.

--- a/custom_components/quizify/tts.py
+++ b/custom_components/quizify/tts.py
@@ -423,17 +423,21 @@ class QuizifyTTSAnnouncer:
         Round 1 is suppressed: the leader always "changes" from nobody on the
         first scored round.
         """
-        leaderboard = summary.leaderboard or []
-        # Entries are dicts (serialize_leaderboard): {name, score, rank, ...},
-        # already sorted high→low. Find the players sharing the top score.
-        top = [e for e in leaderboard if isinstance(e, dict) and "score" in e]
+        # The standings the round closed on: participants (teams in team mode,
+        # players otherwise), already sorted high→low. Domain objects since
+        # #747 — the narrator wants two attributes, not a wire row.
+        top = [
+            e
+            for e in (summary.leaderboard or [])
+            if getattr(e, "score", None) is not None
+        ]
         if not top:
             return
-        top_score = top[0]["score"]
+        top_score = top[0].score
         if not top_score:
             # Nobody has scored yet — no standings to narrate.
             return
-        leaders = [e["name"] for e in top if e["score"] == top_score]
+        leaders = [e.name for e in top if e.score == top_score]
         if len(leaders) > 1:
             if self._announce_standings:
                 frags.append(tts_phrases.phrase(lang, "tie_at_top"))

--- a/tests/test_be_a_ws_state_r4.py
+++ b/tests/test_be_a_ws_state_r4.py
@@ -14,7 +14,7 @@ server/websocket.py + game/state.py + game/lightning.py surface:
 * #453 — every join/leave broadcast a full roster to every socket (O(N²) on a
          room-wide blip). Now coalesced through a ~150ms flush window into one
          ``player_joined`` / ``player_left`` per window.
-* #455 — get_state_snapshot rebuilt the immutable lightning recap on every
+* #455 — serialize_state_snapshot rebuilt the immutable lightning recap on every
          join/reconnect during LIGHTNING_RECAP. Now memoized behind
          ``LightningRound.finished``.
 """
@@ -42,6 +42,9 @@ from custom_components.quizify.game.state import (  # noqa: E402
     QuizifyGameState,
 )
 from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    serialize_state_snapshot,
+)
 from custom_components.quizify.server.websocket import (  # noqa: E402
     QuizifyWebSocketHandler,
 )
@@ -453,7 +456,7 @@ class TestLightningRecapCache:
         assert lr._recap_cache is None
 
     def test_snapshot_reuses_cached_recap(self, tmp_path: Path) -> None:
-        """get_state_snapshot at LIGHTNING_RECAP reuses the cached recap dict
+        """serialize_state_snapshot at LIGHTNING_RECAP reuses the cached recap dict
         rather than rebuilding it each call."""
         state = QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
         state.add_player("A", _ws())
@@ -465,6 +468,6 @@ class TestLightningRecapCache:
         state._lightning = lr
         state.phase = GamePhase.LIGHTNING_RECAP
 
-        snap1 = state.get_state_snapshot()
-        snap2 = state.get_state_snapshot()
+        snap1 = serialize_state_snapshot(state)
+        snap2 = serialize_state_snapshot(state)
         assert snap1["lightning_recap"] is snap2["lightning_recap"]

--- a/tests/test_game_events.py
+++ b/tests/test_game_events.py
@@ -66,7 +66,7 @@ class _FakeGame:
 
     Avoids spinning a full QuizifyGameState (which needs websockets to add
     players) — the emitter only touches phase / round / game_id / total_rounds
-    / get_players / leader / get_round_summary / get_leaderboard.
+    / get_players / leader / get_round_summary / get_standings.
     """
 
     def __init__(self) -> None:
@@ -77,7 +77,8 @@ class _FakeGame:
         self._players: list[_FakePlayer] = []
         self.leader: _FakePlayer | None = None
         self._summary: RoundSummary | None = None
-        self._leaderboard: list[dict] = []
+        # Standings are participants, not wire rows, since #747.
+        self._leaderboard: list[_FakePlayer] = []
         # register/unregister are exercised by attach()/detach().
         self.callbacks: list = []
 
@@ -94,7 +95,7 @@ class _FakeGame:
     def get_round_summary(self):
         return self._summary
 
-    def get_leaderboard(self):
+    def get_standings(self):
         return list(self._leaderboard)
 
 
@@ -156,7 +157,7 @@ def test_no_hass_is_noop_everywhere():
     t.notify_streak_milestone("Alice", 5, 50)
     game._summary = _summary(results=[_result("Alice", True)])
     t.notify_answer_revealed(game)
-    game._leaderboard = [{"name": "Alice", "score": 100}]
+    game._leaderboard = [_FakePlayer("Alice", 100)]
     t.notify_game_ended(game)
     # No bus at all → nothing to assert but that it didn't raise.
 
@@ -193,7 +194,7 @@ def test_disabled_emitter_fires_nothing_on_any_path():
     t.notify_streak_milestone("Alice", 5, 50)
     game._summary = _summary(results=[_result("Alice", True)])
     t.notify_answer_revealed(game)
-    game._leaderboard = [{"name": "Alice", "score": 100}]
+    game._leaderboard = [_FakePlayer("Alice", 100)]
     t.notify_game_ended(game)
 
     assert hass.bus.fired == []
@@ -370,12 +371,9 @@ def test_streak_milestone_payload():
 def test_game_ended_leaderboard_trimmed():
     hass = _FakeHass()
     game = _FakeGame()
-    # The real serialize_leaderboard carries many keys; the event keeps only
-    # name+score.
-    game._leaderboard = [
-        {"name": "Bob", "score": 420, "rank": 1, "streak": 3, "submitted": True},
-        {"name": "Alice", "score": 300, "rank": 2, "streak": 0},
-    ]
+    # A participant carries far more than the bus needs (streak, submitted,
+    # power-ups, …); the event keeps only name+score.
+    game._leaderboard = [_FakePlayer("Bob", 420), _FakePlayer("Alice", 300)]
     t = _emitter(hass, game)
     t.notify_game_ended(game)
     event, data = hass.bus.fired[0]

--- a/tests/test_game_state.py
+++ b/tests/test_game_state.py
@@ -25,6 +25,9 @@ from custom_components.quizify.game.state import (  # noqa: E402
 )
 from custom_components.quizify.game.powerups import PowerUpEffect, PowerUpType  # noqa: E402
 from custom_components.quizify.game.questions import Answer, Question  # noqa: E402
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    serialize_state_snapshot,
+)
 
 
 class _FakeRuntime:
@@ -309,13 +312,13 @@ class TestPlayerRegistry:
         state.remove_player("Alice")
         assert state.get_player_timer("Alice") is None
 
-    def test_get_state_snapshot_has_required_keys(
+    def test_serialize_state_snapshot_has_required_keys(
         self, state: QuizifyGameState
     ) -> None:
         state.add_player("Alice", _fake_ws())
         state.start_game(language="de", num_rounds=3)
         state.start_next_question()
-        snapshot = state.get_state_snapshot()
+        snapshot = serialize_state_snapshot(state)
         # Keys the client relies on — if any of these vanish, the UI
         # silently breaks (which is how the C3 finale-stats bug shipped).
         assert "phase" in snapshot

--- a/tests/test_hot_seat_question_image_802.py
+++ b/tests/test_hot_seat_question_image_802.py
@@ -117,8 +117,12 @@ def test_the_restore_path_forwards_the_image_too() -> None:
     assert "for (var k in q)" in body
     assert "msg[k] = q[k]" in body
 
-    state_source = (_CC / "game" / "state.py").read_text("utf-8")
-    hot_seat_block = state_source.split('block["question"] = {', 1)[1].split("}", 1)[0]
+    # The snapshot builder moved to the server layer in #747; the hot-seat
+    # question block it writes is unchanged.
+    snapshot_source = (_CC / "server" / "serializers.py").read_text("utf-8")
+    hot_seat_block = snapshot_source.split('block["question"] = {', 1)[1].split(
+        "}", 1
+    )[0]
     assert '"image_url"' in hot_seat_block
 
 

--- a/tests/test_hot_seat_state_contract_664.py
+++ b/tests/test_hot_seat_state_contract_664.py
@@ -31,6 +31,7 @@ from custom_components.quizify.game.state import QuizifyGameState
 from custom_components.quizify.server.round_message_builder import (
     RoundMessageBuilder,
 )
+from custom_components.quizify.server.serializers import serialize_state_snapshot
 
 
 def _ws() -> MagicMock:
@@ -59,7 +60,7 @@ def game(tmp_path: Path) -> QuizifyGameState:
 
 
 def _snapshot(game: QuizifyGameState) -> dict:
-    return game.get_state_snapshot()
+    return serialize_state_snapshot(game)
 
 
 def _for_player(game: QuizifyGameState, name: str) -> dict:

--- a/tests/test_house_plays_along_hot_seat_708.py
+++ b/tests/test_house_plays_along_hot_seat_708.py
@@ -1,0 +1,243 @@
+"""The house plays along in the Hot Seat too (#708, via the #788 drivers).
+
+``_notify_tts_*`` / ``_notify_house_*`` were called from the normal-round path
+only. Every detour mode therefore ran in silence: the narrator said nothing
+while the chair answered, no ``quizify_question_shown`` reached the bus, and
+the "time running out" beat that drives the faster light pulse never fired —
+so the room kept whatever colour the previous phase had left it.
+
+#788 gives each mode's driver a ``MilestoneSink``, which is what makes "walk
+the same path as a normal round" something a mode can *do* rather than
+something someone has to remember. These tests pin the Hot Seat half of that:
+the chair's question is an ordinary question as far as the house is concerned,
+and so is its settlement.
+
+Two deliberate limits, both of them the mode's rules rather than an oversight:
+
+  * the spoken **options** are withheld. Only the seat holder has answer
+    buttons; reading A/B/C/D to the room would hand the spectators a board the
+    mode does not give them.
+  * the **Lightning Round is not wired here.** ``announce_question`` reads a
+    question aloud, and five of those inside seventy-five seconds would talk
+    over the mode they are meant to accompany. Lightning needs its own phrases,
+    its own light recipe and its own bus event — the remaining half of #708.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.phase_controller import GamePhase  # noqa: E402
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server.connection import (  # noqa: E402
+    ConnectionManager,
+)
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _FakeRuntime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    def create_task(self, coro):  # noqa: ANN001, ANN202
+        return asyncio.ensure_future(coro)
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN202
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, func, *args)
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    ws.close = AsyncMock()
+    return ws
+
+
+class _Announcer:
+    """Records what the quizmaster was asked to say."""
+
+    def __init__(self) -> None:
+        self.questions: list[tuple] = []
+        self.countdowns: list[float] = []
+        self.reveals: int = 0
+
+    def announce_question(self, question, round_no, total_rounds, options=None):  # noqa: ANN001, ANN201
+        self.questions.append((question, round_no, total_rounds, options))
+
+    def announce_countdown(self, seconds_remaining):  # noqa: ANN001, ANN201
+        self.countdowns.append(seconds_remaining)
+
+    def announce_reveal(self, game_state):  # noqa: ANN001, ANN201
+        self.reveals += 1
+
+
+class _Emitter:
+    """Records what reached the Home Assistant bus."""
+
+    def __init__(self) -> None:
+        self.questions: list[tuple] = []
+        self.time_running_out: list[float] = []
+        self.reveals: int = 0
+
+    def notify_question_shown(self, question, round_no, total_rounds):  # noqa: ANN001, ANN201
+        self.questions.append((question, round_no, total_rounds))
+
+    def notify_time_running_out(self, seconds_remaining):  # noqa: ANN001, ANN201
+        self.time_running_out.append(seconds_remaining)
+
+    def notify_answer_revealed(self, game_state):  # noqa: ANN001, ANN201
+        self.reveals += 1
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    st = QuizifyGameState(runtime=_FakeRuntime(tmp_path), entry_id="test")
+    for name in ("Anna", "Ben", "Cem", "Dana"):
+        st.add_player(name, _ws())
+    st.start_game(num_rounds=6, language="en", hot_seat_seed=7, lightning_seed=7)
+    return st
+
+
+@pytest.fixture
+def handler(
+    game: QuizifyGameState, tmp_path: Path
+) -> QuizifyWebSocketHandler:
+    h = QuizifyWebSocketHandler(
+        runtime=_FakeRuntime(tmp_path), game_state_provider=lambda: game
+    )
+    h._conn = ConnectionManager(_FakeRuntime(tmp_path), lambda: game)
+    h._conn.broadcast = AsyncMock()
+    h._conn.broadcast_to_admins_and_dashboards = AsyncMock()
+    h._conn.send = AsyncMock()
+    # The reveal hold is four seconds of television; the beat is not what is
+    # under test here.
+    h.HOT_SEAT_REVEAL_HOLD = 0.0
+    return h
+
+
+async def _run_one_auction(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState
+) -> None:
+    """Open an auction, place one bid, and let the driver run to settlement."""
+    game.phase = GamePhase.ANSWER_REVEAL
+    # A bid is a share of what the bidder holds, so a room on zero has nothing
+    # to bid with and the auction correctly finds no winner.
+    for score, player in enumerate(game.get_players(), start=1):
+        player.score = score * 20
+    assert game.start_hot_seat_auction() is True, "the auction refused to open"
+    hs = game.hot_seat
+    assert hs is not None
+    # Sub-second windows: this test is about which hooks fire, not about how
+    # long a real auction lasts.
+    hs.auction_seconds = 0.05
+    hs.answer_seconds = 0.4
+    hs.start_auction_clock()
+    assert hs.record_bid("Anna", 50) is True
+
+    handler._start_hot_seat_loop(game)
+    for _ in range(200):
+        await asyncio.sleep(0.01)
+        if game.phase == GamePhase.HOT_SEAT_REVEAL:
+            break
+    handler._cancel_hot_seat_loop()
+    assert game.phase == GamePhase.HOT_SEAT_REVEAL, (
+        "the auction never reached settlement — the test setup drifted"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_narrator_reads_the_seat_holders_question(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState
+) -> None:
+    announcer = _Announcer()
+    handler._tts_announcer = announcer  # type: ignore[assignment]
+
+    await _run_one_auction(handler, game)
+
+    assert announcer.questions, (
+        "the quizmaster said nothing while the chair answered — #708"
+    )
+    question, round_no, total_rounds, options = announcer.questions[0]
+    assert question is not None and question.question
+    assert (round_no, total_rounds) == (game.round, game.total_rounds)
+    # The spectators do not get an answer board, so they do not get one read
+    # to them either.
+    assert options is None
+
+
+@pytest.mark.asyncio
+async def test_the_hot_seat_question_reaches_the_event_bus(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState
+) -> None:
+    emitter = _Emitter()
+    handler.set_event_emitter(emitter)  # type: ignore[arg-type]
+
+    await _run_one_auction(handler, game)
+
+    assert emitter.questions, (
+        "no quizify_question_shown fired for the chair's question — #708"
+    )
+    assert emitter.reveals == 1, (
+        "the settlement never reached quizify_answer_revealed — #708"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_chairs_clock_drives_the_time_running_out_beat(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState
+) -> None:
+    """The beat the faster light pulse and the spoken warning hang off.
+
+    Both consumers keep their own once-per-window guard, so the driver pushes
+    every tick and lets them decide — same contract as the normal round.
+    """
+    announcer = _Announcer()
+    emitter = _Emitter()
+    handler._tts_announcer = announcer  # type: ignore[assignment]
+    handler.set_event_emitter(emitter)  # type: ignore[arg-type]
+
+    await _run_one_auction(handler, game)
+
+    assert announcer.countdowns, (
+        "the chair's answer window pushed no countdown beat — #708"
+    )
+    assert emitter.time_running_out, (
+        "the chair's answer window pushed nothing to the bus — #708"
+    )
+    # The auction is sealed; a countdown there would be narrating a window
+    # nobody is answering in.
+    assert max(announcer.countdowns) <= 0.4
+
+
+@pytest.mark.asyncio
+async def test_a_missing_consumer_never_stalls_the_mode(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState
+) -> None:
+    """A broken narrator is not a reason to strand a game in the auction."""
+
+    class _Exploding:
+        def announce_question(self, *_a, **_k):  # noqa: ANN002, ANN003, ANN201
+            raise RuntimeError("tts entity is gone")
+
+        def announce_countdown(self, *_a, **_k):  # noqa: ANN002, ANN003, ANN201
+            raise RuntimeError("tts entity is gone")
+
+        def announce_reveal(self, *_a, **_k):  # noqa: ANN002, ANN003, ANN201
+            raise RuntimeError("tts entity is gone")
+
+    handler._tts_announcer = _Exploding()  # type: ignore[assignment]
+
+    await _run_one_auction(handler, game)
+    assert game.phase == GamePhase.HOT_SEAT_REVEAL

--- a/tests/test_lightning.py
+++ b/tests/test_lightning.py
@@ -28,6 +28,9 @@ from custom_components.quizify.game.lightning import (  # noqa: E402
 from custom_components.quizify.game.questions import QuestionBank  # noqa: E402
 from custom_components.quizify.game.state import GamePhase, QuizifyGameState  # noqa: E402
 from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    serialize_state_snapshot,
+)
 from custom_components.quizify.server.websocket import (  # noqa: E402
     QuizifyWebSocketHandler,
 )
@@ -268,7 +271,7 @@ class TestGameStateLightning:
     def test_snapshot_exposes_lightning(self, state: QuizifyGameState) -> None:
         state.add_player("A", _fake_ws())
         state.start_lightning_round()
-        snap = state.get_state_snapshot()
+        snap = serialize_state_snapshot(state)
         assert snap["phase"] == "LIGHTNING"
         assert "lightning" in snap
         assert "question" in snap["lightning"]
@@ -279,7 +282,7 @@ class TestGameStateLightning:
         state.add_player("A", _fake_ws())
         state.start_lightning_round()
         assert state.lightning_splash_pending is True
-        snap = state.get_state_snapshot()
+        snap = serialize_state_snapshot(state)
         assert snap["lightning"]["splash_pending"] is True
 
     def test_begin_questions_clears_splash(self, state: QuizifyGameState) -> None:
@@ -287,7 +290,7 @@ class TestGameStateLightning:
         state.start_lightning_round()
         assert state.begin_lightning_questions() is True
         assert state.lightning_splash_pending is False
-        snap = state.get_state_snapshot()
+        snap = serialize_state_snapshot(state)
         assert snap["lightning"]["splash_pending"] is False
 
     def test_begin_questions_idempotent(self, state: QuizifyGameState) -> None:
@@ -307,7 +310,7 @@ class TestGameStateLightning:
         state.add_player("A", _fake_ws())
         state.start_lightning_round()
         state.finish_lightning_round()
-        snap = state.get_state_snapshot()
+        snap = serialize_state_snapshot(state)
         assert snap["phase"] == "LIGHTNING_RECAP"
         assert "lightning_recap" in snap
 

--- a/tests/test_lightning_snapshot_221.py
+++ b/tests/test_lightning_snapshot_221.py
@@ -7,7 +7,7 @@ with **no** ``lightning`` sub-object. When such a message arrived while the
 phase was LIGHTNING, the player client's LIGHTNING case (player-core.js ~437)
 found no ``msg.lightning`` and fell through to an empty ``lightning-view`` —
 a blank screen. The fix makes the builder carry the same ``lightning``
-sub-state that ``QuizifyGameState.get_state_snapshot()`` already produced, so
+sub-state that ``serialize_state_snapshot(QuizifyGameState)`` already produced, so
 reconnect snapshots and live refreshes are wire-identical.
 
 These tests assert the builder's ``game_state`` payload includes a non-empty
@@ -32,6 +32,9 @@ from custom_components.quizify.game.state import (  # noqa: E402
 )
 from custom_components.quizify.server.round_message_builder import (  # noqa: E402
     RoundMessageBuilder,
+)
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    serialize_state_snapshot,
 )
 
 
@@ -119,7 +122,7 @@ def test_lightning_substate_matches_snapshot_shape(
     assert state.start_lightning_round() is True
     assert state.begin_lightning_questions() is True
 
-    snap = state.get_state_snapshot()
+    snap = serialize_state_snapshot(state)
     payload = builder.build_game_state_with_leaderboard(
         state, players=state.get_players()
     )

--- a/tests/test_lightning_view_registration_239.py
+++ b/tests/test_lightning_view_registration_239.py
@@ -40,6 +40,9 @@ from custom_components.quizify.game.state import (  # noqa: E402
     GamePhase,
     QuizifyGameState,
 )
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    serialize_state_snapshot,
+)
 
 _WWW_JS = _REPO_ROOT / "custom_components" / "quizify" / "www" / "js"
 _LIGHTNING_VIEW_IDS = (
@@ -99,7 +102,7 @@ def test_reconnect_snapshot_carries_lightning_substate(tmp_path: Path) -> None:
     """The reconnect snapshot must hand the (now revealable) client its data.
 
     Mirrors the #221 contract from the snapshot side: a player reconnecting
-    into a live LIGHTNING round gets ``get_state_snapshot()``, which must
+    into a live LIGHTNING round gets ``serialize_state_snapshot()``, which must
     include the ``lightning`` sub-state the client's LIGHTNING case reads to
     pick splash vs question — otherwise even a fixed showView() has nothing
     to render.
@@ -110,7 +113,7 @@ def test_reconnect_snapshot_carries_lightning_substate(tmp_path: Path) -> None:
     assert state.begin_lightning_questions() is True
     assert state.phase == GamePhase.LIGHTNING
 
-    snap = state.get_state_snapshot()
+    snap = serialize_state_snapshot(state)
 
     assert snap["phase"] == "LIGHTNING"
     assert "lightning" in snap

--- a/tests/test_lobby_language_776.py
+++ b/tests/test_lobby_language_776.py
@@ -48,6 +48,9 @@ from custom_components.quizify.game.state import (  # noqa: E402
 )
 from custom_components.quizify.server import protocol  # noqa: E402
 from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    serialize_state_snapshot,
+)
 from custom_components.quizify.server.websocket import (  # noqa: E402
     MSG_SET_LANGUAGE,
     QuizifyWebSocketHandler,
@@ -156,12 +159,12 @@ async def test_the_host_language_reaches_the_lobby_snapshot(handler, game) -> No
     """This is the whole issue: before the fix the snapshot said "de" until
     start_game, so the joining phone's very first frame stamped it German."""
     assert game.phase == GamePhase.LOBBY
-    assert game.get_state_snapshot()["language"] == "de"
+    assert serialize_state_snapshot(game)["language"] == "de"
 
     await handler._handle_set_language(_ws(), {"language": "en"}, game)
 
     assert game.language == "en"
-    assert game.get_state_snapshot()["language"] == "en"
+    assert serialize_state_snapshot(game)["language"] == "en"
 
 
 @pytest.mark.asyncio

--- a/tests/test_pause_reason_in_snapshot_703.py
+++ b/tests/test_pause_reason_in_snapshot_703.py
@@ -1,7 +1,7 @@
 """Regression tests for issue #703.
 
 ``pause_reason`` was added by the two pause *broadcasts* and nowhere else:
-``get_state_snapshot`` had no PAUSED branch, so ``_handle_reconnect``,
+``serialize_state_snapshot`` had no PAUSED branch, so ``_handle_reconnect``,
 ``_handle_join`` and ``_handle_get_state`` all sent a snapshot without it.
 
 The client reads exactly that field: ``updatePausedView`` shows "Host
@@ -26,6 +26,9 @@ sys.path.insert(0, str(_REPO_ROOT))
 from custom_components.quizify.game.state import (  # noqa: E402
     GamePhase,
     QuizifyGameState,
+)
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    serialize_state_snapshot,
 )
 
 
@@ -62,16 +65,16 @@ class TestSnapshotCarriesThePauseReason:
     ) -> None:
         """The bug: a reconnecting phone could not tell why the game stopped."""
         _paused(game, "admin_disconnected")
-        assert game.get_state_snapshot()["pause_reason"] == "admin_disconnected"
+        assert serialize_state_snapshot(game)["pause_reason"] == "admin_disconnected"
 
     def test_deliberate_pause_is_named_too(self, game: QuizifyGameState) -> None:
         _paused(game, "admin_paused")
-        assert game.get_state_snapshot()["pause_reason"] == "admin_paused"
+        assert serialize_state_snapshot(game)["pause_reason"] == "admin_paused"
 
     def test_snapshot_matches_get_pause_reason(self, game: QuizifyGameState) -> None:
         """One source of truth: the field is read off the phase controller."""
         _paused(game, "admin_disconnected")
-        snapshot = game.get_state_snapshot()
+        snapshot = serialize_state_snapshot(game)
         assert snapshot["pause_reason"] == game.get_pause_reason()
 
     def test_no_pause_reason_outside_a_pause(self, game: QuizifyGameState) -> None:
@@ -83,12 +86,12 @@ class TestSnapshotCarriesThePauseReason:
         game.add_player("Alice", _ws())
         game.start_game(language="de", num_rounds=3, difficulty="easy")
         assert game.start_next_question() is not None
-        assert "pause_reason" not in game.get_state_snapshot()
+        assert "pause_reason" not in serialize_state_snapshot(game)
 
     def test_reason_is_gone_again_after_resume(self, game: QuizifyGameState) -> None:
         _paused(game, "admin_disconnected")
         assert game.resume() is True
-        assert "pause_reason" not in game.get_state_snapshot()
+        assert "pause_reason" not in serialize_state_snapshot(game)
 
     def test_every_snapshot_consumer_sees_it(self, game: QuizifyGameState) -> None:
         """join / reconnect / get_state all serialize this same dict.
@@ -97,7 +100,7 @@ class TestSnapshotCarriesThePauseReason:
         one PAUSED branch covers all three paths at once.
         """
         _paused(game, "admin_disconnected")
-        first = game.get_state_snapshot()
-        second = game.get_state_snapshot()
+        first = serialize_state_snapshot(game)
+        second = serialize_state_snapshot(game)
         assert first["pause_reason"] == second["pause_reason"] == "admin_disconnected"
         assert first["phase"] == GamePhase.PAUSED.value

--- a/tests/test_pause_resume_reconnect_snapshot_286.py
+++ b/tests/test_pause_resume_reconnect_snapshot_286.py
@@ -47,6 +47,9 @@ from custom_components.quizify.server.connection import (  # noqa: E402
 from custom_components.quizify.server.round_message_builder import (  # noqa: E402
     RoundMessageBuilder,
 )
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    serialize_state_snapshot,
+)
 from custom_components.quizify.server.websocket import (  # noqa: E402
     QuizifyWebSocketHandler,
 )
@@ -154,7 +157,7 @@ async def test_get_state_reply_projects_for_player(
 
     # The reply must match the canonical-projection a join would have produced.
     join_projected = RoundMessageBuilder().project_snapshot_for_player(
-        game, snapshot=game.get_state_snapshot(), player=alice
+        game, snapshot=serialize_state_snapshot(game), player=alice
     )
     assert visible == join_projected["question"]["answers"]
 
@@ -184,7 +187,7 @@ async def test_get_state_reply_stays_canonical_for_admin_dashboard(
     state_msgs = [m for m in msgs if m.get("type") == "game_state"]
     assert state_msgs
     visible = state_msgs[-1]["question"]["answers"]
-    canonical = game.get_state_snapshot()["question"]["answers"]
+    canonical = serialize_state_snapshot(game)["question"]["answers"]
     assert visible == canonical
 
 
@@ -361,7 +364,7 @@ def test_resume_preserves_per_player_elapsed_so_speed_bonus_not_inflated(
 def test_snapshot_leaderboard_carries_client_contract_fields(
     game: QuizifyGameState,
 ) -> None:
-    """``get_state_snapshot`` leaderboard must be wire-identical to the live
+    """``serialize_state_snapshot`` leaderboard must be wire-identical to the live
     ``serialize_leaderboard`` broadcast — carrying ``submitted``, ``best_streak``,
     ``rounds_played``, ``powerups_used``, ``round_score`` — so reconnect-after-
     submit re-locks and FINALE reconnect shows real stats."""
@@ -370,7 +373,7 @@ def test_snapshot_leaderboard_carries_client_contract_fields(
     correct_idx = next(i for i, a in enumerate(question.answers) if a.correct)
     game.submit_answer("Alice", correct_idx)
 
-    leaderboard = game.get_state_snapshot()["leaderboard"]
+    leaderboard = serialize_state_snapshot(game)["leaderboard"]
     assert leaderboard
     required = {
         "submitted",

--- a/tests/test_perf_wasted_work_304.py
+++ b/tests/test_perf_wasted_work_304.py
@@ -4,7 +4,7 @@ Pins the behaviour of three local perf fixes so a future edit can't silently
 regress them:
 
   1. ``QuizifyGameState._fire_broadcast`` must NOT build a full
-     ``get_state_snapshot()`` for named events (``round_evaluated`` /
+     ``serialize_state_snapshot()`` for named events (``round_evaluated`` /
      ``game_ended``) — those route to handlers that build their own messages,
      so the snapshot was always discarded. The broadcast payload now carries
      only ``{"event": ...}``.
@@ -30,6 +30,7 @@ from custom_components.quizify.game.state import (  # noqa: E402
     GamePhase,
     QuizifyGameState,
 )
+from custom_components.quizify.server import serializers  # noqa: E402
 from custom_components.quizify.server.websocket import (  # noqa: E402
     QuizifyWebSocketHandler,
 )
@@ -90,11 +91,16 @@ class TestFireBroadcastSkipsSnapshot:
         assert set(payload.keys()) == {"event"}
 
     @pytest.mark.asyncio
-    async def test_get_state_snapshot_not_called_by_fire_broadcast(
-        self, tmp_path: Path
+    async def test_state_snapshot_not_built_by_fire_broadcast(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """``_fire_broadcast`` must not invoke ``get_state_snapshot`` for a
-        named event (it's the expensive call we eliminated)."""
+        """``_fire_broadcast`` must not build a state snapshot for a named
+        event (it's the expensive call we eliminated).
+
+        The builder moved out of the domain object in #747, so the counter now
+        wraps the module function rather than a method — same claim, one layer
+        further out: nothing on the ``_fire_broadcast`` path may reach it.
+        """
         gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
 
         async def _noop(payload: dict) -> None:
@@ -103,13 +109,13 @@ class TestFireBroadcastSkipsSnapshot:
         gs.set_broadcast_callback(_noop)
 
         calls = {"n": 0}
-        original = gs.get_state_snapshot
+        original = serializers.serialize_state_snapshot
 
-        def _counting():  # noqa: ANN202
+        def _counting(game_state):  # noqa: ANN001, ANN202
             calls["n"] += 1
-            return original()
+            return original(game_state)
 
-        gs.get_state_snapshot = _counting  # type: ignore[assignment]
+        monkeypatch.setattr(serializers, "serialize_state_snapshot", _counting)
         gs._fire_broadcast("round_evaluated")
         await asyncio.sleep(0)
         assert calls["n"] == 0

--- a/tests/test_reconnect_snapshot_projection_253.py
+++ b/tests/test_reconnect_snapshot_projection_253.py
@@ -1,6 +1,6 @@
 """Regression tests for issue #253 — reconnect/mid-join snapshot vs per-player state.
 
-The player-agnostic ``get_state_snapshot()`` disagreed with the per-player live
+The player-agnostic ``serialize_state_snapshot()`` disagreed with the per-player live
 game on the scoring-critical path:
 
 * QUESTION_ACTIVE / LIGHTNING: the snapshot emitted answers in CANONICAL order,
@@ -33,6 +33,9 @@ from custom_components.quizify.game.state import (  # noqa: E402
 )
 from custom_components.quizify.server.round_message_builder import (  # noqa: E402
     RoundMessageBuilder,
+)
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    serialize_state_snapshot,
 )
 
 
@@ -108,7 +111,7 @@ def test_question_snapshot_answers_match_player_submit_mapping(
     question = state.get_current_question()
     player = state.get_player("Alice")
 
-    snapshot = state.get_state_snapshot()
+    snapshot = serialize_state_snapshot(state)
     projected = builder.project_snapshot_for_player(
         state, snapshot=snapshot, player=player
     )
@@ -138,7 +141,7 @@ def test_canonical_snapshot_still_mis_orders_for_a_player(
     canonical — which is the case the projection exists to fix."""
     _start_round_with_shuffles(state)
     question = state.get_current_question()
-    raw = state.get_state_snapshot()
+    raw = serialize_state_snapshot(state)
 
     canonical_answers = raw["question"]["answers"]
     shuffle = state.get_player_shuffle("Alice")
@@ -158,7 +161,7 @@ def test_late_joiner_gets_a_minted_shuffle_on_reconnect(
     bob = state.get_player("Bob")
     assert "Bob" not in state.player_shuffles  # no shuffle before projection
 
-    snapshot = state.get_state_snapshot()
+    snapshot = serialize_state_snapshot(state)
     projected = builder.project_snapshot_for_player(
         state, snapshot=snapshot, player=bob
     )
@@ -176,7 +179,7 @@ def test_projection_does_not_mutate_canonical_snapshot(
     """Admin/dashboard recipients still get canonical order — the projection
     works on a copy and leaves the source snapshot intact."""
     _start_round_with_shuffles(state)
-    snapshot = state.get_state_snapshot()
+    snapshot = serialize_state_snapshot(state)
     canonical_before = list(snapshot["question"]["answers"])
 
     builder.project_snapshot_for_player(
@@ -204,7 +207,7 @@ def test_question_snapshot_time_remaining_uses_player_timer(
     assert timer is not None
     timer.add_time(15.0)  # time_boost power-up: extends only Alice's clock
 
-    snapshot = state.get_state_snapshot()
+    snapshot = serialize_state_snapshot(state)
     canonical_remaining = snapshot["question"]["time_remaining"]
     projected = builder.project_snapshot_for_player(
         state, snapshot=snapshot, player=alice
@@ -233,7 +236,7 @@ def test_reveal_snapshot_is_flat_with_all_answers(
     state.evaluate_round()
     assert state.phase == GamePhase.ANSWER_REVEAL
 
-    snapshot = state.get_state_snapshot()
+    snapshot = serialize_state_snapshot(state)
     # The raw snapshot nests under round_summary (the bug).
     assert "round_summary" in snapshot
 
@@ -280,7 +283,7 @@ def test_reveal_raw_snapshot_carries_question_for_dashboard(
     state.evaluate_round()
     assert state.phase == GamePhase.ANSWER_REVEAL
 
-    rs = state.get_state_snapshot()["round_summary"]
+    rs = serialize_state_snapshot(state)["round_summary"]
     assert rs["question_text"] == question.question
     # Round-shuffle order, i.e. what the TV drew while the question was live.
     assert rs["answers"] == [question.answers[i].text for i in state.shuffle_map]
@@ -315,7 +318,7 @@ def test_lightning_snapshot_answers_match_player_shuffle(
     assert q is not None
     alice = state.get_player("Alice")
 
-    snapshot = state.get_state_snapshot()
+    snapshot = serialize_state_snapshot(state)
     projected = builder.project_snapshot_for_player(
         state, snapshot=snapshot, player=alice
     )
@@ -351,7 +354,7 @@ def test_lightning_late_joiner_gets_minted_shuffle(
     lr._shuffles.pop("Zoe", None)
     assert "Zoe" not in lr._shuffles
 
-    snapshot = state.get_state_snapshot()
+    snapshot = serialize_state_snapshot(state)
     projected = builder.project_snapshot_for_player(
         state, snapshot=snapshot, player=state.get_player("Zoe")
     )

--- a/tests/test_reset_game_207.py
+++ b/tests/test_reset_game_207.py
@@ -32,6 +32,9 @@ from custom_components.quizify.game.state import (  # noqa: E402
     QuizifyGameState,
 )
 from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    serialize_state_snapshot,
+)
 from custom_components.quizify.server.websocket import (  # noqa: E402
     QuizifyWebSocketHandler,
 )
@@ -107,7 +110,7 @@ async def test_reset_clears_players_admin_and_phase(
     assert game.get_players() == []
     assert game.get_player("Admin") is None
 
-    snapshot = game.get_state_snapshot()
+    snapshot = serialize_state_snapshot(game)
     assert snapshot["phase"] == "LOBBY"
     assert snapshot["players"] == []
 

--- a/tests/test_snapshot_restore_parity_730_731.py
+++ b/tests/test_snapshot_restore_parity_730_731.py
@@ -55,8 +55,10 @@ from custom_components.quizify.game.state import (  # noqa: E402
 from custom_components.quizify.server.round_message_builder import (  # noqa: E402
     RoundMessageBuilder,
 )
-from custom_components.quizify.server.serializers import (  # noqa: E402
+from custom_components.quizify.server.serializers import (
+    # noqa: E402,
     serialize_question_for_player,
+    serialize_state_snapshot,
 )
 
 JS = _REPO / "custom_components" / "quizify" / "www" / "js"
@@ -310,14 +312,14 @@ def test_every_live_question_field_reaches_the_snapshot(
         timer_duration=30.0,
         player_score=0,
     )
-    snapshot_question = state.get_state_snapshot()["question"]
+    snapshot_question = serialize_state_snapshot(state)["question"]
 
     missing = set(live) - set(snapshot_question)
     assert missing == set(QUESTION_SOURCED_ELSEWHERE), (
         "question_started and the snapshot have drifted apart. Fields the live "
         f"path sends and the snapshot does not carry: "
         f"{sorted(missing - set(QUESTION_SOURCED_ELSEWHERE))}. Either add them "
-        "to the snapshot in get_state_snapshot(), or add them to "
+        "to the snapshot in serialize_state_snapshot(), or add them to "
         "QUESTION_SOURCED_ELSEWHERE with the reason a restore sources them "
         "elsewhere. Fields listed as exceptions that the live path no longer "
         f"sends: {sorted(set(QUESTION_SOURCED_ELSEWHERE) - missing)}."
@@ -334,7 +336,7 @@ def test_the_question_type_is_in_the_snapshot_for_every_question(
     is in, which is how the hand-written list justified itself.
     """
     state = _game_in_question_active(tmp_path, "geographie")
-    assert state.get_state_snapshot()["question"]["question_type"] == "multiple_choice"
+    assert serialize_state_snapshot(state)["question"]["question_type"] == "multiple_choice"
 
 
 def _hot_seat_in_question_stage(tmp_path: Path) -> QuizifyGameState:
@@ -373,7 +375,7 @@ def test_every_live_hot_seat_question_field_reaches_the_snapshot(
 ) -> None:
     state = _hot_seat_in_question_stage(tmp_path)
     projected = RoundMessageBuilder().project_snapshot_for_player(
-        state, snapshot=state.get_state_snapshot(), player=state.get_player("Anna")
+        state, snapshot=serialize_state_snapshot(state), player=state.get_player("Anna")
     )
     block = projected["hot_seat"]
     assert block["stage"] == "question"
@@ -387,7 +389,7 @@ def test_every_live_hot_seat_question_field_reaches_the_snapshot(
         "hot_seat_question and the snapshot's hot_seat block have drifted "
         f"apart. Sent live, absent from the snapshot: "
         f"{sorted(missing - set(HOT_SEAT_SOURCED_ELSEWHERE))}. Carry them in "
-        "get_state_snapshot(), or name them in HOT_SEAT_SOURCED_ELSEWHERE. "
+        "serialize_state_snapshot(), or name them in HOT_SEAT_SOURCED_ELSEWHERE. "
         f"Listed but no longer sent: "
         f"{sorted(set(HOT_SEAT_SOURCED_ELSEWHERE) - missing)}."
     )
@@ -411,6 +413,6 @@ def test_the_auction_snapshot_still_withholds_the_question(tmp_path: Path) -> No
     state.phase = GamePhase.ANSWER_REVEAL
     assert state.start_hot_seat_auction()
 
-    block = state.get_state_snapshot()["hot_seat"]
+    block = serialize_state_snapshot(state)["hot_seat"]
     assert block["stage"] == "auction"
     assert "question" not in block

--- a/tests/test_team_auction_and_wager_804.py
+++ b/tests/test_team_auction_and_wager_804.py
@@ -39,6 +39,7 @@ import pytest
 from custom_components.quizify.game.hot_seat import HotSeatRound, stake_of
 from custom_components.quizify.game.phase_controller import GamePhase
 from custom_components.quizify.game.state import QuizifyGameState
+from custom_components.quizify.server.serializers import serialize_state_snapshot
 
 
 def _ws() -> MagicMock:
@@ -513,7 +514,7 @@ def _project(st: QuizifyGameState, name: str) -> dict:
 
     return RoundMessageBuilder().project_snapshot_for_player(
         st,
-        snapshot=st.get_state_snapshot(),
+        snapshot=serialize_state_snapshot(st),
         player=st.get_player(name),
     )["hot_seat"]
 

--- a/tests/test_team_reset_for_new_game_799.py
+++ b/tests/test_team_reset_for_new_game_799.py
@@ -168,7 +168,7 @@ def test_the_rematch_leaderboard_is_flat(tmp_path: Path) -> None:
         hot_seat_enabled=False,
     )
 
-    scores = {row["name"]: row["score"] for row in game.get_leaderboard()}
+    scores = {p.name: p.score for p in game.get_standings()}
     assert set(scores) == {"Sofa", "Cara"}
     assert all(v == 0 for v in scores.values()), scores
 
@@ -225,4 +225,4 @@ def test_a_team_whose_members_all_went_dark_is_dissolved(
 
     names = [t.name for t in game.team_registry.all_teams()]
     assert names == ["Cara"], names
-    assert [row["name"] for row in game.get_leaderboard()] == ["Cara"]
+    assert [p.name for p in game.get_standings()] == ["Cara"]

--- a/tests/test_team_serialization_365.py
+++ b/tests/test_team_serialization_365.py
@@ -105,10 +105,10 @@ def test_the_ranking_is_players_without_teams(state: QuizifyGameState) -> None:
 
 
 def test_the_leaderboard_follows_the_mode(state: QuizifyGameState) -> None:
-    before = {row["name"] for row in state.get_leaderboard()}
+    before = {p.name for p in state.get_standings()}
     state.create_team("Sofa", "Anna")
 
-    after = {row["name"] for row in state.get_leaderboard()}
+    after = {p.name for p in state.get_standings()}
 
     assert before == {"Anna", "Jan", "Mira"}
     assert after == {"Sofa", "Jan", "Mira"}, (

--- a/tests/test_team_wire_365.py
+++ b/tests/test_team_wire_365.py
@@ -29,6 +29,9 @@ from custom_components.quizify.game.state import (  # noqa: E402
     QuizifyGameState,
 )
 from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    serialize_state_snapshot,
+)
 from custom_components.quizify.server.websocket import (  # noqa: E402
     QuizifyWebSocketHandler,
 )
@@ -281,7 +284,7 @@ async def test_the_snapshot_always_carries_the_teams_key(
     game: QuizifyGameState,
 ) -> None:
     """A reconnecting phone must tell "no teams" from "teams not sent"."""
-    snapshot = game.get_state_snapshot()
+    snapshot = serialize_state_snapshot(game)
 
     assert snapshot["teams"] == []
 

--- a/tests/test_tts_announcer_281.py
+++ b/tests/test_tts_announcer_281.py
@@ -101,11 +101,23 @@ def _result(name, correct, points=100):
     )
 
 
+class _Standing:
+    """One row of ``RoundSummary.leaderboard``.
+
+    Participants, not wire rows, since #747 — the narrator reads ``name`` and
+    ``score`` off whichever object the ranking is about (a team in team mode,
+    a player otherwise).
+    """
+
+    def __init__(self, name, score):  # noqa: ANN001
+        self.name = name
+        self.score = score
+
+
 def _lb(*pairs):
-    """Build a sorted-by-score leaderboard of {name, score, rank} dicts."""
+    """Build the standings for a round, highest score first."""
     ranked = sorted(pairs, key=lambda p: p[1], reverse=True)
-    return [{"name": n, "score": s, "rank": i + 1}
-            for i, (n, s) in enumerate(ranked)]
+    return [_Standing(n, s) for n, s in ranked]
 
 
 def _last_message(hass):

--- a/tests/test_tv_grid_shuffle_521.py
+++ b/tests/test_tv_grid_shuffle_521.py
@@ -37,6 +37,7 @@ from custom_components.quizify.server.round_message_builder import (  # noqa: E4
 from custom_components.quizify.server.serializers import (  # noqa: E402
     _compute_answer_distribution,
     serialize_question_for_admin,
+    serialize_state_snapshot,
 )
 
 
@@ -153,7 +154,7 @@ def test_active_question_snapshot_matches_the_live_grid(
     must land on the same order the live payload used."""
     question = _start_round(state)
     live = builder.build_admin_question(state, question=question)
-    snap = state.get_state_snapshot()["question"]
+    snap = serialize_state_snapshot(state)["question"]
     assert snap["answers"] == [a["text"] for a in live["answers"]]
 
 
@@ -168,7 +169,7 @@ def test_reveal_snapshot_index_addresses_its_own_answers(
     state.evaluate_round()
     assert state.phase == GamePhase.ANSWER_REVEAL
 
-    rs = state.get_state_snapshot()["round_summary"]
+    rs = serialize_state_snapshot(state)["round_summary"]
     assert rs["answers"][rs["correct_answer_index"]] == (
         question.answers[correct_idx].text
     )

--- a/tests/test_tv_language_and_header_805_807_808.py
+++ b/tests/test_tv_language_and_header_805_807_808.py
@@ -89,12 +89,18 @@ def _clamp_bounds(rule: str, selector: str) -> tuple[float, float]:
 
 
 def test_a_snapshot_carries_the_game_language() -> None:
-    """The fix reads a field; this pins that the server still sends it."""
-    state = (
-        _REPO_ROOT / "custom_components" / "quizify" / "game" / "state.py"
+    """The fix reads a field; this pins that the server still sends it.
+
+    The builder moved to ``server/serializers.py`` in #747, so this reads it
+    where it lives now.
+    """
+    serializers = (
+        _REPO_ROOT / "custom_components" / "quizify" / "server" / "serializers.py"
     ).read_text(encoding="utf-8")
-    snapshot = state.split("def get_state_snapshot(", 1)[1].split("\n    def ", 1)[0]
-    assert '"language": self.language' in snapshot
+    snapshot = serializers.split("def serialize_state_snapshot(", 1)[1].split(
+        "\ndef ", 1
+    )[0]
+    assert '"language": game_state.language' in snapshot
 
 
 def test_every_snapshot_reaches_the_language_sync() -> None:

--- a/tests/test_wager_window_656.py
+++ b/tests/test_wager_window_656.py
@@ -43,6 +43,7 @@ from custom_components.quizify.server.round_message_builder import (  # noqa: E4
     RoundMessageBuilder,
 )
 from custom_components.quizify.server.serializers import (  # noqa: E402
+    serialize_state_snapshot,
     serialize_wager_window,
 )
 
@@ -256,7 +257,7 @@ class TestPayloadWithholdsTheQuestion:
         state.start_next_question()
         question_text = state.get_current_question().question
 
-        snapshot = state.get_state_snapshot()
+        snapshot = serialize_state_snapshot(state)
 
         assert snapshot["phase"] == "WAGER_ACTIVE"
         assert "question" not in snapshot


### PR DESCRIPTION
Two halves of one boundary. #788 is the flow-control half — four game loops living inside the transport handler — and #747 the wire-format half, where the same handler's domain object was building the client format and importing the server layer to do it. They are done together because the drivers are what make the second one possible: a mode loop that no longer assembles payloads is a mode loop the wire format can be taken away from.

## #788 — one driver per mode

`game/drivers/` holds `LightningDriver`, `HotSeatDriver`, `NormalRoundDriver` and `WagerWindowDriver`. Each owns the mode's rules over time: how long a window stays open, what cuts it short, the phase re-check after every sleep, and the settlement. Each talks to the outside world through two narrow protocols in `game/drivers/protocols.py` — a per-mode `Broadcaster` for the fan-out points and a `MilestoneSink` for the house beats. A driver builds no payload dicts and touches no socket, which is what lets it live in `game/` without dragging the wire format back in.

`QuizifyWebSocketHandler` implements both protocols and keeps every payload it already owned. It is 127 lines shorter, and what left it was the part that was never transport.

**The task registry stays on the handler, deliberately.** The issue asks for it to move with the drivers, but `tests/test_round_task_teardown_746.py::test_every_handler_task_is_classified` walks the handler's `__init__` for annotated `asyncio.Task | None` attributes and fails if one is not classified — that guard is the reason a sixth omission is no longer expressible, and moving the tasks would have meant rewriting it. So a driver is the coroutine; the handler still owns its lifetime, and the five-way teardown matrix is untouched and still proven by that file.

## #708 — partly, and only where it is right

The Hot Seat now walks the same house path a normal round walks. The narrator reads the seat holder's question, `quizify_question_shown` and `quizify_answer_revealed` fire, and the answer window pushes the time-running-out beat that drives the faster light pulse. All four hooks were reachable from the normal-round path only, which is why the room went quiet for the whole detour.

**This does not close #708.** Two reasons, both of them the issue's own content:

* Lightning gets no `MilestoneSink` on purpose. `announce_question` reads a question aloud; five of those inside seventy-five seconds would talk over the mode they are meant to accompany. Lightning needs its own phrases, not the normal round's.
* `lights.py::_PHASE_LIGHT_RECIPES` still has five keys against eleven phases, `tts_phrases.py` still contains no `hot_seat` / `wager` / `lightning` string, and `quizify_hot_seat_started` / `quizify_wager_open` / `quizify_lightning_started` do not exist. Those are what #708 asks for by name, and none of them is a milestone-sink problem.

What has changed is that the remaining work is now wiring rather than restructuring: a driver holds the sink, so "walk every path the normal round walks" is something a mode can be given instead of something someone has to remember at each new loop.

## #747 — one builder, and the arrow points one way

`get_state_snapshot` built the client wire format inside `QuizifyGameState` — 262 lines duplicating keys the serializers next door already emitted (`image_url`, `reveal_style`, `question_type`, `estimate`, `time_remaining`) — and reached into `server.serializers` from a function-local import. Two builders in two layers is the shape behind #297, #434, #521 and #253; every one of them was drift between them.

It is now `server/serializers.py::serialize_state_snapshot(game_state)`. `game/state.py` is 255 lines shorter and imports nothing from `server/` any more: `get_leaderboard()` was the last holdout, and its two remaining callers put a serialized leaderboard where nothing client-facing reads one — `RoundSummary.leaderboard`, whose only consumer is the narrator's standings line, and the `end_game()` idempotency cache. Both now hold `get_standings()`, the participants in rank order, and the narrator reads two attributes instead of two dict keys.

## How I convinced myself nothing else moved

* **The snapshot is the same builder.** Undo the `self.` → `game_state.` renames mechanically and the old method body and the new function body differ only by four hoisted locals — no key added, dropped or reordered. The eighteen test files that assert on snapshot contents pass with no change beyond the call site.
* **The loops are the same loops.** Every existing regression file for them is green untouched: `test_round_task_teardown_746.py` (16 assertions on the teardown matrix, including the behavioural one that runs the real lightning loop and ends the game inside a tick), `test_hot_seat_teardown_671.py`, `test_wager_window_656.py`, `test_lightning.py`, `test_ws_state_batch_w2.py`'s #413 tick-coalescing test.
* **The behaviour change is pinned by a test that fails without it.** `tests/test_house_plays_along_hot_seat_708.py` drives a real auction to settlement through the handler. With the three `_milestone` calls removed from `HotSeatDriver`, three of its four tests fail; the fourth (a narrator that raises must not strand the mode) passes either way, which is the point of it.
* **The layering is pinned too.** `tests/test_layering_game_does_not_import_server_747.py` walks the AST of every `game/` module, because the import that got past every other check was inside a method body. It fails on `origin/main` and passes here.

## Checks

`ruff check custom_components/` clean, `mypy` clean (60 files), full suite **3292 passed, 11 xfailed**. The two failures in `tests/test_service_start_settings_744.py` are the known local preset-store problem tracked as #823 and are unrelated.

`www/` is untouched. Two stale comments there still name `state.get_leaderboard()` (`www/js/player-end.js`, `www/js/player.bundle.js`); they are prose only, and I left them alone because other work is in that tree.

Closes #788
Closes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)
