### PR TITLE
chore: cut 1.16.0-RC1, and make the two pack version sources agree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,37 @@
 All notable changes to Quizify are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [1.16.0-RC1] — 2026-09-06
+
+Thirty-four entries, chosen in one sitting and built in one — and the biggest of
+them were the ones nobody had asked for.
+
+### 🔒 The door was open, and the pictures were not ours
+
+A page open in any browser on the network could reach the game's socket and, in
+the right moment, claim the host's seat — lights, speakers and scenes with it.
+And a photograph of the Jules Rimet trophy had been shipping in every install
+under a licence that requires a credit it never carried; three more pictures were
+free in the United States only, two of them tagged on their own source page as
+protected in Germany. Four questions are text now, two carry different pictures,
+and the check that missed all of it no longer greps for a phrase.
+
+### 📺 Three screens that were quietly three products
+
+The television never followed the game's language, so a German house running an
+English quiz framed English questions in German. The phone kept a picture from
+the round before. The host's page had no way forward on the last round but a red
+button that warned of something it does not do. And the escape hatch for a host
+whose phone dies turned out never to have been armed at all.
+
+### 🏗 And underneath
+
+Every game mode now owns its own loop instead of writing one into the socket
+handler, the three surfaces share one client and one set of renderers, and a new
+guard fails the build when a frame reaches a screen that has no case for it. Team
+mode gets its own Hot Seat auction and final wager. A phone's first load went from
+1.98 MB to 314 KB.
+
 ## [1.15.0] — 2026-09-06
 
 Twenty-four entries, chosen in one sitting and built in one — then played, which

--- a/custom_components/quizify/manifest.json
+++ b/custom_components/quizify/manifest.json
@@ -14,5 +14,5 @@
   "documentation": "https://github.com/mholzi/quizify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/quizify/issues",
-  "version": "1.15.0"
+  "version": "1.16.0-RC1"
 }

--- a/custom_components/quizify/questions/copa-mundial-es.json
+++ b/custom_components/quizify/questions/copa-mundial-es.json
@@ -1,7 +1,7 @@
 {
   "name": "Copa Mundial",
   "language": "es",
-  "version": "1.0",
+  "version": "1.1",
   "theme": "worldcup",
   "season": {
     "start": "06-01",

--- a/custom_components/quizify/questions/cultura-pop-es.json
+++ b/custom_components/quizify/questions/cultura-pop-es.json
@@ -1,7 +1,7 @@
 {
   "name": "Cultura Pop",
   "language": "es",
-  "version": "1.1",
+  "version": "1.2",
   "theme": "popculture",
   "questions": [
     {

--- a/custom_components/quizify/questions/deportes-es.json
+++ b/custom_components/quizify/questions/deportes-es.json
@@ -1,7 +1,7 @@
 {
   "name": "Deportes",
   "language": "es",
-  "version": "1.2",
+  "version": "1.3",
   "theme": "sport",
   "questions": [
     {

--- a/custom_components/quizify/questions/essen-de.json
+++ b/custom_components/quizify/questions/essen-de.json
@@ -1,7 +1,7 @@
 {
   "name": "Essen & Trinken",
   "language": "de",
-  "version": "1.2",
+  "version": "1.3",
   "theme": "food",
   "questions": [
     {

--- a/custom_components/quizify/questions/food-en.json
+++ b/custom_components/quizify/questions/food-en.json
@@ -1,7 +1,7 @@
 {
   "name": "Food & Drink",
   "language": "en",
-  "version": "1.2",
+  "version": "1.3",
   "theme": "food",
   "questions": [
     {

--- a/custom_components/quizify/questions/pop-culture.json
+++ b/custom_components/quizify/questions/pop-culture.json
@@ -1,7 +1,7 @@
 {
   "name": "Pop Culture",
   "language": "en",
-  "version": "1.2",
+  "version": "1.3",
   "theme": "popculture",
   "questions": [
     {

--- a/custom_components/quizify/questions/popkultur.json
+++ b/custom_components/quizify/questions/popkultur.json
@@ -1,7 +1,7 @@
 {
   "name": "Popkultur",
   "language": "de",
-  "version": "1.2",
+  "version": "1.3",
   "theme": "popculture",
   "questions": [
     {

--- a/custom_components/quizify/questions/sport-de.json
+++ b/custom_components/quizify/questions/sport-de.json
@@ -1,7 +1,7 @@
 {
   "name": "Sport",
   "language": "de",
-  "version": "1.2",
+  "version": "1.3",
   "theme": "sport",
   "questions": [
     {

--- a/custom_components/quizify/questions/sport-en.json
+++ b/custom_components/quizify/questions/sport-en.json
@@ -1,7 +1,7 @@
 {
   "name": "Sport",
   "language": "en",
-  "version": "1.2",
+  "version": "1.3",
   "theme": "sport",
   "questions": [
     {

--- a/custom_components/quizify/questions/weltmeisterschaft.json
+++ b/custom_components/quizify/questions/weltmeisterschaft.json
@@ -1,7 +1,7 @@
 {
   "name": "Weltmeisterschaft",
   "language": "de",
-  "version": "1.2",
+  "version": "1.3",
   "theme": "worldcup",
   "season": {
     "start": "06-01",

--- a/custom_components/quizify/questions/world-cup.json
+++ b/custom_components/quizify/questions/world-cup.json
@@ -1,7 +1,7 @@
 {
   "name": "World Cup",
   "language": "en",
-  "version": "1.2",
+  "version": "1.3",
   "theme": "worldcup",
   "season": {
     "start": "06-01",

--- a/tests/test_pack_version_sources_agree.py
+++ b/tests/test_pack_version_sources_agree.py
@@ -1,0 +1,86 @@
+"""Every pack states one version, not two.
+
+Quizify keeps a pack's version in two places: the ``version`` field inside the
+pack file, and its entry in ``questions/versions.json``. They are not
+interchangeable — ``QuestionBank._load_pack`` builds ``_pack_versions`` from the
+**pack file's own field** (``game/questions.py``, ``raw.get("version", "1.0")``),
+and that is what the admin screen shows. ``versions.json`` is the catalogue.
+
+So a bump written to only one of them is invisible: CI stays green, the
+catalogue claims a new version, and the host reads the old number off the
+screen.
+
+Found on 2026-09-06 during the ``rc-cut`` pack check for v1.16.0-RC1. Eleven
+packs disagreed. Nine came from PR #818, which rewrote pack content for the
+image-licence sweep and bumped only ``versions.json``. The other two,
+``essen-de`` and ``food-en``, had been drifting since #583 in August — nobody
+noticed, because nothing compared the two sources.
+
+The rc-cut job asks a human to run this comparison by hand every week. This test
+does it on every push instead.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+QUESTIONS = (
+    Path(__file__).resolve().parent.parent
+    / "custom_components"
+    / "quizify"
+    / "questions"
+)
+VERSIONS_FILE = QUESTIONS / "versions.json"
+
+
+def _catalogue() -> dict[str, str]:
+    return json.loads(VERSIONS_FILE.read_text(encoding="utf-8"))
+
+
+def _pack_slugs() -> list[str]:
+    return sorted(_catalogue())
+
+
+def test_the_catalogue_lists_a_file_for_every_entry() -> None:
+    """A catalogue entry without a pack file is a version for nothing."""
+    missing = [
+        slug for slug in _catalogue() if not (QUESTIONS / f"{slug}.json").exists()
+    ]
+    assert not missing, f"versions.json lists packs that do not exist: {missing}"
+
+
+def test_every_pack_file_is_in_the_catalogue() -> None:
+    """A pack outside the catalogue ships with no recorded version at all."""
+    catalogue = _catalogue()
+    strays = sorted(
+        path.stem
+        for path in QUESTIONS.glob("*.json")
+        if path.name != "versions.json" and path.stem not in catalogue
+    )
+    assert not strays, f"pack files missing from versions.json: {strays}"
+
+
+@pytest.mark.parametrize("slug", _pack_slugs())
+def test_the_pack_and_the_catalogue_state_the_same_version(slug: str) -> None:
+    """The number the admin screen shows must be the number the catalogue holds.
+
+    The pack file is the source the running integration reads; the catalogue is
+    what the repository documents. When they differ, one of them is lying to
+    somebody, and there is no way to tell which from either file alone.
+    """
+    catalogue_version = _catalogue()[slug]
+    pack = json.loads((QUESTIONS / f"{slug}.json").read_text(encoding="utf-8"))
+    pack_version = pack.get("version")
+
+    assert pack_version is not None, (
+        f"{slug}.json has no 'version' field; the admin screen would fall back "
+        f"to '1.0' while versions.json says {catalogue_version!r}"
+    )
+    assert pack_version == catalogue_version, (
+        f"{slug}: the pack file says {pack_version!r}, versions.json says "
+        f"{catalogue_version!r}. The admin screen reads the pack file, so it "
+        f"would show {pack_version!r}. Bump both or neither."
+    )


### PR DESCRIPTION
Cuts the release candidate for the v1.16.0 milestone: 34 of 34 plan entries merged, `main` green on all seven checks.

- `manifest.json`: `1.15.0` → `1.16.0-RC1`
- `CHANGELOG.md`: a `[1.16.0-RC1]` section

## The pack check found something

Step 3 of the rc-cut job compares each changed pack's own `version` field with its entry in `questions/versions.json`. **Eleven packs disagreed.**

They are not interchangeable sources. `QuestionBank._load_pack` builds `_pack_versions` from the pack file's own field (`game/questions.py`, `raw.get("version", "1.0")`) — that is the number the admin screen shows. `versions.json` is the catalogue. A bump written to one of them only is invisible: CI stays green, the catalogue claims a new version, and the host reads the old number off the screen.

| Origin | Packs |
|---|---|
| #818 (image-licence sweep — content changed, only the catalogue bumped) | `popkultur`, `pop-culture`, `sport-de`, `sport-en`, `world-cup`, `weltmeisterschaft`, `deportes-es`, `cultura-pop-es`, `copa-mundial-es` |
| **older than this week** — drifting since #583 in August | `essen-de`, `food-en` |

The pack files now carry the catalogue's numbers.

## And a guard, so the weekly hand-check is not the only thing standing between us and this

`tests/test_pack_version_sources_agree.py` compares both sources for every pack on every push, and additionally refuses a catalogue entry with no pack file and a pack file with no catalogue entry.

Failing-first: with the `questions/` changes stashed, **11 of 38 fail**, each naming its pack and both numbers. With them, 38 pass.

## Gates

- Full suite: **3413 passed, 11 xfailed**. The two `test_service_start_settings_744.py` failures on the developer machine are #823 (a preset store inside the venv past its 20-entry cap) and are green in CI.
- `ruff check custom_components/` clean, `mypy` at baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)