### PR TITLE
chore: cut 1.16.0-RC2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to Quizify are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [1.16.0-RC2] — 2026-09-06
+
+Six games on a real television found nine things RC1 got wrong. All nine are here.
+
+### 🪑 The evening could end at the hot seat
+
+With Hot Seat on — the default — a host running the game from the admin page was
+left, once the chair was settled, with a red **End Game** and no way forward. The
+server was ready to go on; only the page had not noticed. It had been listening
+for a full snapshot while the game announced the moment as a single event.
+
+### 🧭 And the phones could not tell a host from a ghost
+
+A host who never joins as a player owns no row in any roster, so a closed tab and
+a host sitting right there looked identical on the wire. The phones read that
+silence as death and offered every guest a reset button mid-game. The server
+always knew the answer — it now says so, and the escape hatch for a room whose
+host really has gone still works.
+
+### 📺 The television
+
+The leaderboard now moves when a hot-seat stake settles, the team question
+counts teams instead of heads, the lobby fits 720p again, and the lightning panel
+says which score it is showing.
+
 ## [1.16.0-RC1] — 2026-09-06
 
 Thirty-four entries, chosen in one sitting and built in one — and the biggest of

--- a/custom_components/quizify/manifest.json
+++ b/custom_components/quizify/manifest.json
@@ -14,5 +14,5 @@
   "documentation": "https://github.com/mholzi/quizify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/quizify/issues",
-  "version": "1.16.0-RC1"
+  "version": "1.16.0-RC2"
 }


### PR DESCRIPTION
Cuts the second release candidate. RC1 failed its live test on real hardware.

- `manifest.json`: `1.16.0-RC1` → `1.16.0-RC2`
- `CHANGELOG.md`: a `[1.16.0-RC2]` section

## What RC1 got wrong, and where it is fixed

| | |
|---|---|
| **#832 (blocker)** — host page stuck at the hot-seat result, no Next Question | #841 |
| #833, #835, #836, #837 — television leaderboards, team counting, 720p lobby | #843 |
| #834, #838, #839 — phone reset affordance, leftovers on the join screen, stale timer announcement | #840 |
| **#842** — found while fixing #834: the wire cannot distinguish an admin-only host from a departed one | #840 |

## Pack version check

**Nothing to report this round.** No file under `custom_components/quizify/questions/` changed since `v1.16.0-RC1`, and `tests/test_pack_version_sources_agree.py` — added with RC1 after it found eleven packs disagreeing — is green across all 36.

## Gates

- Full suite green, `ruff check custom_components/` clean, `mypy` at baseline.
- `main` was green on all seven checks before this branch was cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)