### PR TITLE
Two television findings from the v1.16.0-RC2 live test

### DIFF
--- a/custom_components/quizify/server/round_message_builder.py
+++ b/custom_components/quizify/server/round_message_builder.py
@@ -542,7 +542,16 @@ class RoundMessageBuilder:
             }
 
         all_answers = []
+        # #853: who each row actually belongs to. The rows stay per player —
+        # the phone reveal reads its own out of them — but the television's
+        # distribution has to divide by entrants, the way the counter above it
+        # has since #835. A team is one vote (#365) however many phones carry
+        # its row. Keyed on the team id rather than its name, for #728's
+        # reason: nothing stops two teams from sharing a name.
+        entrant_of: dict[str, str] = {}
         for player in game_state.get_players():
+            _team = team_of(player.name) if team_of is not None else None
+            entrant_of[player.name] = getattr(_team, "team_id", None) or player.name
             row = _team_row(player.name)
             if row is not None:
                 all_answers.append(row)
@@ -606,6 +615,7 @@ class RoundMessageBuilder:
             question_id=summary.question.id,
             display_order=game_state.shuffle_map,
             next_image_url=next_image_url,
+            entrant_of=entrant_of,
         )
         if store_cached is not None:
             store_cached(cache_key, msg)

--- a/custom_components/quizify/server/serializers.py
+++ b/custom_components/quizify/server/serializers.py
@@ -851,6 +851,7 @@ def serialize_round_summary(
     estimate: dict[str, Any] | None = None,
     display_order: list[int] | None = None,
     next_image_url: str | None = None,
+    entrant_of: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Build round summary broadcast payload.
 
@@ -868,7 +869,10 @@ def serialize_round_summary(
       that path for no gain.
 
     ``answer_distribution`` is emitted in CANONICAL space so the #151 bars
-    attach to the tiles the dashboard actually drew.
+    attach to the tiles the dashboard actually drew, and — given
+    ``entrant_of``, a player-name → team-id map — it counts one vote per
+    entrant rather than one per head (#853). ``all_answers`` itself stays
+    per player: the phone reveal reads its own row out of it.
 
     ``next_image_url`` is the picture the NEXT round will show (#736), so
     clients can warm it while the reveal is on screen instead of after
@@ -882,7 +886,7 @@ def serialize_round_summary(
     # entries is question-JSON order; the bars hang off the canonical grid,
     # so the mapping happens here rather than in the client.
     answer_distribution = _compute_answer_distribution(
-        all_answers or [], num_answer_options, display_order
+        all_answers or [], num_answer_options, display_order, entrant_of
     )
 
     summary: dict[str, Any] = {
@@ -923,10 +927,37 @@ def serialize_round_summary(
     return summary
 
 
+def _dedupe_by_entrant(
+    all_answers: list[dict[str, Any]],
+    entrant_of: dict[str, str] | None,
+) -> list[dict[str, Any]]:
+    """One row per entrant, in the order the rows arrived (#853).
+
+    ``all_answers`` is per PLAYER and has to stay that way — the phone reveal
+    reads its own row out of it for the answer it gave, the points it earned
+    and its own ``correct_button_index``. In team mode every member carries
+    the same team row (#365), so counting the list counts heads.
+    """
+    if not entrant_of:
+        return all_answers
+    seen: set[str] = set()
+    rows: list[dict[str, Any]] = []
+    for entry in all_answers:
+        name = entry.get("player_name")
+        key = entrant_of.get(name, name) if isinstance(name, str) else None
+        if key is not None:
+            if key in seen:
+                continue
+            seen.add(key)
+        rows.append(entry)
+    return rows
+
+
 def _compute_answer_distribution(
     all_answers: list[dict[str, Any]],
     num_options: int,
     display_order: list[int] | None = None,
+    entrant_of: dict[str, str] | None = None,
 ) -> list[dict[str, Any]]:
     """Compute per-option vote counts and percentages.
 
@@ -937,10 +968,20 @@ def _compute_answer_distribution(
     ``display_order`` (the round's canonical shuffle) maps each vote onto the
     tile the dashboard actually rendered (#521); without it the bars would
     count the right votes against the wrong answers.
+
+    ``entrant_of`` maps a player's name onto the thing that actually answers —
+    their team's id in team mode, their own name otherwise (#853). A team has
+    exactly one answer (#365) but a row per member, so without this a team of
+    two was two votes: Sofa on Argentina and Dan alone on Brazil read 67/33 on
+    the television instead of the 50/50 that happened, and a large team's pick
+    dominated a chart the room reads as "what did we all choose". It is also
+    what the counter above the bars has counted since #835 — one entrant, one
+    vote — so the two numbers on that screen now agree.
     """
+    rows = _dedupe_by_entrant(all_answers, entrant_of)
     counts = [0] * num_options
     no_answer_count = 0
-    total = len(all_answers)
+    total = len(rows)
 
     # original index -> position in the rendered grid
     to_display: dict[int, int] = {}
@@ -951,7 +992,7 @@ def _compute_answer_distribution(
     ):
         to_display = {orig: pos for pos, orig in enumerate(display_order)}
 
-    for entry in all_answers:
+    for entry in rows:
         idx = entry.get("answer_index")
         if entry.get("no_answer") or idx is None:
             no_answer_count += 1

--- a/custom_components/quizify/www/dashboard.html
+++ b/custom_components/quizify/www/dashboard.html
@@ -2201,6 +2201,27 @@
             if (name !== 'finale' && els.eveningTally) {
                 els.eveningTally.classList.add('hidden');
             }
+            // #850: the third panel on this board with a writer and no
+            // clearer, after #706's answer tally and #807's evening leaders.
+            // `handleRoundSummary` is the only thing that ever fills
+            // `#fun-fact`, and only `question_started` ever took the class
+            // off again — so the last fact of a game survived the finale, the
+            // reset and the whole next lobby with its text still in it, and
+            // every other door into the question view put it back on screen:
+            // a QUESTION_ACTIVE snapshot with no question block, a
+            // WAGER_ACTIVE or HOT_SEAT snapshot with no detour block, and the
+            // ANSWER_REVEAL rebuild all call showView('question') without
+            // touching it. The room then read the previous game's fact — in
+            // the previous game's language, because the `data-i18n` label had
+            // already switched — through the first question of the next game,
+            // when it is looking hardest at the screen. Clearing on every
+            // view change means a new path cannot forget again: the reveal
+            // writes the fact without a view change, and the reconnect path
+            // re-renders it from the snapshot immediately afterwards.
+            if (els.funFact) {
+                els.funFact.classList.remove('visible');
+                if (els.funFactText) els.funFactText.textContent = '';
+            }
         }
 
         // ---- #374: TV lobby join QR + live player roster ----

--- a/tests/test_team_answer_distribution_853.py
+++ b/tests/test_team_answer_distribution_853.py
@@ -1,0 +1,238 @@
+"""#853 — in team mode the television's answer distribution counted heads.
+
+Found on real hardware during the v1.16.0-RC2 live test, on the screen #835
+had just fixed. Team **Sofa** (Anna + Cleo) answered *Argentina*; **Dan**,
+playing alone, answered *Brazil*. Two entrants, one answer each. The
+television read::
+
+    2/2                      <- entrants, correct since #835
+    A  Argentina   67%       <- 2 of 3 people
+    B  Brazil      33%       <- 1 of 3 people
+    C  Croatia      0%
+
+``_compute_answer_distribution`` divides by ``len(all_answers)``, and
+``all_answers`` is per player — every member of a team carries the team's row
+(#365), because the phone reveal reads its own row out of it for the answer it
+gave and the points it earned. So a team of two was two votes: 67/33 where
+50/50 happened, and a large team's pick dominating a chart the room reads as
+"what did we all choose". The counter directly above the bars had counted the
+other way since #835, which is what made it visible.
+
+The rows stay per player. The distribution now collapses them onto the thing
+that actually answers — the team id, or the player's own name when they play
+alone — which is the same entrant the counter above it counts.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from custom_components.quizify.game.state import QuizifyGameState
+from custom_components.quizify.server.round_message_builder import RoundMessageBuilder
+from custom_components.quizify.server.serializers import (
+    _compute_answer_distribution,
+    serialize_round_summary,
+)
+
+REPO = Path(__file__).resolve().parent.parent
+BUILDER = (
+    REPO / "custom_components" / "quizify" / "server" / "round_message_builder.py"
+)
+
+
+class _Runtime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    return ws
+
+
+def _open_round(st: QuizifyGameState):  # noqa: ANN202
+    """What ``_emit_question`` does, minus the sockets.
+
+    The canonical shuffle has to be stored or ``num_answer_options`` is zero
+    and there are no bars to count; the per-player shuffles are the identity
+    here so a submitted button index is also the question-JSON index.
+    """
+    question = st.start_next_question()
+    assert question is not None
+    order = list(range(len(question.answers)))
+    st.set_round_shuffle(order, [question.answers[i].text for i in order])
+    for player in st.get_players():
+        st.set_player_shuffle(player.name, list(order))
+    return question
+
+
+def _live_test_room(tmp_path: Path) -> QuizifyGameState:
+    """The room from the screenshot: a team of two and one solo guest."""
+    st = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="test")
+    for name in ("Anna", "Cleo", "Dan"):
+        st.add_player(name, _ws())
+    st.create_team("Sofa", "Anna")
+    st.join_team(st.get_team_of("Anna")["team_id"], "Cleo")
+    st.start_game(num_rounds=8, language="en")
+    return st
+
+
+def _distribution(st: QuizifyGameState) -> dict[int, dict]:
+    summary = RoundMessageBuilder().build_round_summary(st)
+    assert summary is not None
+    return {d["index"]: d for d in summary["answer_distribution"]}
+
+
+# ---------------------------------------------------------------------------
+# The screen from the live test
+# ---------------------------------------------------------------------------
+
+
+def test_a_team_of_two_is_one_vote(tmp_path: Path) -> None:
+    """67/33 is what the room was shown; 50/50 is what happened."""
+    st = _live_test_room(tmp_path)
+    _open_round(st)
+    st.submit_answer("Anna", 0)
+    st.submit_answer("Dan", 1)
+    st.evaluate_round()
+
+    dist = _distribution(st)
+    assert (dist[0]["count"], dist[0]["percent"]) == (1, 50)
+    assert (dist[1]["count"], dist[1]["percent"]) == (1, 50)
+    assert (dist[2]["count"], dist[2]["percent"]) == (0, 0)
+
+
+def test_the_bars_count_what_the_counter_above_them_counts(tmp_path: Path) -> None:
+    """#835 made the tally entrants; the chart under it has to agree."""
+    st = _live_test_room(tmp_path)
+    _open_round(st)
+    st.submit_answer("Anna", 0)
+    st.submit_answer("Dan", 1)
+    st.evaluate_round()
+
+    dist = _distribution(st)
+    votes = sum(d["count"] for d in dist.values())
+    assert votes == len(st.get_ranked_participants()) == 2
+
+
+def test_the_second_member_does_not_vote_again(tmp_path: Path) -> None:
+    """Cleo re-taps the team's answer. It is still one answer (#365)."""
+    st = _live_test_room(tmp_path)
+    _open_round(st)
+    st.submit_answer("Anna", 0)
+    st.submit_answer("Dan", 1)
+    st.evaluate_round()
+    before = _distribution(st)[0]["count"]
+
+    st2 = _live_test_room(tmp_path)
+    _open_round(st2)
+    st2.submit_answer("Anna", 0)
+    st2.submit_answer("Cleo", 0)
+    st2.submit_answer("Dan", 1)
+    st2.evaluate_round()
+    assert _distribution(st2)[0]["count"] == before == 1
+
+
+def test_a_silent_team_is_one_missing_vote(tmp_path: Path) -> None:
+    """The no-answer bucket divides by entrants too, or the percentages
+    would not add up to a hundred."""
+    st = _live_test_room(tmp_path)
+    _open_round(st)
+    st.submit_answer("Dan", 1)
+    st.evaluate_round()
+
+    dist = _distribution(st)
+    assert (dist[1]["count"], dist[1]["percent"]) == (1, 50)
+    assert (dist[None]["count"], dist[None]["percent"]) == (1, 50)
+
+
+def test_the_rows_themselves_stay_per_player(tmp_path: Path) -> None:
+    """Collapsing ``all_answers`` would break the phone reveal (#365/#308)."""
+    st = _live_test_room(tmp_path)
+    _open_round(st)
+    st.submit_answer("Anna", 0)
+    st.submit_answer("Dan", 1)
+    st.evaluate_round()
+
+    summary = RoundMessageBuilder().build_round_summary(st)
+    assert [r["player_name"] for r in summary["all_answers"]] == [
+        "Anna",
+        "Cleo",
+        "Dan",
+    ]
+
+
+def test_an_ordinary_game_is_untouched(tmp_path: Path) -> None:
+    st = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="test")
+    for name in ("Anna", "Ben", "Cleo"):
+        st.add_player(name, _ws())
+    st.start_game(num_rounds=8, language="en")
+    _open_round(st)
+    st.submit_answer("Anna", 0)
+    st.submit_answer("Ben", 0)
+    st.submit_answer("Cleo", 1)
+    st.evaluate_round()
+
+    dist = _distribution(st)
+    assert (dist[0]["count"], dist[0]["percent"]) == (2, 67)
+    assert (dist[1]["count"], dist[1]["percent"]) == (1, 33)
+
+
+# ---------------------------------------------------------------------------
+# The seam
+# ---------------------------------------------------------------------------
+
+
+def test_the_map_reaches_the_serializer(tmp_path: Path) -> None:
+    """The serializer can only divide by what the builder hands it."""
+    source = BUILDER.read_text(encoding="utf-8")
+    call = re.search(r"msg = serialize_round_summary\((.*?)\n        \)", source, re.S)
+    assert call is not None
+    assert "entrant_of=entrant_of" in call.group(1), (
+        "build_round_summary stopped naming the entrants — the bars are back "
+        "to counting heads"
+    )
+
+
+def test_teams_are_keyed_by_id_not_by_name(tmp_path: Path) -> None:
+    """#728's reason: nothing stops two teams from sharing a name."""
+    st = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="test")
+    for name in ("Anna", "Ben"):
+        st.add_player(name, _ws())
+    st.create_team("Sofa", "Anna")
+    st.create_team("Sofa", "Ben")
+    st.start_game(num_rounds=8, language="en")
+    _open_round(st)
+    st.submit_answer("Anna", 0)
+    st.submit_answer("Ben", 1)
+    st.evaluate_round()
+
+    dist = _distribution(st)
+    assert (dist[0]["count"], dist[1]["count"]) == (1, 1), (
+        "two same-named teams collapsed into one entrant"
+    )
+
+
+def test_the_argument_is_optional_and_changes_nothing_when_absent() -> None:
+    """Every caller outside team mode, and forty tests, pass three arguments."""
+    rows = [
+        {"player_name": "Anna", "answer_index": 0},
+        {"player_name": "Ben", "answer_index": 0},
+        {"player_name": "Cleo", "answer_index": 1},
+    ]
+    assert _compute_answer_distribution(rows, 2) == _compute_answer_distribution(
+        rows, 2, None, None
+    )
+    assert serialize_round_summary(
+        correct_answer_index=0,
+        correct_answer_text="A",
+        fun_fact="",
+        leaderboard=[],
+        round_num=1,
+        total_rounds=5,
+        all_answers=rows,
+        num_answer_options=2,
+    )["answer_distribution"] == _compute_answer_distribution(rows, 2)

--- a/tests/test_tv_fun_fact_cleared_850.py
+++ b/tests/test_tv_fun_fact_cleared_850.py
@@ -1,0 +1,110 @@
+"""#850 — the television kept the last game's DID YOU KNOW panel.
+
+Found on real hardware during the v1.16.0-RC2 live test. A German game had
+just started — round 1, a German music question — and the panel in the lower
+right still held the closing fact of the English game before it, under a
+``WUSSTEST DU?`` label that *had* followed the room into German because it is
+a static ``data-i18n`` string. It is replaced the moment that round's own
+reveal lands, so the window is one question long — the first question of the
+evening, when the room is looking hardest at the screen.
+
+``#fun-fact`` is the third panel on this board with a writer and no clearer,
+after #706's answer tally and #807's evening leaders, and it fails the same
+way for the same reason. ``handleRoundSummary`` fills it;
+``question_started`` was the only thing that ever took the class off again,
+and nothing ever emptied the text. So the fact survived the finale, the reset
+and the whole next lobby — and every *other* door into the question view put
+it back on screen: a ``QUESTION_ACTIVE`` snapshot with no ``question`` block,
+a ``WAGER_ACTIVE`` or ``HOT_SEAT`` snapshot with no detour block, and the
+``ANSWER_REVEAL`` rebuild all call ``showView('question')`` without touching
+it.
+
+The fix is #706's and #807's: clear it on every view change, so a new path
+cannot forget. The reveal is unaffected — it writes the fact without a view
+change, and the reconnect path re-renders it from the snapshot immediately
+after the view is shown.
+
+Measured in Chrome at 1280x720 with the socket stubbed, replaying
+game_ended → game_reset → LOBBY(de) → question_started: before the fix
+``#fun-fact`` carried ``visible`` and the previous game's 165px of text right
+through the reset; after it, the panel is empty and 68px from the finale
+onwards.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DASHBOARD = _REPO_ROOT / "custom_components" / "quizify" / "www" / "dashboard.html"
+
+SOURCE = _DASHBOARD.read_text(encoding="utf-8")
+
+
+def _fn_body(name: str) -> str:
+    """The body of a top-level (8-space indented) function in dashboard.html."""
+    marker = f"function {name}("
+    assert marker in SOURCE, f"{name}() is gone"
+    return SOURCE.split(marker, 1)[1].split("\n        }", 1)[0]
+
+
+def test_every_view_change_takes_the_fun_fact_down() -> None:
+    body = _fn_body("showView")
+    assert "els.funFact" in body, (
+        "showView never touches #fun-fact — the last game's fact will hang in "
+        "the right column through the finale, the reset and the next lobby"
+    )
+
+
+def test_the_text_is_emptied_and_not_merely_hidden() -> None:
+    """Removing the class alone leaves the previous game's sentence in the
+    DOM, still sized into the 549.8px right column and one missed
+    ``question_started`` away from being read out to the room."""
+    body = _fn_body("showView")
+    block = re.search(r"if \(els\.funFact\) \{(.*?)\n            \}", body, re.S)
+    assert block, "the fun-fact clear is not a block of showView's own"
+    assert "classList.remove('visible')" in block.group(1)
+    assert re.search(
+        r"els\.funFactText\.textContent = ''", block.group(1)
+    ), "the panel keeps its text and its height"
+
+
+def test_the_clear_is_not_scoped_to_one_view() -> None:
+    """#706 and #807 could name the one view that keeps their line. This one
+    cannot: the fact belongs to a *reveal*, not to a view, and the reveal
+    arrives without a view change at all."""
+    body = _fn_body("showView")
+    block = re.search(r"(if \([^)]*els\.funFact[^)]*\) \{)", body)
+    assert block, "showView no longer guards the fun-fact clear"
+    assert "name !==" not in block.group(1), (
+        "gating on a view name lets the reveal-reconnect and hot-seat paths "
+        "back into the question view with a stale fact"
+    )
+
+
+def test_the_reveal_still_writes_the_fact_without_a_view_change() -> None:
+    """The clear is only safe because handleRoundSummary shows no view."""
+    body = _fn_body("handleRoundSummary")
+    assert "showView(" not in body, (
+        "handleRoundSummary now changes view, so showView would wipe the fact "
+        "it is about to write"
+    )
+    assert "els.funFactText.textContent" in body
+
+
+def test_a_television_reconnecting_at_the_reveal_gets_its_fact_back() -> None:
+    """``ANSWER_REVEAL`` calls showView('question') — which now clears — and
+    must re-render the fact from the snapshot afterwards."""
+    branch = SOURCE.split("case 'ANSWER_REVEAL':", 1)[1].split("case '", 1)[0]
+    assert "showView('question')" in branch
+    assert "renderRevealFromSnapshot" in branch
+    assert "rs.fun_fact" in _fn_body("renderRevealFromSnapshot")
+
+
+def test_all_three_header_and_panel_lines_are_cleared_the_same_way() -> None:
+    """#706 fixed the answer progress, #807 the line below it, and #850 the
+    panel in the other column. None may drift back to a single writer."""
+    body = _fn_body("showView")
+    for element in ("els.answerProgress", "els.eveningTally", "els.funFact"):
+        assert element in body, f"{element} lost its clearer in showView"


### PR DESCRIPTION
Both found on real hardware during the v1.16.0-RC2 live test, both on the television, and both the same shape as things fixed earlier the same day.

## #850 — the last game's DID YOU KNOW panel

`#fun-fact` is the third panel on that board with a writer and no clearer, after #706's answer tally and #807's evening leaders. `handleRoundSummary` fills it; `question_started` was the only thing that ever took the `visible` class off again, and nothing ever emptied the text.

So the closing fact of a game survived the finale, the reset and the whole next lobby — and every *other* door into the question view put it back on screen: a `QUESTION_ACTIVE` snapshot with no `question` block, a `WAGER_ACTIVE` or `HOT_SEAT` snapshot with no detour block, and the `ANSWER_REVEAL` rebuild all call `showView('question')` without touching it. The room read the previous game's fact, under a label that had already switched to the new game's language, through the first question of the next game.

`showView` now clears it on every view change — #706's and #807's fix. That is safe because the reveal writes the fact *without* a view change, and the reconnect path re-renders it from the snapshot immediately after the view is shown.

## #853 — the answer distribution counted heads

`_compute_answer_distribution` divided by `len(all_answers)`, and `all_answers` is per player. It has to stay that way: the phone reveal reads its own row out of it for the answer it gave, the points it earned and its own `correct_button_index`. But in team mode every member carries the team's row (#365), so a team of two was two votes — Sofa on Argentina and Dan alone on Brazil read `67/33` where `50/50` happened, and a large team's pick dominated a chart the room reads as "what did we all choose".

The bars now collapse onto the entrant: the team's id, or the player's own name when they play alone. That is the same entrant the counter directly above them has counted since #835, so the two numbers on that screen agree. Keyed on the team id rather than its name, for #728's reason.

## Verification

Rendered `dashboard.html` in Chrome at **1280x720** over CDP with `www/` served locally and the WebSocket stubbed, then read the DOM back. Replaying `round_summary` → `game_ended` → `game_reset` → `LOBBY(de)` → `question_started`:

| step | before | after |
|---|---|---|
| finale | `dashboard-funfact visible`, previous fact, 165px | `dashboard-funfact`, empty, 0px |
| reset | `visible`, previous fact | empty |
| lobby (de) | `visible`, German label + English fact | empty |
| next game, question 1 | previous fact still in the box, 165px | empty, 68px |

Also confirmed the reveal still shows its own fact (`opacity: 1`), that a television reconnecting during `ANSWER_REVEAL` gets the fact back from the snapshot, and that a `QUESTION_ACTIVE` snapshot with no question block no longer shows a stale one.

Both fixes stash-checked: without the dashboard change 4 of the 6 #850 tests fail; without the serializer change 6 of the 9 #853 tests fail.

Suite: 3510 passed, 11 xfailed. The two failures in `tests/test_service_start_settings_744.py` (`at most 20 presets can be saved`) reproduce unchanged on a pristine `origin/main` and are untouched by this branch. `ruff check custom_components/` clean, `mypy` clean on both changed modules, `scripts/build_gzip.py` produced no drift.

Closes #850
Closes #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)