### PR TITLE
chore: cut 1.16.0-RC3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to Quizify are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [1.16.0-RC3] — 2026-09-06
+
+The second candidate was played too. It found three ways an evening could end
+early, and all three are fixed.
+
+### 🚪 The room could get locked
+
+A host who runs the game from the admin page and closes the tab could not come
+back — reopening it showed the setup screen, because the one phase a host-less
+room parks in was the one phase that had no landing. The guests could not rescue
+the room either: the frame that tells them the host is gone was sent from a task
+the server had already cancelled, and it carried a name nothing on the phone was
+listening for.
+
+### 🪑 And the chair could not answer
+
+On a picture or estimate round, the seat holder was shown an empty question: the
+answer grid was being filled inside a section the round had hidden. The stake
+went to a timeout every time.
+
+### 📺 Three screens showing the game before this one
+
+The host's leaderboard was a round behind at every reveal, the television kept
+the last game's fun fact into the next one, and the lobby showed the previous
+game's difficulty — the same shape as the language bug, and fixed the same way.
+
 ## [1.16.0-RC2] — 2026-09-06
 
 Six games on a real television found nine things RC1 got wrong. All nine are here.

--- a/custom_components/quizify/manifest.json
+++ b/custom_components/quizify/manifest.json
@@ -14,5 +14,5 @@
   "documentation": "https://github.com/mholzi/quizify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/quizify/issues",
-  "version": "1.16.0-RC2"
+  "version": "1.16.0-RC3"
 }


### PR DESCRIPTION
Cuts the third release candidate. RC2 was played on real hardware and failed on three blockers.

- `manifest.json`: `1.16.0-RC2` → `1.16.0-RC3`
- `CHANGELOG.md`: a `[1.16.0-RC3]` section

## What RC2 got wrong

| | |
|---|---|
| **#846** host cannot rejoin a running game | #856 |
| **#847** seat holder gets no answers, stake lost to a timeout | #856 |
| **#848** `host_presence` announces arrivals, never departures | #856 |
| #849, #851, #852 — three screens showing the game before this one | #855 |
| #850, #853 — TV fun fact, team distribution | #854 |

## #848 is worth reading twice

Two broken links, not one:

1. `_handle_disconnect` runs in the `finally` of `handle()`, where aiohttp has **already cancelled that request's task**. The broadcast's `asyncio.gather` is an `await` that yields, so it raised `CancelledError` and nothing left the server — while the dedupe flag had already flipped to "told", which is why none of the three live reproductions ever caught up.
2. The frame carried `connected`. Its only reader, on any surface, looks for `host_connected` behind a `typeof … === 'boolean'` guard, and therefore silently kept its previous answer. **Even a working broadcast would have armed zero hatches.**

A test now asserts that the frame's key is the key its only reader reads, and the counting test from the #842 PR — which stayed green through RC2 while measuring nothing — has been replaced.

## Pack version check

No file under `custom_components/quizify/questions/` changed since `v1.16.0-RC2`; `tests/test_pack_version_sources_agree.py` green across all 36.

## Gates

Suite 3571 passed / 11 xfailed, `ruff check custom_components/` clean, `mypy` at baseline, `main` green on all seven checks before this branch was cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)