### PR TITLE
chore: cut 1.16.0-RC4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to Quizify are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [1.16.0-RC4] — 2026-09-07
+
+The third candidate was played too. It left one way for a room to get stuck and
+two things it never showed anybody.
+
+### 🚪 The last locked door
+
+The guests' way out appeared on the lightning recap and after the Hot Seat, but
+not on the ordinary reveal — which is where a room without a host waits most. A
+phone that reloaded onto that screen was fine; a phone that simply lived through
+the round was not, because only one of the two ways in ever chose the stage.
+Both routes now go through one table, and a test insists that every screen the
+reload can reach is a screen the round can reach too.
+
+### 🪑 The chair's outcome reaches the phones
+
+Whoever bought the seat, what it paid, and what it did to your own points: the
+phones were told none of it. The result frame carried all three and was thrown
+away on the assumption that a reveal would follow. It does not, so the Hot Seat
+panel now says it — including whether a spectator's bet came in.
+
+### 🥇 And two awards stop sharing a name
+
+The podium's "Top Score" is the winner's total. The award beside it is the best
+single round anyone played, and it was called the same thing.
+
 ## [1.16.0-RC3] — 2026-09-06
 
 The second candidate was played too. It found three ways an evening could end

--- a/custom_components/quizify/manifest.json
+++ b/custom_components/quizify/manifest.json
@@ -14,5 +14,5 @@
   "documentation": "https://github.com/mholzi/quizify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/quizify/issues",
-  "version": "1.16.0-RC3"
+  "version": "1.16.0-RC4"
 }


### PR DESCRIPTION
Cuts the fourth release candidate. RC3 was played on real hardware: all three RC2 blockers verified fixed, one new blocker found.

- `manifest.json`: `1.16.0-RC3` → `1.16.0-RC4`
- `CHANGELOG.md`: a `[1.16.0-RC4]` section

## What RC3 got wrong

| | |
|---|---|
| **#858** guests' escape hatch never armed on the ordinary reveal | #862 |
| #859 the phones were never shown the Hot Seat settlement | #862 |
| #860 two podium awards both called "Top Score" | #861 |

## #858 is the third of a kind, and that is why the test looks the way it does

After #832 (the host page waited for a snapshot while the transition arrived as a single event) and #848 (a frame whose name its reader did not know), this was the same seam again: `handleGameState` picks the waiting stage off the phase in one table-driven line, while `handleMessage` picked it from hand-written cases — and `round_summary` was not one of them. A phone that reloaded onto the reveal armed; a phone that lived through the round did not.

The live half is now a table applied once, and `tests/test_stage_entry_parity_858.py` asserts the **rule**: every stage the snapshot can select must be reachable from a live frame, each opener is a declared protocol frame the router handles, the table is applied exactly once, and both routes leave the phone showing identical controls under the real DOM stub.

The weaker assertion — "`round_summary` calls `setResetStage`" — was considered and rejected: it is the fix restated, and it would have passed for #832 and #848.

## Pack version check

No file under `custom_components/quizify/questions/` changed since `v1.16.0-RC3`; the guard is green across all 36.

## Gates

Suite 3606 passed / 11 xfailed, `ruff check custom_components/` clean, `mypy` at baseline, `main` green on all seven checks before this branch was cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)