### PR TITLE
chore: cut 1.16.0-RC5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 All notable changes to Quizify are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [1.16.0-RC5] — 2026-09-07
+
+The fourth candidate was played too. It kept every promise it made and broke one
+thing while keeping them.
+
+### 🪑 The chair's card outstayed its welcome
+
+Showing the phones what the Hot Seat settlement did to their points — new in the
+last candidate — left the card standing for the rest of the game, because the
+only thing that ever took it down was the next auction, and there is only one
+auction per game. Every later question was then played behind it, with the
+answers pushed off the bottom of the phone. The card now leaves when the game
+moves on, and a new guard insists that anything able to stand between the
+question and the answers must name what takes it away again.
+
+### 📺 Everybody is on the final board
+
+At 720p and 768p the podium showed three players and scrolled the rest — on a
+screen that cannot scroll. Three players, then, whoever else had played. Up to
+eight now fit at every resolution; beyond that the board says how many it is not
+naming. Part of the missing space was sixteen pixels of a phone's stylesheet
+reaching the television again.
+
 ## [1.16.0-RC4] — 2026-09-07
 
 The third candidate was played too. It left one way for a room to get stuck and

--- a/custom_components/quizify/manifest.json
+++ b/custom_components/quizify/manifest.json
@@ -14,5 +14,5 @@
   "documentation": "https://github.com/mholzi/quizify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/quizify/issues",
-  "version": "1.16.0-RC4"
+  "version": "1.16.0-RC5"
 }


### PR DESCRIPTION
Cuts the fifth release candidate. RC4 was played on real hardware: everything it claimed was verified, six older fixes were re-verified, and one new blocker came out of RC4's own fix.

- `manifest.json`: `1.16.0-RC4` → `1.16.0-RC5`
- `CHANGELOG.md`: a `[1.16.0-RC5]` section

## What RC4 got wrong

| | |
|---|---|
| **#864** the Hot Seat settlement card was never taken down again | #867 |
| #865 the podium showed three players at 720p and 768p and scrolled the rest | #868 |
| #866 the Mixed tile kept the previous language | #868 |

## The guard, and why it needed a counterpart

RC4 shipped `test_stage_entry_parity_858.py`: every stage the snapshot can select must be reachable from a live frame. #864 walked straight past it, because that test guards the **arming** and says nothing about the **teardown** — the same matrix `server/websocket.py` records breaking five times (#362, #407, #656, #671, #746).

`GAME_VIEW_PANELS` is now the counterpart. Statically, every block `player.html` ships hidden above `#answers-container` must declare who takes it down; each row names exactly one of a teardown or an owner; every raiser is a real protocol frame the router handles; and the table is applied once, not per-case. Behaviourally the real modules run under `dom_stub.js` and the answer grid is measured after every raiser × every moving-on frame.

**What it cannot see is written into the file as its own test**: no layout engine, so a CSS change that resizes a panel is invisible; four of the five rows are declarations only; a panel correctly hidden while holding stale content passes; and it is a client-side guard.

## #865 had three causes

The three-row floor from #695 was a lid on a surface that cannot scroll; `renderLeaderboard`'s own header carried 16px of `margin-bottom` from the **phone's** stylesheet, which `dashboard.html` has always loaded (the same species as #775 and #836); and nothing existed between "the rows fit" and "they don't". Measured at three resolutions and swept from 3 to 12 players — 3–8 whole everywhere, 1080p whole to 12.

## Pack version check

No file under `custom_components/quizify/questions/` changed since `v1.16.0-RC4`; the guard is green across all 36.

## Gates

Suite 3639 passed / 11 xfailed, `ruff check custom_components/` clean, `mypy` at baseline, `main` green on all seven checks before this branch was cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)