### PR TITLE
fix: the FINALE snapshot carries the share card and shared ranks

### DIFF
--- a/custom_components/quizify/server/serializers.py
+++ b/custom_components/quizify/server/serializers.py
@@ -528,22 +528,42 @@ def serialize_state_snapshot(game_state: QuizifyGameState) -> dict[str, Any]:
             snapshot["round_summary"]["estimate"] = s.estimate
 
     if game_state.phase == GamePhase.FINALE:
-        # Use cached values computed once in end_game()
-        podium = game_state.get_finale_podium() or calculate_podium(
-            game_state.get_ranked_participants()
-        )
-        snapshot["podium"] = [
-            {"name": p.name, "score": p.score, "rank": i + 1}
-            for i, p in enumerate(podium)
-        ]
+        # The end screen is built by ``serialize_finale`` — the same function
+        # the live ``finale`` frame goes through (#878). It used to be a second
+        # hand-written list of the fields worth forwarding, and that list was
+        # missing two things the live frame has carried since #369 and #308:
+        #
+        # * ``share`` — the shareable result card. The end screen is the one
+        #   that stays up longest in an evening, so any reload or wifi blip on
+        #   it silently removed the card the guest was about to paste into the
+        #   group chat: ``renderShareCard`` hides the section when ``share``
+        #   is absent, and a snapshot never carried it.
+        # * shared podium ranks — the old list numbered ``rank: i + 1``, so a
+        #   reloaded phone showed two players who actually tied on 1st and 2nd.
+        #
+        # Same shape as #730/#731: forward the frame instead of re-listing it,
+        # so a field added to the finale payload cannot go missing here again.
+        ranked = game_state.get_ranked_participants()
+        # Cached by end_game (#415); recomputed only when a snapshot is asked
+        # for before the cache exists.
+        podium = game_state.get_finale_podium() or calculate_podium(ranked)
         cached_awards = game_state.get_finale_superlatives()
         awards = (
             cached_awards
             if cached_awards is not None
-            else compute_superlatives(game_state.get_ranked_participants())
+            else compute_superlatives(ranked)
         )
-        if awards:
-            snapshot["superlatives"] = [s.to_dict() for s in awards]
+        finale = serialize_finale(
+            podium,
+            ranked,
+            superlatives=[a.to_dict() for a in awards],
+            packs=resolve_pack_labels(game_state),
+        )
+        for key, value in finale.items():
+            # ``type`` names the live frame, not a phase; ``leaderboard`` and
+            # ``all_players`` are the list the snapshot already carries above.
+            if key not in ("type", "leaderboard", "all_players"):
+                snapshot[key] = value
 
     lightning = game_state.lightning
     if game_state.phase == GamePhase.LIGHTNING and lightning is not None:
@@ -797,6 +817,33 @@ def build_share_payload(
             "powerups": p.powerups_used,
         })
     return {"packs": list(packs or []), "players": entries}
+
+
+def resolve_pack_labels(game_state: QuizifyGameState) -> list[str]:
+    """Display names of the packs this game was played with (#369).
+
+    ``categories`` is the multi-select the host picked; ``category`` is the
+    single-pick fallback. Empty when the host played "mixed", and the share
+    card simply omits the line rather than inventing a pack name.
+
+    Slugs are mapped to display names because the card is written to be pasted
+    into a group chat and "picture-round-en" reads like a filename, while the
+    picker calls the same pack "Picture Round". An unknown slug (a pack removed
+    mid-game) falls back to the slug rather than vanishing from the line.
+
+    Lives here rather than in the finale broadcast because both paths to the
+    end screen need it: the live frame and the FINALE snapshot a reloading
+    phone restores from (#878).
+    """
+    packs = list(getattr(game_state, "categories", None) or [])
+    if not packs and getattr(game_state, "category", None):
+        packs = [game_state.category]
+    try:
+        meta = game_state.question_bank.get_pack_versions()
+        packs = [(meta.get(slug) or {}).get("name") or slug for slug in packs]
+    except (AttributeError, TypeError):  # pragma: no cover - defensive
+        pass
+    return packs
 
 
 def serialize_finale(

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -59,6 +59,7 @@ from custom_components.quizify.server.origin import reject_cross_origin
 from custom_components.quizify.server.rate_limit import SlidingWindowLimiter
 from custom_components.quizify.server.round_message_builder import RoundMessageBuilder
 from custom_components.quizify.server.serializers import (
+    resolve_pack_labels,
     serialize_answer_progress,
     serialize_finale,
     serialize_leaderboard,
@@ -4778,22 +4779,10 @@ class QuizifyWebSocketHandler:
             else compute_superlatives(all_players)
         )
         awards = [s.to_dict() for s in superlatives]
-        # Pack labels for the shareable card (#369). ``categories`` is the
-        # multi-select the host picked; ``category`` is the single-pick
-        # fallback. Empty when the host played "mixed", and the card simply
-        # omits the line rather than inventing a pack name.
-        packs = list(getattr(game_state, "categories", None) or [])
-        if not packs and getattr(game_state, "category", None):
-            packs = [game_state.category]
-        # Slug -> display name. The card is written to be pasted into a group
-        # chat, and "picture-round-en" reads like a filename; the picker calls
-        # the same pack "Picture Round". Unknown slugs (a pack removed
-        # mid-game) fall back to the slug rather than vanishing from the line.
-        try:
-            _meta = game_state.question_bank.get_pack_versions()
-            packs = [(_meta.get(slug) or {}).get("name") or slug for slug in packs]
-        except (AttributeError, TypeError):  # pragma: no cover - defensive
-            pass
+        # Pack labels for the shareable card (#369). The FINALE snapshot needs
+        # the identical list (#878), so the resolution lives next to the
+        # serializers both paths share.
+        packs = resolve_pack_labels(game_state)
         finale_msg = serialize_finale(
             podium, all_players, superlatives=awards, packs=packs
         )

--- a/tests/test_finale_snapshot_share_878.py
+++ b/tests/test_finale_snapshot_share_878.py
@@ -1,0 +1,192 @@
+"""The FINALE snapshot must carry what the live ``finale`` frame carries (#878).
+
+Both paths end in ``end.updateEndView(msg)``, and that function reads
+``data.share`` — so whatever the server leaves out of one path simply is not on
+the end screen for anyone who arrived by it.
+
+The snapshot used to hand-list the finale fields, and the list was short by two:
+
+* **no ``share``** — ``renderShareCard`` hides the section when the block is
+  missing. The end screen stays up longest in an evening, so a reload or a wifi
+  blip on it silently removed the result card the guest was about to paste into
+  the group chat. A phone that joined late, straight into FINALE, never had one
+  at all.
+* **``rank: i + 1``** on the podium, while the live frame shares ranks on ties
+  (#308) — so a reloaded phone could show two players who actually tied sitting
+  on 1st and 2nd.
+
+Same shape as #730/#731: the fix is not "add the two fields" but to build the
+block from ``serialize_finale``, the function the live frame already goes
+through. The parity test below is what keeps a third field from going missing.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+from custom_components.quizify.server.serializers import (  # noqa: E402
+    resolve_pack_labels,
+    serialize_finale,
+    serialize_state_snapshot,
+)
+
+
+class _Runtime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+
+def _fake_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    return ws
+
+
+def _finished_game(
+    tmp_path: Path,
+    scores: dict[str, int],
+    histories: dict[str, list[str]] | None = None,
+) -> QuizifyGameState:
+    """A game sitting in FINALE with the given final scores.
+
+    The rounds are stamped on rather than played: what is under test is the
+    serialization of a finished game, and a hand-set ``round_history`` is the
+    same input the real path arrives with.
+    """
+    gs = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+    for name in scores:
+        gs.add_player(name, _fake_ws())
+    gs.start_game(language="de", num_rounds=2, lightning_enabled=False)
+    for p in gs.get_players():
+        p.score = scores[p.name]
+        p.round_history = list((histories or {}).get(p.name, ["correct", "wrong"]))
+    gs.end_game()
+    assert gs.phase == GamePhase.FINALE
+    return gs
+
+
+# ---------------------------------------------------------------------------
+# The share card
+# ---------------------------------------------------------------------------
+
+
+def test_finale_snapshot_carries_the_share_card(tmp_path: Path) -> None:
+    """A phone that reloads on the end screen still gets something to paste."""
+    gs = _finished_game(tmp_path, {"Alice": 30, "Bob": 10})
+
+    snapshot = serialize_state_snapshot(gs)
+
+    assert "share" in snapshot, "the end screen has nothing to share after a reload"
+    names = [e["name"] for e in snapshot["share"]["players"]]
+    assert names == ["Alice", "Bob"]
+    alice = snapshot["share"]["players"][0]
+    assert alice["rank"] == 1
+    assert alice["total_players"] == 2
+    assert alice["results"] == ["correct", "wrong"]
+
+
+def test_snapshot_share_matches_the_live_frame(tmp_path: Path) -> None:
+    """Byte-for-byte the same card, whichever path the phone arrived by."""
+    gs = _finished_game(tmp_path, {"Alice": 30, "Bob": 10})
+    live = serialize_finale(
+        gs.get_finale_podium(),
+        gs.get_ranked_participants(),
+        superlatives=[s.to_dict() for s in (gs.get_finale_superlatives() or [])],
+        packs=resolve_pack_labels(gs),
+    )
+
+    assert serialize_state_snapshot(gs)["share"] == live["share"]
+
+
+def test_snapshot_share_carries_the_pack_labels(tmp_path: Path) -> None:
+    """The card names the packs, so the line is not blank after a reload."""
+    gs = _finished_game(tmp_path, {"Alice": 10})
+    gs.categories = ["geographie", "musik"]
+
+    packs = serialize_state_snapshot(gs)["share"]["packs"]
+
+    assert len(packs) == 2
+    # Display names when the bank knows the slug, the slug itself when it does
+    # not — never an empty line and never a dropped pack.
+    assert all(p for p in packs)
+
+
+# ---------------------------------------------------------------------------
+# Shared podium ranks (#308) on the restore path too
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_podium_shares_ranks_on_a_tie(tmp_path: Path) -> None:
+    """Two players on the same score are both 1st — after a reload as well."""
+    gs = _finished_game(tmp_path, {"Alice": 20, "Bob": 20, "Cara": 5})
+
+    podium = serialize_state_snapshot(gs)["podium"]
+
+    ranks = {e["name"]: e["rank"] for e in podium}
+    assert ranks["Alice"] == 1
+    assert ranks["Bob"] == 1, "a tie was printed as 1st/2nd by sort order"
+    assert ranks["Cara"] == 3
+
+
+def test_snapshot_podium_equals_the_live_podium(tmp_path: Path) -> None:
+    gs = _finished_game(tmp_path, {"Alice": 20, "Bob": 20, "Cara": 5})
+    live = serialize_finale(gs.get_finale_podium(), gs.get_ranked_participants())
+
+    assert serialize_state_snapshot(gs)["podium"] == live["podium"]
+
+
+# ---------------------------------------------------------------------------
+# The guard against a third missing field
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_carries_every_finale_field(tmp_path: Path) -> None:
+    """Whatever the live finale frame grows, the restore path grows with it."""
+    gs = _finished_game(tmp_path, {"Alice": 30, "Bob": 10})
+    live = serialize_finale(
+        gs.get_finale_podium(),
+        gs.get_ranked_participants(),
+        superlatives=[s.to_dict() for s in (gs.get_finale_superlatives() or [])],
+        packs=resolve_pack_labels(gs),
+    )
+    snapshot = serialize_state_snapshot(gs)
+
+    # ``type`` names the live frame, not a phase — the snapshot says ``phase``.
+    # ``all_players`` is the leaderboard under a second name; the snapshot
+    # carries it once, as ``leaderboard``, and that one must agree.
+    ignored = ("type", "all_players")
+    missing = [k for k in live if k not in snapshot and k not in ignored]
+    assert not missing, f"the FINALE snapshot drops {missing}"
+    assert snapshot["leaderboard"] == live["all_players"]
+
+
+def test_superlatives_stay_absent_when_there_are_none(tmp_path: Path) -> None:
+    """An empty award list is no key, same as the live frame (#415 shape)."""
+    gs = _finished_game(tmp_path, {"Alice": 0}, histories={"Alice": []})
+    gs._finale_superlatives = []
+
+    assert "superlatives" not in serialize_state_snapshot(gs)
+
+
+@pytest.mark.parametrize("phase", [GamePhase.LOBBY, GamePhase.QUESTION_ACTIVE])
+def test_share_rides_the_finale_only(tmp_path: Path, phase: GamePhase) -> None:
+    """The card is a once-per-game payload — it must not ride every snapshot."""
+    gs = _finished_game(tmp_path, {"Alice": 10, "Bob": 5})
+    gs.phase = phase
+
+    assert "share" not in serialize_state_snapshot(gs)

--- a/tests/test_pack_labels_and_icons.py
+++ b/tests/test_pack_labels_and_icons.py
@@ -27,6 +27,9 @@ QUESTIONS = REPO / "custom_components" / "quizify" / "questions"
 ICONS_JS = REPO / "custom_components" / "quizify" / "www" / "js" / "icons.js"
 VIEWS_PY = REPO / "custom_components" / "quizify" / "server" / "views.py"
 WS_PY = REPO / "custom_components" / "quizify" / "server" / "websocket.py"
+SERIALIZERS_PY = (
+    REPO / "custom_components" / "quizify" / "server" / "serializers.py"
+)
 
 
 def _shipped_themes() -> set[str]:
@@ -87,8 +90,14 @@ def test_share_card_gets_display_names_not_slugs() -> None:
     Asserted on the source because building a finale payload needs a live
     game state; what matters is that the mapping happens at all, and that it
     keeps the slug when a pack is unknown rather than dropping the line.
+
+    The mapping moved out of the finale broadcast and into
+    ``serializers.resolve_pack_labels`` with #878, because the FINALE snapshot
+    a reloading phone restores from has to produce the identical Packs line.
+    Both callers are checked: the resolution itself, and the broadcast still
+    going through it rather than growing a second copy.
     """
-    src = WS_PY.read_text(encoding="utf-8")
+    src = SERIALIZERS_PY.read_text(encoding="utf-8")
     assert "get_pack_versions()" in src, (
         "the finale no longer resolves pack display names — the share card "
         "will print slugs like 'picture-round-en' again."
@@ -96,4 +105,8 @@ def test_share_card_gets_display_names_not_slugs() -> None:
     assert 'or slug for slug in packs' in src, (
         "the slug fallback is gone; an unknown pack would vanish from the "
         "card's Packs line instead of appearing under its slug."
+    )
+    assert "resolve_pack_labels(game_state)" in WS_PY.read_text(encoding="utf-8"), (
+        "the finale broadcast stopped using the shared resolver — the live "
+        "frame and the FINALE snapshot can drift apart again."
     )


### PR DESCRIPTION
Closes #878

## The bug

A phone that reloads — or joins late — on the end screen restores from the FINALE **state snapshot**, not from the live `finale` frame. Both paths end in `end.updateEndView(msg)` → `renderShareCard(data.share)`, and that function hides the section when `share` is missing.

The snapshot (`server/serializers.py`) hand-listed the finale fields, and the list was short by two:

- **no `share`** — so any reload or wifi blip on the screen that stays up longest in an evening silently removed the result card the guest was about to paste into the group chat. A phone that joined straight into FINALE never had one at all.
- **`rank: i + 1`** on the podium, while the live frame has shared ranks on ties since #308 — a reloaded phone could show two players who actually tied sitting on 1st and 2nd.

## The fix

Same shape as #730/#731, so the fix is not "add the two fields". The FINALE block is now built by `serialize_finale(...)` — the function the live frame already goes through — and forwards every key it carries (`type` and the duplicate `all_players` excluded; the snapshot already carries the leaderboard once, and a test now pins that the two agree).

The pack-label resolution moved out of `_broadcast_finale` into `serializers.resolve_pack_labels(game_state)`, so the snapshot's Packs line is the identical list rather than a second copy that can drift. `tests/test_pack_labels_and_icons.py::test_share_card_gets_display_names_not_slugs` follows it there and additionally pins that the broadcast still goes through the shared resolver.

No client change: both paths already forward the frame, so the phone renders the card as soon as the server sends it.

## Tests

New `tests/test_finale_snapshot_share_878.py` (9 tests), including the two the issue asks for:

- `test_finale_snapshot_carries_the_share_card` — the missing share payload
- `test_snapshot_podium_shares_ranks_on_a_tie` — Alice and Bob on 20 points are both rank 1, Cara is 3

**Proven failing without the fix.** With the FINALE block reverted to its pre-fix form (`rank: i + 1`, no `share`) and everything else in place: `6 failed, 3 passed`.

```
FAILED test_finale_snapshot_carries_the_share_card
  AssertionError: the end screen has nothing to share after a reload
FAILED test_snapshot_share_matches_the_live_frame        KeyError: 'share'
FAILED test_snapshot_share_carries_the_pack_labels       KeyError: 'share'
FAILED test_snapshot_podium_shares_ranks_on_a_tie
  AssertionError: a tie was printed as 1st/2nd by sort order — assert 2 == 1
FAILED test_snapshot_podium_equals_the_live_podium
  At index 1 diff: {'name': 'Bob', 'score': 20, 'rank': 2} != {'rank': 1, ...}
FAILED test_snapshot_carries_every_finale_field
  AssertionError: the FINALE snapshot drops ['share']
```

The three that still passed are the guards, not the bug: superlatives staying absent when there are none, and `share` not riding non-FINALE snapshots.

## Gates

- `pytest -q -p no:randomly` — **3648 passed, 11 xfailed**
- `ruff check custom_components/` — clean (no `ruff format`)
- `mypy custom_components/quizify` — clean, 60 source files

One note on the suite: under pytest-randomly's shuffled order the run is intermittently red in `tests/test_service_start_settings_744.py` (saved-preset service tests). Those pass in isolation and in deterministic order, they share no code with this change, and repeat randomized runs come back green — a pre-existing order dependency, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFeVnkXSBFSPF2oKzdb1u4
