### PR TITLE
refactor(server): give each driver its own broadcaster instead of the handler

### DIFF
--- a/custom_components/quizify/server/broadcasters.py
+++ b/custom_components/quizify/server/broadcasters.py
@@ -1,0 +1,616 @@
+"""One small fan-out object per driver protocol (#881).
+
+#788 moved the game loops out of ``QuizifyWebSocketHandler`` and gave each
+driver a narrow ``Broadcaster`` contract to talk through. The object actually
+handed to every driver was still the handler itself, so the contract existed
+only as a type annotation: a driver held ~150 methods, and a test that wanted
+to drive one mode against a fake had to re-stub whichever handler methods that
+mode happened to touch.
+
+This module holds the other half of #788. Each class here implements exactly
+one of the protocols in
+:mod:`custom_components.quizify.game.drivers.protocols`, owns the frame
+literals for its mode, and knows nothing except a
+:class:`~custom_components.quizify.server.connection.ConnectionManager` and the
+:class:`~custom_components.quizify.server.round_message_builder.RoundMessageBuilder`.
+The handler now *holds* these instead of *being* them.
+
+Two protocol methods are not fan-out at all — ``resume_normal_question`` (the
+hot seat's escape hatch when nobody bids) and ``close_wager_window`` (arm the
+timers, then emit the question). They drive the round rather than describing
+it, so they stay on the handler and are injected here as callbacks; the driver
+still sees one object satisfying one protocol.
+
+Behaviour-preserving: every payload below is the byte-for-byte dict the handler
+used to build, sent to the same recipients over the same connection-manager
+call. The comments that explained *why* a frame is shaped the way it is moved
+with it — they are the reason the shape must not drift.
+
+Connection managers are resolved through a provider rather than captured once,
+because a large part of the suite swaps ``handler._conn`` after construction
+(``handler._conn = ConnectionManager(...)``, or a fake). A broadcaster
+constructed directly in a test can pass the manager itself; the handler passes
+``lambda: self._conn`` so a swapped manager is picked up on the next send.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any
+
+from custom_components.quizify.const import WAGER_WINDOW_DURATION
+from custom_components.quizify.game.hot_seat import stake_of as hot_seat_stake
+from custom_components.quizify.game.team import (
+    ANSWER_CHANGE_LOCK_SECONDS as LIGHTNING_ANSWER_LOCK_SECONDS,
+)
+from custom_components.quizify.server.serializers import serialize_leaderboard
+
+if TYPE_CHECKING:
+    from aiohttp import web
+
+    from custom_components.quizify.game.state import QuizifyGameState, TeamAnswerAck
+    from custom_components.quizify.server.connection import ConnectionManager
+    from custom_components.quizify.server.round_message_builder import (
+        RoundMessageBuilder,
+    )
+
+__all__ = [
+    "HotSeatBroadcaster",
+    "LightningBroadcaster",
+    "RoundBroadcaster",
+    "WagerBroadcaster",
+]
+
+
+class _Broadcaster:
+    """Shared plumbing: how to reach the wire, and how to build round frames."""
+
+    def __init__(
+        self,
+        conn: ConnectionManager | Callable[[], ConnectionManager],
+        messages: RoundMessageBuilder,
+    ) -> None:
+        self._conn_source = conn
+        self._messages = messages
+
+    @property
+    def _conn(self) -> ConnectionManager:
+        """The connection manager to send over, resolved per call."""
+        source = self._conn_source
+        if callable(source):
+            return source()
+        return source
+
+
+# ---------------------------------------------------------------------------
+# Lightning Round (#42/#201/#285/#552)
+# ---------------------------------------------------------------------------
+
+
+class LightningBroadcaster(_Broadcaster):
+    """The Lightning Round's fan-out points.
+
+    Satisfies
+    :class:`custom_components.quizify.game.drivers.protocols.LightningBroadcaster`
+    — plus the two frames the *message handlers* (not the driver) need, which
+    live here for the same reason: they are lightning frames, and one object
+    per mode is easier to keep honest than six frames spread over a 5k-line
+    file.
+    """
+
+    async def send_lightning_splash(self, game_state: QuizifyGameState) -> None:
+        """Fan out the intro-splash payload (rules preview) to all clients."""
+        lr = game_state.lightning
+        if lr is None:
+            return
+        await self._conn.broadcast({
+            "type": "lightning_splash",
+            "num_questions": lr.num_questions,
+            "seconds_per_question": lr.seconds_per_question,
+        })
+
+    async def send_lightning_question(
+        self, game_state: QuizifyGameState, lr: Any
+    ) -> None:
+        """Send the current lightning question per-player (own shuffle) and
+        to admin/dashboard (canonical order)."""
+        q = lr.current_question
+        if q is None:
+            return
+        # Fan out the per-player lightning question in parallel (#258).
+        lightning_sends = []
+        for player in game_state.get_players():
+            if not player.connected:
+                continue
+            lightning_sends.append(self._conn.send(player.ws, {
+                "type": "lightning_question",
+                "question_text": q.question,
+                "answers": lr.shuffled_answers_for(player.name),
+                "index": lr.index,
+                "num_questions": lr.num_questions,
+                "seconds": lr.seconds_per_question,
+                "category": q.category,
+                "image_url": q.image_url,
+            }))
+        if lightning_sends:
+            await asyncio.gather(*lightning_sends)
+        await self._conn.broadcast_to_admins_and_dashboards({
+            "type": "lightning_question",
+            "question_text": q.question,
+            "answers": [a.text for a in q.answers],
+            "index": lr.index,
+            "num_questions": lr.num_questions,
+            "seconds": lr.seconds_per_question,
+            "category": q.category,
+            "image_url": q.image_url,
+        })
+
+    async def send_lightning_tick(
+        self, game_state: QuizifyGameState, lr: Any
+    ) -> None:
+        """Push the shared lightning countdown."""
+        remaining = round(lr.time_remaining(), 1)
+        await self._conn.broadcast({
+            "type": "lightning_tick",
+            "remaining": remaining,
+            "index": lr.index,
+        })
+
+    async def send_lightning_recap(self, game_state: QuizifyGameState) -> None:
+        """Push the end-of-mode recap."""
+        lr = game_state.lightning
+        if lr is None:
+            return
+        await self._conn.broadcast({
+            "type": "lightning_recap",
+            "recap": lr.build_recap(),
+        })
+
+    async def send_lightning_answer_result(
+        self, ws: web.WebSocketResponse, lr: Any, player_name: str, *, correct: bool
+    ) -> None:
+        """Lightweight ack: lock the player's buttons + show right/wrong."""
+        await self._conn.send(ws, {
+            "type": "lightning_answer_result",
+            "correct": correct,
+            "index": lr.index,
+            "score": lr.score_for(player_name),
+        })
+
+    async def send_lightning_team_answer(
+        self, game_state: QuizifyGameState, lr: Any, setter: str
+    ) -> None:
+        """Show the team's standing lightning answer on every member's phone.
+
+        Mirrors the normal round's ``team_answer`` (#365): the index is
+        remapped per member, because each phone shuffles the answers for
+        itself — one number sent to the whole team would highlight the wrong
+        row for everybody but the person who tapped.
+        """
+        standing = lr.standing_answer(setter)
+        if standing is None or standing.answer_index is None:
+            return
+        members = lr.members_of(setter)
+        for name in members:
+            member = game_state.get_player(name)
+            if member is None or member.ws is None or not member.connected:
+                continue
+            order = lr.ensure_shuffle(name)
+            try:
+                shown_index = order.index(standing.answer_index)
+            except ValueError:
+                continue
+            await self._conn.send(member.ws, {
+                "type": "lightning_team_answer",
+                "index": lr.index,
+                "answer_index": shown_index,
+                "set_by": setter,
+                "members": list(members),
+                "lock_seconds": LIGHTNING_ANSWER_LOCK_SECONDS,
+            })
+
+
+# ---------------------------------------------------------------------------
+# Hot Seat (#616/#804/#833)
+# ---------------------------------------------------------------------------
+
+
+class HotSeatBroadcaster(_Broadcaster):
+    """The Hot Seat's fan-out points.
+
+    Satisfies
+    :class:`custom_components.quizify.game.drivers.protocols.HotSeatBroadcaster`.
+    ``resume_normal_question`` is the one member that is not a broadcast — the
+    mode's escape hatch when nobody bids — so it is injected as a callback and
+    only forwarded here.
+    """
+
+    def __init__(
+        self,
+        conn: ConnectionManager | Callable[[], ConnectionManager],
+        messages: RoundMessageBuilder,
+        *,
+        resume_normal_question: Callable[[QuizifyGameState], Awaitable[None]],
+    ) -> None:
+        super().__init__(conn, messages)
+        self._resume_normal_question = resume_normal_question
+
+    async def send_hot_seat_auction(
+        self, game_state: QuizifyGameState, hs: Any
+    ) -> None:
+        """Open the auction: the room's clock, then each phone's own purse."""
+        await self._conn.broadcast({
+            "type": "hot_seat_auction",
+            "seconds": hs.auction_seconds,
+            "players": len(hs.scores),
+            # #698: the television's round indicator is interpolated from
+            # these two. Without them the auction kept the previous round's
+            # number and the question that follows printed the literal string
+            # "undefined" for the whole answer window.
+            "round_num": game_state.round,
+            "total_rounds": game_state.total_rounds,
+        })
+        # Each player needs their own number: a percentage is only meaningful
+        # next to the points it costs *them*. In team mode that is the team's
+        # score (#804) — ``player.score`` there is the shadow value #669 gated
+        # the mode off for, and a slider priced against it costs nothing.
+        sends = []
+        for player in game_state.get_players():
+            if not player.connected or player.ws is None:
+                continue
+            sends.append(self._conn.send(player.ws, {
+                "type": "hot_seat_auction_you",
+                "score": hs.scores.get(hs.entrant_for(player.name), 0),
+                "seconds": hs.auction_seconds,
+            }))
+        if sends:
+            await asyncio.gather(*sends, return_exceptions=True)
+
+    async def send_hot_seat_bid_accepted(
+        self, ws: web.WebSocketResponse, hs: Any, player_name: str, *, pct: int
+    ) -> None:
+        """Confirm one sealed bid to its bidder, then tell the room the count."""
+        await self._conn.send(ws, {
+            "type": "hot_seat_bid_accepted",
+            "bid": pct,
+            "points": hot_seat_stake(
+                hs.scores.get(hs.entrant_for(player_name), 0), pct
+            ),
+        })
+        # Blind auction: the room learns how many have bid, never how much.
+        await self._conn.broadcast({
+            "type": "hot_seat_bid_count",
+            "count": len(hs.bids),
+            "total": len(hs.scores),
+        })
+
+    async def send_hot_seat_bet_accepted(
+        self,
+        ws: web.WebSocketResponse,
+        hs: Any,
+        player_name: str,
+        *,
+        side: Any,
+        pct: int,
+    ) -> None:
+        """Confirm a spectator's stake on the seat holder."""
+        await self._conn.send(ws, {
+            "type": "hot_seat_bet_accepted",
+            "side": side,
+            "bet": pct,
+            "points": hot_seat_stake(
+                hs.scores.get(hs.entrant_for(player_name), 0), pct
+            ),
+        })
+
+    async def send_hot_seat_answer_accepted(
+        self, ws: web.WebSocketResponse
+    ) -> None:
+        """Acknowledge the seat holder's single answer."""
+        await self._conn.send(ws, {"type": "hot_seat_answer_accepted"})
+
+    async def send_hot_seat_tick(self, stage: str, remaining: int) -> None:
+        """Push the countdown for ``"auction"`` or ``"question"``."""
+        await self._conn.broadcast({
+            "type": "hot_seat_tick",
+            "phase": stage,
+            "remaining": remaining,
+        })
+
+    async def send_hot_seat_no_bids(self) -> None:
+        """Tell the room nobody wanted the chair."""
+        await self._conn.broadcast({"type": "hot_seat_no_bids"})
+
+    async def send_hot_seat_awarded(
+        self, game_state: QuizifyGameState, hs: Any
+    ) -> None:
+        """Break the seal: who paid what, and who is sitting down."""
+        await self._conn.broadcast({
+            "type": "hot_seat_awarded",
+            # The PERSON taking the chair. Outside team mode that is also the
+            # entrant, so this field keeps its old meaning for every client;
+            # ``entrant`` names who pays (#804).
+            "winner": hs.seat_holder,
+            "entrant": hs.winner_name,
+            "pct": hs.winning_pct,
+            "stake": hs.winning_stake,
+            "bids": hs.reveal(),
+        })
+
+    async def send_hot_seat_question(
+        self, game_state: QuizifyGameState, hs: Any
+    ) -> None:
+        """Send the question: shuffled to the seat holder, canonical to the room.
+
+        The spectators get the question text and the betting controls but no
+        answer buttons — they are not answering it, they are staking on
+        whoever is.
+        """
+        q = hs.question
+        if q is None:
+            return
+        payload = {
+            "type": "hot_seat_question",
+            "question": q.question,
+            "difficulty": q.difficulty,
+            # #698: see the auction broadcast — the TV interpolates both.
+            "round_num": game_state.round,
+            "total_rounds": game_state.total_rounds,
+            "image_url": getattr(q, "image_url", "") or "",
+            "seconds": hs.answer_seconds,
+            "winner": hs.seat_holder,
+            "entrant": hs.winner_name,
+        }
+        sends = []
+        for player in game_state.get_players():
+            if not player.connected or player.ws is None:
+                continue
+            if player.name == hs.seat_holder:
+                sends.append(self._conn.send(player.ws, {
+                    **payload,
+                    "answers": hs.shuffled_answers(),
+                    "you_are_seated": True,
+                }))
+            else:
+                sends.append(self._conn.send(player.ws, {
+                    **payload,
+                    "answers": [],
+                    "you_are_seated": False,
+                    # A teammate of the seat holder may not bet: they stake the
+                    # purse the chair already staked (#804). Told here so the
+                    # phone shows why instead of a slider nothing accepts.
+                    "you_are_seat_team": hs.is_on_seat_team(player.name),
+                    "score": hs.scores.get(hs.entrant_for(player.name), 0),
+                }))
+        if sends:
+            await asyncio.gather(*sends, return_exceptions=True)
+        # The room watches the same board the seat holder does, so the TV gets
+        # the *shuffled* order rather than the canonical one — which also keeps
+        # #521 shut, where JSON order put the correct tile first in half the
+        # packs. Admins additionally get the correct index; dashboards take no
+        # token (#604) and must not learn it before the reveal.
+        tv_payload = {**payload, "answers": hs.shuffled_answers()}
+        await self._conn.broadcast_to_admins_and_dashboards(
+            {**tv_payload, "correct_index": hs.correct_index},
+            dashboard_message=tv_payload,
+        )
+
+    async def send_hot_seat_result(
+        self, game_state: QuizifyGameState, hs: Any
+    ) -> None:
+        """Push the settlement."""
+        await self._conn.broadcast({
+            "type": "hot_seat_result",
+            "round_num": game_state.round,
+            "total_rounds": game_state.total_rounds,
+            **hs.summary(),
+            # The rows the room can see (#804): teams in team mode, players
+            # otherwise. Keyed by ``player.name`` this reported the shadow
+            # scores the settlement no longer writes to.
+            "scores": {
+                participant.name: participant.score
+                for participant in game_state.get_ranked_participants()
+            },
+            # #833: the standings AFTER the settlement, in the shape every
+            # board already renders. ``scores`` above is a name→number map —
+            # no rank, no entrant id, nothing a leaderboard row is built from —
+            # so the one screen the whole room reads had no way to repaint and
+            # kept showing the player who had just lost everything in first
+            # place. ``finish_hot_seat`` has already applied the deltas by the
+            # time this runs, so these are the real numbers.
+            "leaderboard": serialize_leaderboard(
+                game_state.get_ranked_participants()
+            ),
+        })
+
+    async def resume_normal_question(self, game_state: QuizifyGameState) -> None:
+        """Leave the detour and start an ordinary question instead."""
+        await self._resume_normal_question(game_state)
+
+
+# ---------------------------------------------------------------------------
+# Normal round (#203/#365/#413)
+# ---------------------------------------------------------------------------
+
+
+class RoundBroadcaster(_Broadcaster):
+    """The normal round's fan-out points.
+
+    Satisfies
+    :class:`custom_components.quizify.game.drivers.protocols.RoundBroadcaster`,
+    and additionally owns the round's other frames — the summary and the two
+    team-mode ones — which are fan-out with no rules attached.
+    """
+
+    async def send_timer_tick(
+        self,
+        game_state: QuizifyGameState,
+        remaining_by_player: dict[str, float],
+        dashboard_remaining: float | None,
+    ) -> None:
+        """Turn one driver tick into ``timer_tick`` frames.
+
+        The driver has already dropped every recipient whose displayed second
+        did not change (#413) and every disconnected player, so this only has
+        to address what is left. Built as one fan-out and delivered in parallel
+        (#258) so a single stalled client can't delay the room; the dashboard
+        copy is pre-serialized ONCE and goes out over the broadcast string path
+        (admin-as-player is already excluded there).
+        """
+        sends = []
+        if remaining_by_player:
+            by_name = {p.name: p for p in game_state.get_players()}
+            for name, remaining in remaining_by_player.items():
+                player = by_name.get(name)
+                if player is None:
+                    continue
+                sends.append(self._conn.send(player.ws, {
+                    "type": "timer_tick",
+                    "remaining": round(remaining, 1),
+                }))
+        if dashboard_remaining is not None:
+            sends.append(
+                self._conn.broadcast_to_admins_and_dashboards({
+                    "type": "timer_tick",
+                    "remaining": round(dashboard_remaining, 1),
+                })
+            )
+        if sends:
+            await asyncio.gather(*sends)
+
+    async def send_round_summary(self, game_state: QuizifyGameState) -> None:
+        """Broadcast round summary to all clients.
+
+        Payload assembly (correct-index resolution, the per-player answer
+        table, the summary serialization) lives in the RoundMessageBuilder
+        (#189); this keeps ownership of the broadcast. ``None`` means there is
+        no round summary yet — same no-op as before.
+        """
+        summary_msg = self._messages.build_round_summary(game_state)
+        if summary_msg is None:
+            return
+        await self._conn.broadcast(summary_msg)
+
+    async def send_teams_update(self, game_state: QuizifyGameState) -> None:
+        """Tell the room who is playing with whom.
+
+        Sent uncoalesced, unlike the roster: opening a team has to appear on
+        the other phones *now*, because the next thing that happens is someone
+        looking for it in the list. It is also what makes a join land on the
+        founder's screen — without it she cannot tell whether it worked.
+        """
+        await self._conn.broadcast({
+            "type": "teams_update",
+            "teams": game_state.team_registry.to_list(),
+        })
+
+    async def send_team_answer(
+        self,
+        game_state: QuizifyGameState,
+        ack: TeamAnswerAck,
+        *,
+        setter: str,
+    ) -> None:
+        """Show the standing answer on every member's phone (#365).
+
+        The index is remapped per member: every player sees the answers in
+        their own shuffled order (#253), so sending one number to the whole
+        team would put the dots on the wrong row for everyone but the setter.
+        """
+        team = game_state.team_registry.get(ack.team_id)
+        if team is None:
+            return
+        for name in team.members:
+            member = game_state.get_player(name)
+            if member is None or member.ws is None or not member.connected:
+                continue
+            shuffle = game_state.get_player_shuffle(name)
+            try:
+                shown_index = shuffle.index(ack.answer_index)
+            except ValueError:
+                # No shuffle stored for this member yet (they joined between
+                # the question start and this tap). Their client re-reads the
+                # answer from the next projected snapshot.
+                continue
+            await self._conn.send(member.ws, {
+                "type": "team_answer",
+                "team_id": ack.team_id,
+                "answer_index": shown_index,
+                "set_by": setter,
+                # The lock belongs to the team, not to the person who tapped:
+                # every member's buttons go quiet for the same two seconds,
+                # which is what stops the tap war rather than slowing one side.
+                "lock_seconds": ack.lock_seconds,
+                "members": list(team.members),
+            })
+
+
+# ---------------------------------------------------------------------------
+# Wager window (#656)
+# ---------------------------------------------------------------------------
+
+
+class WagerBroadcaster(_Broadcaster):
+    """The betting window's fan-out.
+
+    Satisfies
+    :class:`custom_components.quizify.game.drivers.protocols.WagerBroadcaster`.
+    Like the hot seat's escape hatch, ``close_wager_window`` is a round
+    transition rather than a frame — it arms the timers and emits the question
+    — so it is injected and forwarded.
+    """
+
+    def __init__(
+        self,
+        conn: ConnectionManager | Callable[[], ConnectionManager],
+        messages: RoundMessageBuilder,
+        *,
+        close: Callable[[QuizifyGameState], Awaitable[None]],
+    ) -> None:
+        super().__init__(conn, messages)
+        self._close = close
+
+    async def send_wager_window(
+        self, game_state: QuizifyGameState, question: Any
+    ) -> None:
+        """Announce the betting window.
+
+        Sends every phone its own bank and gives the host/TV the lock-in
+        tally. Arming the deadline is the handler's job — the task lives in
+        the #746 registry, not here.
+        """
+        players = game_state.get_players()
+        sends = [
+            self._conn.send(
+                player.ws,
+                self._messages.build_wager_window(
+                    game_state,
+                    question=question,
+                    player=player,
+                    window_duration=WAGER_WINDOW_DURATION,
+                ),
+            )
+            for player in players
+            if player.connected
+        ]
+        if sends:
+            await asyncio.gather(*sends)
+
+        await self._conn.broadcast_to_admins_and_dashboards(
+            self._messages.build_wager_progress(
+                game_state, window_duration=WAGER_WINDOW_DURATION
+            )
+        )
+        # Phase broadcast last: the phones already hold the window payload, so
+        # a client driving off the phase alone (reconnect path) lands on a view
+        # it can render rather than an empty one.
+        await self._conn.broadcast(
+            self._messages.build_game_state_with_leaderboard(
+                game_state, players=players
+            )
+        )
+
+    async def close_wager_window(self, game_state: QuizifyGameState) -> None:
+        """The deadline passed: arm the round timers and send the question."""
+        await self._close(game_state)

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -7,6 +7,7 @@ import contextlib
 import ipaddress
 import logging
 import random
+from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 from aiohttp import WSMsgType, web
@@ -34,7 +35,6 @@ from custom_components.quizify.game.drivers import (
     WagerWindowDriver,
 )
 from custom_components.quizify.game.highlights import compute_superlatives
-from custom_components.quizify.game.hot_seat import stake_of as hot_seat_stake
 from custom_components.quizify.game.phase_controller import TICK_INTERVAL
 from custom_components.quizify.game.player_registry import sanitize_player_name
 from custom_components.quizify.game.powerups import (
@@ -48,12 +48,15 @@ from custom_components.quizify.game.state import (
     QuizifyGameState,
     TeamAnswerAck,
 )
-from custom_components.quizify.game.team import (
-    ANSWER_CHANGE_LOCK_SECONDS as LIGHTNING_ANSWER_LOCK_SECONDS,
-)
 from custom_components.quizify.game.team import Team
 from custom_components.quizify.game.types import Difficulty
 from custom_components.quizify.server.broadcast_dispatcher import BroadcastDispatcher
+from custom_components.quizify.server.broadcasters import (
+    HotSeatBroadcaster,
+    LightningBroadcaster,
+    RoundBroadcaster,
+    WagerBroadcaster,
+)
 from custom_components.quizify.server.connection import ConnectionManager
 from custom_components.quizify.server.origin import reject_cross_origin
 from custom_components.quizify.server.rate_limit import SlidingWindowLimiter
@@ -565,6 +568,53 @@ class QuizifyWebSocketHandler:
         # room of eight taps eight times per round, not once per game.
         self._progress_dirty = False
         self._progress_flush_task: asyncio.Task | None = None
+
+    # ------------------------------------------------------------------
+    # The four fan-out objects the drivers actually talk to (#881)
+    # ------------------------------------------------------------------
+    # #788 gave each driver a narrow ``Broadcaster`` protocol and then handed
+    # it ``self``, so the contract was an annotation and nothing more: a driver
+    # held every method on this class, and a mode could not be exercised
+    # against a small fake. Each protocol now has one small implementation in
+    # ``server/broadcasters.py`` that owns its mode's frames; the handler holds
+    # them rather than being them.
+    #
+    # Built on first use rather than in ``__init__`` so a handler assembled
+    # with ``__new__`` — which several tests do, to exercise one message
+    # handler against a stub connection — gets them from the same wiring the
+    # real one uses instead of a hand-rolled copy.
+    #
+    # ``lambda: self._conn`` rather than ``self._conn``: much of the suite
+    # replaces the connection manager after construction, and a reference
+    # captured once would keep sending into the discarded one.
+
+    @cached_property
+    def _lightning_out(self) -> LightningBroadcaster:
+        """The Lightning Round's fan-out (#42/#201)."""
+        return LightningBroadcaster(lambda: self._conn, self._round_messages)
+
+    @cached_property
+    def _hot_seat_out(self) -> HotSeatBroadcaster:
+        """The Hot Seat's fan-out (#616/#804)."""
+        return HotSeatBroadcaster(
+            lambda: self._conn,
+            self._round_messages,
+            resume_normal_question=self._continue_normal_question,
+        )
+
+    @cached_property
+    def _round_out(self) -> RoundBroadcaster:
+        """The normal round's fan-out (#203/#365/#413)."""
+        return RoundBroadcaster(lambda: self._conn, self._round_messages)
+
+    @cached_property
+    def _wager_out(self) -> WagerBroadcaster:
+        """The betting window's fan-out (#656)."""
+        return WagerBroadcaster(
+            lambda: self._conn,
+            self._round_messages,
+            close=self._close_wager_window,
+        )
 
     # Coalescing window for visual reactions (#304), seconds.
     _REACTION_FLUSH_WINDOW = 0.15
@@ -1397,19 +1447,6 @@ class QuizifyWebSocketHandler:
     # Teams (#365)
     # ------------------------------------------------------------------
 
-    async def _broadcast_teams(self, game_state: QuizifyGameState) -> None:
-        """Tell the room who is playing with whom.
-
-        Sent uncoalesced, unlike the roster: opening a team has to appear on
-        the other phones *now*, because the next thing that happens is someone
-        looking for it in the list. It is also what makes a join land on the
-        founder's screen — without it she cannot tell whether it worked.
-        """
-        await self._conn.broadcast({
-            "type": "teams_update",
-            "teams": game_state.team_registry.to_list(),
-        })
-
     async def _handle_create_team(
         self, ws: web.WebSocketResponse, data: dict, game_state: QuizifyGameState
     ) -> None:
@@ -1428,7 +1465,7 @@ class QuizifyWebSocketHandler:
             return
 
         await self._conn.send(ws, {"type": "team_joined", "team": team})
-        await self._broadcast_teams(game_state)
+        await self._round_out.send_teams_update(game_state)
 
     async def _handle_join_team(
         self, ws: web.WebSocketResponse, data: dict, game_state: QuizifyGameState
@@ -1449,7 +1486,7 @@ class QuizifyWebSocketHandler:
             return
 
         await self._conn.send(ws, {"type": "team_joined", "team": team})
-        await self._broadcast_teams(game_state)
+        await self._round_out.send_teams_update(game_state)
 
     async def _handle_leave_team(
         self, ws: web.WebSocketResponse, data: dict, game_state: QuizifyGameState
@@ -1467,47 +1504,7 @@ class QuizifyWebSocketHandler:
             return
 
         await self._conn.send(ws, {"type": "team_left"})
-        await self._broadcast_teams(game_state)
-
-    async def _broadcast_team_answer(
-        self,
-        game_state: QuizifyGameState,
-        ack: TeamAnswerAck,
-        *,
-        setter: str,
-    ) -> None:
-        """Show the standing answer on every member's phone (#365).
-
-        The index is remapped per member: every player sees the answers in
-        their own shuffled order (#253), so sending one number to the whole
-        team would put the dots on the wrong row for everyone but the setter.
-        """
-        team = game_state.team_registry.get(ack.team_id)
-        if team is None:
-            return
-        for name in team.members:
-            member = game_state.get_player(name)
-            if member is None or member.ws is None or not member.connected:
-                continue
-            shuffle = game_state.get_player_shuffle(name)
-            try:
-                shown_index = shuffle.index(ack.answer_index)
-            except ValueError:
-                # No shuffle stored for this member yet (they joined between
-                # the question start and this tap). Their client re-reads the
-                # answer from the next projected snapshot.
-                continue
-            await self._conn.send(member.ws, {
-                "type": "team_answer",
-                "team_id": ack.team_id,
-                "answer_index": shown_index,
-                "set_by": setter,
-                # The lock belongs to the team, not to the person who tapped:
-                # every member's buttons go quiet for the same two seconds,
-                # which is what stops the tap war rather than slowing one side.
-                "lock_seconds": ack.lock_seconds,
-                "members": list(team.members),
-            })
+        await self._round_out.send_teams_update(game_state)
 
     # ------------------------------------------------------------------
     # Submit answer
@@ -1567,7 +1564,9 @@ class QuizifyWebSocketHandler:
             # anything. Every member — the setter included — gets the standing
             # answer in their own answer order, so the dots appear on the same
             # question for all of them.
-            await self._broadcast_team_answer(game_state, result, setter=player.name)
+            await self._round_out.send_team_answer(
+                game_state, result, setter=player.name
+            )
             self._mark_progress_dirty()
             return
 
@@ -2815,7 +2814,7 @@ class QuizifyWebSocketHandler:
         state = self._snapshot(game_state)
         state["type"] = "game_state"
         await self._conn.broadcast(state)
-        await self._broadcast_lightning_splash(game_state)
+        await self._lightning_out.send_lightning_splash(game_state)
 
         # Auto-advance: no host tap. The loop itself dismisses the splash after
         # the grace and starts question 1.
@@ -2832,19 +2831,6 @@ class QuizifyWebSocketHandler:
         if question is None:
             return
         await self._deliver_question(game_state, question)
-
-    async def _broadcast_lightning_splash(
-        self, game_state: QuizifyGameState
-    ) -> None:
-        """Fan out the intro-splash payload (rules preview) to all clients."""
-        lr = game_state.lightning
-        if lr is None:
-            return
-        await self._conn.broadcast({
-            "type": "lightning_splash",
-            "num_questions": lr.num_questions,
-            "seconds_per_question": lr.seconds_per_question,
-        })
 
     async def _handle_lightning_answer(
         self, ws: web.WebSocketResponse, data: dict, game_state: QuizifyGameState
@@ -2891,48 +2877,14 @@ class QuizifyWebSocketHandler:
         # a teammate may still change it. Every member is told what stands, in
         # their own answer order.
         if lr.team_mode and lr.entrant_for(player.name) != player.name:
-            await self._broadcast_lightning_team_answer(game_state, lr, player.name)
+            await self._lightning_out.send_lightning_team_answer(
+                game_state, lr, player.name
+            )
             return
 
-        # Lightweight ack: lock the player's buttons + show right/wrong.
-        await self._conn.send(ws, {
-            "type": "lightning_answer_result",
-            "correct": bool(result),
-            "index": lr.index,
-            "score": lr.score_for(player.name),
-        })
-
-    async def _broadcast_lightning_team_answer(
-        self, game_state: QuizifyGameState, lr: Any, setter: str
-    ) -> None:
-        """Show the team's standing lightning answer on every member's phone.
-
-        Mirrors the normal round's ``team_answer`` (#365): the index is
-        remapped per member, because each phone shuffles the answers for
-        itself — one number sent to the whole team would highlight the wrong
-        row for everybody but the person who tapped.
-        """
-        standing = lr.standing_answer(setter)
-        if standing is None or standing.answer_index is None:
-            return
-        members = lr.members_of(setter)
-        for name in members:
-            member = game_state.get_player(name)
-            if member is None or member.ws is None or not member.connected:
-                continue
-            order = lr.ensure_shuffle(name)
-            try:
-                shown_index = order.index(standing.answer_index)
-            except ValueError:
-                continue
-            await self._conn.send(member.ws, {
-                "type": "lightning_team_answer",
-                "index": lr.index,
-                "answer_index": shown_index,
-                "set_by": setter,
-                "members": list(members),
-                "lock_seconds": LIGHTNING_ANSWER_LOCK_SECONDS,
-            })
+        await self._lightning_out.send_lightning_answer_result(
+            ws, lr, player.name, correct=bool(result)
+        )
 
     def _start_lightning_loop(
         self,
@@ -2950,7 +2902,7 @@ class QuizifyWebSocketHandler:
         """
         self._cancel_lightning_loop()
         driver = LightningDriver(
-            self,
+            self._lightning_out,
             splash_grace=self.LIGHTNING_SPLASH_GRACE,
             splash_hold=self.AUTO_LIGHTNING_SPLASH_HOLD,
         )
@@ -2958,21 +2910,6 @@ class QuizifyWebSocketHandler:
             driver.run(game_state, auto_dismiss_splash=auto_dismiss_splash)
         )
         self._lightning_task.add_done_callback(self._log_task_exception)
-
-    # -- LightningBroadcaster (game/drivers/protocols.py) ---------------
-
-    async def send_lightning_question(
-        self, game_state: QuizifyGameState, lr: Any
-    ) -> None:
-        await self._broadcast_lightning_question(game_state, lr)
-
-    async def send_lightning_tick(
-        self, game_state: QuizifyGameState, lr: Any
-    ) -> None:
-        await self._broadcast_lightning_tick(game_state, lr)
-
-    async def send_lightning_recap(self, game_state: QuizifyGameState) -> None:
-        await self._broadcast_lightning_recap(game_state)
 
     def _cancel_lightning_loop(self) -> None:
         if self._lightning_task is not None:
@@ -3022,19 +2959,9 @@ class QuizifyWebSocketHandler:
             await self._conn.send_error(ws, ERR_INVALID_ACTION, "Bid already placed")
             return
 
-        await self._conn.send(ws, {
-            "type": "hot_seat_bid_accepted",
-            "bid": pct,
-            "points": hot_seat_stake(
-                hs.scores.get(hs.entrant_for(player.name), 0), pct
-            ),
-        })
-        # Blind auction: the room learns how many have bid, never how much.
-        await self._conn.broadcast({
-            "type": "hot_seat_bid_count",
-            "count": len(hs.bids),
-            "total": len(hs.scores),
-        })
+        await self._hot_seat_out.send_hot_seat_bid_accepted(
+            ws, hs, player.name, pct=pct
+        )
 
     async def _handle_hot_seat_bet(
         self, ws: web.WebSocketResponse, data: dict, game_state: QuizifyGameState
@@ -3073,14 +3000,9 @@ class QuizifyWebSocketHandler:
             await self._conn.send_error(ws, ERR_INVALID_ACTION, "Bet not accepted")
             return
 
-        await self._conn.send(ws, {
-            "type": "hot_seat_bet_accepted",
-            "side": side,
-            "bet": pct,
-            "points": hot_seat_stake(
-                hs.scores.get(hs.entrant_for(player.name), 0), pct
-            ),
-        })
+        await self._hot_seat_out.send_hot_seat_bet_accepted(
+            ws, hs, player.name, side=side, pct=pct
+        )
 
     async def _handle_hot_seat_answer(
         self, ws: web.WebSocketResponse, data: dict, game_state: QuizifyGameState
@@ -3106,7 +3028,7 @@ class QuizifyWebSocketHandler:
         result = hs.record_answer(player.name, idx)
         if result is None:
             return
-        await self._conn.send(ws, {"type": "hot_seat_answer_accepted"})
+        await self._hot_seat_out.send_hot_seat_answer_accepted(ws)
 
     async def _start_hot_seat(self, game_state: QuizifyGameState) -> bool:
         """Open the auction and drive it to the reveal. False means "skipped".
@@ -3127,32 +3049,7 @@ class QuizifyWebSocketHandler:
         state = self._snapshot(game_state)
         state["type"] = "game_state"
         await self._conn.broadcast(state)
-        await self._conn.broadcast({
-            "type": "hot_seat_auction",
-            "seconds": hs.auction_seconds,
-            "players": len(hs.scores),
-            # #698: the television's round indicator is interpolated from
-            # these two. Without them the auction kept the previous round's
-            # number and the question that follows printed the literal string
-            # "undefined" for the whole answer window.
-            "round_num": game_state.round,
-            "total_rounds": game_state.total_rounds,
-        })
-        # Each player needs their own number: a percentage is only meaningful
-        # next to the points it costs *them*. In team mode that is the team's
-        # score (#804) — ``player.score`` there is the shadow value #669 gated
-        # the mode off for, and a slider priced against it costs nothing.
-        sends = []
-        for player in game_state.get_players():
-            if not player.connected or player.ws is None:
-                continue
-            sends.append(self._conn.send(player.ws, {
-                "type": "hot_seat_auction_you",
-                "score": hs.scores.get(hs.entrant_for(player.name), 0),
-                "seconds": hs.auction_seconds,
-            }))
-        if sends:
-            await asyncio.gather(*sends, return_exceptions=True)
+        await self._hot_seat_out.send_hot_seat_auction(game_state, hs)
 
         self._start_hot_seat_loop(game_state)
         return True
@@ -3166,187 +3063,12 @@ class QuizifyWebSocketHandler:
         """
         self._cancel_hot_seat_loop()
         driver = HotSeatDriver(
-            self, milestones=self, reveal_hold=self.HOT_SEAT_REVEAL_HOLD
+            self._hot_seat_out,
+            milestones=self,
+            reveal_hold=self.HOT_SEAT_REVEAL_HOLD,
         )
         self._hot_seat_task = asyncio.ensure_future(driver.run(game_state))
         self._hot_seat_task.add_done_callback(self._log_task_exception)
-
-    # -- HotSeatBroadcaster (game/drivers/protocols.py) -----------------
-
-    async def send_hot_seat_tick(self, stage: str, remaining: int) -> None:
-        await self._conn.broadcast({
-            "type": "hot_seat_tick",
-            "phase": stage,
-            "remaining": remaining,
-        })
-
-    async def send_hot_seat_no_bids(self) -> None:
-        await self._conn.broadcast({"type": "hot_seat_no_bids"})
-
-    async def send_hot_seat_awarded(
-        self, game_state: QuizifyGameState, hs: Any
-    ) -> None:
-        await self._conn.broadcast({
-            "type": "hot_seat_awarded",
-            # The PERSON taking the chair. Outside team mode that is also the
-            # entrant, so this field keeps its old meaning for every client;
-            # ``entrant`` names who pays (#804).
-            "winner": hs.seat_holder,
-            "entrant": hs.winner_name,
-            "pct": hs.winning_pct,
-            "stake": hs.winning_stake,
-            "bids": hs.reveal(),
-        })
-
-    async def send_hot_seat_question(
-        self, game_state: QuizifyGameState, hs: Any
-    ) -> None:
-        await self._broadcast_hot_seat_question(game_state, hs)
-
-    async def send_hot_seat_result(
-        self, game_state: QuizifyGameState, hs: Any
-    ) -> None:
-        await self._conn.broadcast({
-            "type": "hot_seat_result",
-            "round_num": game_state.round,
-            "total_rounds": game_state.total_rounds,
-            **hs.summary(),
-            # The rows the room can see (#804): teams in team mode, players
-            # otherwise. Keyed by ``player.name`` this reported the shadow
-            # scores the settlement no longer writes to.
-            "scores": {
-                participant.name: participant.score
-                for participant in game_state.get_ranked_participants()
-            },
-            # #833: the standings AFTER the settlement, in the shape every
-            # board already renders. ``scores`` above is a name→number map —
-            # no rank, no entrant id, nothing a leaderboard row is built from —
-            # so the one screen the whole room reads had no way to repaint and
-            # kept showing the player who had just lost everything in first
-            # place. ``finish_hot_seat`` has already applied the deltas by the
-            # time this runs, so these are the real numbers.
-            "leaderboard": serialize_leaderboard(
-                game_state.get_ranked_participants()
-            ),
-        })
-
-    async def resume_normal_question(self, game_state: QuizifyGameState) -> None:
-        await self._continue_normal_question(game_state)
-
-    async def _broadcast_hot_seat_question(
-        self, game_state: QuizifyGameState, hs: Any
-    ) -> None:
-        """Send the question: shuffled to the seat holder, canonical to the room.
-
-        The spectators get the question text and the betting controls but no
-        answer buttons — they are not answering it, they are staking on
-        whoever is.
-        """
-        q = hs.question
-        if q is None:
-            return
-        payload = {
-            "type": "hot_seat_question",
-            "question": q.question,
-            "difficulty": q.difficulty,
-            # #698: see the auction broadcast — the TV interpolates both.
-            "round_num": game_state.round,
-            "total_rounds": game_state.total_rounds,
-            "image_url": getattr(q, "image_url", "") or "",
-            "seconds": hs.answer_seconds,
-            "winner": hs.seat_holder,
-            "entrant": hs.winner_name,
-        }
-        sends = []
-        for player in game_state.get_players():
-            if not player.connected or player.ws is None:
-                continue
-            if player.name == hs.seat_holder:
-                sends.append(self._conn.send(player.ws, {
-                    **payload,
-                    "answers": hs.shuffled_answers(),
-                    "you_are_seated": True,
-                }))
-            else:
-                sends.append(self._conn.send(player.ws, {
-                    **payload,
-                    "answers": [],
-                    "you_are_seated": False,
-                    # A teammate of the seat holder may not bet: they stake the
-                    # purse the chair already staked (#804). Told here so the
-                    # phone shows why instead of a slider nothing accepts.
-                    "you_are_seat_team": hs.is_on_seat_team(player.name),
-                    "score": hs.scores.get(hs.entrant_for(player.name), 0),
-                }))
-        if sends:
-            await asyncio.gather(*sends, return_exceptions=True)
-        # The room watches the same board the seat holder does, so the TV gets
-        # the *shuffled* order rather than the canonical one — which also keeps
-        # #521 shut, where JSON order put the correct tile first in half the
-        # packs. Admins additionally get the correct index; dashboards take no
-        # token (#604) and must not learn it before the reveal.
-        tv_payload = {**payload, "answers": hs.shuffled_answers()}
-        await self._conn.broadcast_to_admins_and_dashboards(
-            {**tv_payload, "correct_index": hs.correct_index},
-            dashboard_message=tv_payload,
-        )
-
-    async def _broadcast_lightning_question(
-        self, game_state: QuizifyGameState, lr: Any
-    ) -> None:
-        """Send the current lightning question per-player (own shuffle) and
-        to admin/dashboard (canonical order)."""
-        q = lr.current_question
-        if q is None:
-            return
-        # Fan out the per-player lightning question in parallel (#258).
-        lightning_sends = []
-        for player in game_state.get_players():
-            if not player.connected:
-                continue
-            lightning_sends.append(self._conn.send(player.ws, {
-                "type": "lightning_question",
-                "question_text": q.question,
-                "answers": lr.shuffled_answers_for(player.name),
-                "index": lr.index,
-                "num_questions": lr.num_questions,
-                "seconds": lr.seconds_per_question,
-                "category": q.category,
-                "image_url": q.image_url,
-            }))
-        if lightning_sends:
-            await asyncio.gather(*lightning_sends)
-        await self._conn.broadcast_to_admins_and_dashboards({
-            "type": "lightning_question",
-            "question_text": q.question,
-            "answers": [a.text for a in q.answers],
-            "index": lr.index,
-            "num_questions": lr.num_questions,
-            "seconds": lr.seconds_per_question,
-            "category": q.category,
-            "image_url": q.image_url,
-        })
-
-    async def _broadcast_lightning_tick(
-        self, game_state: QuizifyGameState, lr: Any
-    ) -> None:
-        remaining = round(lr.time_remaining(), 1)
-        await self._conn.broadcast({
-            "type": "lightning_tick",
-            "remaining": remaining,
-            "index": lr.index,
-        })
-
-    async def _broadcast_lightning_recap(
-        self, game_state: QuizifyGameState
-    ) -> None:
-        lr = game_state.lightning
-        if lr is None:
-            return
-        await self._conn.broadcast({
-            "type": "lightning_recap",
-            "recap": lr.build_recap(),
-        })
 
     async def _broadcast_state_projected(
         self,
@@ -3457,40 +3179,11 @@ class QuizifyWebSocketHandler:
     ) -> None:
         """Announce the betting window and arm its deadline (#656).
 
-        Sends every phone its own bank, gives the host/TV the lock-in tally,
-        and starts the one task that guarantees the window ends — with or
-        without the players.
+        The frames are the WagerBroadcaster's (#881); what stays here is the
+        one task that guarantees the window ends — with or without the
+        players — because the task belongs to the #746 registry.
         """
-        players = game_state.get_players()
-        sends = [
-            self._conn.send(
-                player.ws,
-                self._round_messages.build_wager_window(
-                    game_state,
-                    question=question,
-                    player=player,
-                    window_duration=WAGER_WINDOW_DURATION,
-                ),
-            )
-            for player in players
-            if player.connected
-        ]
-        if sends:
-            await asyncio.gather(*sends)
-
-        await self._conn.broadcast_to_admins_and_dashboards(
-            self._round_messages.build_wager_progress(
-                game_state, window_duration=WAGER_WINDOW_DURATION
-            )
-        )
-        # Phase broadcast last: the phones already hold the window payload, so
-        # a client driving off the phase alone (reconnect path) lands on a view
-        # it can render rather than an empty one.
-        await self._conn.broadcast(
-            self._round_messages.build_game_state_with_leaderboard(
-                game_state, players=players
-            )
-        )
+        await self._wager_out.send_wager_window(game_state, question)
         self._start_wager_window(game_state)
 
     def _start_wager_window(self, game_state: QuizifyGameState) -> None:
@@ -3503,13 +3196,8 @@ class QuizifyWebSocketHandler:
         :class:`~custom_components.quizify.game.drivers.WagerWindowDriver`.
         """
         self._cancel_wager_window()
-        driver = WagerWindowDriver(self, duration=WAGER_WINDOW_DURATION)
+        driver = WagerWindowDriver(self._wager_out, duration=WAGER_WINDOW_DURATION)
         self._wager_window_task = asyncio.create_task(driver.run(game_state))
-
-    # -- WagerBroadcaster (game/drivers/protocols.py) -------------------
-
-    async def close_wager_window(self, game_state: QuizifyGameState) -> None:
-        await self._close_wager_window(game_state)
 
     def _cancel_wager_window(self) -> None:
         """Cancel the pending betting-window deadline, if any.
@@ -3654,48 +3342,10 @@ class QuizifyWebSocketHandler:
         # driver so the module-level name stays the single knob a test (or a
         # future runtime setting) can turn.
         driver = NormalRoundDriver(
-            self, milestones=self, tick_interval=TICK_INTERVAL
+            self._round_out, milestones=self, tick_interval=TICK_INTERVAL
         )
         self._timer_tick_task = asyncio.ensure_future(driver.run(game_state))
         self._timer_tick_task.add_done_callback(self._log_task_exception)
-
-    # -- RoundBroadcaster (game/drivers/protocols.py) -------------------
-
-    async def send_timer_tick(
-        self,
-        game_state: QuizifyGameState,
-        remaining_by_player: dict[str, float],
-        dashboard_remaining: float | None,
-    ) -> None:
-        """Turn one driver tick into ``timer_tick`` frames.
-
-        The driver has already dropped every recipient whose displayed second
-        did not change (#413) and every disconnected player, so this only has
-        to address what is left. Built as one fan-out and delivered in parallel
-        (#258) so a single stalled client can't delay the room; the dashboard
-        copy is pre-serialized ONCE and goes out over the broadcast string path
-        (admin-as-player is already excluded there).
-        """
-        sends = []
-        if remaining_by_player:
-            by_name = {p.name: p for p in game_state.get_players()}
-            for name, remaining in remaining_by_player.items():
-                player = by_name.get(name)
-                if player is None:
-                    continue
-                sends.append(self._conn.send(player.ws, {
-                    "type": "timer_tick",
-                    "remaining": round(remaining, 1),
-                }))
-        if dashboard_remaining is not None:
-            sends.append(
-                self._conn.broadcast_to_admins_and_dashboards({
-                    "type": "timer_tick",
-                    "remaining": round(dashboard_remaining, 1),
-                })
-            )
-        if sends:
-            await asyncio.gather(*sends)
 
     def _cancel_timer_tick(self) -> None:
         """Cancel the timer tick task — and the betting window with it.
@@ -3756,19 +3406,6 @@ class QuizifyWebSocketHandler:
     # ------------------------------------------------------------------
     # Round summary broadcast
     # ------------------------------------------------------------------
-
-    async def _broadcast_round_summary(self, game_state: QuizifyGameState) -> None:
-        """Broadcast round summary to all clients.
-
-        Payload assembly (correct-index resolution, the per-player answer
-        table, the summary serialization) lives in the RoundMessageBuilder
-        (#189); the handler keeps ownership of the broadcast. ``None`` means
-        there is no round summary yet — same no-op as before.
-        """
-        summary_msg = self._round_messages.build_round_summary(game_state)
-        if summary_msg is None:
-            return
-        await self._conn.broadcast(summary_msg)
 
     # ------------------------------------------------------------------
     # Disconnect handling
@@ -4816,7 +4453,7 @@ class QuizifyWebSocketHandler:
         """Handler for the ``round_evaluated`` state event."""
         game_state = self._get_game_state()
         if game_state:
-            await self._broadcast_round_summary(game_state)
+            await self._round_out.send_round_summary(game_state)
             # ONE reveal milestone (#789), after the summary broadcast: the
             # combined spoken utterance (#281) and the bus event carrying the
             # correct answer + how many got it (#366) fan out inside

--- a/tests/test_broadcaster_extraction_881.py
+++ b/tests/test_broadcaster_extraction_881.py
@@ -1,0 +1,490 @@
+"""The drivers' fan-out is pinned to its recipients, not just to its shape (#881).
+
+#788 gave every driver a narrow ``Broadcaster`` protocol and then handed it the
+whole 5k-line WebSocket handler, so the contract was an annotation and nothing
+else. #881 moved the fan-out coroutines and their frame literals into one small
+class per protocol in ``server/broadcasters.py``.
+
+That is a refactor, and the only thing worth testing about a refactor is that
+nothing moved. What could silently break here is not a payload key — the frame
+schemas already have tests — but *who receives which copy*: the lightning
+question is a different list per phone, the hot seat's question is three
+different payloads (chair / spectators / television), and a timer tick is
+addressed to the subset whose displayed second changed. All of that used to be
+expressed inside methods on the handler, addressed off ``self._conn``. If the
+extraction dropped or widened one recipient the schema tests would still pass
+and the room would be wrong.
+
+So these tests drive the REAL drivers through the REAL broadcasters over a REAL
+:class:`ConnectionManager`, with one recording socket per seat in the room, and
+assert per socket what arrived. A frame that loses a recipient, gains one, or
+reaches the television with the answer in it fails here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.game.drivers import (  # noqa: E402
+    HotSeatDriver,
+    LightningDriver,
+    NormalRoundDriver,
+)
+from custom_components.quizify.game.state import (  # noqa: E402
+    GamePhase,
+    QuizifyGameState,
+)
+from custom_components.quizify.server.broadcasters import (  # noqa: E402
+    HotSeatBroadcaster,
+    LightningBroadcaster,
+    RoundBroadcaster,
+)
+from custom_components.quizify.server.connection import ConnectionManager  # noqa: E402
+from custom_components.quizify.server.round_message_builder import (  # noqa: E402
+    RoundMessageBuilder,
+)
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _Runtime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    def create_task(self, coro: Any) -> asyncio.Task:
+        """The history flush schedules through the runtime (game/state.py)."""
+        return asyncio.ensure_future(coro)
+
+
+class _Sock:
+    """One seat in the room, recording every frame that reaches it.
+
+    Implements both delivery paths the connection manager uses: ``send_json``
+    for a single addressed send and ``send_str`` for the pre-serialized
+    broadcast path. Recording both is the point — a frame that moved from one
+    path to the other would change who gets it.
+    """
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+        self.closed = False
+        self.frames: list[dict] = []
+
+    async def send_json(self, message: dict) -> None:
+        self.frames.append(message)
+
+    async def send_str(self, payload: str) -> None:
+        self.frames.append(json.loads(payload))
+
+    def types(self) -> list[str]:
+        return [f.get("type") for f in self.frames]
+
+    def of_type(self, frame_type: str) -> list[dict]:
+        return [f for f in self.frames if f.get("type") == frame_type]
+
+    def one(self, frame_type: str) -> dict:
+        found = self.of_type(frame_type)
+        assert len(found) == 1, (
+            f"{self.label} got {len(found)} {frame_type} frames, expected 1"
+        )
+        return found[0]
+
+
+class _Room:
+    """A game plus the sockets watching it, wired to a real ConnectionManager."""
+
+    def __init__(self, tmp_path: Path, players: list[str]) -> None:
+        self.game = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+        self.socks: dict[str, _Sock] = {}
+        for name in players:
+            sock = _Sock(name)
+            self.socks[name] = sock
+            self.game.add_player(name, sock)
+        self.admin = _Sock("admin")
+        self.dashboard = _Sock("dashboard")
+        self.socks["admin"] = self.admin
+        self.socks["dashboard"] = self.dashboard
+
+        self.conn = ConnectionManager(_Runtime(tmp_path), lambda: self.game)
+        for name in players:
+            self.conn.add_connection(
+                self.socks[name], is_admin=False, is_dashboard=False
+            )
+        self.conn.add_connection(self.admin, is_admin=True, is_dashboard=False)
+        self.conn.add_connection(self.dashboard, is_admin=False, is_dashboard=True)
+
+    def who_got(self, frame_type: str) -> set[str]:
+        return {
+            label for label, sock in self.socks.items() if sock.of_type(frame_type)
+        }
+
+
+def _messages() -> RoundMessageBuilder:
+    return RoundMessageBuilder()
+
+
+# ---------------------------------------------------------------------------
+# Lightning: one list per phone, the canonical one to the television
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lightning_driver_reaches_every_seat_through_the_broadcaster(
+    tmp_path: Path,
+) -> None:
+    """The real ``LightningDriver`` against the real ``LightningBroadcaster``.
+
+    Pins the split the mode is built on: each phone gets its OWN shuffled
+    option list (#253/#286 — the tap is scored through that shuffle, so one
+    shared order mis-scores the room), while the host and the television get
+    the canonical order. The tick and the recap are room-wide and must reach
+    every socket, phones included.
+    """
+    room = _Room(tmp_path, ["Anna", "Ben", "Cleo"])
+    assert room.game.start_lightning_round() is True
+    lr = room.game.lightning
+    assert lr is not None
+    lr._questions = lr._questions[:1]
+    lr.num_questions = 1
+    lr.seconds_per_question = 0.3
+    question = lr.current_question
+    canonical = [a.text for a in question.answers]
+
+    driver = LightningDriver(
+        LightningBroadcaster(room.conn, _messages()),
+        splash_grace=0.0,
+        splash_hold=0.0,
+    )
+    await driver.run(room.game, auto_dismiss_splash=False)
+
+    assert room.game.phase == GamePhase.LIGHTNING_RECAP
+
+    # The question: one copy each, to every seat — nobody is skipped.
+    assert room.who_got("lightning_question") == {
+        "Anna",
+        "Ben",
+        "Cleo",
+        "admin",
+        "dashboard",
+    }
+    for name in ("Anna", "Ben", "Cleo"):
+        frame = room.socks[name].one("lightning_question")
+        assert sorted(frame["answers"]) == sorted(canonical), (
+            f"{name}'s options are not this question's options"
+        )
+        assert frame["index"] == lr.index
+        assert frame["num_questions"] == lr.num_questions
+    # The two screens that render an unshuffled board get the canonical order.
+    for label in ("admin", "dashboard"):
+        assert room.socks[label].one("lightning_question")["answers"] == canonical
+
+    # The clock and the recap are the room's, not one seat's.
+    for label in room.socks:
+        assert room.socks[label].of_type("lightning_tick"), (
+            f"{label} never saw the lightning clock"
+        )
+    assert room.who_got("lightning_recap") == set(room.socks)
+
+
+@pytest.mark.asyncio
+async def test_lightning_question_carries_each_players_own_shuffle(
+    tmp_path: Path,
+) -> None:
+    """The per-phone order is the one the scorer will read the tap through.
+
+    Asserted against ``shuffled_answers_for`` rather than "is a permutation",
+    because a permutation of the right words in the wrong player's order is
+    exactly the bug (#286) — and it is the assertion the old handler method
+    was never given.
+    """
+    room = _Room(tmp_path, ["Anna", "Ben", "Cleo"])
+    assert room.game.start_lightning_round() is True
+    lr = room.game.lightning
+    assert lr is not None
+
+    await LightningBroadcaster(room.conn, _messages()).send_lightning_question(
+        room.game, lr
+    )
+
+    for name in ("Anna", "Ben", "Cleo"):
+        frame = room.socks[name].one("lightning_question")
+        assert frame["answers"] == lr.shuffled_answers_for(name)
+
+
+@pytest.mark.asyncio
+async def test_a_disconnected_phone_is_not_addressed(tmp_path: Path) -> None:
+    """The connected check moved with the loop; prove it came along."""
+    room = _Room(tmp_path, ["Anna", "Ben"])
+    assert room.game.start_lightning_round() is True
+    lr = room.game.lightning
+    assert lr is not None
+    room.game.get_player("Ben").connected = False
+    room.conn.remove_connection(room.socks["Ben"])
+
+    await LightningBroadcaster(room.conn, _messages()).send_lightning_question(
+        room.game, lr
+    )
+
+    assert room.socks["Anna"].of_type("lightning_question")
+    assert room.socks["Ben"].frames == []
+
+
+# ---------------------------------------------------------------------------
+# Normal round: the tick is addressed, not sprayed
+# ---------------------------------------------------------------------------
+
+
+def _started_game(room: _Room) -> None:
+    room.game.start_game(language="de", num_rounds=3, lightning_enabled=False)
+    room.game.start_next_question()
+    assert room.game.phase == GamePhase.QUESTION_ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_normal_round_driver_ticks_reach_players_and_the_television(
+    tmp_path: Path,
+) -> None:
+    """The real ``NormalRoundDriver`` against the real ``RoundBroadcaster``.
+
+    Every connected player has their own countdown (power-ups move it, #4), so
+    each gets an addressed frame; the shared minimum goes to the host and the
+    television on the one broadcast. Both halves have to arrive — this is the
+    frame the whole room reads the clock from.
+    """
+    room = _Room(tmp_path, ["Anna", "Ben"])
+    _started_game(room)
+
+    driver = NormalRoundDriver(
+        RoundBroadcaster(room.conn, _messages()),
+        milestones=None,
+        tick_interval=0.02,
+    )
+    task = asyncio.ensure_future(driver.run(room.game))
+    await asyncio.sleep(0.12)
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert room.who_got("timer_tick") == {"Anna", "Ben", "admin", "dashboard"}
+    for label in ("Anna", "Ben", "admin", "dashboard"):
+        tick = room.socks[label].of_type("timer_tick")[0]
+        assert isinstance(tick["remaining"], (int, float))
+        assert set(tick) == {"type", "remaining"}
+
+
+@pytest.mark.asyncio
+async def test_a_timer_tick_addresses_only_the_named_players(
+    tmp_path: Path,
+) -> None:
+    """The coalescing (#413) hands the broadcaster a SUBSET, and the subset is
+    the whole point: a player whose displayed second did not change gets no
+    frame, and one who is not in the map must not be reached by someone else's.
+    """
+    room = _Room(tmp_path, ["Anna", "Ben", "Cleo"])
+    _started_game(room)
+
+    await RoundBroadcaster(room.conn, _messages()).send_timer_tick(
+        room.game, {"Anna": 7.4}, None
+    )
+
+    assert room.who_got("timer_tick") == {"Anna"}
+    assert room.socks["Anna"].one("timer_tick") == {
+        "type": "timer_tick",
+        "remaining": 7.4,
+    }
+
+    # And the dashboard half on its own: the shared countdown reaches the two
+    # screens and no phone.
+    for sock in room.socks.values():
+        sock.frames.clear()
+    await RoundBroadcaster(room.conn, _messages()).send_timer_tick(
+        room.game, {}, 5.0
+    )
+    assert room.who_got("timer_tick") == {"admin", "dashboard"}
+
+
+# ---------------------------------------------------------------------------
+# Hot Seat: three different payloads, and the television must not learn the
+# answer (#604)
+# ---------------------------------------------------------------------------
+
+
+def _hot_seat_room(tmp_path: Path) -> _Room:
+    room = _Room(tmp_path, ["Anna", "Ben", "Cleo"])
+    room.game.start_game(
+        language="en", num_rounds=8, hot_seat_seed=7, lightning_enabled=False
+    )
+    # A percentage of nothing buys nothing, so the auction needs a room with
+    # points on the board before anyone can outbid anyone.
+    for name, score in (("Anna", 40), ("Ben", 25), ("Cleo", 10)):
+        room.game.get_player(name).score = score
+    room.game.phase = GamePhase.ANSWER_REVEAL
+    assert room.game.start_hot_seat_auction() is True
+    return room
+
+
+@pytest.mark.asyncio
+async def test_hot_seat_driver_splits_the_question_three_ways(
+    tmp_path: Path,
+) -> None:
+    """The real ``HotSeatDriver`` against the real ``HotSeatBroadcaster``.
+
+    The chair answers, the spectators stake, the television watches — three
+    audiences, three payloads off one dict. What must survive the move: only
+    the seat holder gets answer buttons, only the admin socket gets
+    ``correct_index`` (a dashboard takes no token, #604), and the settlement
+    reaches everyone.
+    """
+    room = _hot_seat_room(tmp_path)
+    hs = room.game.hot_seat
+    assert hs is not None
+    hs.answer_seconds = 0.2
+    # Every connected player bids, so the auction closes on the first poll.
+    assert hs.record_bid("Anna", 80) is True
+    assert hs.record_bid("Ben", 10) is True
+    assert hs.record_bid("Cleo", 5) is True
+
+    resumed: list[Any] = []
+
+    async def _resume(game_state: Any) -> None:
+        resumed.append(game_state)
+
+    driver = HotSeatDriver(
+        HotSeatBroadcaster(
+            room.conn, _messages(), resume_normal_question=_resume
+        ),
+        milestones=None,
+        reveal_hold=0.0,
+    )
+    await driver.run(room.game)
+
+    assert resumed == [], "somebody bid, so the detour must not be abandoned"
+    seat = hs.seat_holder
+    assert seat in ("Anna", "Ben", "Cleo")
+    spectators = [n for n in ("Anna", "Ben", "Cleo") if n != seat]
+
+    # The chair.
+    chair_frame = room.socks[seat].one("hot_seat_question")
+    assert chair_frame["you_are_seated"] is True
+    assert chair_frame["answers"] == hs.shuffled_answers()
+    assert "correct_index" not in chair_frame
+
+    # The spectators: the question, no buttons, no answer.
+    for name in spectators:
+        frame = room.socks[name].one("hot_seat_question")
+        assert frame["you_are_seated"] is False
+        assert frame["answers"] == []
+        assert "correct_index" not in frame
+
+    # The host sees the correct tile; the television must not (#604).
+    admin_frame = room.admin.one("hot_seat_question")
+    assert admin_frame["correct_index"] == hs.correct_index
+    assert admin_frame["answers"] == hs.shuffled_answers()
+    tv_frame = room.dashboard.one("hot_seat_question")
+    assert "correct_index" not in tv_frame, (
+        "a dashboard needs no token — it must not learn the answer early"
+    )
+    assert tv_frame["answers"] == hs.shuffled_answers()
+
+    # The room-wide beats reach every seat.
+    assert room.who_got("hot_seat_awarded") == set(room.socks)
+    assert room.who_got("hot_seat_result") == set(room.socks)
+    for label in room.socks:
+        assert room.socks[label].of_type("hot_seat_tick")
+
+
+@pytest.mark.asyncio
+async def test_an_auction_nobody_bid_on_leaves_the_detour(tmp_path: Path) -> None:
+    """The escape hatch is not a frame, and it still has to work.
+
+    ``resume_normal_question`` is the one protocol member the broadcaster does
+    not own — it drives the round rather than describing it, so the handler
+    keeps it and the broadcaster forwards. Pinned because a forward that goes
+    nowhere leaves the game parked in an empty auction.
+    """
+    room = _hot_seat_room(tmp_path)
+    hs = room.game.hot_seat
+    assert hs is not None
+    hs.auction_seconds = 0.05
+
+    resumed: list[Any] = []
+
+    async def _resume(game_state: Any) -> None:
+        resumed.append(game_state)
+
+    driver = HotSeatDriver(
+        HotSeatBroadcaster(
+            room.conn, _messages(), resume_normal_question=_resume
+        ),
+        milestones=None,
+        reveal_hold=0.0,
+    )
+    await driver.run(room.game)
+
+    assert room.who_got("hot_seat_no_bids") == set(room.socks)
+    assert resumed == [room.game]
+
+
+# ---------------------------------------------------------------------------
+# The wiring: the handler holds the broadcasters instead of being them
+# ---------------------------------------------------------------------------
+
+
+def test_the_handler_hands_drivers_the_broadcaster_not_itself(
+    tmp_path: Path,
+) -> None:
+    """The regression #881 is about.
+
+    Every driver used to be constructed with ``self``. Type-checking cannot
+    catch a relapse — the handler satisfied the protocols structurally, which
+    is exactly why the narrow contract meant nothing — so it is pinned here by
+    identity.
+    """
+    game = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+    handler = QuizifyWebSocketHandler(
+        runtime=_Runtime(tmp_path), game_state_provider=lambda: game
+    )
+    outs = [
+        handler._lightning_out,
+        handler._hot_seat_out,
+        handler._round_out,
+        handler._wager_out,
+    ]
+    for out in outs:
+        assert out is not handler
+        assert not isinstance(out, QuizifyWebSocketHandler)
+    # And each one is stable, so a driver armed twice talks to the same object.
+    assert handler._lightning_out is outs[0]
+    assert handler._round_out is outs[2]
+
+
+def test_the_broadcasters_follow_a_swapped_connection_manager(
+    tmp_path: Path,
+) -> None:
+    """Held by provider, not captured once.
+
+    The handler's connection manager is replaced after construction on several
+    paths (and by much of this suite). A broadcaster that captured the original
+    would keep writing into a manager nobody is listening to — silently, since
+    every send swallows its errors.
+    """
+    game = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="t")
+    handler = QuizifyWebSocketHandler(
+        runtime=_Runtime(tmp_path), game_state_provider=lambda: game
+    )
+    first = handler._round_out._conn
+    replacement = ConnectionManager(_Runtime(tmp_path), lambda: game)
+    handler._conn = replacement
+
+    assert handler._round_out._conn is replacement
+    assert handler._round_out._conn is not first
+    assert handler._lightning_out._conn is replacement

--- a/tests/test_hot_seat_seat_answers_847.py
+++ b/tests/test_hot_seat_seat_answers_847.py
@@ -55,8 +55,9 @@ def test_the_server_sends_the_seat_holder_their_answers() -> None:
     """Worth pinning before blaming the phone. The seat holder's frame carries
     the shuffled options and ``you_are_seated``; the spectators' carries an
     empty list. Nothing was missing on the wire."""
-    source = (_CC / "server" / "websocket.py").read_text("utf-8")
-    body = source.split("async def _broadcast_hot_seat_question(", 1)[1].split(
+    # #881: the frame moved to the mode's broadcaster, unchanged.
+    source = (_CC / "server" / "broadcasters.py").read_text("utf-8")
+    body = source.split("async def send_hot_seat_question(", 1)[1].split(
         "\n    async def ", 1
     )[0]
 

--- a/tests/test_hot_seat_television_698.py
+++ b/tests/test_hot_seat_television_698.py
@@ -27,7 +27,12 @@ from pathlib import Path
 import pytest
 
 REPO = Path(__file__).resolve().parent.parent
-WEBSOCKET = REPO / "custom_components" / "quizify" / "server" / "websocket.py"
+# The hot-seat frames moved out of websocket.py into one broadcaster per
+# mode (#881). The payload literals — and therefore this test's subject —
+# went with them.
+BROADCASTERS = (
+    REPO / "custom_components" / "quizify" / "server" / "broadcasters.py"
+)
 DASHBOARD = REPO / "custom_components" / "quizify" / "www" / "dashboard.html"
 I18N = REPO / "custom_components" / "quizify" / "www" / "i18n"
 
@@ -56,7 +61,7 @@ def test_every_hot_seat_broadcast_carries_the_round_numbers() -> None:
     whatever the frame had. A television is a single header — if any of the
     three omits them, the detour lies about where the game is.
     """
-    source = WEBSOCKET.read_text(encoding="utf-8")
+    source = BROADCASTERS.read_text(encoding="utf-8")
     for message_type in ("hot_seat_auction", "hot_seat_question", "hot_seat_result"):
         block = _payload_block(source, message_type)
         assert '"round_num"' in block, f"{message_type} has no round_num: {block}"

--- a/tests/test_round_task_teardown_746.py
+++ b/tests/test_round_task_teardown_746.py
@@ -207,7 +207,8 @@ async def test_lightning_question_is_not_scored_after_end_game(
             ended.append(True)
             await handler.admin_action_end_game(game)
 
-    handler._broadcast_lightning_tick = _tick_then_end
+    # #881: the driver ticks through the Lightning broadcaster now.
+    handler._lightning_out.send_lightning_tick = _tick_then_end
 
     handler._start_lightning_loop(game)
     for _ in range(20):

--- a/tests/test_snapshot_restore_parity_730_731.py
+++ b/tests/test_snapshot_restore_parity_730_731.py
@@ -65,7 +65,10 @@ JS = _REPO / "custom_components" / "quizify" / "www" / "js"
 PLAYER_CORE = JS / "player-core.js"
 PLAYER_GAME = JS / "player-game.js"
 PLAYER_HOTSEAT = JS / "player-hotseat.js"
-WEBSOCKET = _REPO / "custom_components" / "quizify" / "server" / "websocket.py"
+# #881: the hot-seat frames live in the mode's broadcaster now.
+BROADCASTERS = (
+    _REPO / "custom_components" / "quizify" / "server" / "broadcasters.py"
+)
 
 needs_node = pytest.mark.skipif(
     shutil.which("node") is None, reason="node not installed"
@@ -360,11 +363,12 @@ def _live_hot_seat_question_keys() -> set[str]:
 
     Read off the source rather than duplicated here, so a field added to the
     broadcast is picked up without anyone updating this test — the same reason
-    #698 reads the payload literal out of websocket.py. The region stops at the
+    #698 reads the payload literal out of broadcasters.py. The region stops at
+    the
     admin/dashboard send: those carry ``correct_index``, which no phone gets and
     no snapshot may ever hold.
     """
-    source = WEBSOCKET.read_text(encoding="utf-8")
+    source = BROADCASTERS.read_text(encoding="utf-8")
     start = source.index('"type": "hot_seat_question"')
     end = source.index("if sends:", start)
     return set(re.findall(r'"([a-z_]+)":', source[start:end]))

--- a/tests/test_tv_hot_seat_leaderboard_833.py
+++ b/tests/test_tv_hot_seat_leaderboard_833.py
@@ -37,7 +37,10 @@ from custom_components.quizify.server.protocol import SERVER_FRAMES
 
 REPO = Path(__file__).resolve().parent.parent
 DASHBOARD = REPO / "custom_components" / "quizify" / "www" / "dashboard.html"
-WEBSOCKET = REPO / "custom_components" / "quizify" / "server" / "websocket.py"
+# #881: the hot-seat frames live in the mode's broadcaster now.
+BROADCASTERS = (
+    REPO / "custom_components" / "quizify" / "server" / "broadcasters.py"
+)
 
 
 def _ws() -> MagicMock:
@@ -99,7 +102,9 @@ def test_the_result_frame_declares_a_leaderboard() -> None:
 
 
 def test_the_result_broadcast_actually_builds_one() -> None:
-    block = _payload_block(WEBSOCKET.read_text(encoding="utf-8"), "hot_seat_result")
+    block = _payload_block(
+        BROADCASTERS.read_text(encoding="utf-8"), "hot_seat_result"
+    )
     assert "serialize_leaderboard" in block, (
         "a name→number map is not something a board can build rows from"
     )


### PR DESCRIPTION
#788 moved the four game loops out of `QuizifyWebSocketHandler` and gave every driver a narrow `Broadcaster` protocol to talk through. The object handed to each of them was still the handler itself, so the contract existed only as a type annotation — a driver held ~150 methods, and a mode could not be exercised against a small fake without re-stubbing whichever handler methods it happened to touch.

`server/broadcasters.py` now holds one small class per protocol, each taking a `ConnectionManager` and the `RoundMessageBuilder` and owning its mode's frame literals. The handler holds them instead of being them.

## What moved

| | before | after |
|---|---|---|
| `websocket.py` lines | 4,987 | 4,624 |
| `websocket.py` `"type":` frame literals | 44 | 22 |
| `websocket.py` `_broadcast_*` / `send_*` coroutines | 21 | 3 |
| `broadcasters.py` | — | 616 lines, 22 coroutines, 22 frame literals |

- **`LightningBroadcaster`** — splash, question (per-phone shuffle + canonical to host/TV), tick, recap, the answer ack, the team-answer remap.
- **`HotSeatBroadcaster`** — auction open, bid/bet/answer acks, tick, no-bids, awarded, question (chair / spectators / TV), result.
- **`RoundBroadcaster`** — timer tick, round summary, teams update, team answer.
- **`WagerBroadcaster`** — the betting-window fan-out.

`LightningDriver`, `HotSeatDriver`, `NormalRoundDriver` and `WagerWindowDriver` are now constructed with the matching broadcaster rather than `self`.

Two protocol members are not fan-out: `resume_normal_question` (the hot seat's escape hatch when nobody bids) and `close_wager_window` (arm the timers, then emit the question). They drive the round rather than describe it, so they stay on the handler and are injected as callbacks — the driver still sees one object satisfying one protocol.

The broadcasters resolve their connection manager through a provider (`lambda: self._conn`) rather than capturing it, because ~75 tests replace `handler._conn` after construction. They are built as `cached_property` so a handler assembled with `__new__` — which three tests do — gets the same wiring instead of a hand-rolled copy.

## Behaviour

No frame changed its shape, its name or its recipients. Every payload is the dict the handler used to build, sent to the same recipients over the same connection-manager call, with the comments explaining each shape moved alongside it.

`tests/test_broadcaster_extraction_881.py` (9 tests) drives the **real** drivers through the **real** broadcasters over a **real** `ConnectionManager`, with one recording socket per seat in the room, and asserts per socket what arrived:

- `LightningDriver` end to end — every phone, the host and the TV get a `lightning_question`; each phone's options are `shuffled_answers_for(name)`, the two screens get the canonical order; tick and recap reach every socket; a disconnected phone is not addressed.
- `NormalRoundDriver` end to end — the addressed `timer_tick` reaches both players plus host and TV; a tick naming one player reaches only that player; the dashboard half on its own reaches the two screens and no phone.
- `HotSeatDriver` end to end — the chair gets `answers` + `you_are_seated: true`, spectators get `[]`, the admin socket gets `correct_index` and the dashboard does not (#604); awarded/result/tick reach everyone. Plus the no-bid path, which proves the injected `resume_normal_question` still fires.
- The wiring itself: each driver is handed the broadcaster, not the handler (identity, since structural typing cannot catch a relapse), and the broadcasters follow a swapped connection manager.

Mutation-checked: dropping `dashboard_message` from the hot-seat question, truncating the lightning fan-out to one player, and turning the addressed `timer_tick` into a broadcast each fail these tests.

## Verification

- `.venv/bin/python3 -m pytest -q` — 3651 passed, 11 xfailed. The two `test_service_start_settings_744` failures are pre-existing on `main` (a preset-store singleton leaking across the session); confirmed by a full run on `origin/main` in a clean worktree.
- `ruff check custom_components/` — clean (the CI gate). Not `ruff format` — the repo is not format-clean.
- `mypy` — clean, 61 source files.

Six existing tests were repointed, none weakened: four read the hot-seat frame literals out of the source and now read `broadcasters.py`, one patches the lightning tick and now patches it on the broadcaster the driver talks to, and `test_wager_window_656` needed no change once the broadcasters became lazily built.

## Note for #885

`game/drivers/protocols.py` is untouched, as asked. The extraction needed no change there — every concrete class satisfies its protocol as written, including the two non-broadcast members, which are forwarded rather than reshaped.

Closes #881

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFeVnkXSBFSPF2oKzdb1u4