### PR TITLE
Seat the host through the manager the handler reads from

### DIFF
--- a/tests/test_five_correctness_findings_895.py
+++ b/tests/test_five_correctness_findings_895.py
@@ -454,11 +454,15 @@ async def _host_walks_out(
 ) -> MagicMock:
     """A host playing along, whose phone/tab leaves the game mid-question."""
     host_ws = _ws()
-    game.add_player("Host", host_ws)
+    # #882 made the second argument a connection id, not the socket. The room
+    # has to be seated through the same manager the handler reads from, or
+    # ``_handle_disconnect`` mints a second, unrelated id for the same socket
+    # and finds no player behind it.
+    game.add_player("Host", handler._conn.connection_id(host_ws))
     host = game.get_player("Host")
     assert host is not None
     host.is_admin = True
-    game.add_player("Cleo", _ws())
+    game.add_player("Cleo", handler._conn.connection_id(_ws()))
     game.start_game(language="en", num_rounds=3, difficulty="easy")
     assert game.start_next_question() is not None
     assert game.phase == GamePhase.QUESTION_ACTIVE


### PR DESCRIPTION
`main` has been red since #909 landed on top of #910.

The helper in `test_five_correctness_findings_895.py` seats its room with `game.add_player("Host", host_ws)`, but #882/#910 made that second argument an opaque connection id rather than the socket. `_handle_disconnect(host_ws)` then minted a second, unrelated id for the same socket, found no player behind it, and armed no pause — so both #895c tests failed on the assertion that there was a pause to cancel.

The room is now seated through `handler._conn.connection_id(...)`, the same manager the handler reads from, which is the order the production join path already uses. No assertion changed.

**Why CI let it through.** Neither PR could see the other: #910 was resolved against a main that did not yet carry this test file, and #909 against a main that did not yet carry the id change. Each was six-way green on its own. This is the "green when opened is not green when merged" case, and it is the second time it has cost a red main.

Suite 3934 passed, ruff 0.15.17 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AM3Ne8aJwtYP85qF9uB91b