### PR TITLE
fix(team): one score ledger, not two — analytics, leader and the winner event

### DIFF
--- a/custom_components/quizify/game/state.py
+++ b/custom_components/quizify/game/state.py
@@ -484,12 +484,26 @@ class QuizifyGameState:
         return self._player_registry.players
 
     @property
-    def leader(self) -> PlayerSession | None:
-        """Current top-scoring player, or None if no players yet."""
-        players = self._player_registry.players
-        if not players:
+    def leader(self) -> PlayerSession | Team | None:
+        """Whoever is currently top of the ranking, or None in an empty room.
+
+        A *participant*, not a player (#923). In team mode the room's truth is
+        ``Team.score``; ``PlayerSession.score`` is a by-product of whichever
+        member happened to carry a round, which is 0 for everybody else. Taking
+        the max over the raw player dict therefore named a person — and named
+        them with a number no screen shows — while the podium, the reveal and
+        the television all showed the winning team. ``quizify_winner_decided``
+        (``game_events``), the ``leader``/``top_score`` sensors and the TTS
+        game-over line all read this, so all four disagreed with
+        ``quizify_game_ended`` for the same finale.
+
+        Solo mode is untouched: ``get_ranked_participants`` returns the players
+        themselves, in registry order, so the same player wins the same ties.
+        """
+        participants = self.get_ranked_participants()
+        if not participants:
             return None
-        return max(players.values(), key=lambda p: p.score)
+        return max(participants, key=lambda p: p.score)
 
     # ------------------------------------------------------------------
     # State change observers (HA sensor push)
@@ -1102,9 +1116,21 @@ class QuizifyGameState:
         # STEAL is rejected on estimate rounds, #406.)
         player.round_score += points
         player.round_score_breakdown = computation.breakdown
-        player.score += points
-        if player.score < 0:
-            player.score = 0
+        # The running total is the *participant's* (#923). A team member's
+        # points are booked onto the team by ``_credit_team_round`` a few
+        # frames later; adding them here as well kept a second, per-person
+        # ledger that no screen shows and that reads 0 for every member except
+        # whoever carried this round. Analytics, the ``leader`` sensor and
+        # ``quizify_winner_decided`` all used to read that ledger and so
+        # contradicted the podium beside them. ``round_score`` above is a
+        # different thing and stays: it is what the carrier hands back to
+        # ``_credit_team_round``, and the reveal reports it as this round's
+        # points. Solo mode and the player who joined no team are unaffected —
+        # they are their own participant.
+        if self._keeps_own_score(player.name):
+            player.score += points
+            if player.score < 0:
+                player.score = 0
 
         # Track hard question score
         if correct and diff_enum == Difficulty.HARD:
@@ -1376,6 +1402,11 @@ class QuizifyGameState:
                 _team_bank=team.score,
             )
             if isinstance(result, AnswerResult):
+                # The milestone was earned on the team's streak (lent to the
+                # carrier above), so it is tallied on the team (#923) — the
+                # analytics rollup reads this counter off the entrant.
+                if result.milestone_bonus:
+                    team.streak_milestones_hit += 1
                 self._credit_team_round(
                     team,
                     result.points_earned,
@@ -1738,9 +1769,14 @@ class QuizifyGameState:
                     "estimate_rank": entry["rank"],
                     "estimate_exact": entry["exact"],
                 }
-                player.score += points
-                if player.score < 0:
-                    player.score = 0
+                # Participant's total, not the carrier's (#923) — the twin
+                # of the guard in ``submit_answer``. The team is credited from
+                # ``round_score`` in ``_apply_estimate_results_to_teams``, so
+                # the running total here would be a second ledger.
+                if self._keeps_own_score(player.name):
+                    player.score += points
+                    if player.score < 0:
+                        player.score = 0
                 if diff_enum == Difficulty.HARD:
                     player.hard_score += points
                 player.last_answer_correct = entry["exact"]
@@ -2023,16 +2059,26 @@ class QuizifyGameState:
         game_id = self.game_id
 
         duration = int(time.time() - (self._game_start_time or time.time()))
-        players = {p.name: p.score for p in self.get_players()}
-        # Per-player details feed the all-time rollup (best streak, milestone
-        # hits). Keep this map narrow so the analytics module never sees the
-        # full PlayerSession object — easier to evolve independently.
+        # Participants, not players (#923). What gets written here is the
+        # record of who played and who won: the all-time standings, the
+        # evening tally (#612) and the end-screen head-to-head (#613) are all
+        # built from it, and the season standing pushed to each phone (#624)
+        # comes back out of it. In team mode the entrant is the team, so a
+        # per-person map wrote a shadow score into the season table and put
+        # "Tonight: Bert 2 wins" under a podium that says team Sofa won.
+        # ``get_ranked_participants`` is the same list the podium is drawn
+        # from; in solo mode it is exactly ``get_players()``.
+        participants = self.get_ranked_participants()
+        players = {p.name: p.score for p in participants}
+        # Per-participant details feed the all-time rollup (best streak,
+        # milestone hits). Keep this map narrow so the analytics module never
+        # sees the full domain object — easier to evolve independently.
         player_details = {
             p.name: {
                 "best_streak": p.max_streak,
                 "streak_milestones_hit": p.streak_milestones_hit,
             }
-            for p in self.get_players()
+            for p in participants
         }
 
         async def _do_record() -> None:
@@ -2941,6 +2987,21 @@ class QuizifyGameState:
             if self._team_registry.get_by_member(p.name) is None
         ]
         return teams + solo
+
+    def _keeps_own_score(self, player_name: str) -> bool:
+        """Whether this player's points land in a row of their own (#923).
+
+        The inverse question of ``get_ranked_participants``: that method says
+        who the ranking is about, this one says whose ``score`` field is part
+        of it. True for everybody in solo mode, and for the guest who joined no
+        team in team mode — they keep their own row, so their own total is the
+        room's truth about them. False for a team member: their points belong
+        to the team, and a second copy on ``PlayerSession.score`` is a ledger
+        nothing renders.
+        """
+        if not self.team_mode:
+            return True
+        return self._team_registry.get_by_member(player_name) is None
 
     def _entrant_key(self, participant: Any) -> str:
         """The key a participant bids, bets and settles under (#804).

--- a/custom_components/quizify/game/team.py
+++ b/custom_components/quizify/game/team.py
@@ -106,6 +106,11 @@ class Team:
     # dashboard, the reveal and the finale need no team-specific rendering
     # path: they receive rows and cannot tell the difference (#365).
     max_streak: int = 0
+    #: Streak milestones this team has hit, tallied from the carrier's
+    #: settlement (#923). A team is what the analytics record calls an
+    #: entrant, so it needs the counter a player keeps — otherwise the
+    #: all-time rollup would report every team as having hit none.
+    streak_milestones_hit: int = 0
     powerups_used: int = 0
     submitted: bool = False
     is_admin: bool = False
@@ -256,6 +261,7 @@ class Team:
         self.score = 0
         self.streak = 0
         self.max_streak = 0
+        self.streak_milestones_hit = 0
         self.round_history = []
         self.round_scores = []
         self.answer_times = []

--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -3946,7 +3946,14 @@ class QuizifyWebSocketHandler:
         for player in game_state.get_players():
             if not self._conn.is_connection_open(player.connection_id):
                 continue
-            standing = self._all_time_standing(player.name)
+            # The standing belongs to the entrant, not the person (#923): in
+            # team mode the game was recorded under the team's name, so asking
+            # for the member's own name returns nothing and the phone shows no
+            # line at all. Ask for the row the podium beside it is drawn from.
+            participant = game_state.get_ranked_participant_for(player.name)
+            standing = self._all_time_standing(
+                participant.name if participant is not None else player.name
+            )
             if standing is None:
                 continue
             sends.append(

--- a/tests/test_end_screen_standing_624.py
+++ b/tests/test_end_screen_standing_624.py
@@ -78,7 +78,11 @@ def test_each_player_gets_their_own_standing() -> None:
     )
 
     assert "for player in game_state.get_players()" in body
-    assert "self._all_time_standing(player.name)" in body
+    # The lookup key is the *entrant's* name since #923: in team mode the game
+    # is recorded under the team, so a member's own name finds nothing. Still
+    # one send per player — the rank is delivered to a phone, not to a room.
+    assert "self._all_time_standing(" in body
+    assert "get_ranked_participant_for(player.name)" in body
     assert '"type": "all_time_update"' in body
     # Asserts the absent CALL, not the absent word: the docstring above
     # explains why this is not a broadcast, and `_without_comments` strips

--- a/tests/test_team_scoring_365.py
+++ b/tests/test_team_scoring_365.py
@@ -97,11 +97,13 @@ def test_the_team_scores_once_not_once_per_member(game: QuizifyGameState) -> Non
 
     team = _team(game)
     assert team.score > 0
-    scored_members = [
-        p for p in (game.get_player("Anna"), game.get_player("Jan")) if p.score > 0
-    ]
-    assert len(scored_members) == 1, "exactly one member carries the team's points"
-    assert team.score == scored_members[0].score
+    # And nowhere else. Until #923 the carrier also kept the points on their
+    # own ``score``, which this test used to assert ("exactly one member
+    # carries the team's points") — a second ledger no screen shows, read by
+    # analytics, the ``leader`` sensor and ``quizify_winner_decided``. The
+    # rule was always "one answer, one score"; it now holds for the totals too.
+    assert game.get_player("Anna").score == 0
+    assert game.get_player("Jan").score == 0
 
 
 def test_a_wrong_team_answer_breaks_the_team_streak(game: QuizifyGameState) -> None:

--- a/tests/test_team_shadow_score_923.py
+++ b/tests/test_team_shadow_score_923.py
@@ -1,0 +1,478 @@
+"""One score ledger, not two (#923).
+
+Team mode used to keep a second, per-person total. ``Team.score`` is what every
+screen shows — the leaderboard, the reveal, the podium and the television all
+draw ``get_ranked_participants()`` — but ``submit_answer`` also did
+``player.score += points`` while settling a team, so ``PlayerSession.score``
+accumulated a value that is 0 for every member except whoever carried that
+round, and that nothing renders.
+
+Three readers outside the game layer still consumed it, and each of them
+disagreed with the podium sitting next to it:
+
+* ``_record_analytics`` — the all-time standings, the evening tally (#612), the
+  end-screen head-to-head (#613) and the season standing pushed to each phone
+  (#624). Observed on v1.17.0-RC1: team Sofa won with 112 points and the end
+  screen underneath read "Tonight: Bert 2 wins · Dora 1 win".
+* ``GameState.leader`` — the ``leader`` and ``top_score`` sensors, and the TTS
+  game-over line.
+* ``quizify_winner_decided`` — a person's name on the HA bus for a finale that
+  ``quizify_game_ended`` reported as a team podium. Two events, one game, two
+  answers to "who won".
+
+This is the fourth and fifth reader of a defect class the project has paid for
+one consumer at a time (#668 wager, #800 reaction bonus, #804 hot seat, #835
+live leaderboard). So the last test here is a guard rather than a scenario: it
+walks the AST of ``server/``, ``sensor.py``, ``game_events.py``,
+``analytics.py`` and ``tts.py`` for ``.score`` reads and fails on any receiver
+that is not already on a short, named allowlist. The next reader has to be
+added on purpose.
+
+Solo mode is the control throughout: nothing below may change for a room
+without teams, and the guest who joined no team is a participant of their own,
+so they keep their own total in a team game.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from custom_components.quizify.game.state import QuizifyGameState
+from custom_components.quizify.game_events import (
+    EVENT_GAME_ENDED,
+    EVENT_WINNER_DECIDED,
+    QuizifyEventEmitter,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_CC = _REPO_ROOT / "custom_components" / "quizify"
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+class _Runtime:
+    """Enough runtime for the game state; queued tasks are run by the test."""
+
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+        self.tasks: list[Any] = []
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+    def create_task(self, coro):  # noqa: ANN001
+        self.tasks.append(coro)
+        return None
+
+    def drain(self) -> None:
+        """Run whatever ``_record_analytics`` handed us, synchronously."""
+        while self.tasks:
+            asyncio.run(self.tasks.pop(0))
+
+
+class _RecordingAnalytics:
+    """Captures the one call ``_record_analytics`` makes."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    async def record_game(self, **kwargs: Any) -> None:
+        self.calls.append(kwargs)
+
+
+class _FakeBus:
+    def __init__(self) -> None:
+        self.fired: list[tuple[str, dict]] = []
+
+    def async_fire(self, event_type, data):  # noqa: ANN001
+        self.fired.append((event_type, dict(data)))
+
+
+class _FakeHass:
+    def __init__(self) -> None:
+        self.bus = _FakeBus()
+
+
+def _team_game(
+    tmp_path: Path,
+    runtime: _Runtime | None = None,
+    *,
+    category: str = "picture-round-en",
+) -> QuizifyGameState:
+    """Two teams of two plus one guest who joined none — three entrants."""
+    st = QuizifyGameState(
+        runtime=runtime or _Runtime(tmp_path), entry_id="test"
+    )
+    for name in ("Anna", "Jan", "Mira", "Tom", "Eva"):
+        st.add_player(name)
+    st.create_team("Sofa", "Anna")
+    st.join_team(st.get_team_of("Anna")["team_id"], "Jan")
+    st.create_team("Küche", "Mira")
+    st.join_team(st.get_team_of("Mira")["team_id"], "Tom")
+    st.start_game(
+        category=category, difficulty="easy", num_rounds=3, language="en"
+    )
+    st.start_next_question()
+    return st
+
+
+def _solo_game(tmp_path: Path, runtime: _Runtime | None = None) -> QuizifyGameState:
+    """The control: the same room with no teams at all."""
+    st = QuizifyGameState(
+        runtime=runtime or _Runtime(tmp_path), entry_id="test"
+    )
+    for name in ("Anna", "Jan", "Mira"):
+        st.add_player(name)
+    st.start_game(
+        category="picture-round-en", difficulty="easy", num_rounds=3, language="en"
+    )
+    st.start_next_question()
+    return st
+
+
+def _team(st: QuizifyGameState, name: str):  # noqa: ANN202
+    return next(t for t in st.team_registry.all_teams() if t.name == name)
+
+
+def _correct_index(st: QuizifyGameState) -> int:
+    question = st.get_current_question()
+    return next(i for i, a in enumerate(question.answers) if a.correct)
+
+
+# ---------------------------------------------------------------------------
+# 1. The shadow ledger is not written any more
+# ---------------------------------------------------------------------------
+
+
+def test_a_team_member_carries_no_personal_total(tmp_path: Path) -> None:
+    """The carrier scores for the team, not beside it."""
+    st = _team_game(tmp_path)
+    st.submit_answer("Anna", _correct_index(st))
+    st.evaluate_round()
+
+    assert _team(st, "Sofa").score > 0, "the team must have scored at all"
+    assert st.get_player("Anna").score == 0
+    assert st.get_player("Jan").score == 0
+
+
+def test_a_guest_who_joined_no_team_keeps_their_own_total(tmp_path: Path) -> None:
+    """A solo entrant in a team game is a participant, so their score is real.
+
+    This is the line the fix must not cross: ``get_ranked_participants`` gives
+    that guest a row of their own next to the teams (Markus, 2026-08-12), so
+    their own total *is* the room's truth about them.
+    """
+    st = _team_game(tmp_path)
+    st.submit_answer("Eva", _correct_index(st))
+    st.evaluate_round()
+
+    assert st.get_player("Eva").score > 0
+
+
+def test_solo_mode_still_scores_the_player(tmp_path: Path) -> None:
+    """The control: no teams, nothing changes."""
+    st = _solo_game(tmp_path)
+    st.submit_answer("Anna", _correct_index(st))
+    st.evaluate_round()
+
+    assert st.get_player("Anna").score > 0
+    assert st.get_player("Jan").score == 0  # never answered
+
+
+def test_the_estimate_path_keeps_the_same_rule(tmp_path: Path) -> None:
+    """The number-line round scores the team, not the member who dragged it.
+
+    ``_evaluate_estimate_round`` has its own ``player.score += points`` — the
+    twin of the multiple-choice one, and the twin of this bug.
+    """
+    st = _team_game(tmp_path, category="estimation-en")
+    answer = st.get_current_question().estimate_answer
+    st.submit_guess("Anna", answer)
+    st.submit_guess("Eva", answer)
+    st.evaluate_round()
+
+    assert _team(st, "Sofa").score > 0
+    assert st.get_player("Anna").score == 0, "the carrier keeps no shadow total"
+    assert st.get_player("Eva").score > 0, "the solo guest is her own entrant"
+
+
+# ---------------------------------------------------------------------------
+# 2. The readers now agree with the podium
+# ---------------------------------------------------------------------------
+
+
+def test_the_leader_is_the_winning_team(tmp_path: Path) -> None:
+    st = _team_game(tmp_path)
+    _team(st, "Sofa").score = 112
+    _team(st, "Küche").score = 40
+    st.get_player("Eva").score = 90
+
+    leader = st.leader
+    assert leader is not None
+    assert leader.name == "Sofa"
+    assert leader.score == 112
+
+
+def test_the_leader_can_still_be_a_solo_guest(tmp_path: Path) -> None:
+    """Teams do not automatically outrank the guest who joined none."""
+    st = _team_game(tmp_path)
+    _team(st, "Sofa").score = 40
+    st.get_player("Eva").score = 90
+
+    leader = st.leader
+    assert leader is not None
+    assert leader.name == "Eva"
+
+
+def test_the_leader_is_unchanged_in_solo_mode(tmp_path: Path) -> None:
+    st = _solo_game(tmp_path)
+    st.get_player("Anna").score = 10
+    st.get_player("Jan").score = 30
+
+    leader = st.leader
+    assert leader is not None
+    assert leader.name == "Jan"
+
+
+def test_an_empty_room_has_no_leader(tmp_path: Path) -> None:
+    st = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="test")
+    assert st.leader is None
+
+
+def test_analytics_records_the_teams_not_their_members(tmp_path: Path) -> None:
+    """What lands in analytics.json decides every downstream tally.
+
+    The all-time standings, the evening tally and the head-to-head all read
+    ``player_scores`` back out of this record, so a per-person map there is
+    what put "Tonight: Bert 2 wins" under a team podium.
+    """
+    runtime = _Runtime(tmp_path)
+    st = _team_game(tmp_path, runtime)
+    analytics = _RecordingAnalytics()
+    st.set_stats_services(analytics, None)
+
+    _team(st, "Sofa").score = 112
+    _team(st, "Küche").score = 40
+    st.get_player("Eva").score = 90
+    st.end_game()
+    runtime.drain()
+
+    assert len(analytics.calls) == 1
+    recorded = analytics.calls[0]["players"]
+    assert recorded == {"Sofa": 112, "Küche": 40, "Eva": 90}
+    assert "Anna" not in recorded and "Jan" not in recorded
+    # The details map has to be keyed the same way, or the all-time rollup
+    # would credit a best streak to a name that has no score row.
+    assert set(analytics.calls[0]["player_details"]) == set(recorded)
+
+
+def test_analytics_is_unchanged_in_solo_mode(tmp_path: Path) -> None:
+    runtime = _Runtime(tmp_path)
+    st = _solo_game(tmp_path, runtime)
+    analytics = _RecordingAnalytics()
+    st.set_stats_services(analytics, None)
+
+    st.get_player("Anna").score = 70
+    st.get_player("Jan").score = 30
+    st.end_game()
+    runtime.drain()
+
+    recorded = analytics.calls[0]["players"]
+    assert recorded == {"Anna": 70, "Jan": 30, "Mira": 0}
+
+
+def test_both_house_events_name_the_same_winner(tmp_path: Path) -> None:
+    """``quizify_winner_decided`` and ``quizify_game_ended``, one finale.
+
+    A blueprint may react to either. Before this they disagreed: the first
+    named a person off the shadow ledger, the second the team podium.
+    """
+    st = _team_game(tmp_path)
+    _team(st, "Sofa").score = 112
+    _team(st, "Küche").score = 40
+    st.get_player("Eva").score = 90
+
+    hass = _FakeHass()
+    emitter = QuizifyEventEmitter(hass=hass, game_state=st)
+    emitter.configure(enabled=True)
+
+    st.end_game()
+    emitter._on_state_changed()
+    emitter.notify_game_ended(st)
+
+    fired = dict(hass.bus.fired)
+    assert fired[EVENT_WINNER_DECIDED] == {"winner_name": "Sofa", "score": 112}
+    assert fired[EVENT_GAME_ENDED]["leaderboard"][0] == {
+        "name": "Sofa",
+        "score": 112,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 3. The guard: no new reader of a raw ``.score``
+# ---------------------------------------------------------------------------
+
+def _key(*parts: str) -> str:
+    """The identity of one ``.score`` read: file, enclosing scope, receiver."""
+    return "::".join(parts)
+
+
+_RMB = "server/round_message_builder.py"
+_SER = "server/serializers.py"
+
+#: Every ``<receiver>.score`` this code base is allowed to read outside the
+#: game layer, as ``file::enclosing scope::receiver``. Each entry is a
+#: participant — a row of ``get_ranked_participants()`` — and the note says who
+#: hands it over. A new entry means somebody found a further way to read a
+#: score; adding it here is the moment to check that what they read is a
+#: participant and not a person standing in for one.
+_ALLOWED_SCORE_READERS: dict[str, str] = {
+    _key(
+        "server/broadcasters.py",
+        "HotSeatBroadcaster",
+        "send_hot_seat_result",
+        "participant",
+    ): "the entrant a Hot Seat settlement paid (#804)",
+    _key(_RMB, "RoundMessageBuilder", "build_wager_window", "participant"): (
+        "the bank the final bet is staked against (#804)"
+    ),
+    _key(_RMB, "RoundMessageBuilder", "build_player_question", "participant"): (
+        "the total shown on the phone during a round (#835)"
+    ),
+    _key(
+        _RMB, "RoundMessageBuilder", "project_snapshot_for_player", "participant"
+    ): "the same total, restored after a reload (#835)",
+    _key(_SER, "serialize_leaderboard", "p"): (
+        "a row handed in by get_ranked_participants (#365)"
+    ),
+    _key(_SER, "serialize_player_list", "p"): (
+        "the lobby roster — people, deliberately. The score column reads 0 for "
+        "a team member because their points are the team's (#923)"
+    ),
+    _key(_SER, "build_share_payload", "p"): (
+        "the finale's shareable card, built from the standings (#369)"
+    ),
+    _key(_SER, "serialize_finale", "p"): (
+        "the podium, built from calculate_podium(participants) (#365)"
+    ),
+    _key("sensor.py", "QuizifyLeaderSensor", "extra_state_attributes", "leader"): (
+        "GameState.leader, a participant since #923"
+    ),
+    _key("sensor.py", "QuizifyTopScoreSensor", "native_value", "leader"): (
+        "GameState.leader, a participant since #923"
+    ),
+    _key("game_events.py", "QuizifyEventEmitter", "_on_state_changed", "leader"): (
+        "GameState.leader, a participant since #923"
+    ),
+    _key("game_events.py", "QuizifyEventEmitter", "notify_game_ended", "participant"): (
+        "a row of get_standings() (#747)"
+    ),
+    _key("tts.py", "QuizifyTTSAnnouncer", "_on_state_changed", "leader"): (
+        "GameState.leader, a participant since #923"
+    ),
+    _key("tts.py", "QuizifyTTSAnnouncer", "_announce_standings_fragment", "top[0]"): (
+        "the round's standings, participants since #747"
+    ),
+    _key("tts.py", "QuizifyTTSAnnouncer", "_announce_standings_fragment", "e"): (
+        "the same standings, scanned for a tie at the top (#747)"
+    ),
+}
+
+
+class _ScoreReadVisitor(ast.NodeVisitor):
+    """Collects ``<receiver>.score`` reads, keyed by file and enclosing scope."""
+
+    def __init__(self, rel: str, found: dict[str, list[int]]) -> None:
+        self._rel = rel
+        self._found = found
+        self._scope: list[str] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._scope.append(node.name)
+        self.generic_visit(node)
+        self._scope.pop()
+
+    visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore[assignment]
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._scope.append(node.name)
+        self.generic_visit(node)
+        self._scope.pop()
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if node.attr == "score":
+            key = "::".join([self._rel, *self._scope, ast.unparse(node.value)])
+            self._found.setdefault(key, []).append(node.lineno)
+        self.generic_visit(node)
+
+
+def _score_readers() -> dict[str, list[int]]:
+    """``file::scope::receiver`` -> line numbers, for the scanned modules."""
+    files = sorted(_CC.joinpath("server").glob("*.py"))
+    files += [
+        _CC / "sensor.py",
+        _CC / "game_events.py",
+        _CC / "analytics.py",
+        # The narrator too: it speaks the game-over winner off ``leader`` and
+        # the tie-at-the-top line off the standings, so it is a reader of the
+        # same truth even though the issue only listed the four above.
+        _CC / "tts.py",
+    ]
+
+    found: dict[str, list[int]] = {}
+    for path in files:
+        rel = path.relative_to(_CC).as_posix()
+        _ScoreReadVisitor(rel, found).visit(ast.parse(path.read_text("utf-8")))
+    return found
+
+
+def test_no_unknown_reader_of_a_raw_score() -> None:
+    """A new ``.score`` outside the game layer has to be declared here.
+
+    Five consumers of the shadow ledger were migrated one issue at a time
+    (#668, #800, #804, #835, #923) because nothing stopped a sixth from being
+    written. This is that stop: the failure message tells the author what to
+    check, and the allowlist above records the answer for the next reader.
+    """
+    unknown = sorted(
+        f"{key} (line{'s' if len(lines) > 1 else ''} "
+        f"{', '.join(str(n) for n in lines)})"
+        for key, lines in _score_readers().items()
+        if key not in _ALLOWED_SCORE_READERS
+    )
+    assert not unknown, (
+        "New `.score` read(s) outside the game layer:\n  "
+        + "\n  ".join(unknown)
+        + "\n\nIn team mode `PlayerSession.score` is not the room's truth — "
+        "`Team.score` is, via `get_ranked_participants()`. If the object above "
+        "is a participant (a team, or a player who joined no team), add it to "
+        "`_ALLOWED_SCORE_READERS` with a one-line note. If it is a person, "
+        "route it through `get_ranked_participant_for(name)` instead."
+    )
+
+
+def test_the_allowlist_has_no_dead_entries() -> None:
+    """An allowlist that outlives its readers stops documenting anything."""
+    found = _score_readers()
+    dead = sorted(key for key in _ALLOWED_SCORE_READERS if key not in found)
+    assert not dead, f"Allowlisted `.score` readers that no longer exist: {dead}"
+
+
+@pytest.mark.parametrize("module", ["analytics.py"])
+def test_the_analytics_module_reads_no_score_attribute(module: str) -> None:
+    """Analytics sees names and numbers, never a domain object (#923).
+
+    ``_record_analytics`` narrows participants to ``{name: score}`` on purpose,
+    so that the module can evolve without learning what a team is. An
+    attribute read here would mean that boundary moved.
+    """
+    keys = [k for k in _score_readers() if k.startswith(f"{module}::")]
+    assert keys == []


### PR DESCRIPTION
Closes #923

## The defect

In team mode the game kept **two** score ledgers. `Team.score` is the one every screen shows, via `get_ranked_participants()`. But `submit_answer` also ran `player.score += points` while `_settling_team` was set, so `PlayerSession.score` accumulated a value that is 0 for every member except whoever carried that round — and that no screen renders.

Three readers outside the game layer consumed that shadow ledger, and each one disagreed with the podium sitting right next to it:

- **`_record_analytics`** — the all-time standings, the evening tally (#612), the end-screen head-to-head (#613) and the season standing pushed to each phone (#624) are all built from what it writes. Observed on v1.17.0-RC1: team Sofa won with 112 points and the end screen underneath read *"Tonight: Bert 2 wins · Dora 1 win"* and *"Head to head: Anna 13 – 6 Cleo"* — person names for a game a team won.
- **`GameState.leader`** — the `leader` and `top_score` sensors, plus the TTS game-over line.
- **`quizify_winner_decided`** — a person's name on the HA bus for a finale that `quizify_game_ended` reported as a team podium. Two events, one game, two answers to "who won".

This is the fourth and fifth reader of a defect class the project has paid for one consumer at a time (#668 wager, #800 reaction bonus, #804 hot seat, #835 live leaderboard). Each of those migrated its own reader and left the ledger standing. This PR closes the source instead.

## What changed

**Stop writing the shadow total.** `submit_answer` and `_evaluate_estimate_round` only add to `player.score` when the player keeps a row of their own — that is solo mode, and the guest who joined no team in a team game. The new `_keeps_own_score()` is the inverse question of `get_ranked_participants()`: that one says who the ranking is about, this one says whose `score` field is part of it. `round_score` is untouched — it is what the carrier hands back to `_credit_team_round`, and the reveal reports it as this round's points.

**Route the readers through the ranking.** `GameState.leader` is now the top of `get_ranked_participants()`, so it can be a team; solo mode returns exactly the same player for exactly the same ties. `_record_analytics` writes participants, and `Team` gained the `streak_milestones_hit` counter the all-time rollup expects from an entrant (it already had `max_streak`). `_dispatch_all_time_standings` looks each phone's standing up under the *entrant's* name — in team mode the game is recorded under the team, so asking for the member's own name found nothing and the phone showed no line at all.

**A guard, so there is no sixth reader.** `test_no_unknown_reader_of_a_raw_score` walks the AST of `server/`, `sensor.py`, `game_events.py`, `analytics.py` and `tts.py`, collects every `<receiver>.score` read keyed by file, enclosing scope and receiver, and fails on anything not on a named allowlist. Each allowlist entry is a participant, with a one-line note saying who hands it over; the failure message tells the author what to check. `test_the_allowlist_has_no_dead_entries` fails when an entry outlives its reader, so the list cannot rot into decoration.

## Tests

`tests/test_team_shadow_score_923.py`, 14 tests. Solo mode is the control throughout, and the guest who joined no team is asserted to keep their own total — that is the line the fix must not cross.

Reverting only the production diff and re-running the file fails five of them:

```
tests/test_team_shadow_score_923.py:162: AssertionError: assert 16 == 0
tests/test_team_shadow_score_923.py:203: AssertionError: the carrier keeps no shadow total
tests/test_team_shadow_score_923.py:220: AssertionError: assert 'Eva' == 'Sofa'
tests/test_team_shadow_score_923.py:270: AssertionError: assert {'Anna': 0, '...Mira': 0, ...} == {'Eva': 90, '..., 'Sofa': 112}
tests/test_team_shadow_score_923.py:312: AssertionError: assert {'score': 90,..._name': 'Eva'} == {'score': 112...name': 'Sofa'}

FAILED test_a_team_member_carries_no_personal_total
FAILED test_the_estimate_path_keeps_the_same_rule
FAILED test_the_leader_is_the_winning_team
FAILED test_analytics_records_the_teams_not_their_members
FAILED test_both_house_events_name_the_same_winner
5 failed, 9 passed
```

Two existing tests were updated rather than worked around. `test_team_scoring_365.py` used to assert *"exactly one member carries the team's points"* — that assertion **was** the shadow ledger, so it now asserts both members are at 0. `test_end_screen_standing_624.py` asserted the literal `self._all_time_standing(player.name)`; the lookup key changed, the one-send-per-phone rule it actually guards did not.

Full suite: **4002 passed**. `mypy`: clean, 61 source files. `ruff check .`: 213 findings, unchanged from the baseline on `main` — the only finding in a touched file (`F401 GamePhase` in `test_team_scoring_365.py`) is pre-existing and left alone.

## Not fixed here

`serialize_player_list` still carries a `score` field per person, which now reads 0 for a team member. It is inert — no frontend file reads `players[].score`; the reveal and lobby draw their numbers from the `leaderboard` payload built from participants. It is allowlisted with that note rather than removed, since dropping a wire field is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TaxQuikD1LKQmoJTphvkWV