### PR TITLE
test: wait on the flush task, not a fixed sleep (#918)

### DIFF
--- a/tests/test_answer_progress_619.py
+++ b/tests/test_answer_progress_619.py
@@ -116,6 +116,36 @@ def test_the_payload_carries_no_scores(game: QuizifyGameState) -> None:
 # --- coalescing ------------------------------------------------------------
 
 
+async def _flush(handler: QuizifyWebSocketHandler) -> None:
+    """Wait for the flush the handler has already armed — nothing else (#918).
+
+    These tests used to sleep four flush windows and then read whatever had
+    landed. That is a race, not a wait: the window only starts ticking when
+    the flush task takes its first step, which is one loop iteration *after*
+    the test suspends. Any stall in between — a loaded machine, a GC pause,
+    the OS descheduling a full-suite run — pushes the flush's own deadline
+    past the test's fixed sleep, the assertion finds no frame at all, and the
+    test fails for a reason that has nothing to do with the code it guards.
+
+    Awaiting the task removes the clock from the assertion entirely: the test
+    resumes when the flush has actually broadcast, however long that took. It
+    also stops swallowing failures — an exception inside the flush used to go
+    to ``_log_task_exception`` and show up here as a merely absent frame.
+    """
+    task = handler._progress_flush_task
+    assert task is not None, "no flush armed — _mark_progress_dirty did nothing"
+    await task
+
+
+def _progress_frames(handler: QuizifyWebSocketHandler) -> list[dict]:
+    """Every ``answer_progress`` frame the handler has broadcast so far."""
+    return [
+        call.args[0]
+        for call in handler._conn.broadcast.call_args_list
+        if call.args and call.args[0].get("type") == "answer_progress"
+    ]
+
+
 @pytest.mark.asyncio
 async def test_a_tap_storm_is_one_broadcast(
     handler: QuizifyWebSocketHandler, game: QuizifyGameState
@@ -126,15 +156,13 @@ async def test_a_tap_storm_is_one_broadcast(
 
     for _ in range(5):
         handler._mark_progress_dirty()
-    await asyncio.sleep(handler._REACTION_FLUSH_WINDOW * 4)
+    await _flush(handler)
 
-    progress_frames = [
-        call.args[0]
-        for call in handler._conn.broadcast.call_args_list
-        if call.args and call.args[0].get("type") == "answer_progress"
-    ]
-    assert len(progress_frames) == 1
-    assert progress_frames[0]["total"] == 5
+    assert len(_progress_frames(handler)) == 1
+    assert _progress_frames(handler)[0]["total"] == 5
+    # No tail re-arm: the flush drained everything the storm marked, so the
+    # single frame above is the whole story and not just the first of two.
+    assert handler._progress_dirty is False
 
 
 @pytest.mark.asyncio
@@ -152,14 +180,9 @@ async def test_the_frame_reflects_the_room_at_flush_time(
     handler._mark_progress_dirty()
     game.get_player("Anna").submit_answer(0, 0.0)
     game.get_player("Ben").submit_answer(1, 0.0)
-    await asyncio.sleep(handler._REACTION_FLUSH_WINDOW * 4)
+    await _flush(handler)
 
-    frame = next(
-        call.args[0]
-        for call in handler._conn.broadcast.call_args_list
-        if call.args and call.args[0].get("type") == "answer_progress"
-    )
-    assert frame["submitted"] == 2
+    assert _progress_frames(handler)[0]["submitted"] == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

`test_the_frame_reflects_the_room_at_flush_time` (and its sibling
`test_a_tap_storm_is_one_broadcast`) slept a fixed `_REACTION_FLUSH_WINDOW * 4`
and then read whatever broadcast frames had landed by then. That waits on
**time**, not on **state**: the flush window only starts ticking once
`_flush_progress_after_window()` takes its first scheduling step — one loop
iteration after the test suspends. Under contention (a loaded machine, a GC
pause, a full-suite run with many other tests/fixtures competing for the
loop), that first step can be delayed enough that the flush's own deadline
lands *after* the test's fixed sleep already elapsed, so the assertion finds
no `answer_progress` frame at all and fails for a reason that has nothing to
do with the flush path it's supposed to guard (see #918).

## Fix

Added a `_flush(handler)` helper that awaits `handler._progress_flush_task`
directly instead of sleeping a fixed duration. The test now resumes exactly
when the flush has actually broadcast, however long that took, and stops
swallowing exceptions raised inside the flush coroutine (previously those
only surfaced through `_log_task_exception` and showed up here as a merely
absent frame).

Also extracted the frame-filtering list comprehension — duplicated across
both async tests — into a shared `_progress_frames(handler)` helper, and
`test_a_tap_storm_is_one_broadcast` now additionally asserts
`handler._progress_dirty is False` after the flush, confirming the coalescing
storm didn't leave a tail re-arm pending.

No production code changed — this is a test-only fix.

## Proof of the race

Reverted the fix locally (`git apply -R` on the diff, never `git stash`) and
ran the pre-fix `test_the_frame_reflects_the_room_at_flush_time` **20-way in
parallel** under heavy CPU load (multiple `yes` processes pinning all cores):

```
pass=19 fail=1
```

The one failure was exactly the predicted failure mode:

```
RuntimeError: coroutine raised StopIteration
```

— the old `next(...)` generator found no `answer_progress` frame yet (PEP 479
turns an uncaught `StopIteration` inside a coroutine into a `RuntimeError`).

Re-applied the fix and reran the identical 20-way parallel stress:

```
pass=20 fail=0
```

Also ran the fixed test file 30-way parallel under the same load: `pass=30
fail=0`, and 20 further serial runs with no added load: `pass=20 fail=0`.

## Full suite / lint

- `pytest -q` (full suite): **3988 passed**
- `ruff check tests/test_answer_progress_619.py`: clean
- `ruff check .`: 213 pre-existing errors elsewhere in the repo (baseline,
  unrelated to this change — `ruff` in the venv is 0.15.17 vs the
  `requirements_lint.txt`-pinned 0.16.6, and the repo isn't format-clean per
  `CLAUDE.md`)
- `mypy`: same pre-existing error classes on this file as before the change
  (13 vs 14 before — one fewer, since the two duplicated frame-filter
  comprehensions collapsed into one shared helper)

Closes #918

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TaxQuikD1LKQmoJTphvkWV