### PR TITLE
Fill the season window with holiday packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ No apps to download. No accounts to create. Just scan a QR code and play.
 
 **Works on Any Screen** — Dashboard mode for the TV. Players use their phones. Admin runs the show. No extra hardware needed.
 
-**Twelve Themes, Three Languages** — 4,740 questions across 36 themed packs (Geography, Pop Culture, Animals & Nature, Sport, Music, Science, History, Food & Drink, Technology, World Cup, Estimation, Picture Round) in German, English and Spanish. Mix them, filter them, swap mid-session.
+**Fourteen Themes, Three Languages** — 5,343 questions across 42 themed packs (Geography, Pop Culture, Animals & Nature, Sport, Music, Science, History, Food & Drink, Technology, World Cup, Estimation, Picture Round, Christmas, New Year's Eve) in German, English and Spanish. Mix them, filter them, swap mid-session.
 
 ---
 
@@ -318,7 +318,7 @@ Then **"Start New Game"** (same settings, same players) or **Reset Game** (fresh
 
 ## Question Packs
 
-Quizify ships with **4,740 questions across 36 themed packs in 12 themes**, in German, English and Spanish.
+Quizify ships with **5,343 questions across 42 themed packs in 14 themes**, in German, English and Spanish.
 
 | Theme | 🇩🇪 Deutsch | 🇬🇧 English | 🇪🇸 Español |
 |-------|-------------|-------------|-------------|
@@ -334,8 +334,12 @@ Quizify ships with **4,740 questions across 36 themed packs in 12 themes**, in G
 | 🏆 **Weltmeisterschaft / World Cup / Copa Mundial** | 109 | 110 | 111 |
 | 🎯 **Schätzfragen / Estimation / Estimación** | 15 | 15 | 15 |
 | 🖼️ **Bilderrätsel / Picture Round / Ronda de Imágenes** | 17 | 17 | 17 |
+| 🎄 **Weihnachten / Christmas / Navidad** | 101 | 101 | 101 |
+| 🎆 **Silvester / New Year's Eve / Nochevieja** | 100 | 100 | 100 |
 
-Spanish arrived in 1.3.0, reached every written theme in 1.9.0 and was completed in 1.10.0 — every row in the table above ships in all three languages, World Cup, Estimation and Picture Round included. The Estimation packs hold slider questions rather than multiple choice — see [How to Play](#the-experience); every themed pack now carries five slider questions of its own (#566) on top of its written ones.
+Spanish arrived in 1.3.0, reached every written theme in 1.9.0 and was completed in 1.10.0 — every row in the table above ships in all three languages, World Cup, Estimation, Picture Round and the two holiday packs included. The Estimation packs hold slider questions rather than multiple choice — see [How to Play](#the-experience); every themed pack now carries five slider questions of its own (#566) on top of its written ones.
+
+Two of the rows only show up when they are due. The **Christmas** packs carry a season window from 1 to 26 December and the **New Year's Eve** packs one from 27 December to 6 January; inside its window a seasonal pack is pinned as the featured pack on the setup screen and its card in the picker gets a badge. Outside it, the pack is still selectable like any other — it simply stops asking for attention. The World Cup packs use the same mechanism for June and July.
 
 Pack selection lives on the **first screen**: a featured pack card (e.g. World Cup) up top, with every other pack as a tappable chip right beneath it — tap to select or deselect, mix several, then hit **Start Game**. Game settings (difficulty, rounds, timer) stay one tap away under **Adjust settings**. **Mixed mode** drops you a random question from every selected pack, so you can stir Geography + Pop + Sport together for chaos mode.
 

--- a/custom_components/quizify/questions/christmas-en.json
+++ b/custom_components/quizify/questions/christmas-en.json
@@ -1,0 +1,2089 @@
+{
+  "name": "Christmas",
+  "language": "en",
+  "version": "1.0",
+  "theme": "trivia",
+  "season": {
+    "start": "12-01",
+    "end": "12-26",
+    "label": "🎄 Christmas season"
+  },
+  "questions": [
+    {
+      "id": "christmas_en_001",
+      "question": "Which company's advertising fixed the modern image of the plump, jolly Santa from 1931 onwards?",
+      "answers": [
+        {
+          "text": "Coca-Cola",
+          "correct": true
+        },
+        {
+          "text": "Pepsi",
+          "correct": false
+        },
+        {
+          "text": "Nestlé",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The red suit predates the campaign — illustrator Haddon Sundblom standardised the look rather than inventing it.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_002",
+      "question": "Who commissioned Rudolph the reindeer in 1939?",
+      "answers": [
+        {
+          "text": "A US department store",
+          "correct": true
+        },
+        {
+          "text": "A Disney film studio",
+          "correct": false
+        },
+        {
+          "text": "A cigarette brand",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Robert L. May wrote the rhyming story as a giveaway booklet for the Montgomery Ward chain.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_003",
+      "question": "Why has the North American air-defence command NORAD tracked Santa every year since 1955?",
+      "answers": [
+        {
+          "text": "Because of a misprinted telephone number",
+          "correct": true
+        },
+        {
+          "text": "Because two generals made a bet",
+          "correct": false
+        },
+        {
+          "text": "Because of a cinema film",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "A store advertisement printed a command centre's number instead of the Santa hotline, and the duty officer played along.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_004",
+      "question": "Which holiday was the song 'Jingle Bells' originally written for?",
+      "answers": [
+        {
+          "text": "Thanksgiving",
+          "correct": true
+        },
+        {
+          "text": "Easter",
+          "correct": false
+        },
+        {
+          "text": "Independence Day",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "James Lord Pierpont published it in 1857 as 'One Horse Open Sleigh' — a winter song with no Christmas content at all.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_005",
+      "question": "Which song was the first ever broadcast to Earth from space?",
+      "answers": [
+        {
+          "text": "Jingle Bells",
+          "correct": true
+        },
+        {
+          "text": "Silent Night",
+          "correct": false
+        },
+        {
+          "text": "White Christmas",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "In December 1965 the Gemini 6 crew first reported an 'unidentified object', then produced a harmonica and sleigh bells.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_006",
+      "question": "Which instrument accompanied the first performance of 'Silent Night'?",
+      "answers": [
+        {
+          "text": "A guitar",
+          "correct": true
+        },
+        {
+          "text": "An organ",
+          "correct": false
+        },
+        {
+          "text": "A harp",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Why the organ stayed silent is unclear; the story about mice in the bellows was invented much later.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_007",
+      "question": "Which Christmas recording is regarded as the best-selling single of all time?",
+      "answers": [
+        {
+          "text": "'White Christmas' by Bing Crosby",
+          "correct": true
+        },
+        {
+          "text": "'Last Christmas' by Wham!",
+          "correct": false
+        },
+        {
+          "text": "'Feliz Navidad' by José Feliciano",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Estimates run past 50 million copies sold; no other single comes close.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_008",
+      "question": "How long did it take Wham!'s 'Last Christmas' to reach number one in the UK charts?",
+      "answers": [
+        {
+          "text": "More than 35 years",
+          "correct": true
+        },
+        {
+          "text": "Two weeks",
+          "correct": false
+        },
+        {
+          "text": "It went straight to number one",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "In 1984 the charity single 'Do They Know It's Christmas?' blocked the top spot; the song finally got there in early 2021.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_009",
+      "question": "How long did Mariah Carey and Walter Afanasieff reportedly take to write 'All I Want for Christmas Is You'?",
+      "answers": [
+        {
+          "text": "About a quarter of an hour",
+          "correct": true
+        },
+        {
+          "text": "About half a year",
+          "correct": false
+        },
+        {
+          "text": "About three weeks",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The two still tell the story differently; the only point they agree on is that it happened very fast.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_010",
+      "question": "What is the poinsettia named after?",
+      "answers": [
+        {
+          "text": "A US ambassador to Mexico",
+          "correct": true
+        },
+        {
+          "text": "An English gardener",
+          "correct": false
+        },
+        {
+          "text": "A saint",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Joel Roberts Poinsett sent the plant home from Mexico to the United States in the 1820s.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_011",
+      "question": "Which statement about the poinsettia as a houseplant is true?",
+      "answers": [
+        {
+          "text": "It is not deadly poisonous to humans",
+          "correct": true
+        },
+        {
+          "text": "One leaf can kill a child",
+          "correct": false
+        },
+        {
+          "text": "Its sap is a powerful nerve poison",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The milky sap irritates skin and stomach and nothing more; the killer reputation traces back to one unverified case from 1919.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_012",
+      "question": "How does mistletoe feed itself?",
+      "answers": [
+        {
+          "text": "It taps its host tree and also photosynthesises",
+          "correct": true
+        },
+        {
+          "text": "It lives on rainwater alone",
+          "correct": false
+        },
+        {
+          "text": "It feeds on insects",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "As a hemiparasite it draws water and minerals from the tree but makes its own sugar.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_013",
+      "question": "Why is there a good case that the reindeer pulling the sleigh are female?",
+      "answers": [
+        {
+          "text": "Males shed their antlers before winter",
+          "correct": true
+        },
+        {
+          "text": "Males cannot travel as far",
+          "correct": false
+        },
+        {
+          "text": "Males hibernate",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Female reindeer keep their antlers into spring, so in December almost the only reindeer wearing antlers are cows.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_014",
+      "question": "What happens to reindeer eyes in the Arctic winter?",
+      "answers": [
+        {
+          "text": "The reflective layer behind the retina turns from gold to blue",
+          "correct": true
+        },
+        {
+          "text": "They go temporarily blind",
+          "correct": false
+        },
+        {
+          "text": "They grow a third eyelid",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "The blue version scatters more light inside the eye, making the animals more sensitive during the polar night.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_015",
+      "question": "Where does the big Christmas tree on London's Trafalgar Square come from?",
+      "answers": [
+        {
+          "text": "It is an annual gift from Oslo",
+          "correct": true
+        },
+        {
+          "text": "It is grown on a plantation in Wales",
+          "correct": false
+        },
+        {
+          "text": "It is auctioned off anew each year",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Norway has sent one every year since 1947 as thanks for British support during the Second World War.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_016",
+      "question": "Who had the first commercial Christmas card printed in 1843?",
+      "answers": [
+        {
+          "text": "Henry Cole in London",
+          "correct": true
+        },
+        {
+          "text": "Queen Victoria",
+          "correct": false
+        },
+        {
+          "text": "Charles Dickens",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Cole simply had too much correspondence, so he printed a thousand cards and sold them at a shilling each.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_017",
+      "question": "How long did Charles Dickens take to write 'A Christmas Carol'?",
+      "answers": [
+        {
+          "text": "About six weeks",
+          "correct": true
+        },
+        {
+          "text": "About four years",
+          "correct": false
+        },
+        {
+          "text": "About eight months",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "He wrote it in 1843 while short of money and published it at his own expense; it sold out within days.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_018",
+      "question": "What happened to Christmas in England under Oliver Cromwell?",
+      "answers": [
+        {
+          "text": "Parliament banned the festival outright",
+          "correct": true
+        },
+        {
+          "text": "It was moved to 1 January",
+          "correct": false
+        },
+        {
+          "text": "It was raised to a state holiday",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "In 1647 the Puritans abolished it as unbiblical, and several towns rioted in response.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_019",
+      "question": "When did Christmas become a federal public holiday in the United States?",
+      "answers": [
+        {
+          "text": "1870",
+          "correct": true
+        },
+        {
+          "text": "1776",
+          "correct": false
+        },
+        {
+          "text": "1935",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Until then 25 December was an ordinary working day in several states.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_020",
+      "question": "Who invented the Advent wreath in 1839?",
+      "answers": [
+        {
+          "text": "The Hamburg educator Johann Hinrich Wichern",
+          "correct": true
+        },
+        {
+          "text": "Martin Luther",
+          "correct": false
+        },
+        {
+          "text": "A canon of Cologne cathedral",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Wichern hung a cartwheel of candles in his children's home so the children could count down the wait.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_021",
+      "question": "In which country was the printed Advent calendar invented?",
+      "answers": [
+        {
+          "text": "Germany",
+          "correct": true
+        },
+        {
+          "text": "England",
+          "correct": false
+        },
+        {
+          "text": "The Netherlands",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Gerhard Lang sold the first printed cut-out sheets around 1904; the little doors came later.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_022",
+      "question": "What does the X in 'Xmas' stand for?",
+      "answers": [
+        {
+          "text": "The Greek letter Chi",
+          "correct": true
+        },
+        {
+          "text": "A crossed-out cross",
+          "correct": false
+        },
+        {
+          "text": "The Roman numeral ten",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Chi is the first letter of Christós; the abbreviation is centuries old rather than a modern shortcut.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_023",
+      "question": "How did Christmas Island in the Indian Ocean get its name?",
+      "answers": [
+        {
+          "text": "A captain passed it on Christmas Day 1643",
+          "correct": true
+        },
+        {
+          "text": "A nativity scene was found there",
+          "correct": false
+        },
+        {
+          "text": "It is shaped like a star",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "William Mynors sailed by and simply entered the date as the name.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_024",
+      "question": "Which meal counts as the classic Christmas dinner in Japan?",
+      "answers": [
+        {
+          "text": "Fried chicken from a fast-food chain",
+          "correct": true
+        },
+        {
+          "text": "Grilled eel",
+          "correct": false
+        },
+        {
+          "text": "Duck in orange sauce",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "A 1974 advertising campaign built around the slogan 'Kentucky for Christmas' hardened into a tradition.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_025",
+      "question": "What is the typical Christmas cake in Japan?",
+      "answers": [
+        {
+          "text": "A sponge cake with cream and strawberries",
+          "correct": true
+        },
+        {
+          "text": "A dark fruit cake",
+          "correct": false
+        },
+        {
+          "text": "A layered cake with marzipan",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Red and white like the national colours; the cake sells on 24 December and almost nowhere after that.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_026",
+      "question": "What do millions of Swedes traditionally watch at 3 p.m. on 24 December?",
+      "answers": [
+        {
+          "text": "A Donald Duck programme",
+          "correct": true
+        },
+        {
+          "text": "The king's speech",
+          "correct": false
+        },
+        {
+          "text": "An ice hockey match",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "'Kalle Anka' has run almost unchanged since 1959, and attempts to move it have caused public outrage.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_027",
+      "question": "What is put up on the main square of Gävle, Sweden, every Advent?",
+      "answers": [
+        {
+          "text": "A giant goat made of straw",
+          "correct": true
+        },
+        {
+          "text": "A polar bear carved from ice",
+          "correct": false
+        },
+        {
+          "text": "A tower of gingerbread",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The goat has been erected since 1966 and has been set on fire dozens of times.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_028",
+      "question": "What do Norwegians traditionally hide on Christmas Eve?",
+      "answers": [
+        {
+          "text": "The brooms",
+          "correct": true
+        },
+        {
+          "text": "The shoes",
+          "correct": false
+        },
+        {
+          "text": "The keys",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Old belief held that witches are abroad that night looking for something to ride.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_029",
+      "question": "How many Yule Lads visit Icelandic children in the nights before Christmas?",
+      "answers": [
+        {
+          "text": "Thirteen",
+          "correct": true
+        },
+        {
+          "text": "Three",
+          "correct": false
+        },
+        {
+          "text": "Seven",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Each has his own quirk: one steals skyr, one licks spoons, one slams doors.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_030",
+      "question": "What does the Icelandic 'Jólabókaflóð' refer to?",
+      "answers": [
+        {
+          "text": "The flood of books before Christmas",
+          "correct": true
+        },
+        {
+          "text": "A December tidal wave",
+          "correct": false
+        },
+        {
+          "text": "Fireworks on Christmas Eve",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Books are the classic gift, and the evening of the 24th belongs to reading with chocolate.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_031",
+      "question": "What is the Catalan 'Caga Tió'?",
+      "answers": [
+        {
+          "text": "A log that produces presents",
+          "correct": true
+        },
+        {
+          "text": "A nativity figure with a lantern",
+          "correct": false
+        },
+        {
+          "text": "A Christmas pastry",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Children feed the painted log for weeks, then beat it with sticks on 24 December until sweets fall out.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_032",
+      "question": "Which figure traditionally belongs in a corner of a Catalan nativity scene?",
+      "answers": [
+        {
+          "text": "A crouching man with his trousers down",
+          "correct": true
+        },
+        {
+          "text": "A fisherman with a net",
+          "correct": false
+        },
+        {
+          "text": "A mountaineer",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "The 'Caganer' symbolically fertilises the soil and is considered a good omen for the coming year.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_033",
+      "question": "Which Christmas tree decoration is considered lucky in Ukraine?",
+      "answers": [
+        {
+          "text": "Spider webs",
+          "correct": true
+        },
+        {
+          "text": "Salt crystals",
+          "correct": false
+        },
+        {
+          "text": "Dried chilli pods",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "A legend tells of a poor widow whose bare tree was decorated overnight by spiders.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_034",
+      "question": "How do many worshippers in Caracas get to early Mass on Christmas morning?",
+      "answers": [
+        {
+          "text": "On roller skates",
+          "correct": true
+        },
+        {
+          "text": "On donkeys",
+          "correct": false
+        },
+        {
+          "text": "Barefoot and in step",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Some neighbourhoods close streets to traffic for the 'Misa de Aguinaldo'.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_035",
+      "question": "Which frightening figure accompanies St Nicholas in the Alpine countries?",
+      "answers": [
+        {
+          "text": "The Krampus",
+          "correct": true
+        },
+        {
+          "text": "The goblin Puck",
+          "correct": false
+        },
+        {
+          "text": "Father Frost",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "On 5 December whole Krampus runs move through Alpine towns in fur, horns and cowbells.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_036",
+      "question": "From which country does the Dutch Sinterklaas arrive by steamboat each year, according to tradition?",
+      "answers": [
+        {
+          "text": "Spain",
+          "correct": true
+        },
+        {
+          "text": "Norway",
+          "correct": false
+        },
+        {
+          "text": "Iceland",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "His November arrival is broadcast live across the country, and he brings presents on 5 December.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_037",
+      "question": "What has been proclaimed in Turku, Finland, at noon on 24 December since the Middle Ages?",
+      "answers": [
+        {
+          "text": "The Christmas Peace",
+          "correct": true
+        },
+        {
+          "text": "The end of the fishing season",
+          "correct": false
+        },
+        {
+          "text": "The new royal name",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "The reading is broadcast on radio and counts as one of the country's oldest unbroken traditions.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_038",
+      "question": "Where, according to Finnish tradition, is Santa's workshop?",
+      "answers": [
+        {
+          "text": "On the Korvatunturi fell in Lapland",
+          "correct": true
+        },
+        {
+          "text": "On Svalbard",
+          "correct": false
+        },
+        {
+          "text": "On an island off Helsinki",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The fell is shaped like a pair of ears, which is how Santa is said to hear every child's wish.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_039",
+      "question": "Which postal code has Canada Post assigned to Santa Claus?",
+      "answers": [
+        {
+          "text": "H0H 0H0",
+          "correct": true
+        },
+        {
+          "text": "X0X 0X0",
+          "correct": false
+        },
+        {
+          "text": "N0E 0L0",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Volunteers answer millions of letters every year, each in the language the child wrote in.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_040",
+      "question": "In which region did the historical bishop Nicholas, the origin of St Nicholas Day, actually live?",
+      "answers": [
+        {
+          "text": "Myra, in present-day Turkey",
+          "correct": true
+        },
+        {
+          "text": "Northern Sweden",
+          "correct": false
+        },
+        {
+          "text": "Sicily",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "His bones were taken to Bari in 1087 and remain there today.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_041",
+      "question": "Who promoted the Christ Child as the gift-bringer in German-speaking countries?",
+      "answers": [
+        {
+          "text": "Martin Luther",
+          "correct": true
+        },
+        {
+          "text": "Emperor Charles V",
+          "correct": false
+        },
+        {
+          "text": "The Brothers Grimm",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Luther wanted to push back the cult of saints; ironically it was Catholic regions that later held on to the Christkind longest.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_042",
+      "question": "Who plays the Nuremberg Christkind at the city's Christmas market?",
+      "answers": [
+        {
+          "text": "A young woman elected every two years",
+          "correct": true
+        },
+        {
+          "text": "A child from the cathedral school",
+          "correct": false
+        },
+        {
+          "text": "A puppet on a crane",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Applicants must live in Nuremberg, be at least 1.60 metres tall and have a head for heights.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_043",
+      "question": "Since when is Dresden's Striezelmarkt documented?",
+      "answers": [
+        {
+          "text": "Since 1434",
+          "correct": true
+        },
+        {
+          "text": "Since 1834",
+          "correct": false
+        },
+        {
+          "text": "Since 1634",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "It began as a one-day meat market before the feast, which makes it one of the oldest Christmas markets anywhere.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_044",
+      "question": "Which German region produces the classic nutcracker and incense-smoker figures?",
+      "answers": [
+        {
+          "text": "The Ore Mountains",
+          "correct": true
+        },
+        {
+          "text": "The Black Forest",
+          "correct": false
+        },
+        {
+          "text": "East Frisia",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "When mining declined whole villages lived from carving, which is why the nutcracker so often wears a uniform.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_045",
+      "question": "How was Tchaikovsky's ballet 'The Nutcracker' received at its 1892 premiere?",
+      "answers": [
+        {
+          "text": "Coolly, mostly negatively",
+          "correct": true
+        },
+        {
+          "text": "As an instant triumph",
+          "correct": false
+        },
+        {
+          "text": "It was abandoned after the first act",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Critics found the plot thin and the children's roles odd; it only became a Christmas fixture decades later.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_046",
+      "question": "How many parts does Johann Sebastian Bach's Christmas Oratorio have?",
+      "answers": [
+        {
+          "text": "Six",
+          "correct": true
+        },
+        {
+          "text": "Three",
+          "correct": false
+        },
+        {
+          "text": "Twelve",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "The parts were written for six separate services between 25 December 1734 and 6 January 1735.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_047",
+      "question": "At which time of year was Handel's 'Messiah' first performed?",
+      "answers": [
+        {
+          "text": "In spring, shortly before Easter",
+          "correct": true
+        },
+        {
+          "text": "On Christmas Day",
+          "correct": false
+        },
+        {
+          "text": "In midsummer",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "The premiere was in Dublin in April 1742; only later did the work drift into the Christmas season.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_048",
+      "question": "What happened along parts of the Western Front at Christmas 1914?",
+      "answers": [
+        {
+          "text": "Soldiers from both sides left the trenches and celebrated together",
+          "correct": true
+        },
+        {
+          "text": "The war was officially suspended for two days",
+          "correct": false
+        },
+        {
+          "text": "A record battle was fought",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "There was singing, cigarettes and in places football; high commands forbade any repeat in later years.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_049",
+      "question": "Who put up the first electrically lit Christmas tree in 1882?",
+      "answers": [
+        {
+          "text": "A colleague of Thomas Edison",
+          "correct": true
+        },
+        {
+          "text": "Nikola Tesla",
+          "correct": false
+        },
+        {
+          "text": "Werner von Siemens",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Edward H. Johnson had 80 red, white and blue bulbs hand-wired and set the tree rotating as well.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_050",
+      "question": "What was tinsel originally made of?",
+      "answers": [
+        {
+          "text": "Thinly beaten silver",
+          "correct": true
+        },
+        {
+          "text": "Dyed paper",
+          "correct": false
+        },
+        {
+          "text": "Fish scales",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Nuremberg craftsmen were beating it from around 1610; it tarnished over time and had to be replaced.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_051",
+      "question": "Where did the making of glass Christmas baubles begin?",
+      "answers": [
+        {
+          "text": "Lauscha in Thuringia",
+          "correct": true
+        },
+        {
+          "text": "Murano near Venice",
+          "correct": false
+        },
+        {
+          "text": "Karlsbad",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Legend says a glassblower could not afford apples and nuts for his tree, so he blew himself some out of glass.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_052",
+      "question": "What did English mince pies originally contain?",
+      "answers": [
+        {
+          "text": "Actual meat",
+          "correct": true
+        },
+        {
+          "text": "Nothing but honey",
+          "correct": false
+        },
+        {
+          "text": "Ground shells",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Minced meat, suet and dried fruit together were a preserving trick; the meat only vanished in the 19th century.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_053",
+      "question": "What is the British 'Stir-up Sunday'?",
+      "answers": [
+        {
+          "text": "The Sunday the Christmas pudding is mixed",
+          "correct": true
+        },
+        {
+          "text": "The first Sunday of Advent",
+          "correct": false
+        },
+        {
+          "text": "Christmas tree auction day",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Every family member stirs once, clockwise, and makes a wish while doing it.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_054",
+      "question": "Which drink outsells cola in Sweden at Christmas?",
+      "answers": [
+        {
+          "text": "Julmust",
+          "correct": true
+        },
+        {
+          "text": "Mulled wine",
+          "correct": false
+        },
+        {
+          "text": "Buttermilk",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "The dark malt drink shifts December market shares so hard that Coca-Cola at times produced a version itself.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_055",
+      "question": "Which continent does the turkey, now the Christmas roast in many countries, come from?",
+      "answers": [
+        {
+          "text": "The Americas",
+          "correct": true
+        },
+        {
+          "text": "Asia",
+          "correct": false
+        },
+        {
+          "text": "North Africa",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Before it was brought over in the 16th century, Europe's festive roasts were goose, pork or peacock.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_056",
+      "question": "What is one of the most common Christmas Eve dinners in Germany?",
+      "answers": [
+        {
+          "text": "Sausages with potato salad",
+          "correct": true
+        },
+        {
+          "text": "Lobster with rice",
+          "correct": false
+        },
+        {
+          "text": "Leg of lamb",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The classic has a practical reason: it can be prepared in the morning and does not tie up the evening.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_057",
+      "question": "What was the British 'Boxing Day' on 26 December originally?",
+      "answers": [
+        {
+          "text": "The day servants and the poor received their gift box",
+          "correct": true
+        },
+        {
+          "text": "A day for prize fighting",
+          "correct": false
+        },
+        {
+          "text": "The day presents are exchanged in shops",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The name comes from alms boxes and parcels, not from the sport and not from unwrapping.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_058",
+      "question": "When do the 'Twelve Days of Christmas' of the song actually run?",
+      "answers": [
+        {
+          "text": "From 25 December to 5 January",
+          "correct": true
+        },
+        {
+          "text": "From 13 to 24 December",
+          "correct": false
+        },
+        {
+          "text": "From 1 to 12 December",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "They end on the eve of Epiphany, so the song counts away from Christmas rather than towards it.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_059",
+      "question": "What does the German word 'Weihnachten' go back to?",
+      "answers": [
+        {
+          "text": "'Consecrated nights'",
+          "correct": true
+        },
+        {
+          "text": "'White nights'",
+          "correct": false
+        },
+        {
+          "text": "'Wheat nights'",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The Middle High German phrase 'ze den wîhen nahten' means the hallowed nights around the feast.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_060",
+      "question": "Where does the red-and-green colour pairing of Christmas come from?",
+      "answers": [
+        {
+          "text": "From holly, with red berries against green leaves",
+          "correct": true
+        },
+        {
+          "text": "From the flag of the Papal States",
+          "correct": false
+        },
+        {
+          "text": "From postmen's uniforms",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Evergreens bearing red fruit stood for life in winter long before Christianity.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_061",
+      "question": "What was the original Yule log?",
+      "answers": [
+        {
+          "text": "A large log meant to burn through the holidays",
+          "correct": true
+        },
+        {
+          "text": "A letter full of riddles",
+          "correct": false
+        },
+        {
+          "text": "A cake shaped like a tree trunk",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Only when open hearths grew rare did the motif move onto the cake plate; the French bûche de Noël is a replica.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_062",
+      "question": "How did the 1946 film 'It's a Wonderful Life' become the classic it is?",
+      "answers": [
+        {
+          "text": "Its copyright lapsed and stations aired it for free",
+          "correct": true
+        },
+        {
+          "text": "It won ten Oscars",
+          "correct": false
+        },
+        {
+          "text": "It became required viewing in schools",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "It lost money at the box office; the endless 1970s television repeats made it a fixture.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_063",
+      "question": "In which city is most of 'Home Alone' set?",
+      "answers": [
+        {
+          "text": "Chicago",
+          "correct": true
+        },
+        {
+          "text": "Boston",
+          "correct": false
+        },
+        {
+          "text": "Denver",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The family flies to Paris while Kevin stays behind in suburban Chicago; filming was in Winnetka, Illinois.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_064",
+      "question": "Why do many people count 'Die Hard' as a Christmas film?",
+      "answers": [
+        {
+          "text": "It takes place at a Christmas party on 24 December",
+          "correct": true
+        },
+        {
+          "text": "The hero's middle name is Nicholas",
+          "correct": false
+        },
+        {
+          "text": "It opened on Christmas Eve",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The argument is as old as it is stubborn, and the director and the lead actor have publicly disagreed about it.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_065",
+      "question": "Who wrote the jazz score for the 1965 television classic 'A Charlie Brown Christmas'?",
+      "answers": [
+        {
+          "text": "Vince Guaraldi",
+          "correct": true
+        },
+        {
+          "text": "Dave Brubeck",
+          "correct": false
+        },
+        {
+          "text": "Duke Ellington",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "The network first thought a jazz trio was wrong for a children's show; the record went on to sell millions.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_066",
+      "question": "Who turned 'Rudolph, the Red-Nosed Reindeer' into a worldwide hit song in 1949?",
+      "answers": [
+        {
+          "text": "The singer Gene Autry",
+          "correct": true
+        },
+        {
+          "text": "Frank Sinatra",
+          "correct": false
+        },
+        {
+          "text": "Louis Armstrong",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Autry hesitated for a long time and only recorded it because his wife pushed him; it became his best-selling record.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_067",
+      "question": "In which text did Santa's eight reindeer first appear by name?",
+      "answers": [
+        {
+          "text": "In a poem from 1823",
+          "correct": true
+        },
+        {
+          "text": "In a Charles Dickens novel",
+          "correct": false
+        },
+        {
+          "text": "In a newspaper advertisement from 1902",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "'A Visit from St. Nicholas' also named Donder and Blitzen, which are Dutch for thunder and lightning.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_068",
+      "question": "In which country was the charity Christmas seal invented in 1904?",
+      "answers": [
+        {
+          "text": "Denmark",
+          "correct": true
+        },
+        {
+          "text": "Canada",
+          "correct": false
+        },
+        {
+          "text": "Italy",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "A postal clerk proposed the extra stamp to fund children's hospitals, and the idea spread worldwide.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_069",
+      "question": "Which legend explains the hung-up Christmas stockings?",
+      "answers": [
+        {
+          "text": "Nicholas threw gold through a window and it landed in stockings",
+          "correct": true
+        },
+        {
+          "text": "A tailor lost his stocking up a chimney",
+          "correct": false
+        },
+        {
+          "text": "Miners dried their stockings by the fire",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "In the story the gold saved the three daughters of a ruined man from destitution.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_070",
+      "question": "What is true about the 'German tradition' of the Christmas pickle on the tree?",
+      "answers": [
+        {
+          "text": "Hardly anyone in Germany has heard of it",
+          "correct": true
+        },
+        {
+          "text": "It comes from the Spreewald",
+          "correct": false
+        },
+        {
+          "text": "It was invented in Bavaria in 1850",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The custom is mainly American and was marketed there with an invented German origin story.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_071",
+      "question": "Where did the custom of kissing under mistletoe arise?",
+      "answers": [
+        {
+          "text": "In England",
+          "correct": true
+        },
+        {
+          "text": "In Greece",
+          "correct": false
+        },
+        {
+          "text": "In Russia",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The 18th-century rule was that each kiss cost a berry, and when the sprig was bare the kissing stopped.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_072",
+      "question": "What happens to the wood of the big Rockefeller Center tree after the holidays?",
+      "answers": [
+        {
+          "text": "It is milled into lumber for charity housing",
+          "correct": true
+        },
+        {
+          "text": "It is auctioned off",
+          "correct": false
+        },
+        {
+          "text": "It stays up until Easter",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Since 2007 the boards go to Habitat for Humanity; a tree has stood there almost every year since 1931.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_073",
+      "question": "What rank did the 'Good King Wenceslas' of the carol actually hold?",
+      "answers": [
+        {
+          "text": "He was a duke of Bohemia",
+          "correct": true
+        },
+        {
+          "text": "He was a Byzantine emperor",
+          "correct": false
+        },
+        {
+          "text": "He was a king of Poland",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Wenceslas I was only granted royal title posthumously; the carol promotes him in advance.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_074",
+      "question": "Where does the melody of 'O Christmas Tree' come from?",
+      "answers": [
+        {
+          "text": "From an old folk song",
+          "correct": true
+        },
+        {
+          "text": "From Beethoven",
+          "correct": false
+        },
+        {
+          "text": "From an English hymn",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Ernst Anschütz wrote today's words in 1824 to a long-known tune that had previously been about an unfaithful lover.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_075",
+      "question": "Which honour did 'Silent Night' receive from UNESCO in 2011?",
+      "answers": [
+        {
+          "text": "It became Austrian intangible cultural heritage",
+          "correct": true
+        },
+        {
+          "text": "It joined the Memory of the World register",
+          "correct": false
+        },
+        {
+          "text": "It was declared a world anthem",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The song has been translated into well over 300 languages and dialects.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_076",
+      "question": "What does the Latin word 'adventus', the root of Advent, mean?",
+      "answers": [
+        {
+          "text": "Arrival",
+          "correct": true
+        },
+        {
+          "text": "Expectation",
+          "correct": false
+        },
+        {
+          "text": "Darkness",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Advent was originally a fasting period, which is why the food before 24 December used to be plain.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_077",
+      "question": "What traditionally goes under the tablecloth at the Polish 'Wigilia'?",
+      "answers": [
+        {
+          "text": "Hay",
+          "correct": true
+        },
+        {
+          "text": "Coins",
+          "correct": false
+        },
+        {
+          "text": "A lump of coal",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "It recalls the manger, and one place at the table is also left free for an unexpected guest.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_078",
+      "question": "What are the Greek 'kallikantzaroi'?",
+      "answers": [
+        {
+          "text": "Goblins who make mischief between Christmas and Epiphany",
+          "correct": true
+        },
+        {
+          "text": "Cretan Christmas pastries",
+          "correct": false
+        },
+        {
+          "text": "Carol singers in Athens",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Legend says they saw at the world tree all year and only surface during the twelve nights.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_079",
+      "question": "On which day is Christmas ('Genna') celebrated in Ethiopia?",
+      "answers": [
+        {
+          "text": "7 January",
+          "correct": true
+        },
+        {
+          "text": "24 December",
+          "correct": false
+        },
+        {
+          "text": "2 February",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The Ethiopian Orthodox Church follows its own calendar, and the Ethiopian year runs behind the Gregorian one.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_080",
+      "question": "How many evenings do the Mexican 'posadas' before Christmas last?",
+      "answers": [
+        {
+          "text": "Nine",
+          "correct": true
+        },
+        {
+          "text": "Three",
+          "correct": false
+        },
+        {
+          "text": "Twelve",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "They re-enact the search for shelter; each evening ends at a different front door with singing and a piñata.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_081",
+      "question": "What do the seven points of the classic Mexican Christmas piñata stand for?",
+      "answers": [
+        {
+          "text": "The seven deadly sins",
+          "correct": true
+        },
+        {
+          "text": "The seven days of the week",
+          "correct": false
+        },
+        {
+          "text": "Seven stars in the sky",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Striking it blindfolded means striking blindly at sin, and the sweets are the reward of faith.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_082",
+      "question": "Who draws the numbers of Spain's 'El Gordo' Christmas lottery and sings out the prizes?",
+      "answers": [
+        {
+          "text": "Schoolchildren",
+          "correct": true
+        },
+        {
+          "text": "Television presenters",
+          "correct": false
+        },
+        {
+          "text": "Notaries of the Bank of Spain",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Children of the San Ildefonso school have sung number and amount in alternation since the 18th century.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_083",
+      "question": "Who traditionally brings children their presents in Spain?",
+      "answers": [
+        {
+          "text": "The Three Kings",
+          "correct": true
+        },
+        {
+          "text": "Santa Claus on 24 December",
+          "correct": false
+        },
+        {
+          "text": "St Nicholas on 6 December",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "On the night before 6 January children put out shoes and some water for the camels.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_084",
+      "question": "Which country is known for the longest Christmas season in the world?",
+      "answers": [
+        {
+          "text": "The Philippines",
+          "correct": true
+        },
+        {
+          "text": "Iceland",
+          "correct": false
+        },
+        {
+          "text": "Portugal",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "As soon as September starts the carols come on, and the season runs into January.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_085",
+      "question": "What shape is the Filipino Christmas lantern, the 'parol'?",
+      "answers": [
+        {
+          "text": "A five-pointed star",
+          "correct": true
+        },
+        {
+          "text": "A crescent moon",
+          "correct": false
+        },
+        {
+          "text": "A bell",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "It stands for the star of Bethlehem and was originally built from bamboo and rice paper.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_086",
+      "question": "In which season does Australia celebrate Christmas?",
+      "answers": [
+        {
+          "text": "In high summer",
+          "correct": true
+        },
+        {
+          "text": "In late autumn",
+          "correct": false
+        },
+        {
+          "text": "In early spring",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Barbecues on the beach and open-air 'Carols by Candlelight' are part of the day there.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_087",
+      "question": "Why do Russian Orthodox believers celebrate Christmas on 7 January?",
+      "answers": [
+        {
+          "text": "Because the church keeps the Julian calendar",
+          "correct": true
+        },
+        {
+          "text": "Because a tsar moved the date",
+          "correct": false
+        },
+        {
+          "text": "Because 25 December is a working day",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The gap to the Gregorian calendar currently stands at thirteen days.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_088",
+      "question": "What does the recipe rule for Nuremberg Elisenlebkuchen require?",
+      "answers": [
+        {
+          "text": "No more than ten per cent flour",
+          "correct": true
+        },
+        {
+          "text": "At least half honey",
+          "correct": false
+        },
+        {
+          "text": "Exactly seven spices",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "The protected designation also demands a high proportion of nuts, which is why they stay so moist.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_089",
+      "question": "What is the shape of the Dresden Christstollen meant to represent?",
+      "answers": [
+        {
+          "text": "The Christ child wrapped in swaddling cloth",
+          "correct": true
+        },
+        {
+          "text": "A sledge",
+          "correct": false
+        },
+        {
+          "text": "A snow-covered hill",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The icing sugar stands for the cloths; the recipe was long limited by the Advent ban on butter.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_090",
+      "question": "Which city is panettone from?",
+      "answers": [
+        {
+          "text": "Milan",
+          "correct": true
+        },
+        {
+          "text": "Naples",
+          "correct": false
+        },
+        {
+          "text": "Turin",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "With its starter and several rises the dough often takes more than 30 hours.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_091",
+      "question": "How far back is spiced hot wine documented in Europe?",
+      "answers": [
+        {
+          "text": "To Roman antiquity",
+          "correct": true
+        },
+        {
+          "text": "To the 18th century",
+          "correct": false
+        },
+        {
+          "text": "To the 1920s",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "A Roman cookbook describes 'conditum paradoxum' of wine, honey and pepper — the ancestor of mulled wine.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_092",
+      "question": "In which city is the decorated Christmas tree first documented?",
+      "answers": [
+        {
+          "text": "Strasbourg",
+          "correct": true
+        },
+        {
+          "text": "Vienna",
+          "correct": false
+        },
+        {
+          "text": "Copenhagen",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "A 1539 guild record mentions a tree in the cathedral; candles came much later.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_093",
+      "question": "Since when has the British royal Christmas message existed?",
+      "answers": [
+        {
+          "text": "Since 1932",
+          "correct": true
+        },
+        {
+          "text": "Since 1901",
+          "correct": false
+        },
+        {
+          "text": "Since 1966",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "George V spoke on radio first; the first televised message followed only in 1957.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_094",
+      "question": "What is notable about José Feliciano's 1970 'Feliz Navidad'?",
+      "answers": [
+        {
+          "text": "The lyric is just a few lines in Spanish and English",
+          "correct": true
+        },
+        {
+          "text": "It is the longest charting Christmas song",
+          "correct": false
+        },
+        {
+          "text": "It was recorded without instruments",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Feliciano needed only minutes for the words and played the cuatro on the track.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_095",
+      "question": "Which astronomical explanation did Johannes Kepler propose for the star of Bethlehem?",
+      "answers": [
+        {
+          "text": "A close conjunction of Jupiter and Saturn",
+          "correct": true
+        },
+        {
+          "text": "A comet impact",
+          "correct": false
+        },
+        {
+          "text": "A solar eclipse",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Kepler watched such a conjunction in 1603 and calculated back to the year 7 BCE.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_096",
+      "question": "What does the Bible say about the date of Jesus's birth?",
+      "answers": [
+        {
+          "text": "It gives no date at all",
+          "correct": true
+        },
+        {
+          "text": "It names 25 December",
+          "correct": false
+        },
+        {
+          "text": "It names 6 January",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "25 December took hold in the 4th century and coincided with Roman festivals around the winter solstice.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_097",
+      "question": "How many gifts do you receive in total if every day of 'The Twelve Days of Christmas' repeats all the earlier ones?",
+      "type": "estimate",
+      "answer": 364,
+      "min": 0,
+      "max": 1000,
+      "unit": "gifts",
+      "difficulty": "medium",
+      "fun_fact": "364 — almost one for every day of the year, including twelve partridges in a pear tree.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_098",
+      "question": "In which year was 'Silent Night' sung for the first time?",
+      "type": "estimate",
+      "answer": 1818,
+      "min": 1700,
+      "max": 1950,
+      "unit": "year",
+      "difficulty": "medium",
+      "fun_fact": "1818, in Oberndorf near Salzburg, accompanied on a guitar rather than the organ.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_099",
+      "question": "How tall is the Gävle straw goat that goes up every Advent in Sweden?",
+      "type": "estimate",
+      "answer": 13,
+      "min": 1,
+      "max": 60,
+      "unit": "metres",
+      "difficulty": "hard",
+      "fun_fact": "13 metres tall and about 3.6 tonnes; even so it has often failed to survive Advent.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_100",
+      "question": "How many reindeer are named in the 1823 poem 'A Visit from St. Nicholas'?",
+      "type": "estimate",
+      "answer": 8,
+      "min": 0,
+      "max": 40,
+      "unit": "reindeer",
+      "difficulty": "easy",
+      "fun_fact": "Eight; Rudolph was added 116 years later as an advertising invention.",
+      "category": "Christmas"
+    },
+    {
+      "id": "christmas_en_101",
+      "question": "How many doors does a classic Advent calendar have?",
+      "type": "estimate",
+      "answer": 24,
+      "min": 0,
+      "max": 100,
+      "unit": "doors",
+      "difficulty": "easy",
+      "fun_fact": "24 — the calendar ends on Christmas Eve rather than on Christmas Day.",
+      "category": "Christmas"
+    }
+  ]
+}

--- a/custom_components/quizify/questions/navidad-es.json
+++ b/custom_components/quizify/questions/navidad-es.json
@@ -1,0 +1,2089 @@
+{
+  "name": "Navidad",
+  "language": "es",
+  "version": "1.0",
+  "theme": "trivia",
+  "season": {
+    "start": "12-01",
+    "end": "12-26",
+    "label": "🎄 Temporada navideña"
+  },
+  "questions": [
+    {
+      "id": "navidad_es_001",
+      "question": "¿La publicidad de qué empresa fijó desde 1931 la imagen actual de un Papá Noel rechoncho y risueño?",
+      "answers": [
+        {
+          "text": "Coca-Cola",
+          "correct": true
+        },
+        {
+          "text": "Pepsi",
+          "correct": false
+        },
+        {
+          "text": "Nestlé",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El traje rojo ya existía antes: el ilustrador Haddon Sundblom unificó la imagen, no la inventó.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_002",
+      "question": "¿Para quién se inventó el reno Rudolph en 1939?",
+      "answers": [
+        {
+          "text": "Para unos grandes almacenes de EE. UU.",
+          "correct": true
+        },
+        {
+          "text": "Para una película de Disney",
+          "correct": false
+        },
+        {
+          "text": "Para una marca de tabaco",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Robert L. May escribió el cuento en verso como regalo publicitario de la cadena Montgomery Ward.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_003",
+      "question": "¿Por qué el mando de defensa aérea NORAD sigue al Papá Noel cada año desde 1955?",
+      "answers": [
+        {
+          "text": "Por un número de teléfono mal impreso",
+          "correct": true
+        },
+        {
+          "text": "Por una apuesta entre dos generales",
+          "correct": false
+        },
+        {
+          "text": "Por una película de cine",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Un anuncio de unos grandes almacenes imprimió el número de un centro de mando en lugar del de Papá Noel, y el oficial de guardia siguió el juego.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_004",
+      "question": "¿Para qué fiesta se escribió originalmente la canción 'Jingle Bells'?",
+      "answers": [
+        {
+          "text": "Para Acción de Gracias",
+          "correct": true
+        },
+        {
+          "text": "Para la Pascua",
+          "correct": false
+        },
+        {
+          "text": "Para la fiesta nacional",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "James Lord Pierpont la publicó en 1857 como 'One Horse Open Sleigh': una canción de invierno sin nada navideño.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_005",
+      "question": "¿Qué canción fue la primera transmitida a la Tierra desde el espacio?",
+      "answers": [
+        {
+          "text": "Jingle Bells",
+          "correct": true
+        },
+        {
+          "text": "Noche de paz",
+          "correct": false
+        },
+        {
+          "text": "White Christmas",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "En diciembre de 1965 la tripulación del Gemini 6 informó primero de un 'objeto no identificado' y después sacó una armónica y cascabeles.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_006",
+      "question": "¿Con qué instrumento se acompañó el estreno de 'Noche de paz'?",
+      "answers": [
+        {
+          "text": "Con una guitarra",
+          "correct": true
+        },
+        {
+          "text": "Con un órgano",
+          "correct": false
+        },
+        {
+          "text": "Con un arpa",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "No se sabe por qué calló el órgano; la historia de los ratones en el fuelle es muy posterior.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_007",
+      "question": "¿Qué grabación navideña se considera el sencillo más vendido de todos los tiempos?",
+      "answers": [
+        {
+          "text": "'White Christmas' de Bing Crosby",
+          "correct": true
+        },
+        {
+          "text": "'Last Christmas' de Wham!",
+          "correct": false
+        },
+        {
+          "text": "'Feliz Navidad' de José Feliciano",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Las estimaciones superan los 50 millones de copias vendidas; ningún otro sencillo se acerca.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_008",
+      "question": "¿Cuánto tardó 'Last Christmas' de Wham! en llegar al número uno en las listas británicas?",
+      "answers": [
+        {
+          "text": "Más de 35 años",
+          "correct": true
+        },
+        {
+          "text": "Dos semanas",
+          "correct": false
+        },
+        {
+          "text": "Llegó directamente al número uno",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "En 1984 el sencillo benéfico 'Do They Know It's Christmas?' le cerró el paso; solo lo consiguió a principios de 2021.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_009",
+      "question": "¿Cuánto tardaron supuestamente Mariah Carey y Walter Afanasieff en escribir 'All I Want for Christmas Is You'?",
+      "answers": [
+        {
+          "text": "Un cuarto de hora aproximadamente",
+          "correct": true
+        },
+        {
+          "text": "Medio año aproximadamente",
+          "correct": false
+        },
+        {
+          "text": "Unas tres semanas",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Los dos siguen contando la historia de forma distinta; solo coinciden en que fue muy rápido.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_010",
+      "question": "¿De dónde viene el nombre inglés de la flor de Pascua, 'poinsettia'?",
+      "answers": [
+        {
+          "text": "De un embajador de EE. UU. en México",
+          "correct": true
+        },
+        {
+          "text": "De un jardinero inglés",
+          "correct": false
+        },
+        {
+          "text": "De un santo",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Joel Roberts Poinsett envió la planta desde México a Estados Unidos en la década de 1820.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_011",
+      "question": "¿Qué afirmación sobre la flor de Pascua como planta de interior es cierta?",
+      "answers": [
+        {
+          "text": "No es mortalmente venenosa para las personas",
+          "correct": true
+        },
+        {
+          "text": "Una hoja puede matar a un niño",
+          "correct": false
+        },
+        {
+          "text": "Su savia es un potente neurotóxico",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El látex irrita la piel y el estómago, nada más; su fama mortal viene de un caso de 1919 nunca confirmado.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_012",
+      "question": "¿Cómo se alimenta el muérdago?",
+      "answers": [
+        {
+          "text": "Perfora el árbol que lo aloja y además hace fotosíntesis",
+          "correct": true
+        },
+        {
+          "text": "Vive solo del agua de lluvia",
+          "correct": false
+        },
+        {
+          "text": "Se alimenta de insectos",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Como hemiparásito toma agua y sales del árbol, pero fabrica su propio azúcar.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_013",
+      "question": "¿Por qué hay buenos motivos para pensar que los renos del trineo son hembras?",
+      "answers": [
+        {
+          "text": "Los machos pierden la cornamenta antes del invierno",
+          "correct": true
+        },
+        {
+          "text": "Los machos no aguantan distancias largas",
+          "correct": false
+        },
+        {
+          "text": "Los machos hibernan",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Las hembras conservan la cornamenta hasta la primavera, así que en diciembre casi solo ellas la llevan.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_014",
+      "question": "¿Qué les ocurre a los ojos de los renos durante el invierno ártico?",
+      "answers": [
+        {
+          "text": "La capa reflectante del fondo del ojo pasa de dorada a azul",
+          "correct": true
+        },
+        {
+          "text": "Se quedan ciegos temporalmente",
+          "correct": false
+        },
+        {
+          "text": "Les crece un tercer párpado",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La versión azul dispersa más luz dentro del ojo y hace a los animales más sensibles durante la noche polar.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_015",
+      "question": "¿De dónde viene el gran árbol de Navidad de Trafalgar Square, en Londres?",
+      "answers": [
+        {
+          "text": "Es un regalo anual de Oslo",
+          "correct": true
+        },
+        {
+          "text": "Se cultiva en una plantación de Gales",
+          "correct": false
+        },
+        {
+          "text": "Se subasta cada año",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Noruega lo envía cada año desde 1947 en agradecimiento por el apoyo británico durante la Segunda Guerra Mundial.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_016",
+      "question": "¿Quién mandó imprimir en 1843 la primera tarjeta de Navidad comercial?",
+      "answers": [
+        {
+          "text": "Henry Cole, en Londres",
+          "correct": true
+        },
+        {
+          "text": "La reina Victoria",
+          "correct": false
+        },
+        {
+          "text": "Charles Dickens",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Cole tenía demasiada correspondencia, así que imprimió mil tarjetas y las vendió a un chelín.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_017",
+      "question": "¿Cuánto tardó Charles Dickens en escribir 'Cuento de Navidad'?",
+      "answers": [
+        {
+          "text": "Unas seis semanas",
+          "correct": true
+        },
+        {
+          "text": "Unos cuatro años",
+          "correct": false
+        },
+        {
+          "text": "Unos ocho meses",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Lo escribió en 1843 con apuros de dinero y lo publicó por su cuenta: se agotó en pocos días.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_018",
+      "question": "¿Qué pasó con la Navidad en Inglaterra bajo Oliver Cromwell?",
+      "answers": [
+        {
+          "text": "El Parlamento prohibió la fiesta",
+          "correct": true
+        },
+        {
+          "text": "Se trasladó al 1 de enero",
+          "correct": false
+        },
+        {
+          "text": "Se convirtió en fiesta de Estado",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "En 1647 los puritanos la suprimieron por considerarla no bíblica y varias ciudades se amotinaron.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_019",
+      "question": "¿Cuándo se convirtió la Navidad en fiesta federal en Estados Unidos?",
+      "answers": [
+        {
+          "text": "En 1870",
+          "correct": true
+        },
+        {
+          "text": "En 1776",
+          "correct": false
+        },
+        {
+          "text": "En 1935",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Hasta entonces el 25 de diciembre era un día laborable normal en varios estados.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_020",
+      "question": "¿Quién inventó la corona de Adviento en 1839?",
+      "answers": [
+        {
+          "text": "El educador hamburgués Johann Hinrich Wichern",
+          "correct": true
+        },
+        {
+          "text": "Martín Lutero",
+          "correct": false
+        },
+        {
+          "text": "Un canónigo de la catedral de Colonia",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Wichern colgó una rueda de carro con velas en su hogar infantil para que los niños contaran la espera.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_021",
+      "question": "¿En qué país nació el calendario de Adviento impreso?",
+      "answers": [
+        {
+          "text": "En Alemania",
+          "correct": true
+        },
+        {
+          "text": "En Inglaterra",
+          "correct": false
+        },
+        {
+          "text": "En los Países Bajos",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Gerhard Lang puso a la venta hacia 1904 las primeras láminas recortables; las ventanitas llegaron después.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_022",
+      "question": "¿Qué representa la X de la abreviatura inglesa 'Xmas'?",
+      "answers": [
+        {
+          "text": "La letra griega ji",
+          "correct": true
+        },
+        {
+          "text": "Una cruz tachada",
+          "correct": false
+        },
+        {
+          "text": "El número romano diez",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Ji es la primera letra de Christós: la abreviatura tiene siglos y no es un atajo moderno.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_023",
+      "question": "¿Cómo recibió su nombre la Isla de Navidad, en el océano Índico?",
+      "answers": [
+        {
+          "text": "Un capitán pasó junto a ella el día de Navidad de 1643",
+          "correct": true
+        },
+        {
+          "text": "Se encontró allí un belén",
+          "correct": false
+        },
+        {
+          "text": "Tiene forma de estrella",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "William Mynors pasó navegando y anotó sencillamente la fecha como nombre.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_024",
+      "question": "¿Qué comida se considera la cena de Navidad clásica en Japón?",
+      "answers": [
+        {
+          "text": "Pollo frito de una cadena de comida rápida",
+          "correct": true
+        },
+        {
+          "text": "Anguila a la parrilla",
+          "correct": false
+        },
+        {
+          "text": "Pato a la naranja",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Una campaña publicitaria de 1974 con el lema 'Kentucky para Navidad' acabó convertida en tradición.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_025",
+      "question": "¿Cuál es la tarta de Navidad típica en Japón?",
+      "answers": [
+        {
+          "text": "Un bizcocho con nata y fresas",
+          "correct": true
+        },
+        {
+          "text": "Un pastel oscuro de frutas",
+          "correct": false
+        },
+        {
+          "text": "Un pastel de capas con mazapán",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Roja y blanca como los colores nacionales: se vende el 24 de diciembre y casi nada después.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_026",
+      "question": "¿Qué ven tradicionalmente millones de suecos a las tres de la tarde del 24 de diciembre?",
+      "answers": [
+        {
+          "text": "Un programa del Pato Donald",
+          "correct": true
+        },
+        {
+          "text": "El discurso del rey",
+          "correct": false
+        },
+        {
+          "text": "Un partido de hockey sobre hielo",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "'Kalle Anka' se emite casi sin cambios desde 1959, y los intentos de moverlo han provocado indignación pública.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_027",
+      "question": "¿Qué se instala cada Adviento en la plaza principal de Gävle, en Suecia?",
+      "answers": [
+        {
+          "text": "Un cabrón gigante de paja",
+          "correct": true
+        },
+        {
+          "text": "Un oso polar tallado en hielo",
+          "correct": false
+        },
+        {
+          "text": "Una torre de pan de jengibre",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El animal se levanta desde 1966 y ha ardido decenas de veces.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_028",
+      "question": "¿Qué esconden tradicionalmente los noruegos en Nochebuena?",
+      "answers": [
+        {
+          "text": "Las escobas",
+          "correct": true
+        },
+        {
+          "text": "Los zapatos",
+          "correct": false
+        },
+        {
+          "text": "Las llaves",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Según la vieja creencia, esa noche las brujas andan sueltas buscando algo con lo que volar.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_029",
+      "question": "¿Cuántos 'Yule Lads' visitan a los niños islandeses en las noches previas a la Navidad?",
+      "answers": [
+        {
+          "text": "Trece",
+          "correct": true
+        },
+        {
+          "text": "Tres",
+          "correct": false
+        },
+        {
+          "text": "Siete",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Cada uno tiene su manía: uno roba skyr, otro lame cucharas, otro da portazos.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_030",
+      "question": "¿A qué se refiere la 'Jólabókaflóð' islandesa?",
+      "answers": [
+        {
+          "text": "A la avalancha de libros antes de Navidad",
+          "correct": true
+        },
+        {
+          "text": "A una marea alta de diciembre",
+          "correct": false
+        },
+        {
+          "text": "A los fuegos artificiales de Nochebuena",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El libro es el regalo clásico y la noche del 24 se dedica a leer con chocolate.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_031",
+      "question": "¿Qué es el 'Caga Tió' catalán?",
+      "answers": [
+        {
+          "text": "Un tronco que suelta regalos",
+          "correct": true
+        },
+        {
+          "text": "Una figura del belén con farol",
+          "correct": false
+        },
+        {
+          "text": "Un dulce navideño",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los niños alimentan el tronco pintado durante semanas y el 24 de diciembre lo golpean con palos hasta que salen dulces.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_032",
+      "question": "¿Qué figura se coloca tradicionalmente en un rincón del belén catalán?",
+      "answers": [
+        {
+          "text": "Un hombre en cuclillas con los pantalones bajados",
+          "correct": true
+        },
+        {
+          "text": "Un pescador con una red",
+          "correct": false
+        },
+        {
+          "text": "Un montañero",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El 'caganer' abona simbólicamente la tierra y se considera un augurio de buena cosecha.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_033",
+      "question": "¿Qué adorno del árbol se considera de buena suerte en Ucrania?",
+      "answers": [
+        {
+          "text": "Las telarañas",
+          "correct": true
+        },
+        {
+          "text": "Los cristales de sal",
+          "correct": false
+        },
+        {
+          "text": "Las guindillas secas",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Una leyenda habla de una viuda pobre cuyo árbol desnudo fue adornado durante la noche por unas arañas.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_034",
+      "question": "¿Cómo van muchos fieles de Caracas a la misa de madrugada en Navidad?",
+      "answers": [
+        {
+          "text": "En patines",
+          "correct": true
+        },
+        {
+          "text": "En burro",
+          "correct": false
+        },
+        {
+          "text": "Descalzos y en fila",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "En algunos barrios se cortan calles al tráfico para la Misa de Aguinaldo.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_035",
+      "question": "¿Qué figura aterradora acompaña a San Nicolás en los países alpinos?",
+      "answers": [
+        {
+          "text": "El Krampus",
+          "correct": true
+        },
+        {
+          "text": "El duende Puck",
+          "correct": false
+        },
+        {
+          "text": "El Abuelo Invierno",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El 5 de diciembre desfilan cuadrillas de Krampus con pieles, cuernos y cencerros.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_036",
+      "question": "Según la tradición, ¿de qué país llega cada año en barco el Sinterklaas neerlandés?",
+      "answers": [
+        {
+          "text": "De España",
+          "correct": true
+        },
+        {
+          "text": "De Noruega",
+          "correct": false
+        },
+        {
+          "text": "De Islandia",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Su llegada en noviembre se retransmite en directo por televisión y reparte regalos el 5 de diciembre.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_037",
+      "question": "¿Qué se proclama en Turku, Finlandia, al mediodía del 24 de diciembre desde la Edad Media?",
+      "answers": [
+        {
+          "text": "La Paz de Navidad",
+          "correct": true
+        },
+        {
+          "text": "El fin de la temporada de pesca",
+          "correct": false
+        },
+        {
+          "text": "El nombre del nuevo rey",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La lectura se retransmite por radio y es una de las tradiciones ininterrumpidas más antiguas del país.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_038",
+      "question": "Según la tradición finlandesa, ¿dónde está el taller de Papá Noel?",
+      "answers": [
+        {
+          "text": "En la colina de Korvatunturi, en Laponia",
+          "correct": true
+        },
+        {
+          "text": "En Svalbard",
+          "correct": false
+        },
+        {
+          "text": "En una isla frente a Helsinki",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La colina tiene forma de orejas: así es como Papá Noel oye los deseos de todos los niños.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_039",
+      "question": "¿Qué código postal ha asignado el correo canadiense a Papá Noel?",
+      "answers": [
+        {
+          "text": "H0H 0H0",
+          "correct": true
+        },
+        {
+          "text": "X0X 0X0",
+          "correct": false
+        },
+        {
+          "text": "N0E 0L0",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Cada año hay voluntarios que responden a millones de cartas, cada una en el idioma en que fue escrita.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_040",
+      "question": "¿En qué región vivió el obispo histórico Nicolás, origen del día de San Nicolás?",
+      "answers": [
+        {
+          "text": "En Mira, en la actual Turquía",
+          "correct": true
+        },
+        {
+          "text": "En el norte de Suecia",
+          "correct": false
+        },
+        {
+          "text": "En Sicilia",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Sus restos fueron llevados a Bari en 1087 y allí siguen.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_041",
+      "question": "¿Quién impulsó al Niño Jesús como portador de los regalos en los países de habla alemana?",
+      "answers": [
+        {
+          "text": "Martín Lutero",
+          "correct": true
+        },
+        {
+          "text": "El emperador Carlos V",
+          "correct": false
+        },
+        {
+          "text": "Los hermanos Grimm",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Lutero quería frenar el culto a los santos; paradójicamente, fueron las regiones católicas las que más conservaron la figura.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_042",
+      "question": "¿Quién encarna al Christkind de Núremberg en su mercado navideño?",
+      "answers": [
+        {
+          "text": "Una joven elegida cada dos años",
+          "correct": true
+        },
+        {
+          "text": "Un niño de la escuela catedralicia",
+          "correct": false
+        },
+        {
+          "text": "Una marioneta sobre una grúa",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Las candidatas deben vivir en Núremberg, medir al menos 1,60 metros y no tener vértigo.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_043",
+      "question": "¿Desde cuándo está documentado el Striezelmarkt de Dresde?",
+      "answers": [
+        {
+          "text": "Desde 1434",
+          "correct": true
+        },
+        {
+          "text": "Desde 1834",
+          "correct": false
+        },
+        {
+          "text": "Desde 1634",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Empezó como un mercado de carne de un solo día antes de la fiesta, lo que lo convierte en uno de los más antiguos.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_044",
+      "question": "¿De qué región alemana proceden los cascanueces y los muñecos sahumadores clásicos?",
+      "answers": [
+        {
+          "text": "De los Montes Metálicos",
+          "correct": true
+        },
+        {
+          "text": "De la Selva Negra",
+          "correct": false
+        },
+        {
+          "text": "De Frisia Oriental",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Cuando decayó la minería, pueblos enteros vivieron de la talla; por eso el cascanueces suele llevar uniforme.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_045",
+      "question": "¿Cómo se recibió el ballet 'El cascanueces' de Chaikovski en su estreno de 1892?",
+      "answers": [
+        {
+          "text": "Con frialdad, en general mal",
+          "correct": true
+        },
+        {
+          "text": "Como un triunfo inmediato",
+          "correct": false
+        },
+        {
+          "text": "Se interrumpió tras el primer acto",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La crítica encontró la trama floja y raros los papeles infantiles; solo décadas después se volvió un clásico navideño.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_046",
+      "question": "¿De cuántas partes consta el Oratorio de Navidad de Johann Sebastian Bach?",
+      "answers": [
+        {
+          "text": "De seis",
+          "correct": true
+        },
+        {
+          "text": "De tres",
+          "correct": false
+        },
+        {
+          "text": "De doce",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Estaban pensadas para seis oficios distintos entre el 25 de diciembre de 1734 y el 6 de enero de 1735.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_047",
+      "question": "¿En qué época del año se estrenó 'El Mesías' de Händel?",
+      "answers": [
+        {
+          "text": "En primavera, poco antes de Pascua",
+          "correct": true
+        },
+        {
+          "text": "El día de Navidad",
+          "correct": false
+        },
+        {
+          "text": "En pleno verano",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El estreno fue en Dublín en abril de 1742; solo más tarde pasó a asociarse con la Navidad.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_048",
+      "question": "¿Qué ocurrió en algunos tramos del frente occidental en la Navidad de 1914?",
+      "answers": [
+        {
+          "text": "Soldados de ambos bandos salieron de las trincheras y celebraron juntos",
+          "correct": true
+        },
+        {
+          "text": "La guerra se suspendió oficialmente dos días",
+          "correct": false
+        },
+        {
+          "text": "Se libró una batalla récord",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Hubo canciones, cigarrillos y en algunos puntos fútbol; los altos mandos prohibieron repetirlo en los años siguientes.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_049",
+      "question": "¿Quién montó en 1882 el primer árbol de Navidad con luz eléctrica?",
+      "answers": [
+        {
+          "text": "Un colaborador de Thomas Edison",
+          "correct": true
+        },
+        {
+          "text": "Nikola Tesla",
+          "correct": false
+        },
+        {
+          "text": "Werner von Siemens",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Edward H. Johnson hizo cablear a mano 80 bombillas rojas, blancas y azules y además puso el árbol a girar.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_050",
+      "question": "¿De qué estaba hecho originalmente el espumillón?",
+      "answers": [
+        {
+          "text": "De plata batida muy fina",
+          "correct": true
+        },
+        {
+          "text": "De papel teñido",
+          "correct": false
+        },
+        {
+          "text": "De escamas de pescado",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los artesanos de Núremberg lo batían desde hacia 1610; se oscurecía con el tiempo y había que cambiarlo.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_051",
+      "question": "¿Dónde empezó la fabricación de bolas de vidrio para el árbol?",
+      "answers": [
+        {
+          "text": "En Lauscha, en Turingia",
+          "correct": true
+        },
+        {
+          "text": "En Murano, cerca de Venecia",
+          "correct": false
+        },
+        {
+          "text": "En Karlovy Vary",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Cuenta la leyenda que un soplador de vidrio no podía pagar manzanas y nueces para su árbol y se las sopló en vidrio.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_052",
+      "question": "¿Qué contenían originalmente los 'mince pies' ingleses?",
+      "answers": [
+        {
+          "text": "Carne de verdad",
+          "correct": true
+        },
+        {
+          "text": "Solo miel",
+          "correct": false
+        },
+        {
+          "text": "Conchas molidas",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Carne picada, sebo y fruta seca eran juntos un truco de conservación; la carne desapareció en el siglo XIX.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_053",
+      "question": "¿Qué es el 'Stir-up Sunday' británico?",
+      "answers": [
+        {
+          "text": "El domingo en que se prepara el pudin de Navidad",
+          "correct": true
+        },
+        {
+          "text": "El primer domingo de Adviento",
+          "correct": false
+        },
+        {
+          "text": "El día de la subasta de árboles",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Cada miembro de la familia da una vuelta en el sentido de las agujas del reloj y pide un deseo.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_054",
+      "question": "¿Qué bebida vende más que la cola en Suecia durante la Navidad?",
+      "answers": [
+        {
+          "text": "El julmust",
+          "correct": true
+        },
+        {
+          "text": "El vino caliente",
+          "correct": false
+        },
+        {
+          "text": "El suero de leche",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La bebida oscura de malta altera tanto las cuotas de diciembre que Coca-Cola llegó a producir su propia versión.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_055",
+      "question": "¿De qué continente procede el pavo, hoy el asado navideño en muchos países?",
+      "answers": [
+        {
+          "text": "De América",
+          "correct": true
+        },
+        {
+          "text": "De Asia",
+          "correct": false
+        },
+        {
+          "text": "Del norte de África",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Antes de su llegada en el siglo XVI, los asados de fiesta en Europa eran el ganso, el cerdo o el pavo real.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_056",
+      "question": "¿Cuál es una de las cenas de Nochebuena más habituales en Alemania?",
+      "answers": [
+        {
+          "text": "Salchichas con ensalada de patata",
+          "correct": true
+        },
+        {
+          "text": "Bogavante con arroz",
+          "correct": false
+        },
+        {
+          "text": "Pierna de cordero",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El clásico tiene un motivo práctico: se prepara por la mañana y no ocupa la noche.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_057",
+      "question": "¿Qué era originalmente el 'Boxing Day' británico del 26 de diciembre?",
+      "answers": [
+        {
+          "text": "El día en que criados y pobres recibían su caja de regalo",
+          "correct": true
+        },
+        {
+          "text": "Un día de combates de boxeo",
+          "correct": false
+        },
+        {
+          "text": "El día de cambiar los regalos en las tiendas",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El nombre viene de las cajas de limosnas y los paquetes, no del deporte ni de los cambios.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_058",
+      "question": "¿Cuándo transcurren realmente los 'doce días de Navidad' de la canción?",
+      "answers": [
+        {
+          "text": "Del 25 de diciembre al 5 de enero",
+          "correct": true
+        },
+        {
+          "text": "Del 13 al 24 de diciembre",
+          "correct": false
+        },
+        {
+          "text": "Del 1 al 12 de diciembre",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Terminan la víspera de Reyes: la canción cuenta desde la Navidad, no hacia ella.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_059",
+      "question": "¿A qué expresión se remonta la palabra alemana 'Weihnachten'?",
+      "answers": [
+        {
+          "text": "A 'noches consagradas'",
+          "correct": true
+        },
+        {
+          "text": "A 'noches blancas'",
+          "correct": false
+        },
+        {
+          "text": "A 'noches de trigo'",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La expresión del alto alemán medio 'ze den wîhen nahten' designa las noches santificadas de la fiesta.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_060",
+      "question": "¿De dónde viene la combinación de rojo y verde como colores navideños?",
+      "answers": [
+        {
+          "text": "Del acebo, con bayas rojas y hojas verdes",
+          "correct": true
+        },
+        {
+          "text": "De la bandera de los Estados Pontificios",
+          "correct": false
+        },
+        {
+          "text": "De los uniformes de los carteros",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Las plantas de hoja perenne con frutos rojos simbolizaban la vida en invierno mucho antes del cristianismo.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_061",
+      "question": "¿Qué era originalmente el 'tronco de Navidad'?",
+      "answers": [
+        {
+          "text": "Un gran leño que debía arder durante las fiestas",
+          "correct": true
+        },
+        {
+          "text": "Una carta llena de acertijos",
+          "correct": false
+        },
+        {
+          "text": "Un pastel con forma de tronco",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Solo cuando las chimeneas abiertas escasearon el motivo pasó al plato: el bûche de Noël francés es una réplica.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_062",
+      "question": "¿Cómo se convirtió en clásico la película de 1946 '¡Qué bello es vivir!'?",
+      "answers": [
+        {
+          "text": "Caducaron sus derechos y las cadenas la emitían gratis",
+          "correct": true
+        },
+        {
+          "text": "Ganó diez Oscar",
+          "correct": false
+        },
+        {
+          "text": "Se hizo obligatoria en las escuelas",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "En taquilla perdió dinero; fueron las reposiciones televisivas de los años setenta las que la consagraron.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_063",
+      "question": "¿En qué ciudad transcurre la mayor parte de 'Solo en casa'?",
+      "answers": [
+        {
+          "text": "En Chicago",
+          "correct": true
+        },
+        {
+          "text": "En Boston",
+          "correct": false
+        },
+        {
+          "text": "En Denver",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La familia vuela a París y Kevin se queda en un suburbio de Chicago; se rodó en Winnetka, Illinois.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_064",
+      "question": "¿Por qué mucha gente considera 'La jungla de cristal' una película navideña?",
+      "answers": [
+        {
+          "text": "Transcurre en una fiesta de Navidad del 24 de diciembre",
+          "correct": true
+        },
+        {
+          "text": "El héroe se llama Nicolás de segundo nombre",
+          "correct": false
+        },
+        {
+          "text": "Se estrenó en Nochebuena",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El debate es tan viejo como tenaz: el director y el protagonista se han contradicho en público.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_065",
+      "question": "¿Quién compuso la banda sonora de jazz del clásico televisivo de 1965 'La Navidad de Charlie Brown'?",
+      "answers": [
+        {
+          "text": "Vince Guaraldi",
+          "correct": true
+        },
+        {
+          "text": "Dave Brubeck",
+          "correct": false
+        },
+        {
+          "text": "Duke Ellington",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La cadena pensó al principio que un trío de jazz no encajaba en un programa infantil; el disco vendió millones.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_066",
+      "question": "¿Quién convirtió en 1949 'Rudolph, the Red-Nosed Reindeer' en un éxito mundial?",
+      "answers": [
+        {
+          "text": "El cantante Gene Autry",
+          "correct": true
+        },
+        {
+          "text": "Frank Sinatra",
+          "correct": false
+        },
+        {
+          "text": "Louis Armstrong",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Autry dudó mucho y solo la grabó por insistencia de su mujer; fue su disco más vendido.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_067",
+      "question": "¿En qué texto aparecieron por primera vez con nombre los ocho renos de Papá Noel?",
+      "answers": [
+        {
+          "text": "En un poema de 1823",
+          "correct": true
+        },
+        {
+          "text": "En una novela de Charles Dickens",
+          "correct": false
+        },
+        {
+          "text": "En un anuncio de prensa de 1902",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "'A Visit from St. Nicholas' nombraba también a Donder y Blitzen, que en neerlandés significan trueno y rayo.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_068",
+      "question": "¿En qué país se inventó en 1904 el sello navideño benéfico?",
+      "answers": [
+        {
+          "text": "En Dinamarca",
+          "correct": true
+        },
+        {
+          "text": "En Canadá",
+          "correct": false
+        },
+        {
+          "text": "En Italia",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Un funcionario de correos propuso el sello adicional para financiar hospitales infantiles y la idea se extendió por el mundo.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_069",
+      "question": "¿Qué leyenda explica los calcetines colgados en Navidad?",
+      "answers": [
+        {
+          "text": "Nicolás lanzó oro por una ventana y cayó en unas medias",
+          "correct": true
+        },
+        {
+          "text": "Un sastre perdió su calcetín por la chimenea",
+          "correct": false
+        },
+        {
+          "text": "Los mineros secaban los calcetines junto al fuego",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "En el relato, el oro salvó de la miseria a las tres hijas de un hombre arruinado.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_070",
+      "question": "¿Qué es cierto sobre la 'tradición alemana' del pepinillo en el árbol?",
+      "answers": [
+        {
+          "text": "Casi nadie en Alemania la conoce",
+          "correct": true
+        },
+        {
+          "text": "Viene de la región del Spreewald",
+          "correct": false
+        },
+        {
+          "text": "Se inventó en Baviera en 1850",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La costumbre es sobre todo estadounidense y allí se vendió con un origen alemán inventado.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_071",
+      "question": "¿Dónde nació la costumbre de besarse bajo el muérdago?",
+      "answers": [
+        {
+          "text": "En Inglaterra",
+          "correct": true
+        },
+        {
+          "text": "En Grecia",
+          "correct": false
+        },
+        {
+          "text": "En Rusia",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "En el siglo XVIII la regla era arrancar una baya por cada beso: cuando la rama quedaba pelada, se acababa.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_072",
+      "question": "¿Qué se hace con la madera del gran árbol del Rockefeller Center tras las fiestas?",
+      "answers": [
+        {
+          "text": "Se convierte en tablones para viviendas solidarias",
+          "correct": true
+        },
+        {
+          "text": "Se subasta",
+          "correct": false
+        },
+        {
+          "text": "Se deja en pie hasta Pascua",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Desde 2007 los tablones van a Habitat for Humanity; allí hay árbol casi todos los años desde 1931.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_073",
+      "question": "¿Qué rango tenía en realidad el 'buen rey Wenceslao' del villancico inglés?",
+      "answers": [
+        {
+          "text": "Era duque de Bohemia",
+          "correct": true
+        },
+        {
+          "text": "Era emperador de Bizancio",
+          "correct": false
+        },
+        {
+          "text": "Era rey de Polonia",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "A Wenceslao I se le concedió el título real solo después de muerto; el villancico se adelanta.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_074",
+      "question": "¿De dónde procede la melodía de 'O Tannenbaum'?",
+      "answers": [
+        {
+          "text": "De una vieja canción popular",
+          "correct": true
+        },
+        {
+          "text": "De Beethoven",
+          "correct": false
+        },
+        {
+          "text": "De un himno inglés",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Ernst Anschütz escribió la letra actual en 1824 sobre una melodía ya conocida que antes hablaba de una amante infiel.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_075",
+      "question": "¿Qué reconocimiento recibió 'Noche de paz' de la UNESCO en 2011?",
+      "answers": [
+        {
+          "text": "Fue declarada patrimonio cultural inmaterial de Austria",
+          "correct": true
+        },
+        {
+          "text": "Entró en el registro Memoria del Mundo",
+          "correct": false
+        },
+        {
+          "text": "Fue declarada himno mundial",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La canción se ha traducido a más de 300 lenguas y dialectos.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_076",
+      "question": "¿Qué significa la palabra latina 'adventus', de la que viene el Adviento?",
+      "answers": [
+        {
+          "text": "Llegada",
+          "correct": true
+        },
+        {
+          "text": "Espera",
+          "correct": false
+        },
+        {
+          "text": "Oscuridad",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El Adviento era originalmente un tiempo de ayuno, por eso la comida antes del 24 de diciembre solía ser frugal.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_077",
+      "question": "¿Qué se pone tradicionalmente bajo el mantel en la 'Wigilia' polaca?",
+      "answers": [
+        {
+          "text": "Heno",
+          "correct": true
+        },
+        {
+          "text": "Monedas",
+          "correct": false
+        },
+        {
+          "text": "Un trozo de carbón",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Recuerda al pesebre; además se deja un cubierto libre para un invitado inesperado.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_078",
+      "question": "¿Qué son los 'kalikantzaros' griegos?",
+      "answers": [
+        {
+          "text": "Duendes que hacen travesuras entre Navidad y Reyes",
+          "correct": true
+        },
+        {
+          "text": "Dulces navideños de Creta",
+          "correct": false
+        },
+        {
+          "text": "Cantores de villancicos en Atenas",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Según la leyenda, serran el árbol del mundo todo el año y solo salen a la superficie durante las doce noches.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_079",
+      "question": "¿Qué día se celebra la Navidad ('Genna') en Etiopía?",
+      "answers": [
+        {
+          "text": "El 7 de enero",
+          "correct": true
+        },
+        {
+          "text": "El 24 de diciembre",
+          "correct": false
+        },
+        {
+          "text": "El 2 de febrero",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La Iglesia ortodoxa etíope sigue su propio calendario y el año etíope va por detrás del gregoriano.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_080",
+      "question": "¿Cuántas noches duran las posadas mexicanas antes de Navidad?",
+      "answers": [
+        {
+          "text": "Nueve",
+          "correct": true
+        },
+        {
+          "text": "Tres",
+          "correct": false
+        },
+        {
+          "text": "Doce",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Representan la búsqueda de posada: cada noche termina ante una puerta distinta con cantos y piñata.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_081",
+      "question": "¿Qué representan las siete puntas de la piñata navideña mexicana clásica?",
+      "answers": [
+        {
+          "text": "Los siete pecados capitales",
+          "correct": true
+        },
+        {
+          "text": "Los siete días de la semana",
+          "correct": false
+        },
+        {
+          "text": "Siete estrellas del cielo",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Golpearla con los ojos vendados es golpear a ciegas contra el pecado, y los dulces son la recompensa de la fe.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_082",
+      "question": "¿Quién extrae los números de la lotería de Navidad 'El Gordo' y canta los premios?",
+      "answers": [
+        {
+          "text": "Los niños de un colegio",
+          "correct": true
+        },
+        {
+          "text": "Presentadores de televisión",
+          "correct": false
+        },
+        {
+          "text": "Notarios del Banco de España",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los niños de San Ildefonso cantan número e importe alternándose desde el siglo XVIII.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_083",
+      "question": "¿Quiénes traen tradicionalmente los regalos a los niños en España?",
+      "answers": [
+        {
+          "text": "Los Reyes Magos",
+          "correct": true
+        },
+        {
+          "text": "Papá Noel el 24 de diciembre",
+          "correct": false
+        },
+        {
+          "text": "San Nicolás el 6 de diciembre",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La noche del 5 al 6 de enero los niños dejan los zapatos y un poco de agua para los camellos.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_084",
+      "question": "¿Qué país es conocido por la temporada navideña más larga del mundo?",
+      "answers": [
+        {
+          "text": "Filipinas",
+          "correct": true
+        },
+        {
+          "text": "Islandia",
+          "correct": false
+        },
+        {
+          "text": "Portugal",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "En cuanto empieza septiembre suenan los villancicos, y la temporada se alarga hasta enero.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_085",
+      "question": "¿Qué forma tiene el farol navideño filipino, el 'parol'?",
+      "answers": [
+        {
+          "text": "Una estrella de cinco puntas",
+          "correct": true
+        },
+        {
+          "text": "Una media luna",
+          "correct": false
+        },
+        {
+          "text": "Una campana",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Representa la estrella de Belén y originalmente se hacía con bambú y papel de arroz.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_086",
+      "question": "¿En qué estación celebra Australia la Navidad?",
+      "answers": [
+        {
+          "text": "En pleno verano",
+          "correct": true
+        },
+        {
+          "text": "A finales de otoño",
+          "correct": false
+        },
+        {
+          "text": "A principios de primavera",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Allí forman parte de la fiesta las barbacoas en la playa y los 'Carols by Candlelight' al aire libre.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_087",
+      "question": "¿Por qué los ortodoxos rusos celebran la Navidad el 7 de enero?",
+      "answers": [
+        {
+          "text": "Porque la Iglesia mantiene el calendario juliano",
+          "correct": true
+        },
+        {
+          "text": "Porque un zar cambió la fecha",
+          "correct": false
+        },
+        {
+          "text": "Porque el 25 de diciembre es laborable",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La diferencia con el calendario gregoriano es actualmente de trece días.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_088",
+      "question": "¿Qué exige la normativa del Elisenlebkuchen de Núremberg?",
+      "answers": [
+        {
+          "text": "Como máximo un diez por ciento de harina",
+          "correct": true
+        },
+        {
+          "text": "Al menos la mitad de miel",
+          "correct": false
+        },
+        {
+          "text": "Exactamente siete especias",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La denominación protegida exige además una alta proporción de frutos secos: por eso quedan tan jugosos.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_089",
+      "question": "¿Qué representa la forma del Christstollen de Dresde?",
+      "answers": [
+        {
+          "text": "Al Niño Jesús envuelto en pañales",
+          "correct": true
+        },
+        {
+          "text": "Un trineo",
+          "correct": false
+        },
+        {
+          "text": "Una montaña nevada",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El azúcar glas simboliza los pañales; la receta estuvo mucho tiempo limitada por la prohibición de mantequilla en Adviento.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_090",
+      "question": "¿De qué ciudad procede el panettone?",
+      "answers": [
+        {
+          "text": "De Milán",
+          "correct": true
+        },
+        {
+          "text": "De Nápoles",
+          "correct": false
+        },
+        {
+          "text": "De Turín",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Con la masa madre y varios levados, la elaboración supera a menudo las 30 horas.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_091",
+      "question": "¿Desde cuándo está documentado en Europa el vino caliente especiado?",
+      "answers": [
+        {
+          "text": "Desde la Antigüedad romana",
+          "correct": true
+        },
+        {
+          "text": "Desde el siglo XVIII",
+          "correct": false
+        },
+        {
+          "text": "Desde los años veinte",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Un recetario romano describe el 'conditum paradoxum' de vino, miel y pimienta: el antepasado del vino caliente.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_092",
+      "question": "¿En qué ciudad está documentado por primera vez el árbol de Navidad adornado?",
+      "answers": [
+        {
+          "text": "En Estrasburgo",
+          "correct": true
+        },
+        {
+          "text": "En Viena",
+          "correct": false
+        },
+        {
+          "text": "En Copenhague",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Un registro gremial de 1539 menciona un árbol en la catedral; las velas llegaron mucho después.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_093",
+      "question": "¿Desde cuándo existe el mensaje navideño de la casa real británica?",
+      "answers": [
+        {
+          "text": "Desde 1932",
+          "correct": true
+        },
+        {
+          "text": "Desde 1901",
+          "correct": false
+        },
+        {
+          "text": "Desde 1966",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Jorge V habló primero por radio; la primera emisión televisada llegó en 1957.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_094",
+      "question": "¿Qué tiene de particular 'Feliz Navidad' de José Feliciano, de 1970?",
+      "answers": [
+        {
+          "text": "La letra son unas pocas líneas en español e inglés",
+          "correct": true
+        },
+        {
+          "text": "Es la canción navideña más larga de las listas",
+          "correct": false
+        },
+        {
+          "text": "Se grabó sin instrumentos",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Feliciano tardó unos minutos en escribir la letra y tocó el cuatro en la grabación.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_095",
+      "question": "¿Qué explicación astronómica propuso Johannes Kepler para la estrella de Belén?",
+      "answers": [
+        {
+          "text": "Una conjunción cercana de Júpiter y Saturno",
+          "correct": true
+        },
+        {
+          "text": "El impacto de un cometa",
+          "correct": false
+        },
+        {
+          "text": "Un eclipse de sol",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Kepler observó una conjunción así en 1603 y calculó hacia atrás hasta el año 7 antes de nuestra era.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_096",
+      "question": "¿Qué dice la Biblia sobre la fecha del nacimiento de Jesús?",
+      "answers": [
+        {
+          "text": "No da ninguna fecha",
+          "correct": true
+        },
+        {
+          "text": "Indica el 25 de diciembre",
+          "correct": false
+        },
+        {
+          "text": "Indica el 6 de enero",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El 25 de diciembre se impuso en el siglo IV y coincidía con fiestas romanas del solsticio de invierno.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_097",
+      "question": "¿Cuántos regalos se reciben en total si cada día de 'The Twelve Days of Christmas' se repiten todos los anteriores?",
+      "type": "estimate",
+      "answer": 364,
+      "min": 0,
+      "max": 1000,
+      "unit": "regalos",
+      "difficulty": "medium",
+      "fun_fact": "364, casi uno por cada día del año, entre ellos doce perdices en un peral.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_098",
+      "question": "¿En qué año se cantó por primera vez 'Noche de paz'?",
+      "type": "estimate",
+      "answer": 1818,
+      "min": 1700,
+      "max": 1950,
+      "unit": "año",
+      "difficulty": "medium",
+      "fun_fact": "En 1818, en Oberndorf, cerca de Salzburgo, acompañada por una guitarra en lugar del órgano.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_099",
+      "question": "¿Qué altura tiene el cabrón de paja de Gävle que se instala cada Adviento en Suecia?",
+      "type": "estimate",
+      "answer": 13,
+      "min": 1,
+      "max": 60,
+      "unit": "metros",
+      "difficulty": "hard",
+      "fun_fact": "13 metros de alto y unas 3,6 toneladas; aun así, muchas veces no ha llegado al final del Adviento.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_100",
+      "question": "¿Cuántos renos se nombran en el poema de 1823 'A Visit from St. Nicholas'?",
+      "type": "estimate",
+      "answer": 8,
+      "min": 0,
+      "max": 40,
+      "unit": "renos",
+      "difficulty": "easy",
+      "fun_fact": "Ocho; Rudolph se sumó 116 años después como invención publicitaria.",
+      "category": "Navidad"
+    },
+    {
+      "id": "navidad_es_101",
+      "question": "¿Cuántas ventanitas tiene un calendario de Adviento clásico?",
+      "type": "estimate",
+      "answer": 24,
+      "min": 0,
+      "max": 100,
+      "unit": "ventanitas",
+      "difficulty": "easy",
+      "fun_fact": "24: el calendario termina en Nochebuena, no el día de Navidad.",
+      "category": "Navidad"
+    }
+  ]
+}

--- a/custom_components/quizify/questions/new-years-eve-en.json
+++ b/custom_components/quizify/questions/new-years-eve-en.json
@@ -1,0 +1,2068 @@
+{
+  "name": "New Year's Eve",
+  "language": "en",
+  "version": "1.0",
+  "theme": "trivia",
+  "season": {
+    "start": "12-27",
+    "end": "01-06",
+    "label": "🎆 New Year season"
+  },
+  "questions": [
+    {
+      "id": "new_years_eve_en_001",
+      "question": "Which black-and-white television sketch has run every New Year's Eve in Germany for decades?",
+      "answers": [
+        {
+          "text": "'Dinner for One'",
+          "correct": true
+        },
+        {
+          "text": "'The Queen's 90th Birthday'",
+          "correct": false
+        },
+        {
+          "text": "'Die Feuerzangenbowle'",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "German public broadcaster NDR recorded the English-language sketch in 1963; in Britain itself it is virtually unknown.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_002",
+      "question": "Where does the German name 'Silvester' for 31 December come from?",
+      "answers": [
+        {
+          "text": "From a pope who died on that day",
+          "correct": true
+        },
+        {
+          "text": "From a Latin word for fire",
+          "correct": false
+        },
+        {
+          "text": "From a medieval winter festival",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Pope Sylvester I died on 31 December 335, so his feast day landed on the last day of the year.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_003",
+      "question": "Since when has a lit ball dropped in New York's Times Square at the turn of the year?",
+      "answers": [
+        {
+          "text": "Since 1907",
+          "correct": true
+        },
+        {
+          "text": "Since 1955",
+          "correct": false
+        },
+        {
+          "text": "Since 1980",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Before that the square had fireworks, which the city banned on fire-safety grounds.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_004",
+      "question": "Which poem is the song 'Auld Lang Syne' based on?",
+      "answers": [
+        {
+          "text": "A text by Robert Burns",
+          "correct": true
+        },
+        {
+          "text": "A Shakespeare sonnet",
+          "correct": false
+        },
+        {
+          "text": "An Irish hymn",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Burns sent the words to a song archive in 1788, saying he had taken them down from an old man.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_005",
+      "question": "What do Spaniards traditionally eat in the twelve seconds around midnight?",
+      "answers": [
+        {
+          "text": "Twelve grapes",
+          "correct": true
+        },
+        {
+          "text": "Twelve olives",
+          "correct": false
+        },
+        {
+          "text": "Twelve almonds",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "One grape per chime; anyone who chokes or falls behind supposedly forfeits their luck for the year.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_006",
+      "question": "How did the Spanish twelve-grape custom supposedly start around 1909?",
+      "answers": [
+        {
+          "text": "Growers in Alicante had a record harvest to sell",
+          "correct": true
+        },
+        {
+          "text": "A king decreed it",
+          "correct": false
+        },
+        {
+          "text": "A radio station raffled off grapes",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "The 'uvas de la suerte' began as a marketing idea and became a nationwide habit within a few years.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_007",
+      "question": "Which clock do people in Madrid gather in front of at the turn of the year?",
+      "answers": [
+        {
+          "text": "The clock on the Puerta del Sol",
+          "correct": true
+        },
+        {
+          "text": "The clock of Atocha station",
+          "correct": false
+        },
+        {
+          "text": "The clock of the Prado",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The four preliminary chimes before the twelve are part of the ritual; starting early ruins the count.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_008",
+      "question": "What do many Danes do at the exact moment the year turns?",
+      "answers": [
+        {
+          "text": "They jump off a chair",
+          "correct": true
+        },
+        {
+          "text": "They throw salt over the shoulder",
+          "correct": false
+        },
+        {
+          "text": "They open every window",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The jump marks the leap into the new year, and broken crockery on your doorstep counts as proof of friendship.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_009",
+      "question": "What do Japanese households send in their millions at the turn of the year?",
+      "answers": [
+        {
+          "text": "New Year postcards",
+          "correct": true
+        },
+        {
+          "text": "Dried flowers",
+          "correct": false
+        },
+        {
+          "text": "Calligraphed fans",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "'Nengajo' are collected in advance and delivered by the post office in one batch on New Year's morning.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_010",
+      "question": "Which dish do many Japanese eat on the evening of 31 December?",
+      "answers": [
+        {
+          "text": "Long buckwheat noodles",
+          "correct": true
+        },
+        {
+          "text": "Raw tuna with rice",
+          "correct": false
+        },
+        {
+          "text": "Steamed dumplings",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "'Toshikoshi soba' break easily between the teeth, which symbolises cutting loose from the old year's troubles.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_011",
+      "question": "What is the Scottish New Year's Eve festival called?",
+      "answers": [
+        {
+          "text": "Hogmanay",
+          "correct": true
+        },
+        {
+          "text": "Beltane",
+          "correct": false
+        },
+        {
+          "text": "Samhain",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Because Christmas was long suppressed in Scotland, the big celebration migrated to the turn of the year.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_012",
+      "question": "What is the Scottish 'first footer' supposed to bring into the house after midnight?",
+      "answers": [
+        {
+          "text": "Coal, bread and whisky",
+          "correct": true
+        },
+        {
+          "text": "A white cloth and salt",
+          "correct": false
+        },
+        {
+          "text": "A sprig of holly",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "A dark-haired man makes the best first visitor; a fair-haired one used to be read as a warning of trouble.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_013",
+      "question": "Which pastry belongs to New Year's Eve in the Netherlands?",
+      "answers": [
+        {
+          "text": "Oliebollen",
+          "correct": true
+        },
+        {
+          "text": "Stroopwafels",
+          "correct": false
+        },
+        {
+          "text": "Speculaas",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Legend held that the deep-fried dough balls warded off evil spirits, whose blades slid off the greasy skin.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_014",
+      "question": "What do tens of thousands of Dutch people do at Scheveningen on 1 January?",
+      "answers": [
+        {
+          "text": "They plunge into the North Sea",
+          "correct": true
+        },
+        {
+          "text": "They climb windmills",
+          "correct": false
+        },
+        {
+          "text": "They cycle to the dyke",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The 'Nieuwjaarsduik' happens in single-digit water temperatures, and pea soup follows by tradition.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_015",
+      "question": "Which pulse do Italians eat at New Year as a symbol of luck?",
+      "answers": [
+        {
+          "text": "Lentils",
+          "correct": true
+        },
+        {
+          "text": "Chickpeas",
+          "correct": false
+        },
+        {
+          "text": "White beans",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Their shape recalls coins, and they are classically served with cotechino or zampone.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_016",
+      "question": "Which colour is the traditional Italian underwear on New Year's Eve?",
+      "answers": [
+        {
+          "text": "Red",
+          "correct": true
+        },
+        {
+          "text": "Yellow",
+          "correct": false
+        },
+        {
+          "text": "White",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "It is meant to bring luck and, by tradition, is thrown away on New Year's Day.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_017",
+      "question": "What is hidden in the Greek 'vasilopita'?",
+      "answers": [
+        {
+          "text": "A coin",
+          "correct": true
+        },
+        {
+          "text": "An almond",
+          "correct": false
+        },
+        {
+          "text": "A slip of paper",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Whoever gets the slice with the coin has luck for the year; the first slice traditionally belongs to the house.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_018",
+      "question": "Which colour do many Brazilians wear on New Year's Eve?",
+      "answers": [
+        {
+          "text": "White",
+          "correct": true
+        },
+        {
+          "text": "Green",
+          "correct": false
+        },
+        {
+          "text": "Black",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "White stands for peace; on Copacabana many also jump seven waves and throw flowers into the sea.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_019",
+      "question": "What do many people in Ecuador and Colombia burn at midnight?",
+      "answers": [
+        {
+          "text": "Home-made effigies representing the old year",
+          "correct": true
+        },
+        {
+          "text": "Old calendars",
+          "correct": false
+        },
+        {
+          "text": "Dried corn cobs",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The 'años viejos' often wear the faces of politicians or film characters, sometimes with a will in the pocket.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_020",
+      "question": "Which pattern do many people in the Philippines wear at New Year?",
+      "answers": [
+        {
+          "text": "Polka dots",
+          "correct": true
+        },
+        {
+          "text": "Stripes",
+          "correct": false
+        },
+        {
+          "text": "Checks",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Round shapes stand for coins, which is also why twelve round fruits sit on the table.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_021",
+      "question": "Which Soviet film traditionally airs in Russia at the turn of the year?",
+      "answers": [
+        {
+          "text": "'The Irony of Fate'",
+          "correct": true
+        },
+        {
+          "text": "'Battleship Potemkin'",
+          "correct": false
+        },
+        {
+          "text": "'Solaris'",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "The 1975 comedy has run almost every year for decades and is as much part of the ritual as the sparkling wine.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_022",
+      "question": "Who traditionally brings the presents at New Year in Russia?",
+      "answers": [
+        {
+          "text": "Father Frost with his granddaughter Snegurochka",
+          "correct": true
+        },
+        {
+          "text": "St Nicholas",
+          "correct": false
+        },
+        {
+          "text": "The Three Kings",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "In Soviet times the celebration was deliberately shifted from church Christmas to the turn of the year.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_023",
+      "question": "Which island state greets the new year among the very first in the world?",
+      "answers": [
+        {
+          "text": "Kiribati",
+          "correct": true
+        },
+        {
+          "text": "Iceland",
+          "correct": false
+        },
+        {
+          "text": "Malta",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Kiribati's Line Islands sit in time zone UTC+14, the earliest that exists.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_024",
+      "question": "What did Samoa do to its calendar at the end of 2011?",
+      "answers": [
+        {
+          "text": "It deleted 30 December entirely",
+          "correct": true
+        },
+        {
+          "text": "It stretched 31 December to 48 hours",
+          "correct": false
+        },
+        {
+          "text": "It celebrated New Year twice",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Jumping the date line moved the country closer to Australia and New Zealand, its main trading partners.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_025",
+      "question": "Which people made the earliest known new-year resolutions about 4,000 years ago?",
+      "answers": [
+        {
+          "text": "The Babylonians",
+          "correct": true
+        },
+        {
+          "text": "The Etruscans",
+          "correct": false
+        },
+        {
+          "text": "The Vikings",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "At the Akitu festival they promised the gods to settle debts and return borrowed tools.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_026",
+      "question": "Who fixed 1 January as the start of the year in the Roman calendar?",
+      "answers": [
+        {
+          "text": "Julius Caesar",
+          "correct": true
+        },
+        {
+          "text": "Emperor Augustus",
+          "correct": false
+        },
+        {
+          "text": "Constantine the Great",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Through the calendar reform of 46 BCE; before that the Roman year began in March.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_027",
+      "question": "Which pope is today's globally used calendar named after?",
+      "answers": [
+        {
+          "text": "Gregory XIII",
+          "correct": true
+        },
+        {
+          "text": "Pius IX",
+          "correct": false
+        },
+        {
+          "text": "Innocent III",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The 1582 switch skipped ten days: 4 October was followed immediately by the 15th.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_028",
+      "question": "When did the official new year begin in England before 1752?",
+      "answers": [
+        {
+          "text": "On 25 March",
+          "correct": true
+        },
+        {
+          "text": "On 1 December",
+          "correct": false
+        },
+        {
+          "text": "On 1 September",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Only the switch to the Gregorian calendar moved the start of the year to 1 January.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_029",
+      "question": "What is a leap second, usually inserted at the end of the year, for?",
+      "answers": [
+        {
+          "text": "It keeps atomic time in step with the Earth's rotation",
+          "correct": true
+        },
+        {
+          "text": "It corrects daylight-saving errors",
+          "correct": false
+        },
+        {
+          "text": "It lengthens a leap year",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The Earth's rotation is not perfectly steady, and atomic clocks are more precise than the planet they describe.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_030",
+      "question": "Why do Germans now pour wax rather than lead on New Year's Eve?",
+      "answers": [
+        {
+          "text": "Because lead-pouring kits were banned in the EU",
+          "correct": true
+        },
+        {
+          "text": "Because lead became too expensive",
+          "correct": false
+        },
+        {
+          "text": "Because wax makes prettier shapes",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "A limit on lead in consumer products made the classic sets unsellable in 2018.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_031",
+      "question": "What is a Feuerzangenbowle?",
+      "answers": [
+        {
+          "text": "A punch with a rum-soaked sugarloaf burning above it",
+          "correct": true
+        },
+        {
+          "text": "A bowl of burning candles",
+          "correct": false
+        },
+        {
+          "text": "A pastry fried in a pan",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The sugarloaf sits in a pair of tongs over the pot and drips caramelised into the wine.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_032",
+      "question": "Which New Year's Eve prank involving doughnuts is common in Germany?",
+      "answers": [
+        {
+          "text": "One is filled with mustard instead of jam",
+          "correct": true
+        },
+        {
+          "text": "One is frozen solid",
+          "correct": false
+        },
+        {
+          "text": "One is salted and hidden",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Tradition says whoever gets the mustard doughnut still has luck in the coming year.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_033",
+      "question": "Which piece traditionally closes the Vienna Philharmonic's New Year's Concert?",
+      "answers": [
+        {
+          "text": "The Radetzky March",
+          "correct": true
+        },
+        {
+          "text": "The Emperor Waltz",
+          "correct": false
+        },
+        {
+          "text": "Beethoven's Ninth",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The audience claps along, and the conductor spends the piece conducting the hall rather than the orchestra.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_034",
+      "question": "Which waltz opens the encores at the Vienna New Year's Concert?",
+      "answers": [
+        {
+          "text": "'The Blue Danube'",
+          "correct": true
+        },
+        {
+          "text": "'Wiener Blut'",
+          "correct": false
+        },
+        {
+          "text": "'Roses from the South'",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The orchestra is interrupted after the opening bars so the players can wish the audience a good year.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_035",
+      "question": "Roughly what pressure sits inside a sealed champagne bottle?",
+      "answers": [
+        {
+          "text": "About six bar",
+          "correct": true
+        },
+        {
+          "text": "About one bar",
+          "correct": false
+        },
+        {
+          "text": "About thirty bar",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "That is roughly three times a car tyre, which is why the glass is thick and the cork is wired down.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_036",
+      "question": "When may a sparkling wine be called champagne?",
+      "answers": [
+        {
+          "text": "Only if it comes from the Champagne region",
+          "correct": true
+        },
+        {
+          "text": "Only if it ages at least ten years",
+          "correct": false
+        },
+        {
+          "text": "Only if it is made from a single grape variety",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "France defends the protected designation of origin in courts around the world.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_037",
+      "question": "What is 'sabrage' with a bottle of sparkling wine?",
+      "answers": [
+        {
+          "text": "Striking the neck off with a sabre",
+          "correct": true
+        },
+        {
+          "text": "Chilling it in salted ice",
+          "correct": false
+        },
+        {
+          "text": "Decanting it into a carafe",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The blow lands on the seam of the bottle, and the internal pressure blows off the glass ring with the cork.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_038",
+      "question": "In which country were fireworks invented?",
+      "answers": [
+        {
+          "text": "China",
+          "correct": true
+        },
+        {
+          "text": "Italy",
+          "correct": false
+        },
+        {
+          "text": "Persia",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Black powder was first used to scare off evil spirits with noise; the colours came centuries later.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_039",
+      "question": "What produces the colour red in a firework?",
+      "answers": [
+        {
+          "text": "Strontium compounds",
+          "correct": true
+        },
+        {
+          "text": "Iron filings",
+          "correct": false
+        },
+        {
+          "text": "Sulphur",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Copper burns blue, barium green and sodium yellow: fireworks are applied flame chemistry.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_040",
+      "question": "On how many days a year may New Year fireworks normally be sold in Germany?",
+      "answers": [
+        {
+          "text": "Three days",
+          "correct": true
+        },
+        {
+          "text": "Ten days",
+          "correct": false
+        },
+        {
+          "text": "All year round",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Sales are limited to 29–31 December, and the start shifts if one of those days falls on a Sunday.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_041",
+      "question": "Which readings spike in European cities during the New Year's Eve night?",
+      "answers": [
+        {
+          "text": "Particulate matter levels",
+          "correct": true
+        },
+        {
+          "text": "Ozone levels",
+          "correct": false
+        },
+        {
+          "text": "Radon levels",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "In the first hour of the year they often sit at a multiple of the daily limit.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_042",
+      "question": "Between which dates can Chinese New Year fall?",
+      "answers": [
+        {
+          "text": "Between 21 January and 20 February",
+          "correct": true
+        },
+        {
+          "text": "Between 1 and 15 January",
+          "correct": false
+        },
+        {
+          "text": "Between 1 and 30 March",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The Chinese calendar is lunisolar, and the festival falls on the second new moon after the winter solstice.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_043",
+      "question": "When does the Persian new year festival Nowruz begin?",
+      "answers": [
+        {
+          "text": "At the spring equinox",
+          "correct": true
+        },
+        {
+          "text": "At the winter solstice",
+          "correct": false
+        },
+        {
+          "text": "At the first full moon in February",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Nowruz is celebrated from Iran to Central Asia and is on the UNESCO intangible heritage list.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_044",
+      "question": "In which month does Ethiopia celebrate its new year, 'Enkutatash'?",
+      "answers": [
+        {
+          "text": "September",
+          "correct": true
+        },
+        {
+          "text": "January",
+          "correct": false
+        },
+        {
+          "text": "May",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "The Ethiopian calendar has thirteen months: twelve of 30 days and one short remainder month.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_045",
+      "question": "How does Thailand mark its new year at 'Songkran'?",
+      "answers": [
+        {
+          "text": "With a nationwide water fight",
+          "correct": true
+        },
+        {
+          "text": "With a day of fasting",
+          "correct": false
+        },
+        {
+          "text": "With a kite festival",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The originally ritual pouring of water for purification is now a three-day April water festival.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_046",
+      "question": "Which problem preoccupied the IT world at the turn of 1999 to 2000?",
+      "answers": [
+        {
+          "text": "Years stored as two digits",
+          "correct": true
+        },
+        {
+          "text": "A worldwide power cut",
+          "correct": false
+        },
+        {
+          "text": "A virus called Millennium",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Because '00' could read as 1900, billions went into fixing it worldwide — and very little happened.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_047",
+      "question": "Which poem is read out at Skansen in Sweden at the turn of the year?",
+      "answers": [
+        {
+          "text": "Tennyson's 'Ring out, wild bells'",
+          "correct": true
+        },
+        {
+          "text": "An extract from the Edda",
+          "correct": false
+        },
+        {
+          "text": "A text by Astrid Lindgren",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "The tradition dates from 1895 and the recitation is broadcast nationwide on television.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_048",
+      "question": "Which meat do Hungarians avoid on New Year's Day?",
+      "answers": [
+        {
+          "text": "Poultry",
+          "correct": true
+        },
+        {
+          "text": "Beef",
+          "correct": false
+        },
+        {
+          "text": "Lamb",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Superstition says the luck would fly away; pork, by contrast, roots forwards and brings progress.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_049",
+      "question": "What are Irish households said to do with a loaf of bread at New Year?",
+      "answers": [
+        {
+          "text": "Bang it against walls and doors",
+          "correct": true
+        },
+        {
+          "text": "Bury it in the garden",
+          "correct": false
+        },
+        {
+          "text": "Throw it into the sea",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The noise is meant to drive misfortune out of the house and good bread into the coming year.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_050",
+      "question": "What is smashed on the doorstep at New Year in Turkey and Greece?",
+      "answers": [
+        {
+          "text": "A pomegranate",
+          "correct": true
+        },
+        {
+          "text": "A jug of water",
+          "correct": false
+        },
+        {
+          "text": "A walnut",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The further the seeds scatter, the greater the blessing on the house is supposed to be.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_051",
+      "question": "Which colour is the lucky New Year underwear in Peru and parts of Latin America?",
+      "answers": [
+        {
+          "text": "Yellow",
+          "correct": true
+        },
+        {
+          "text": "Blue",
+          "correct": false
+        },
+        {
+          "text": "Green",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Yellow stands for prosperity; those hoping for love choose red instead.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_052",
+      "question": "What do Mexicans do with an empty suitcase at New Year?",
+      "answers": [
+        {
+          "text": "Walk around the block with it",
+          "correct": true
+        },
+        {
+          "text": "Put it outside the door",
+          "correct": false
+        },
+        {
+          "text": "Burn it",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The walk is meant to secure travel in the coming year; some go only to the corner and back.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_053",
+      "question": "Which salad is a fixture on the Russian New Year's Eve table?",
+      "answers": [
+        {
+          "text": "Olivier salad",
+          "correct": true
+        },
+        {
+          "text": "Beetroot salad with herring",
+          "correct": false
+        },
+        {
+          "text": "Caraway coleslaw",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "It is named after a chef who invented it in 19th-century Moscow, and the original recipe is considered lost.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_054",
+      "question": "Which television programme do nearly all Icelanders watch on New Year's Eve?",
+      "answers": [
+        {
+          "text": "The satirical show 'Áramótaskaupið'",
+          "correct": true
+        },
+        {
+          "text": "A concert from the Harpa hall",
+          "correct": false
+        },
+        {
+          "text": "A live feed from the geysers",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "The streets empty for half an hour, and only afterwards do the fireworks and bonfires start.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_055",
+      "question": "What takes place in Madrid on the afternoon of 31 December?",
+      "answers": [
+        {
+          "text": "A big road race",
+          "correct": true
+        },
+        {
+          "text": "A running of the bulls",
+          "correct": false
+        },
+        {
+          "text": "A motorcade",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The 'San Silvestre Vallecana' draws tens of thousands, and many run in costume.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_056",
+      "question": "Which band released the song 'Happy New Year' in 1980?",
+      "answers": [
+        {
+          "text": "ABBA",
+          "correct": true
+        },
+        {
+          "text": "Queen",
+          "correct": false
+        },
+        {
+          "text": "The Bee Gees",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The lyric is far more melancholy than the title suggests, and in several countries it only charted years later.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_057",
+      "question": "Where does the month name January come from?",
+      "answers": [
+        {
+          "text": "From the Roman god Janus",
+          "correct": true
+        },
+        {
+          "text": "From the Latin word for ice",
+          "correct": false
+        },
+        {
+          "text": "From an Etruscan ruler",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Janus has two faces and looks backwards and forwards at once, which is hard to improve on for a year's start.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_058",
+      "question": "What does the German toast 'Prosit Neujahr' literally mean?",
+      "answers": [
+        {
+          "text": "'May it be of use'",
+          "correct": true
+        },
+        {
+          "text": "'To your health'",
+          "correct": false
+        },
+        {
+          "text": "'Bottoms up'",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "'Prosit' is Latin and entered German through 18th-century student slang.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_059",
+      "question": "Which sporting event traditionally takes place in Germany on 1 January?",
+      "answers": [
+        {
+          "text": "The New Year ski jumping in Garmisch-Partenkirchen",
+          "correct": true
+        },
+        {
+          "text": "A Formula One race",
+          "correct": false
+        },
+        {
+          "text": "The football cup final",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "It is the second stop of the Four Hills Tournament and starts with qualifying in the morning.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_060",
+      "question": "Which flower parade takes place in California on New Year's Day?",
+      "answers": [
+        {
+          "text": "The Rose Parade in Pasadena",
+          "correct": true
+        },
+        {
+          "text": "The Poppy Parade in San Diego",
+          "correct": false
+        },
+        {
+          "text": "The Lily Parade in Sacramento",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Every float must be covered entirely in plant material, down to the last leaf.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_061",
+      "question": "Who made 'Auld Lang Syne' a fixture of the North American New Year?",
+      "answers": [
+        {
+          "text": "Bandleader Guy Lombardo",
+          "correct": true
+        },
+        {
+          "text": "Singer Bing Crosby",
+          "correct": false
+        },
+        {
+          "text": "Broadcaster Orson Welles",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "His orchestra played it live at midnight every year from 1929, first on radio and later on television.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_062",
+      "question": "What is the Welsh 'Mari Lwyd' that travels door to door around New Year?",
+      "answers": [
+        {
+          "text": "A decorated horse skull on a pole",
+          "correct": true
+        },
+        {
+          "text": "A straw doll in a boat",
+          "correct": false
+        },
+        {
+          "text": "A turnip lantern",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "The party demands entry in rhyming verse, and the household has to answer in rhyme.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_063",
+      "question": "Which country greets the new year among the last in the world?",
+      "answers": [
+        {
+          "text": "The United States, with Baker and Howland Islands",
+          "correct": true
+        },
+        {
+          "text": "Portugal",
+          "correct": false
+        },
+        {
+          "text": "Chile",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The uninhabited islands sit in time zone UTC−12, a full 26 hours behind Kiribati.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_064",
+      "question": "What is thrown out of the window at midnight in parts of Cuba and Puerto Rico?",
+      "answers": [
+        {
+          "text": "A bucket of water",
+          "correct": true
+        },
+        {
+          "text": "Old clothes",
+          "correct": false
+        },
+        {
+          "text": "Coins",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The water is meant to wash the old year's bad luck out of the house.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_065",
+      "question": "What do the men in Stonehaven, Scotland, swing through the streets at New Year?",
+      "answers": [
+        {
+          "text": "Burning wire cages on long chains",
+          "correct": true
+        },
+        {
+          "text": "Peat torches",
+          "correct": false
+        },
+        {
+          "text": "Pumpkin lanterns",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "The fireballs end up in the harbour, and the custom is meant to drive off evil spirits.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_066",
+      "question": "What is the Scottish New Year dip into the freezing Firth of Forth called?",
+      "answers": [
+        {
+          "text": "The Loony Dook",
+          "correct": true
+        },
+        {
+          "text": "The Cold Ceilidh",
+          "correct": false
+        },
+        {
+          "text": "The Firth Plunge",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Many take the plunge in costume, and the event raises money for charity.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_067",
+      "question": "Which structure marks the turn of the year in Sydney with one of the world's first big firework displays?",
+      "answers": [
+        {
+          "text": "The Harbour Bridge",
+          "correct": true
+        },
+        {
+          "text": "The television tower",
+          "correct": false
+        },
+        {
+          "text": "The parliament building",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Because of the time zone, pictures from Sydney often reach Europe on the afternoon of 31 December.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_068",
+      "question": "At which landmark does Berlin traditionally hold its biggest New Year's Eve party?",
+      "answers": [
+        {
+          "text": "The Brandenburg Gate",
+          "correct": true
+        },
+        {
+          "text": "Berlin Cathedral",
+          "correct": false
+        },
+        {
+          "text": "The Olympic Stadium",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The stage show on the 'party mile' is broadcast live on television.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_069",
+      "question": "Which building is at the centre of Dubai's New Year's Eve fireworks?",
+      "answers": [
+        {
+          "text": "The Burj Khalifa",
+          "correct": true
+        },
+        {
+          "text": "The airport tower",
+          "correct": false
+        },
+        {
+          "text": "The Sheikh Zayed Mosque",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The facade of the world's tallest building doubles as a projection screen.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_070",
+      "question": "On which beach does one of the world's biggest New Year's Eve parties take place?",
+      "answers": [
+        {
+          "text": "Copacabana in Rio de Janeiro",
+          "correct": true
+        },
+        {
+          "text": "Waikiki Beach in Hawaii",
+          "correct": false
+        },
+        {
+          "text": "Bondi Beach in Sydney",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Millions arrive dressed in white, and after the fireworks flowers go into the water for the sea goddess Iemanjá.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_071",
+      "question": "What happens to the slips of paper visitors write their wishes on at Times Square?",
+      "answers": [
+        {
+          "text": "They are dropped as confetti at midnight",
+          "correct": true
+        },
+        {
+          "text": "They are burned",
+          "correct": false
+        },
+        {
+          "text": "They are archived at city hall",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The wishes are collected beforehand and tipped off the rooftops with the rest of the confetti.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_072",
+      "question": "How long does the Times Square ball take to complete its descent?",
+      "answers": [
+        {
+          "text": "Exactly 60 seconds",
+          "correct": true
+        },
+        {
+          "text": "About five minutes",
+          "correct": false
+        },
+        {
+          "text": "About ten seconds",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "It reaches the bottom precisely at midnight, and the numerals of the new year light up only afterwards.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_073",
+      "question": "Where does the German greeting 'Guten Rutsch' probably come from?",
+      "answers": [
+        {
+          "text": "From an old word for a good journey",
+          "correct": true
+        },
+        {
+          "text": "From icy roads",
+          "correct": false
+        },
+        {
+          "text": "From a sledging custom",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "The popular derivation from Yiddish is regarded by linguists as doubtful.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_074",
+      "question": "Which figure symbolises the new year in many countries?",
+      "answers": [
+        {
+          "text": "A baby wearing a sash with the year on it",
+          "correct": true
+        },
+        {
+          "text": "An eagle",
+          "correct": false
+        },
+        {
+          "text": "A key",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The motif is centuries old and was popularised by magazine covers from the 19th century onwards.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_075",
+      "question": "What is a Scandinavian 'kransekake'?",
+      "answers": [
+        {
+          "text": "A tower of almond-paste rings",
+          "correct": true
+        },
+        {
+          "text": "A wreath of savoury biscuits",
+          "correct": false
+        },
+        {
+          "text": "An ice cake with berries",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The rings shrink from bottom to top, and at New Year a small flag often sits on the summit.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_076",
+      "question": "How many meals does Estonian tradition prescribe on New Year's Eve?",
+      "answers": [
+        {
+          "text": "Seven, nine or twelve",
+          "correct": true
+        },
+        {
+          "text": "Exactly three",
+          "correct": false
+        },
+        {
+          "text": "Exactly five",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Those are the lucky numbers, and the eater is said to gain the strength of that many men.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_077",
+      "question": "What do many Japanese do in the first days of the year at 'hatsumode'?",
+      "answers": [
+        {
+          "text": "They make the year's first visit to a shrine or temple",
+          "correct": true
+        },
+        {
+          "text": "They plant a tree",
+          "correct": false
+        },
+        {
+          "text": "They cast a poem into the sea",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Old lucky charms are handed back on the same visit and new ones bought.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_078",
+      "question": "What are Japanese 'otoshidama'?",
+      "answers": [
+        {
+          "text": "Money gifts for children in small envelopes",
+          "correct": true
+        },
+        {
+          "text": "New Year poems on rice paper",
+          "correct": false
+        },
+        {
+          "text": "Small clay luck figures",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "The amount depends on age, with older children receiving more.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_079",
+      "question": "Which soup do Koreans eat on New Year's Day?",
+      "answers": [
+        {
+          "text": "A soup with sliced rice cakes",
+          "correct": true
+        },
+        {
+          "text": "A soup with seaweed and clams",
+          "correct": false
+        },
+        {
+          "text": "A cold buckwheat soup",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Tradition says you only turn a year older once you have eaten 'tteokguk'.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_080",
+      "question": "What is the Vietnamese new year festival called?",
+      "answers": [
+        {
+          "text": "Tet",
+          "correct": true
+        },
+        {
+          "text": "Diwali",
+          "correct": false
+        },
+        {
+          "text": "Obon",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "It follows the lunar calendar and usually coincides with Chinese New Year; kumquat trees belong in every home.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_081",
+      "question": "What is blown to mark the Jewish new year, Rosh Hashanah?",
+      "answers": [
+        {
+          "text": "A ram's horn",
+          "correct": true
+        },
+        {
+          "text": "A bronze bell",
+          "correct": false
+        },
+        {
+          "text": "A drum",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The shofar is sounded in a fixed sequence of calls, and the festival falls in autumn.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_082",
+      "question": "Why does the Islamic new year drift through the seasons?",
+      "answers": [
+        {
+          "text": "Because the Islamic calendar is purely lunar",
+          "correct": true
+        },
+        {
+          "text": "Because it is tied to Easter",
+          "correct": false
+        },
+        {
+          "text": "Because it is shifted every four years",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The lunar year is about eleven days shorter than the solar one, so 1 Muharram moves forward each year.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_083",
+      "question": "Until when was Christmas Day not a general public holiday in Scotland?",
+      "answers": [
+        {
+          "text": "Until 1958",
+          "correct": true
+        },
+        {
+          "text": "Until 1901",
+          "correct": false
+        },
+        {
+          "text": "Until 1975",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "That is why Hogmanay was for centuries the real winter celebration there.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_084",
+      "question": "What classically appears on the table for the French 'Réveillon de la Saint-Sylvestre'?",
+      "answers": [
+        {
+          "text": "Oysters",
+          "correct": true
+        },
+        {
+          "text": "Stuffed peppers",
+          "correct": false
+        },
+        {
+          "text": "Beef goulash",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Foie gras and champagne usually join them, and the meal starts late and runs long.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_085",
+      "question": "What is a Belgian New Year custom for children?",
+      "answers": [
+        {
+          "text": "They read a letter they wrote to their godparents",
+          "correct": true
+        },
+        {
+          "text": "They ring cowbells in the fields",
+          "correct": false
+        },
+        {
+          "text": "They hide coins in the snow",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "The letter is written on decorated paper and read out ceremonially on New Year's Day.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_086",
+      "question": "What happens at the Appenzell 'Silvesterchlausen' in Switzerland?",
+      "answers": [
+        {
+          "text": "Groups in elaborate costumes go farm to farm and yodel",
+          "correct": true
+        },
+        {
+          "text": "A burning wheel is rolled down the mountain",
+          "correct": false
+        },
+        {
+          "text": "Villagers swap cowbells",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "It happens twice: on 31 December and again on 13 January, following the old calendar.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_087",
+      "question": "What is a 'cotillón' at a Spanish or Latin American New Year's party?",
+      "answers": [
+        {
+          "text": "A bag of hats, horns and streamers",
+          "correct": true
+        },
+        {
+          "text": "A dance for twelve couples",
+          "correct": false
+        },
+        {
+          "text": "A cream dessert",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "After the twelve grapes the bag is opened and the noise starts.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_088",
+      "question": "What is thrown out of office windows in Argentina on the last working day of the year?",
+      "answers": [
+        {
+          "text": "Shredded paper from old files",
+          "correct": true
+        },
+        {
+          "text": "Flowers",
+          "correct": false
+        },
+        {
+          "text": "Coins",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "The paper storm in the financial district of Buenos Aires makes the news every year.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_089",
+      "question": "Where does the word 'confetti' come from?",
+      "answers": [
+        {
+          "text": "From Italian sugared almonds",
+          "correct": true
+        },
+        {
+          "text": "From a French paper maker",
+          "correct": false
+        },
+        {
+          "text": "From a Latin word for wind",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Milanese carnival crowds once threw sweets; when that got too expensive, coloured paper took their place.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_090",
+      "question": "Why was 1900 not a leap year?",
+      "answers": [
+        {
+          "text": "Full centuries are leap years only when divisible by 400",
+          "correct": true
+        },
+        {
+          "text": "Because the calendar was reformed that year",
+          "correct": false
+        },
+        {
+          "text": "Because February was shortened",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The same rule drops 2100, while 2000 did qualify.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_091",
+      "question": "What is sung in the Vatican on the evening of 31 December?",
+      "answers": [
+        {
+          "text": "The Te Deum, as a service of thanksgiving",
+          "correct": true
+        },
+        {
+          "text": "The Requiem",
+          "correct": false
+        },
+        {
+          "text": "The Magnificat",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The pope gives thanks for the closing year; 1 January is then the World Day of Peace.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_092",
+      "question": "When does the Danish head of state give the new year address?",
+      "answers": [
+        {
+          "text": "On the evening of 31 December",
+          "correct": true
+        },
+        {
+          "text": "On the morning of 1 January",
+          "correct": false
+        },
+        {
+          "text": "On 6 January",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The 6 p.m. speech structures the evening: dinner before, celebration after.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_093",
+      "question": "What is the Dutch 'oudejaarsconference'?",
+      "answers": [
+        {
+          "text": "A comedian's satirical review of the year",
+          "correct": true
+        },
+        {
+          "text": "A talk show with politicians",
+          "correct": false
+        },
+        {
+          "text": "A choir concert",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "The show often runs beyond two hours and airs live on the evening of 31 December.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_094",
+      "question": "Which ball season traditionally opens in Vienna around the turn of the year?",
+      "answers": [
+        {
+          "text": "The carnival ball season",
+          "correct": true
+        },
+        {
+          "text": "The opera season",
+          "correct": false
+        },
+        {
+          "text": "The Musikverein concert season",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "The Imperial Ball at the Hofburg takes place on New Year's Eve; the Opera Ball follows only in February.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_095",
+      "question": "How many animal signs does the Chinese zodiac, which gives each year a sign, contain?",
+      "answers": [
+        {
+          "text": "Twelve",
+          "correct": true
+        },
+        {
+          "text": "Ten",
+          "correct": false
+        },
+        {
+          "text": "Twenty-four",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "The rat comes first; legend says the cat arrived too late for the race and is missing as a result.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_096",
+      "question": "How many grapes do people in Spain eat to the chimes on New Year's Eve?",
+      "type": "estimate",
+      "answer": 12,
+      "min": 1,
+      "max": 60,
+      "unit": "grapes",
+      "difficulty": "easy",
+      "fun_fact": "Twelve, one per chime — which is why shops sell them peeled and de-seeded in tins.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_097",
+      "question": "How many times do Japanese temple bells ring on the night before New Year's Day?",
+      "type": "estimate",
+      "answer": 108,
+      "min": 0,
+      "max": 500,
+      "unit": "strikes",
+      "difficulty": "medium",
+      "fun_fact": "The 108 strikes stand for the worldly desires left behind with the old year.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_098",
+      "question": "How many hours pass between the first and the last turn of the year on Earth?",
+      "type": "estimate",
+      "answer": 26,
+      "min": 0,
+      "max": 60,
+      "unit": "hours",
+      "difficulty": "hard",
+      "fun_fact": "26 hours — from UTC+14 in Kiribati's Line Islands to UTC−12 at Baker and Howland Islands.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_099",
+      "question": "In which year did Pope Gregory XIII introduce the calendar used worldwide today?",
+      "type": "estimate",
+      "answer": 1582,
+      "min": 1200,
+      "max": 1900,
+      "unit": "year",
+      "difficulty": "medium",
+      "fun_fact": "1582 — in the changeover, 4 October was followed directly by 15 October.",
+      "category": "New Year's Eve"
+    },
+    {
+      "id": "new_years_eve_en_100",
+      "question": "In which year did German broadcaster NDR record the sketch 'Dinner for One' that has run at New Year ever since?",
+      "type": "estimate",
+      "answer": 1963,
+      "min": 1900,
+      "max": 2000,
+      "unit": "year",
+      "difficulty": "medium",
+      "fun_fact": "1963 — taped before a live audience in Hamburg, in English and without subtitles.",
+      "category": "New Year's Eve"
+    }
+  ]
+}

--- a/custom_components/quizify/questions/nochevieja-es.json
+++ b/custom_components/quizify/questions/nochevieja-es.json
@@ -1,0 +1,2068 @@
+{
+  "name": "Nochevieja",
+  "language": "es",
+  "version": "1.0",
+  "theme": "trivia",
+  "season": {
+    "start": "12-27",
+    "end": "01-06",
+    "label": "🎆 Fin de año"
+  },
+  "questions": [
+    {
+      "id": "nochevieja_es_001",
+      "question": "¿Qué sketch televisivo en blanco y negro se emite cada Nochevieja en Alemania desde hace décadas?",
+      "answers": [
+        {
+          "text": "'Dinner for One'",
+          "correct": true
+        },
+        {
+          "text": "'El 90 cumpleaños de la reina'",
+          "correct": false
+        },
+        {
+          "text": "'Die Feuerzangenbowle'",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La cadena alemana NDR grabó el sketch en inglés en 1963; en el Reino Unido es prácticamente desconocido.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_002",
+      "question": "¿De dónde viene el nombre alemán 'Silvester' para el 31 de diciembre?",
+      "answers": [
+        {
+          "text": "De un papa que murió ese día",
+          "correct": true
+        },
+        {
+          "text": "De una palabra latina para fuego",
+          "correct": false
+        },
+        {
+          "text": "De una fiesta invernal medieval",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El papa Silvestre I murió el 31 de diciembre del año 335 y su festividad quedó en el último día del año.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_003",
+      "question": "¿Desde cuándo cae una bola luminosa en Times Square de Nueva York en el cambio de año?",
+      "answers": [
+        {
+          "text": "Desde 1907",
+          "correct": true
+        },
+        {
+          "text": "Desde 1955",
+          "correct": false
+        },
+        {
+          "text": "Desde 1980",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Antes había fuegos artificiales, que la ciudad prohibió por motivos de seguridad contra incendios.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_004",
+      "question": "¿En qué poema se basa la canción 'Auld Lang Syne'?",
+      "answers": [
+        {
+          "text": "En un texto de Robert Burns",
+          "correct": true
+        },
+        {
+          "text": "En un soneto de Shakespeare",
+          "correct": false
+        },
+        {
+          "text": "En un himno irlandés",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Burns envió la letra a un archivo de canciones en 1788 y dijo habérsela oído a un anciano.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_005",
+      "question": "¿Qué se come tradicionalmente en España en los doce segundos de la medianoche?",
+      "answers": [
+        {
+          "text": "Doce uvas",
+          "correct": true
+        },
+        {
+          "text": "Doce aceitunas",
+          "correct": false
+        },
+        {
+          "text": "Doce almendras",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Una uva por campanada; quien se atraganta o se queda atrás pierde, según la tradición, la suerte del año.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_006",
+      "question": "¿Cómo surgió supuestamente hacia 1909 la costumbre española de las doce uvas?",
+      "answers": [
+        {
+          "text": "Los viticultores de Alicante tenían una cosecha récord que vender",
+          "correct": true
+        },
+        {
+          "text": "Lo decretó un rey",
+          "correct": false
+        },
+        {
+          "text": "Una emisora de radio sorteó uvas",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Las 'uvas de la suerte' empezaron como una idea comercial y en pocos años ya eran costumbre nacional.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_007",
+      "question": "¿Ante qué reloj se reúnen los madrileños en el cambio de año?",
+      "answers": [
+        {
+          "text": "Ante el reloj de la Puerta del Sol",
+          "correct": true
+        },
+        {
+          "text": "Ante el reloj de la estación de Atocha",
+          "correct": false
+        },
+        {
+          "text": "Ante el reloj del Prado",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Los cuatro cuartos previos a las doce campanadas son parte del ritual: empezar antes estropea la cuenta.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_008",
+      "question": "¿Qué hacen muchos daneses en el instante del cambio de año?",
+      "answers": [
+        {
+          "text": "Saltan desde una silla",
+          "correct": true
+        },
+        {
+          "text": "Tiran sal por encima del hombro",
+          "correct": false
+        },
+        {
+          "text": "Abren todas las ventanas",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El salto marca la entrada en el año nuevo, y la vajilla rota ante tu puerta se considera una prueba de amistad.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_009",
+      "question": "¿Qué envían los japoneses por millones en el cambio de año?",
+      "answers": [
+        {
+          "text": "Postales de Año Nuevo",
+          "correct": true
+        },
+        {
+          "text": "Flores secas",
+          "correct": false
+        },
+        {
+          "text": "Abanicos caligrafiados",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Las 'nengajo' se recogen antes y correos las reparte todas juntas la mañana de Año Nuevo.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_010",
+      "question": "¿Qué plato comen muchos japoneses la noche del 31 de diciembre?",
+      "answers": [
+        {
+          "text": "Fideos largos de trigo sarraceno",
+          "correct": true
+        },
+        {
+          "text": "Atún crudo con arroz",
+          "correct": false
+        },
+        {
+          "text": "Empanadillas al vapor",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los 'toshikoshi soba' se cortan fácil de un mordisco: simbolizan romper con las penas del año viejo.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_011",
+      "question": "¿Cómo se llama la fiesta escocesa de Nochevieja?",
+      "answers": [
+        {
+          "text": "Hogmanay",
+          "correct": true
+        },
+        {
+          "text": "Beltane",
+          "correct": false
+        },
+        {
+          "text": "Samhain",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Como la Navidad estuvo mucho tiempo prohibida en Escocia, la gran celebración se trasladó al cambio de año.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_012",
+      "question": "¿Qué debe llevar a la casa el 'first footer' escocés después de medianoche?",
+      "answers": [
+        {
+          "text": "Carbón, pan y whisky",
+          "correct": true
+        },
+        {
+          "text": "Un paño blanco y sal",
+          "correct": false
+        },
+        {
+          "text": "Una rama de acebo",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El mejor primer visitante es un hombre moreno; antiguamente uno rubio se interpretaba como augurio de problemas.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_013",
+      "question": "¿Qué dulce se asocia al cambio de año en los Países Bajos?",
+      "answers": [
+        {
+          "text": "Los oliebollen",
+          "correct": true
+        },
+        {
+          "text": "Los stroopwafels",
+          "correct": false
+        },
+        {
+          "text": "Las speculaas",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Según la leyenda, estas bolas de masa frita ahuyentaban a los malos espíritus porque sus hojas resbalaban en la grasa.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_014",
+      "question": "¿Qué hacen decenas de miles de neerlandeses en Scheveningen el 1 de enero?",
+      "answers": [
+        {
+          "text": "Se lanzan al mar del Norte",
+          "correct": true
+        },
+        {
+          "text": "Suben a los molinos",
+          "correct": false
+        },
+        {
+          "text": "Van en bici hasta el dique",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El 'Nieuwjaarsduik' se hace con el agua a menos de diez grados, y después toca sopa de guisantes.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_015",
+      "question": "¿Qué legumbre comen los italianos en Año Nuevo como símbolo de suerte?",
+      "answers": [
+        {
+          "text": "Lentejas",
+          "correct": true
+        },
+        {
+          "text": "Garbanzos",
+          "correct": false
+        },
+        {
+          "text": "Alubias blancas",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Su forma recuerda a las monedas y se sirven clásicamente con cotechino o zampone.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_016",
+      "question": "¿De qué color es tradicionalmente la ropa interior italiana en Nochevieja?",
+      "answers": [
+        {
+          "text": "Roja",
+          "correct": true
+        },
+        {
+          "text": "Amarilla",
+          "correct": false
+        },
+        {
+          "text": "Blanca",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Se supone que trae suerte y, por tradición, se tira el día de Año Nuevo.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_017",
+      "question": "¿Qué se esconde dentro de la 'vasilopita' griega?",
+      "answers": [
+        {
+          "text": "Una moneda",
+          "correct": true
+        },
+        {
+          "text": "Una almendra",
+          "correct": false
+        },
+        {
+          "text": "Un papelito",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Quien recibe la porción con la moneda tiene suerte todo el año; la primera porción es para la casa.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_018",
+      "question": "¿De qué color se viste mucha gente en Brasil en Nochevieja?",
+      "answers": [
+        {
+          "text": "De blanco",
+          "correct": true
+        },
+        {
+          "text": "De verde",
+          "correct": false
+        },
+        {
+          "text": "De negro",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El blanco simboliza la paz; en Copacabana muchos saltan además siete olas y lanzan flores al mar.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_019",
+      "question": "¿Qué queman muchas personas en Ecuador y Colombia a medianoche?",
+      "answers": [
+        {
+          "text": "Muñecos caseros que representan el año viejo",
+          "correct": true
+        },
+        {
+          "text": "Calendarios viejos",
+          "correct": false
+        },
+        {
+          "text": "Mazorcas secas",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los 'años viejos' suelen llevar caras de políticos o personajes de cine, y a veces un testamento en el bolsillo.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_020",
+      "question": "¿Qué estampado lleva mucha gente en Filipinas en Año Nuevo?",
+      "answers": [
+        {
+          "text": "Lunares",
+          "correct": true
+        },
+        {
+          "text": "Rayas",
+          "correct": false
+        },
+        {
+          "text": "Cuadros",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Las formas redondas representan monedas; por eso también hay doce frutas redondas en la mesa.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_021",
+      "question": "¿Qué película soviética se emite tradicionalmente en Rusia en el cambio de año?",
+      "answers": [
+        {
+          "text": "'La ironía del destino'",
+          "correct": true
+        },
+        {
+          "text": "'El acorazado Potemkin'",
+          "correct": false
+        },
+        {
+          "text": "'Solaris'",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La comedia de 1975 se emite casi todos los años desde hace décadas y forma parte del ritual tanto como el espumoso.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_022",
+      "question": "¿Quién trae tradicionalmente los regalos en Año Nuevo en Rusia?",
+      "answers": [
+        {
+          "text": "El Abuelo Invierno con su nieta Snegúrochka",
+          "correct": true
+        },
+        {
+          "text": "San Nicolás",
+          "correct": false
+        },
+        {
+          "text": "Los Reyes Magos",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "En la época soviética la fiesta se desplazó a propósito de la Navidad religiosa al cambio de año.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_023",
+      "question": "¿Qué estado insular recibe el año nuevo entre los primeros del mundo?",
+      "answers": [
+        {
+          "text": "Kiribati",
+          "correct": true
+        },
+        {
+          "text": "Islandia",
+          "correct": false
+        },
+        {
+          "text": "Malta",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Las islas de la Línea de Kiribati están en la zona horaria UTC+14, la más adelantada que existe.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_024",
+      "question": "¿Qué hizo Samoa con su calendario a finales de 2011?",
+      "answers": [
+        {
+          "text": "Eliminó por completo el 30 de diciembre",
+          "correct": true
+        },
+        {
+          "text": "Alargó el 31 de diciembre a 48 horas",
+          "correct": false
+        },
+        {
+          "text": "Celebró el Año Nuevo dos veces",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Al saltar la línea de cambio de fecha, el país se acercó a Australia y Nueva Zelanda, sus principales socios comerciales.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_025",
+      "question": "¿Qué pueblo hizo, hace unos 4000 años, los primeros propósitos de Año Nuevo conocidos?",
+      "answers": [
+        {
+          "text": "Los babilonios",
+          "correct": true
+        },
+        {
+          "text": "Los etruscos",
+          "correct": false
+        },
+        {
+          "text": "Los vikingos",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "En la fiesta de Akitu prometían a los dioses saldar deudas y devolver los aperos prestados.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_026",
+      "question": "¿Quién fijó el 1 de enero como comienzo del año en el calendario romano?",
+      "answers": [
+        {
+          "text": "Julio César",
+          "correct": true
+        },
+        {
+          "text": "El emperador Augusto",
+          "correct": false
+        },
+        {
+          "text": "Constantino el Grande",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Con la reforma del calendario del año 46 antes de nuestra era; antes el año romano empezaba en marzo.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_027",
+      "question": "¿De qué papa toma el nombre el calendario usado hoy en todo el mundo?",
+      "answers": [
+        {
+          "text": "De Gregorio XIII",
+          "correct": true
+        },
+        {
+          "text": "De Pío IX",
+          "correct": false
+        },
+        {
+          "text": "De Inocencio III",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "En el cambio de 1582 se saltaron diez días: al 4 de octubre le siguió directamente el 15.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_028",
+      "question": "¿Cuándo empezaba oficialmente el año en Inglaterra antes de 1752?",
+      "answers": [
+        {
+          "text": "El 25 de marzo",
+          "correct": true
+        },
+        {
+          "text": "El 1 de diciembre",
+          "correct": false
+        },
+        {
+          "text": "El 1 de septiembre",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Solo con el cambio al calendario gregoriano el inicio del año pasó al 1 de enero.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_029",
+      "question": "¿Para qué sirve el segundo intercalar, que suele añadirse a fin de año?",
+      "answers": [
+        {
+          "text": "Ajusta el tiempo atómico a la rotación de la Tierra",
+          "correct": true
+        },
+        {
+          "text": "Corrige errores del horario de verano",
+          "correct": false
+        },
+        {
+          "text": "Alarga el año bisiesto",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La rotación terrestre no es uniforme y los relojes atómicos son más precisos que el planeta que describen.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_030",
+      "question": "¿Por qué en Alemania hoy se funde cera y no plomo en Nochevieja?",
+      "answers": [
+        {
+          "text": "Porque los juegos de plomo se prohibieron en la UE",
+          "correct": true
+        },
+        {
+          "text": "Porque el plomo se encareció demasiado",
+          "correct": false
+        },
+        {
+          "text": "Porque la cera da figuras más bonitas",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Un límite al plomo en productos de consumo dejó invendibles los juegos clásicos en 2018.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_031",
+      "question": "¿Qué es una Feuerzangenbowle?",
+      "answers": [
+        {
+          "text": "Un ponche sobre el que arde un pan de azúcar empapado en ron",
+          "correct": true
+        },
+        {
+          "text": "Un cuenco con velas encendidas",
+          "correct": false
+        },
+        {
+          "text": "Un dulce hecho en sartén",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El pan de azúcar se sostiene con unas tenazas sobre la olla y gotea caramelizado en el vino.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_032",
+      "question": "¿Qué broma con berlinesas es habitual en Alemania en Nochevieja?",
+      "answers": [
+        {
+          "text": "Una se rellena de mostaza en vez de mermelada",
+          "correct": true
+        },
+        {
+          "text": "Una se congela",
+          "correct": false
+        },
+        {
+          "text": "Una se sala y se esconde",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La tradición dice que quien se lleva la de mostaza tiene igualmente suerte el año siguiente.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_033",
+      "question": "¿Con qué pieza termina tradicionalmente el Concierto de Año Nuevo de la Filarmónica de Viena?",
+      "answers": [
+        {
+          "text": "Con la Marcha Radetzky",
+          "correct": true
+        },
+        {
+          "text": "Con el Vals del Emperador",
+          "correct": false
+        },
+        {
+          "text": "Con la Novena de Beethoven",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El público acompaña con palmas y el director dirige la sala en lugar de la orquesta.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_034",
+      "question": "¿Con qué vals empiezan las propinas del Concierto de Año Nuevo de Viena?",
+      "answers": [
+        {
+          "text": "Con 'El Danubio azul'",
+          "correct": true
+        },
+        {
+          "text": "Con 'Wiener Blut'",
+          "correct": false
+        },
+        {
+          "text": "Con 'Rosas del sur'",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Se interrumpe a la orquesta tras los primeros compases para que los músicos feliciten el año al público.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_035",
+      "question": "¿Qué presión hay aproximadamente dentro de una botella de champán cerrada?",
+      "answers": [
+        {
+          "text": "Unos seis bares",
+          "correct": true
+        },
+        {
+          "text": "Alrededor de un bar",
+          "correct": false
+        },
+        {
+          "text": "Unos treinta bares",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Es unas tres veces la de un neumático: por eso el vidrio es grueso y el corcho va sujeto con alambre.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_036",
+      "question": "¿Cuándo puede un espumoso llamarse champán?",
+      "answers": [
+        {
+          "text": "Solo si procede de la región de Champaña",
+          "correct": true
+        },
+        {
+          "text": "Solo si envejece al menos diez años",
+          "correct": false
+        },
+        {
+          "text": "Solo si se hace con una única variedad de uva",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Francia defiende la denominación de origen protegida ante tribunales de todo el mundo.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_037",
+      "question": "¿Qué es el 'sablage' de una botella de espumoso?",
+      "answers": [
+        {
+          "text": "Cortarle el cuello con un sable",
+          "correct": true
+        },
+        {
+          "text": "Enfriarla en hielo con sal",
+          "correct": false
+        },
+        {
+          "text": "Trasvasarla a una jarra",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El golpe cae sobre la costura de la botella y la presión interior arranca el anillo de vidrio con el corcho.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_038",
+      "question": "¿En qué país se inventaron los fuegos artificiales?",
+      "answers": [
+        {
+          "text": "En China",
+          "correct": true
+        },
+        {
+          "text": "En Italia",
+          "correct": false
+        },
+        {
+          "text": "En Persia",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La pólvora negra sirvió primero para ahuyentar con ruido a los malos espíritus; los colores llegaron siglos después.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_039",
+      "question": "¿Qué produce el color rojo en unos fuegos artificiales?",
+      "answers": [
+        {
+          "text": "Los compuestos de estroncio",
+          "correct": true
+        },
+        {
+          "text": "Las limaduras de hierro",
+          "correct": false
+        },
+        {
+          "text": "El azufre",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El cobre arde azul, el bario verde y el sodio amarillo: la pirotecnia es química de la llama aplicada.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_040",
+      "question": "¿Cuántos días al año pueden venderse normalmente en Alemania los fuegos de Nochevieja?",
+      "answers": [
+        {
+          "text": "Tres días",
+          "correct": true
+        },
+        {
+          "text": "Diez días",
+          "correct": false
+        },
+        {
+          "text": "Todo el año",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La venta se limita del 29 al 31 de diciembre, y la fecha se adelanta si uno de esos días cae en domingo.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_041",
+      "question": "¿Qué mediciones se disparan en las ciudades europeas la noche de Nochevieja?",
+      "answers": [
+        {
+          "text": "Las de partículas en suspensión",
+          "correct": true
+        },
+        {
+          "text": "Las de ozono",
+          "correct": false
+        },
+        {
+          "text": "Las de radón",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "En la primera hora del año suelen multiplicar varias veces el límite diario.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_042",
+      "question": "¿Entre qué fechas puede caer el Año Nuevo chino?",
+      "answers": [
+        {
+          "text": "Entre el 21 de enero y el 20 de febrero",
+          "correct": true
+        },
+        {
+          "text": "Entre el 1 y el 15 de enero",
+          "correct": false
+        },
+        {
+          "text": "Entre el 1 y el 30 de marzo",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El calendario chino es lunisolar y la fiesta cae en la segunda luna nueva tras el solsticio de invierno.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_043",
+      "question": "¿Cuándo empieza el año nuevo persa, el Noruz?",
+      "answers": [
+        {
+          "text": "En el equinoccio de primavera",
+          "correct": true
+        },
+        {
+          "text": "En el solsticio de invierno",
+          "correct": false
+        },
+        {
+          "text": "En la primera luna llena de febrero",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El Noruz se celebra desde Irán hasta Asia Central y está en la lista de patrimonio inmaterial de la UNESCO.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_044",
+      "question": "¿En qué mes celebra Etiopía su año nuevo, el 'Enkutatash'?",
+      "answers": [
+        {
+          "text": "En septiembre",
+          "correct": true
+        },
+        {
+          "text": "En enero",
+          "correct": false
+        },
+        {
+          "text": "En mayo",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El calendario etíope tiene trece meses: doce de 30 días y uno corto de resto.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_045",
+      "question": "¿Cómo celebra Tailandia su año nuevo en el 'Songkran'?",
+      "answers": [
+        {
+          "text": "Con una batalla de agua en todo el país",
+          "correct": true
+        },
+        {
+          "text": "Con un día de ayuno",
+          "correct": false
+        },
+        {
+          "text": "Con una fiesta de cometas",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El vertido ritual de agua para purificarse es hoy una fiesta acuática de tres días en abril.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_046",
+      "question": "¿Qué problema ocupó al mundo informático en el cambio de 1999 a 2000?",
+      "answers": [
+        {
+          "text": "Los años guardados con dos dígitos",
+          "correct": true
+        },
+        {
+          "text": "Un apagón mundial",
+          "correct": false
+        },
+        {
+          "text": "Un virus llamado Millennium",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Como '00' podía leerse como 1900, se invirtieron miles de millones en corregirlo y apenas pasó nada.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_047",
+      "question": "¿Qué poema se recita en Skansen, en Suecia, en el cambio de año?",
+      "answers": [
+        {
+          "text": "'Ring out, wild bells', de Tennyson",
+          "correct": true
+        },
+        {
+          "text": "Un fragmento de la Edda",
+          "correct": false
+        },
+        {
+          "text": "Un texto de Astrid Lindgren",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La tradición viene de 1895 y la lectura se retransmite por televisión a todo el país.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_048",
+      "question": "¿Qué carne se evita en Hungría el día de Año Nuevo?",
+      "answers": [
+        {
+          "text": "Las aves",
+          "correct": true
+        },
+        {
+          "text": "La ternera",
+          "correct": false
+        },
+        {
+          "text": "El cordero",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La superstición dice que la suerte saldría volando; el cerdo, en cambio, hoza hacia delante y trae progreso.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_049",
+      "question": "¿Qué se hace en Irlanda, según la tradición, con un pan en Año Nuevo?",
+      "answers": [
+        {
+          "text": "Se golpea con él las paredes y las puertas",
+          "correct": true
+        },
+        {
+          "text": "Se entierra en el jardín",
+          "correct": false
+        },
+        {
+          "text": "Se lanza al mar",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El ruido debe expulsar la mala suerte de la casa y atraer buen pan para el año que viene.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_050",
+      "question": "¿Qué se estrella contra el umbral en Año Nuevo en Turquía y Grecia?",
+      "answers": [
+        {
+          "text": "Una granada",
+          "correct": true
+        },
+        {
+          "text": "Una jarra de agua",
+          "correct": false
+        },
+        {
+          "text": "Una nuez",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Cuanto más lejos saltan las semillas, mayor debe ser la bendición para la casa.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_051",
+      "question": "¿De qué color es la ropa interior de la suerte en Año Nuevo en Perú y parte de Latinoamérica?",
+      "answers": [
+        {
+          "text": "Amarilla",
+          "correct": true
+        },
+        {
+          "text": "Azul",
+          "correct": false
+        },
+        {
+          "text": "Verde",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El amarillo simboliza la prosperidad; quien desea amor elige el rojo.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_052",
+      "question": "¿Qué se hace en México con una maleta vacía en Año Nuevo?",
+      "answers": [
+        {
+          "text": "Se da una vuelta a la manzana con ella",
+          "correct": true
+        },
+        {
+          "text": "Se deja delante de la puerta",
+          "correct": false
+        },
+        {
+          "text": "Se quema",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El paseo debe asegurar viajes en el año nuevo; algunos llegan solo hasta la esquina y vuelven.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_053",
+      "question": "¿Qué ensalada es imprescindible en la mesa rusa de Nochevieja?",
+      "answers": [
+        {
+          "text": "La ensalada Olivier",
+          "correct": true
+        },
+        {
+          "text": "La ensalada de remolacha con arenque",
+          "correct": false
+        },
+        {
+          "text": "La col con comino",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Lleva el nombre de un cocinero que la creó en el Moscú del siglo XIX; la receta original se considera perdida.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_054",
+      "question": "¿Qué programa de televisión ven casi todos los islandeses en Nochevieja?",
+      "answers": [
+        {
+          "text": "El programa satírico 'Áramótaskaupið'",
+          "correct": true
+        },
+        {
+          "text": "Un concierto desde la Harpa",
+          "correct": false
+        },
+        {
+          "text": "Una conexión en directo con los géiseres",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Las calles se vacían durante media hora; solo después empiezan los fuegos y las hogueras.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_055",
+      "question": "¿Qué se celebra en Madrid la tarde del 31 de diciembre?",
+      "answers": [
+        {
+          "text": "Una gran carrera popular",
+          "correct": true
+        },
+        {
+          "text": "Un encierro de toros",
+          "correct": false
+        },
+        {
+          "text": "Una caravana de coches",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "La San Silvestre Vallecana reúne a decenas de miles de personas y muchos corren disfrazados.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_056",
+      "question": "¿Qué grupo publicó en 1980 la canción 'Happy New Year'?",
+      "answers": [
+        {
+          "text": "ABBA",
+          "correct": true
+        },
+        {
+          "text": "Queen",
+          "correct": false
+        },
+        {
+          "text": "Los Bee Gees",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La letra es mucho más melancólica que el título y en varios países solo triunfó años después.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_057",
+      "question": "¿De dónde viene el nombre del mes de enero?",
+      "answers": [
+        {
+          "text": "Del dios romano Jano",
+          "correct": true
+        },
+        {
+          "text": "De la palabra latina para hielo",
+          "correct": false
+        },
+        {
+          "text": "De un gobernante etrusco",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Jano tiene dos caras y mira a la vez hacia atrás y hacia delante: difícil mejorarlo para empezar un año.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_058",
+      "question": "¿Qué significa literalmente el brindis alemán 'Prosit Neujahr'?",
+      "answers": [
+        {
+          "text": "'Que aproveche'",
+          "correct": true
+        },
+        {
+          "text": "'A tu salud'",
+          "correct": false
+        },
+        {
+          "text": "'Hasta el fondo'",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "'Prosit' es latín y entró en alemán a través de la jerga estudiantil del siglo XVIII.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_059",
+      "question": "¿Qué acontecimiento deportivo se celebra tradicionalmente en Alemania el 1 de enero?",
+      "answers": [
+        {
+          "text": "El salto de esquí de Año Nuevo en Garmisch-Partenkirchen",
+          "correct": true
+        },
+        {
+          "text": "Una carrera de Fórmula 1",
+          "correct": false
+        },
+        {
+          "text": "La final de copa de fútbol",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Es la segunda estación del Torneo de los Cuatro Trampolines y empieza por la mañana con la clasificación.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_060",
+      "question": "¿Qué desfile floral se celebra en California el día de Año Nuevo?",
+      "answers": [
+        {
+          "text": "El Desfile de las Rosas de Pasadena",
+          "correct": true
+        },
+        {
+          "text": "El Desfile de las Amapolas de San Diego",
+          "correct": false
+        },
+        {
+          "text": "El Desfile de los Lirios de Sacramento",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Las carrozas deben ir cubiertas por completo de material vegetal, hasta la última hoja.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_061",
+      "question": "¿Quién convirtió 'Auld Lang Syne' en un fijo del Año Nuevo norteamericano?",
+      "answers": [
+        {
+          "text": "El director de orquesta Guy Lombardo",
+          "correct": true
+        },
+        {
+          "text": "El cantante Bing Crosby",
+          "correct": false
+        },
+        {
+          "text": "El locutor Orson Welles",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Su orquesta la tocó en directo a medianoche cada año desde 1929, primero en la radio y luego en televisión.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_062",
+      "question": "¿Qué es la 'Mari Lwyd' galesa que va de casa en casa por Año Nuevo?",
+      "answers": [
+        {
+          "text": "Un cráneo de caballo adornado sobre un palo",
+          "correct": true
+        },
+        {
+          "text": "Una muñeca de paja en una barca",
+          "correct": false
+        },
+        {
+          "text": "Un farol hecho con un nabo",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El grupo pide entrar con versos rimados y los de la casa deben responder también en verso.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_063",
+      "question": "¿Qué país recibe el año nuevo entre los últimos del mundo?",
+      "answers": [
+        {
+          "text": "Estados Unidos, con las islas Baker y Howland",
+          "correct": true
+        },
+        {
+          "text": "Portugal",
+          "correct": false
+        },
+        {
+          "text": "Chile",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Las islas deshabitadas están en la zona UTC−12, 26 horas por detrás de Kiribati.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_064",
+      "question": "¿Qué se tira por la ventana a medianoche en partes de Cuba y Puerto Rico?",
+      "answers": [
+        {
+          "text": "Un cubo de agua",
+          "correct": true
+        },
+        {
+          "text": "Ropa vieja",
+          "correct": false
+        },
+        {
+          "text": "Monedas",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El agua debe arrastrar fuera de casa la mala suerte del año viejo.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_065",
+      "question": "¿Qué hacen girar por las calles los hombres de Stonehaven, en Escocia, en Año Nuevo?",
+      "answers": [
+        {
+          "text": "Jaulas de alambre ardiendo colgadas de cadenas",
+          "correct": true
+        },
+        {
+          "text": "Antorchas de turba",
+          "correct": false
+        },
+        {
+          "text": "Faroles de calabaza",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Las bolas de fuego acaban en el puerto y la costumbre pretende ahuyentar a los malos espíritus.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_066",
+      "question": "¿Cómo se llama el baño de Año Nuevo escocés en las aguas heladas del Firth of Forth?",
+      "answers": [
+        {
+          "text": "Loony Dook",
+          "correct": true
+        },
+        {
+          "text": "Cold Ceilidh",
+          "correct": false
+        },
+        {
+          "text": "Firth Plunge",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Muchos se lanzan disfrazados y el acto recauda dinero para causas benéficas.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_067",
+      "question": "¿Qué construcción marca en Sídney el cambio de año con uno de los primeros grandes fuegos del mundo?",
+      "answers": [
+        {
+          "text": "El puente del puerto",
+          "correct": true
+        },
+        {
+          "text": "La torre de televisión",
+          "correct": false
+        },
+        {
+          "text": "El edificio del parlamento",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Por el huso horario, las imágenes de Sídney llegan a Europa a menudo la tarde del 31 de diciembre.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_068",
+      "question": "¿Junto a qué monumento celebra Berlín tradicionalmente su mayor fiesta de Nochevieja?",
+      "answers": [
+        {
+          "text": "La Puerta de Brandeburgo",
+          "correct": true
+        },
+        {
+          "text": "La catedral de Berlín",
+          "correct": false
+        },
+        {
+          "text": "El Estadio Olímpico",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El espectáculo del escenario de la 'milla de la fiesta' se retransmite en directo por televisión.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_069",
+      "question": "¿Qué edificio es el centro de los fuegos de Nochevieja de Dubái?",
+      "answers": [
+        {
+          "text": "El Burj Khalifa",
+          "correct": true
+        },
+        {
+          "text": "La torre del aeropuerto",
+          "correct": false
+        },
+        {
+          "text": "La mezquita Sheikh Zayed",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La fachada del edificio más alto del mundo sirve además de pantalla de proyección.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_070",
+      "question": "¿En qué playa se celebra una de las mayores fiestas de Nochevieja del mundo?",
+      "answers": [
+        {
+          "text": "En Copacabana, en Río de Janeiro",
+          "correct": true
+        },
+        {
+          "text": "En Waikiki, en Hawái",
+          "correct": false
+        },
+        {
+          "text": "En Bondi, en Sídney",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Millones de personas acuden vestidas de blanco y, tras los fuegos, lanzan flores al agua para la diosa Iemanjá.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_071",
+      "question": "¿Qué se hace con los papeles en los que los visitantes escriben sus deseos en Times Square?",
+      "answers": [
+        {
+          "text": "Se sueltan como confeti a medianoche",
+          "correct": true
+        },
+        {
+          "text": "Se queman",
+          "correct": false
+        },
+        {
+          "text": "Se archivan en el ayuntamiento",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los deseos se recogen antes y se lanzan desde los tejados junto con el resto del confeti.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_072",
+      "question": "¿Cuánto tarda la bola de Times Square en completar su descenso?",
+      "answers": [
+        {
+          "text": "Exactamente 60 segundos",
+          "correct": true
+        },
+        {
+          "text": "Unos cinco minutos",
+          "correct": false
+        },
+        {
+          "text": "Unos diez segundos",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Llega abajo justo a medianoche y las cifras del año nuevo se encienden solo después.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_073",
+      "question": "¿De dónde viene probablemente el saludo alemán 'Guten Rutsch'?",
+      "answers": [
+        {
+          "text": "De una vieja palabra para un buen viaje",
+          "correct": true
+        },
+        {
+          "text": "De las calles heladas",
+          "correct": false
+        },
+        {
+          "text": "De una costumbre de trineos",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La derivación popular desde el yidis se considera dudosa entre lingüistas.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_074",
+      "question": "¿Qué figura simboliza el año nuevo en muchos países?",
+      "answers": [
+        {
+          "text": "Un bebé con una banda con la cifra del año",
+          "correct": true
+        },
+        {
+          "text": "Un águila",
+          "correct": false
+        },
+        {
+          "text": "Una llave",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "El motivo tiene siglos y lo popularizaron las portadas de revistas a partir del siglo XIX.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_075",
+      "question": "¿Qué es la 'kransekake' escandinava?",
+      "answers": [
+        {
+          "text": "Una torre de aros de mazapán",
+          "correct": true
+        },
+        {
+          "text": "Una corona de galletas saladas",
+          "correct": false
+        },
+        {
+          "text": "Un pastel helado con frutos rojos",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Los aros se van estrechando de abajo arriba y en Año Nuevo suele llevar una banderita en la cima.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_076",
+      "question": "¿Cuántas comidas prescribe la tradición estonia en Nochevieja?",
+      "answers": [
+        {
+          "text": "Siete, nueve o doce",
+          "correct": true
+        },
+        {
+          "text": "Exactamente tres",
+          "correct": false
+        },
+        {
+          "text": "Exactamente cinco",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Son números de la suerte y se dice que quien come tantas veces adquiere la fuerza de tantos hombres.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_077",
+      "question": "¿Qué hacen muchos japoneses en los primeros días del año en el 'hatsumode'?",
+      "answers": [
+        {
+          "text": "Hacen la primera visita del año a un santuario o templo",
+          "correct": true
+        },
+        {
+          "text": "Plantan un árbol",
+          "correct": false
+        },
+        {
+          "text": "Lanzan un poema al mar",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "En la misma visita se devuelven los amuletos viejos y se compran otros nuevos.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_078",
+      "question": "¿Qué son los 'otoshidama' japoneses?",
+      "answers": [
+        {
+          "text": "Regalos de dinero para los niños en sobres pequeños",
+          "correct": true
+        },
+        {
+          "text": "Poemas de Año Nuevo en papel de arroz",
+          "correct": false
+        },
+        {
+          "text": "Figuritas de barro de la suerte",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La cantidad depende de la edad: los niños mayores reciben más.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_079",
+      "question": "¿Qué sopa se come en Corea el día de Año Nuevo?",
+      "answers": [
+        {
+          "text": "Una sopa con rodajas de pastel de arroz",
+          "correct": true
+        },
+        {
+          "text": "Una sopa de algas y almejas",
+          "correct": false
+        },
+        {
+          "text": "Una sopa fría de trigo sarraceno",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Según la tradición, uno no cumple un año más hasta haber comido 'tteokguk'.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_080",
+      "question": "¿Cómo se llama la fiesta del año nuevo vietnamita?",
+      "answers": [
+        {
+          "text": "Tet",
+          "correct": true
+        },
+        {
+          "text": "Diwali",
+          "correct": false
+        },
+        {
+          "text": "Obon",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Sigue el calendario lunar y suele coincidir con el Año Nuevo chino; el kumquat no falta en ninguna casa.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_081",
+      "question": "¿Con qué se anuncia el año nuevo judío, Rosh Hashaná?",
+      "answers": [
+        {
+          "text": "Con un cuerno de carnero",
+          "correct": true
+        },
+        {
+          "text": "Con una campana de bronce",
+          "correct": false
+        },
+        {
+          "text": "Con un tambor",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El shofar se toca siguiendo una secuencia fija de toques, y la fiesta cae en otoño.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_082",
+      "question": "¿Por qué el año nuevo islámico se desplaza por las estaciones?",
+      "answers": [
+        {
+          "text": "Porque el calendario islámico es puramente lunar",
+          "correct": true
+        },
+        {
+          "text": "Porque está ligado a la Pascua",
+          "correct": false
+        },
+        {
+          "text": "Porque se cambia cada cuatro años",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El año lunar es unos once días más corto que el solar, así que el 1 de Muharram se adelanta cada año.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_083",
+      "question": "¿Hasta cuándo no fue el día de Navidad festivo general en Escocia?",
+      "answers": [
+        {
+          "text": "Hasta 1958",
+          "correct": true
+        },
+        {
+          "text": "Hasta 1901",
+          "correct": false
+        },
+        {
+          "text": "Hasta 1975",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Por eso el Hogmanay fue durante siglos la verdadera gran fiesta del invierno allí.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_084",
+      "question": "¿Qué aparece clásicamente en la mesa del 'Réveillon de la Saint-Sylvestre' francés?",
+      "answers": [
+        {
+          "text": "Ostras",
+          "correct": true
+        },
+        {
+          "text": "Pimientos rellenos",
+          "correct": false
+        },
+        {
+          "text": "Gulash de ternera",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Suelen acompañarse de foie gras y champán, y la cena empieza tarde y se alarga.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_085",
+      "question": "¿Cuál es una costumbre belga de Año Nuevo para los niños?",
+      "answers": [
+        {
+          "text": "Leen a sus padrinos una carta escrita por ellos",
+          "correct": true
+        },
+        {
+          "text": "Tocan cencerros en el campo",
+          "correct": false
+        },
+        {
+          "text": "Esconden monedas en la nieve",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La carta se escribe en papel decorado y se lee con solemnidad el día de Año Nuevo.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_086",
+      "question": "¿Qué ocurre en el 'Silvesterchlausen' de Appenzell, en Suiza?",
+      "answers": [
+        {
+          "text": "Grupos con trajes elaborados van de granja en granja cantando a la tirolesa",
+          "correct": true
+        },
+        {
+          "text": "Se hace rodar una rueda ardiendo montaña abajo",
+          "correct": false
+        },
+        {
+          "text": "Los vecinos se intercambian cencerros",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Se celebra dos veces: el 31 de diciembre y de nuevo el 13 de enero, según el calendario viejo.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_087",
+      "question": "¿Qué es un 'cotillón' en una fiesta de Nochevieja española o latinoamericana?",
+      "answers": [
+        {
+          "text": "Una bolsa con gorros, matasuegras y serpentinas",
+          "correct": true
+        },
+        {
+          "text": "Un baile de doce parejas",
+          "correct": false
+        },
+        {
+          "text": "Un postre con nata",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Después de las doce uvas se abre la bolsa y empieza el ruido.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_088",
+      "question": "¿Qué se lanza por las ventanas de las oficinas en Argentina el último día laborable del año?",
+      "answers": [
+        {
+          "text": "Papel roto de expedientes viejos",
+          "correct": true
+        },
+        {
+          "text": "Flores",
+          "correct": false
+        },
+        {
+          "text": "Monedas",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "La lluvia de papel en el distrito financiero de Buenos Aires da la vuelta al mundo cada año.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_089",
+      "question": "¿De dónde viene la palabra 'confeti'?",
+      "answers": [
+        {
+          "text": "De unas almendras confitadas italianas",
+          "correct": true
+        },
+        {
+          "text": "De un fabricante de papel francés",
+          "correct": false
+        },
+        {
+          "text": "De una palabra latina para viento",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "En el carnaval de Milán se lanzaban dulces; cuando se encareció, los sustituyeron trocitos de papel de colores.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_090",
+      "question": "¿Por qué 1900 no fue año bisiesto?",
+      "answers": [
+        {
+          "text": "Los años de siglo solo son bisiestos si son divisibles por 400",
+          "correct": true
+        },
+        {
+          "text": "Porque ese año se reformó el calendario",
+          "correct": false
+        },
+        {
+          "text": "Porque se acortó febrero",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La misma regla deja fuera a 2100, mientras que 2000 sí lo fue.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_091",
+      "question": "¿Qué se canta en el Vaticano la tarde del 31 de diciembre?",
+      "answers": [
+        {
+          "text": "El Te Deum, como acción de gracias",
+          "correct": true
+        },
+        {
+          "text": "El Réquiem",
+          "correct": false
+        },
+        {
+          "text": "El Magníficat",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El papa da gracias por el año que termina; el 1 de enero se celebra la Jornada Mundial de la Paz.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_092",
+      "question": "¿Cuándo pronuncia su discurso de Año Nuevo el jefe de Estado danés?",
+      "answers": [
+        {
+          "text": "La tarde del 31 de diciembre",
+          "correct": true
+        },
+        {
+          "text": "La mañana del 1 de enero",
+          "correct": false
+        },
+        {
+          "text": "El 6 de enero",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El discurso de las seis organiza la noche: primero la cena y después la fiesta.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_093",
+      "question": "¿Qué es la 'oudejaarsconference' neerlandesa?",
+      "answers": [
+        {
+          "text": "El repaso satírico del año a cargo de un humorista",
+          "correct": true
+        },
+        {
+          "text": "Un programa de debate con políticos",
+          "correct": false
+        },
+        {
+          "text": "Un concierto coral",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "El espectáculo suele superar las dos horas y se emite en directo la tarde del 31 de diciembre.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_094",
+      "question": "¿Qué temporada de bailes empieza tradicionalmente en Viena en torno al cambio de año?",
+      "answers": [
+        {
+          "text": "La temporada de bailes de carnaval",
+          "correct": true
+        },
+        {
+          "text": "La temporada de ópera",
+          "correct": false
+        },
+        {
+          "text": "La temporada de conciertos del Musikverein",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "El Baile Imperial de la Hofburg se celebra en Nochevieja; el Baile de la Ópera llega en febrero.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_095",
+      "question": "¿Cuántos signos animales tiene el zodiaco chino, que asigna uno a cada año?",
+      "answers": [
+        {
+          "text": "Doce",
+          "correct": true
+        },
+        {
+          "text": "Diez",
+          "correct": false
+        },
+        {
+          "text": "Veinticuatro",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "La rata abre la lista; según la leyenda, el gato llegó tarde a la carrera y por eso falta.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_096",
+      "question": "¿Cuántas uvas se comen en España con las campanadas de Nochevieja?",
+      "type": "estimate",
+      "answer": 12,
+      "min": 1,
+      "max": 60,
+      "unit": "uvas",
+      "difficulty": "easy",
+      "fun_fact": "Doce, una por campanada; por eso se venden peladas y sin pepitas en lata.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_097",
+      "question": "¿Cuántas veces suenan las campanas de los templos japoneses la noche de fin de año?",
+      "type": "estimate",
+      "answer": 108,
+      "min": 0,
+      "max": 500,
+      "unit": "toques",
+      "difficulty": "medium",
+      "fun_fact": "Los 108 toques representan los deseos mundanos que se dejan atrás con el año viejo.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_098",
+      "question": "¿Cuántas horas transcurren entre el primer y el último cambio de año en la Tierra?",
+      "type": "estimate",
+      "answer": 26,
+      "min": 0,
+      "max": 60,
+      "unit": "horas",
+      "difficulty": "hard",
+      "fun_fact": "26 horas: de UTC+14 en las islas de la Línea de Kiribati a UTC−12 en las islas Baker y Howland.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_099",
+      "question": "¿En qué año introdujo el papa Gregorio XIII el calendario que hoy se usa en todo el mundo?",
+      "type": "estimate",
+      "answer": 1582,
+      "min": 1200,
+      "max": 1900,
+      "unit": "año",
+      "difficulty": "medium",
+      "fun_fact": "En 1582: en el cambio, al 4 de octubre le siguió directamente el 15 de octubre.",
+      "category": "Nochevieja"
+    },
+    {
+      "id": "nochevieja_es_100",
+      "question": "¿En qué año grabó la cadena alemana NDR el sketch 'Dinner for One' que desde entonces se emite en Nochevieja?",
+      "type": "estimate",
+      "answer": 1963,
+      "min": 1900,
+      "max": 2000,
+      "unit": "año",
+      "difficulty": "medium",
+      "fun_fact": "En 1963, ante público en Hamburgo, en inglés y sin subtítulos.",
+      "category": "Nochevieja"
+    }
+  ]
+}

--- a/custom_components/quizify/questions/silvester-de.json
+++ b/custom_components/quizify/questions/silvester-de.json
@@ -1,0 +1,2068 @@
+{
+  "name": "Silvester",
+  "language": "de",
+  "version": "1.0",
+  "theme": "trivia",
+  "season": {
+    "start": "12-27",
+    "end": "01-06",
+    "label": "🎆 Jahreswechsel"
+  },
+  "questions": [
+    {
+      "id": "silvester_de_001",
+      "question": "Welcher schwarzweiße Fernsehsketch läuft in Deutschland seit Jahrzehnten an jedem Silvester?",
+      "answers": [
+        {
+          "text": "'Dinner for One'",
+          "correct": true
+        },
+        {
+          "text": "'Der 90. Geburtstag der Queen'",
+          "correct": false
+        },
+        {
+          "text": "'Die Feuerzangenbowle'",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Der NDR nahm den englischsprachigen Sketch 1963 auf; in Großbritannien selbst ist er praktisch unbekannt.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_002",
+      "question": "Woher kommt der deutsche Name 'Silvester' für den 31. Dezember?",
+      "answers": [
+        {
+          "text": "Von einem Papst, der an diesem Tag starb",
+          "correct": true
+        },
+        {
+          "text": "Von einem lateinischen Wort für Feuer",
+          "correct": false
+        },
+        {
+          "text": "Von einem mittelalterlichen Winterfest",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Papst Silvester I. starb am 31. Dezember 335; sein Gedenktag fiel damit auf den Jahresschluss.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_003",
+      "question": "Seit wann fällt am Times Square in New York zum Jahreswechsel eine leuchtende Kugel?",
+      "answers": [
+        {
+          "text": "Seit 1907",
+          "correct": true
+        },
+        {
+          "text": "Seit 1955",
+          "correct": false
+        },
+        {
+          "text": "Seit 1980",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Vorher gab es dort ein Feuerwerk, das die Stadt aus Brandschutzgründen untersagte.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_004",
+      "question": "Auf welches Gedicht geht das Lied 'Auld Lang Syne' zurück?",
+      "answers": [
+        {
+          "text": "Auf einen Text von Robert Burns",
+          "correct": true
+        },
+        {
+          "text": "Auf ein Sonett von Shakespeare",
+          "correct": false
+        },
+        {
+          "text": "Auf ein Kirchenlied aus Irland",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Burns schickte den Text 1788 an ein Liedarchiv und gab an, er habe ihn von einem alten Mann gehört.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_005",
+      "question": "Was isst man in Spanien traditionell in den zwölf Sekunden um Mitternacht?",
+      "answers": [
+        {
+          "text": "Zwölf Weintrauben",
+          "correct": true
+        },
+        {
+          "text": "Zwölf Oliven",
+          "correct": false
+        },
+        {
+          "text": "Zwölf Mandeln",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Zu jedem Glockenschlag eine Traube — wer sich verschluckt oder nicht mitkommt, hat der Legende nach kein Glück im neuen Jahr.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_006",
+      "question": "Wie entstand der spanische Brauch der zwölf Trauben angeblich um 1909?",
+      "answers": [
+        {
+          "text": "Winzer in Alicante hatten eine Rekordernte zu verkaufen",
+          "correct": true
+        },
+        {
+          "text": "Ein König verordnete ihn",
+          "correct": false
+        },
+        {
+          "text": "Ein Radiosender verloste Trauben",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Die 'uvas de la suerte' waren zunächst eine Vermarktungsidee und wurden binnen weniger Jahre landesweite Gewohnheit.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_007",
+      "question": "Vor welcher Uhr versammeln sich die Madrilenen zum Jahreswechsel?",
+      "answers": [
+        {
+          "text": "Vor der Uhr an der Puerta del Sol",
+          "correct": true
+        },
+        {
+          "text": "Vor der Uhr des Bahnhofs Atocha",
+          "correct": false
+        },
+        {
+          "text": "Vor der Uhr des Prado",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Die vier Vorschläge vor den zwölf Schlägen sind Teil des Rituals — wer zu früh anfängt, verzählt sich.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_008",
+      "question": "Was tun viele Dänen in der Sekunde des Jahreswechsels?",
+      "answers": [
+        {
+          "text": "Sie springen von einem Stuhl",
+          "correct": true
+        },
+        {
+          "text": "Sie werfen Salz über die Schulter",
+          "correct": false
+        },
+        {
+          "text": "Sie öffnen alle Fenster",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Der Sprung soll den Start ins neue Jahr markieren; zerbrochenes Geschirr vor der Haustür gilt zusätzlich als Freundschaftsbeweis.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_009",
+      "question": "Was verschicken Japaner zum Jahreswechsel millionenfach?",
+      "answers": [
+        {
+          "text": "Neujahrspostkarten",
+          "correct": true
+        },
+        {
+          "text": "Getrocknete Blumen",
+          "correct": false
+        },
+        {
+          "text": "Kalligrafierte Fächer",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Die 'Nengajo' werden vorher gesammelt und von der Post gebündelt am Neujahrsmorgen zugestellt.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_010",
+      "question": "Welches Gericht essen viele Japaner am Abend des 31. Dezember?",
+      "answers": [
+        {
+          "text": "Lange Buchweizennudeln",
+          "correct": true
+        },
+        {
+          "text": "Rohen Thunfisch mit Reis",
+          "correct": false
+        },
+        {
+          "text": "Gedämpfte Teigtaschen",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Die 'Toshikoshi Soba' lassen sich leicht durchbeißen — sinnbildlich trennt man sich damit von den Mühen des alten Jahres.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_011",
+      "question": "Wie heißt das schottische Silvesterfest?",
+      "answers": [
+        {
+          "text": "Hogmanay",
+          "correct": true
+        },
+        {
+          "text": "Beltane",
+          "correct": false
+        },
+        {
+          "text": "Samhain",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Weil das Weihnachtsfest in Schottland lange verboten war, wanderte das große Feiern auf den Jahreswechsel.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_012",
+      "question": "Was soll der schottische 'First Footer' nach Mitternacht ins Haus bringen?",
+      "answers": [
+        {
+          "text": "Kohle, Brot und Whisky",
+          "correct": true
+        },
+        {
+          "text": "Ein weißes Tuch und Salz",
+          "correct": false
+        },
+        {
+          "text": "Einen Zweig Stechpalme",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Am besten ist ein dunkelhaariger Mann als erster Gast; ein blonder Besucher galt früher als Vorbote von Ärger.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_013",
+      "question": "Welches Gebäck gehört in den Niederlanden zum Jahreswechsel?",
+      "answers": [
+        {
+          "text": "Oliebollen",
+          "correct": true
+        },
+        {
+          "text": "Stroopwafels",
+          "correct": false
+        },
+        {
+          "text": "Speculaas",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Die frittierten Teigkugeln sollten der Sage nach böse Geister abhalten, weil ihr Fett deren Klingen abgleiten ließ.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_014",
+      "question": "Was tun am 1. Januar zehntausende Niederländer bei Scheveningen?",
+      "answers": [
+        {
+          "text": "Sie springen in die Nordsee",
+          "correct": true
+        },
+        {
+          "text": "Sie steigen auf Windmühlen",
+          "correct": false
+        },
+        {
+          "text": "Sie radeln zum Deich",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Der 'Nieuwjaarsduik' findet bei einstelligen Wassertemperaturen statt; danach gibt es traditionell Erbsensuppe.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_015",
+      "question": "Welche Hülsenfrucht isst man in Italien zum Jahreswechsel als Glückssymbol?",
+      "answers": [
+        {
+          "text": "Linsen",
+          "correct": true
+        },
+        {
+          "text": "Kichererbsen",
+          "correct": false
+        },
+        {
+          "text": "Weiße Bohnen",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Ihre Form erinnert an Münzen; klassisch werden sie mit Cotechino oder Zampone gereicht.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_016",
+      "question": "Welche Farbe hat in Italien traditionell die Unterwäsche in der Silvesternacht?",
+      "answers": [
+        {
+          "text": "Rot",
+          "correct": true
+        },
+        {
+          "text": "Gelb",
+          "correct": false
+        },
+        {
+          "text": "Weiß",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Sie soll Glück bringen und wird der Tradition nach am Neujahrstag weggeworfen.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_017",
+      "question": "Was ist in der griechischen 'Vasilopita' versteckt?",
+      "answers": [
+        {
+          "text": "Eine Münze",
+          "correct": true
+        },
+        {
+          "text": "Eine Mandel",
+          "correct": false
+        },
+        {
+          "text": "Ein Papierzettel",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Wer das Stück mit der Münze bekommt, hat Glück für das Jahr; das erste Stück gehört traditionell dem Haus.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_018",
+      "question": "Welche Kleiderfarbe tragen viele Brasilianer in der Silvesternacht?",
+      "answers": [
+        {
+          "text": "Weiß",
+          "correct": true
+        },
+        {
+          "text": "Grün",
+          "correct": false
+        },
+        {
+          "text": "Schwarz",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Weiß steht für Frieden; an der Copacabana springen viele zusätzlich über sieben Wellen und werfen Blumen ins Meer.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_019",
+      "question": "Was verbrennen viele Menschen in Ecuador und Kolumbien um Mitternacht?",
+      "answers": [
+        {
+          "text": "Selbstgebaute Puppen, die das alte Jahr darstellen",
+          "correct": true
+        },
+        {
+          "text": "Alte Kalender",
+          "correct": false
+        },
+        {
+          "text": "Getrocknete Maiskolben",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Die 'años viejos' tragen oft die Gesichter von Politikern oder Filmfiguren; manchmal steckt ein Testament in der Tasche.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_020",
+      "question": "Welches Muster tragen viele Menschen auf den Philippinen zu Neujahr?",
+      "answers": [
+        {
+          "text": "Punkte",
+          "correct": true
+        },
+        {
+          "text": "Streifen",
+          "correct": false
+        },
+        {
+          "text": "Karos",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Runde Formen stehen für Münzen; auf dem Tisch liegen aus demselben Grund zwölf runde Früchte.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_021",
+      "question": "Welcher sowjetische Film läuft in Russland traditionell zum Jahreswechsel im Fernsehen?",
+      "answers": [
+        {
+          "text": "'Ironie des Schicksals'",
+          "correct": true
+        },
+        {
+          "text": "'Panzerkreuzer Potemkin'",
+          "correct": false
+        },
+        {
+          "text": "'Solaris'",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Die Komödie von 1975 wird seit Jahrzehnten fast jedes Jahr gezeigt und ist Teil des Rituals wie der Sekt.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_022",
+      "question": "Wer bringt in Russland traditionell zu Neujahr die Geschenke?",
+      "answers": [
+        {
+          "text": "Väterchen Frost mit seiner Enkelin Snegurotschka",
+          "correct": true
+        },
+        {
+          "text": "Der heilige Nikolaus",
+          "correct": false
+        },
+        {
+          "text": "Die Heiligen Drei Könige",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "In der Sowjetzeit wurde das Fest bewusst vom kirchlichen Weihnachten auf den Jahreswechsel verschoben.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_023",
+      "question": "Welcher Inselstaat begrüßt das neue Jahr als einer der ersten weltweit?",
+      "answers": [
+        {
+          "text": "Kiribati",
+          "correct": true
+        },
+        {
+          "text": "Island",
+          "correct": false
+        },
+        {
+          "text": "Malta",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Die Linieninseln von Kiribati liegen in der Zeitzone UTC+14 — der frühesten, die es gibt.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_024",
+      "question": "Was tat Samoa Ende 2011 mit seinem Kalender?",
+      "answers": [
+        {
+          "text": "Es strich den 30. Dezember ersatzlos",
+          "correct": true
+        },
+        {
+          "text": "Es verlängerte den 31. Dezember auf 48 Stunden",
+          "correct": false
+        },
+        {
+          "text": "Es feierte Neujahr zweimal",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Mit dem Sprung über die Datumsgrenze rückte das Land näher an Australien und Neuseeland, seine wichtigsten Handelspartner.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_025",
+      "question": "Welches Volk fasste vor rund 4000 Jahren als erstes bekanntes Neujahrsvorsätze?",
+      "answers": [
+        {
+          "text": "Die Babylonier",
+          "correct": true
+        },
+        {
+          "text": "Die Etrusker",
+          "correct": false
+        },
+        {
+          "text": "Die Wikinger",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Beim Fest Akitu versprach man den Göttern, Schulden zu begleichen und geliehene Geräte zurückzugeben.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_026",
+      "question": "Wer legte den 1. Januar als Jahresbeginn im römischen Kalender fest?",
+      "answers": [
+        {
+          "text": "Julius Caesar",
+          "correct": true
+        },
+        {
+          "text": "Kaiser Augustus",
+          "correct": false
+        },
+        {
+          "text": "Konstantin der Große",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Mit der Kalenderreform von 46 vor unserer Zeitrechnung; davor begann das römische Jahr im März.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_027",
+      "question": "Nach welchem Papst ist der heute weltweit gebräuchliche Kalender benannt?",
+      "answers": [
+        {
+          "text": "Nach Gregor XIII.",
+          "correct": true
+        },
+        {
+          "text": "Nach Pius IX.",
+          "correct": false
+        },
+        {
+          "text": "Nach Innozenz III.",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Bei der Umstellung 1582 wurden zehn Tage übersprungen: Auf den 4. Oktober folgte unmittelbar der 15.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_028",
+      "question": "Wann begann in England vor 1752 offiziell das neue Jahr?",
+      "answers": [
+        {
+          "text": "Am 25. März",
+          "correct": true
+        },
+        {
+          "text": "Am 1. Dezember",
+          "correct": false
+        },
+        {
+          "text": "Am 1. September",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Erst mit der Umstellung auf den gregorianischen Kalender rückte der Jahresbeginn auf den 1. Januar.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_029",
+      "question": "Wozu dient eine Schaltsekunde, die meist am Jahresende eingefügt wird?",
+      "answers": [
+        {
+          "text": "Sie gleicht die Atomzeit an die Erdrotation an",
+          "correct": true
+        },
+        {
+          "text": "Sie korrigiert Sommerzeitfehler",
+          "correct": false
+        },
+        {
+          "text": "Sie verlängert das Schaltjahr",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Die Erdrotation läuft nicht gleichmäßig; Atomuhren sind genauer als der Planet, den sie beschreiben.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_030",
+      "question": "Warum gießt man in Deutschland zu Silvester heute Wachs statt Blei?",
+      "answers": [
+        {
+          "text": "Weil Bleigießsets in der EU verboten wurden",
+          "correct": true
+        },
+        {
+          "text": "Weil Blei zu teuer wurde",
+          "correct": false
+        },
+        {
+          "text": "Weil Wachs schönere Figuren ergibt",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Der Grenzwert für Blei in Verbraucherprodukten machte die klassischen Sets 2018 unverkäuflich.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_031",
+      "question": "Was ist eine Feuerzangenbowle?",
+      "answers": [
+        {
+          "text": "Ein Punsch, über dem ein mit Rum getränkter Zuckerhut abbrennt",
+          "correct": true
+        },
+        {
+          "text": "Eine Schale mit brennenden Kerzen",
+          "correct": false
+        },
+        {
+          "text": "Ein Gebäck aus der Pfanne",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Der Zuckerhut liegt in einer Zange über dem Topf und tropft karamellisiert in den Wein.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_032",
+      "question": "Welcher Streich ist in Deutschland an Silvester mit Berlinern verbreitet?",
+      "answers": [
+        {
+          "text": "Ein Gebäckstück wird mit Senf statt Marmelade gefüllt",
+          "correct": true
+        },
+        {
+          "text": "Das Gebäck wird eingefroren",
+          "correct": false
+        },
+        {
+          "text": "Das Gebäck wird gesalzen und versteckt",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Wer den Senf-Berliner erwischt, hat der Überlieferung nach trotzdem Glück im neuen Jahr.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_033",
+      "question": "Mit welchem Stück endet traditionell das Neujahrskonzert der Wiener Philharmoniker?",
+      "answers": [
+        {
+          "text": "Mit dem Radetzky-Marsch",
+          "correct": true
+        },
+        {
+          "text": "Mit dem Kaiserwalzer",
+          "correct": false
+        },
+        {
+          "text": "Mit Beethovens Neunter",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Das Publikum klatscht mit, und der Dirigent dirigiert dabei den Saal statt das Orchester.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_034",
+      "question": "Welcher Walzer wird beim Wiener Neujahrskonzert als erste Zugabe angestimmt?",
+      "answers": [
+        {
+          "text": "'An der schönen blauen Donau'",
+          "correct": true
+        },
+        {
+          "text": "'Wiener Blut'",
+          "correct": false
+        },
+        {
+          "text": "'Rosen aus dem Süden'",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Das Orchester wird nach den ersten Takten unterbrochen, damit die Musiker dem Publikum ein gutes Jahr wünschen können.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_035",
+      "question": "Wie hoch ist der Druck in einer geschlossenen Champagnerflasche ungefähr?",
+      "answers": [
+        {
+          "text": "Etwa sechs bar",
+          "correct": true
+        },
+        {
+          "text": "Etwa ein bar",
+          "correct": false
+        },
+        {
+          "text": "Etwa dreißig bar",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Das ist rund das Dreifache eines Autoreifens — deshalb ist das Glas so dick und der Korken verdrahtet.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_036",
+      "question": "Wann darf ein Schaumwein die Bezeichnung Champagner tragen?",
+      "answers": [
+        {
+          "text": "Nur wenn er aus der Region Champagne stammt",
+          "correct": true
+        },
+        {
+          "text": "Nur wenn er mindestens zehn Jahre reift",
+          "correct": false
+        },
+        {
+          "text": "Nur wenn er aus einer einzigen Rebsorte besteht",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Die geschützte Herkunftsbezeichnung wird von Frankreich weltweit juristisch verteidigt.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_037",
+      "question": "Was ist das 'Sabrage' bei einer Schaumweinflasche?",
+      "answers": [
+        {
+          "text": "Das Köpfen der Flasche mit einem Säbel",
+          "correct": true
+        },
+        {
+          "text": "Das Kühlen im Salzeis",
+          "correct": false
+        },
+        {
+          "text": "Das Umfüllen in eine Karaffe",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Der Schlag trifft die Naht der Flasche; der Innendruck sprengt den Glasring mitsamt Korken ab.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_038",
+      "question": "In welchem Land wurde das Feuerwerk erfunden?",
+      "answers": [
+        {
+          "text": "In China",
+          "correct": true
+        },
+        {
+          "text": "In Italien",
+          "correct": false
+        },
+        {
+          "text": "In Persien",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Schwarzpulver diente zuerst dazu, mit Lärm böse Geister zu vertreiben — die Farben kamen erst Jahrhunderte später.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_039",
+      "question": "Wodurch entsteht die rote Farbe in einem Feuerwerk?",
+      "answers": [
+        {
+          "text": "Durch Strontiumverbindungen",
+          "correct": true
+        },
+        {
+          "text": "Durch Eisenspäne",
+          "correct": false
+        },
+        {
+          "text": "Durch Schwefel",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Kupfer leuchtet blau, Barium grün, Natrium gelb — Feuerwerk ist angewandte Flammenfärbung.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_040",
+      "question": "An wie vielen Tagen im Jahr darf in Deutschland Silvesterfeuerwerk regulär verkauft werden?",
+      "answers": [
+        {
+          "text": "An drei Tagen",
+          "correct": true
+        },
+        {
+          "text": "An zehn Tagen",
+          "correct": false
+        },
+        {
+          "text": "Das ganze Jahr über",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Der Verkauf ist auf den 29. bis 31. Dezember beschränkt; fällt einer davon auf einen Sonntag, verschiebt sich der Start.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_041",
+      "question": "Welche Messwerte steigen in europäischen Städten in der Silvesternacht sprunghaft an?",
+      "answers": [
+        {
+          "text": "Die Feinstaubwerte",
+          "correct": true
+        },
+        {
+          "text": "Die Ozonwerte",
+          "correct": false
+        },
+        {
+          "text": "Die Radonwerte",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "In der ersten Stunde des Jahres liegen sie oft um ein Vielfaches über dem Tagesgrenzwert.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_042",
+      "question": "Zwischen welchen Daten kann das chinesische Neujahrsfest liegen?",
+      "answers": [
+        {
+          "text": "Zwischen dem 21. Januar und dem 20. Februar",
+          "correct": true
+        },
+        {
+          "text": "Zwischen dem 1. und dem 15. Januar",
+          "correct": false
+        },
+        {
+          "text": "Zwischen dem 1. und dem 30. März",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Der chinesische Kalender ist lunisolar; das Fest fällt auf den zweiten Neumond nach der Wintersonnenwende.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_043",
+      "question": "Wann beginnt das persische Neujahrsfest Nouruz?",
+      "answers": [
+        {
+          "text": "Zur Frühlings-Tagundnachtgleiche",
+          "correct": true
+        },
+        {
+          "text": "Zur Wintersonnenwende",
+          "correct": false
+        },
+        {
+          "text": "Am ersten Vollmond im Februar",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Nouruz wird von Iran bis Zentralasien gefeiert und steht auf der UNESCO-Liste des immateriellen Kulturerbes.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_044",
+      "question": "In welchem Monat feiert Äthiopien mit 'Enkutatash' sein Neujahr?",
+      "answers": [
+        {
+          "text": "Im September",
+          "correct": true
+        },
+        {
+          "text": "Im Januar",
+          "correct": false
+        },
+        {
+          "text": "Im Mai",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Der äthiopische Kalender hat dreizehn Monate — zwölf zu 30 Tagen und einen kurzen Restmonat.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_045",
+      "question": "Wie feiert Thailand mit 'Songkran' den Jahreswechsel?",
+      "answers": [
+        {
+          "text": "Mit einer landesweiten Wasserschlacht",
+          "correct": true
+        },
+        {
+          "text": "Mit einem Fastentag",
+          "correct": false
+        },
+        {
+          "text": "Mit einem Drachenfest",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Das ursprünglich rituelle Übergießen zur Reinigung ist heute ein dreitägiges Wasserfest im April.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_046",
+      "question": "Welches Problem beschäftigte die IT-Welt zum Jahreswechsel 1999/2000?",
+      "answers": [
+        {
+          "text": "Zweistellig gespeicherte Jahreszahlen",
+          "correct": true
+        },
+        {
+          "text": "Ein weltweiter Stromausfall",
+          "correct": false
+        },
+        {
+          "text": "Ein Virus namens Millennium",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Weil '00' als 1900 gelesen werden konnte, wurden weltweit Milliarden in die Umstellung gesteckt — und wenig passierte.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_047",
+      "question": "Welches Gedicht wird in Schweden auf Skansen zum Jahreswechsel verlesen?",
+      "answers": [
+        {
+          "text": "'Ring out, wild bells' von Tennyson",
+          "correct": true
+        },
+        {
+          "text": "Ein Auszug aus der Edda",
+          "correct": false
+        },
+        {
+          "text": "Ein Text von Astrid Lindgren",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Die Tradition besteht seit 1895; der Vortrag wird landesweit im Fernsehen übertragen.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_048",
+      "question": "Welches Fleisch meidet man in Ungarn am Neujahrstag?",
+      "answers": [
+        {
+          "text": "Geflügel",
+          "correct": true
+        },
+        {
+          "text": "Rind",
+          "correct": false
+        },
+        {
+          "text": "Lamm",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Der Aberglaube sagt, das Glück fliege sonst davon; Schwein dagegen wühlt nach vorn und bringt Fortschritt.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_049",
+      "question": "Was tut man in Irland der Überlieferung nach zu Neujahr mit einem Brot?",
+      "answers": [
+        {
+          "text": "Man schlägt damit gegen Wände und Türen",
+          "correct": true
+        },
+        {
+          "text": "Man vergräbt es im Garten",
+          "correct": false
+        },
+        {
+          "text": "Man wirft es ins Meer",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Der Lärm soll Unglück aus dem Haus und gutes Brot ins kommende Jahr treiben.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_050",
+      "question": "Was zerschmettert man in der Türkei und in Griechenland zu Neujahr auf der Türschwelle?",
+      "answers": [
+        {
+          "text": "Einen Granatapfel",
+          "correct": true
+        },
+        {
+          "text": "Einen Krug Wasser",
+          "correct": false
+        },
+        {
+          "text": "Eine Walnuss",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Je weiter die Kerne springen, desto größer soll der Segen für das Haus ausfallen.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_051",
+      "question": "Welche Farbe hat in Peru und Teilen Lateinamerikas die Glücks-Unterwäsche zu Neujahr?",
+      "answers": [
+        {
+          "text": "Gelb",
+          "correct": true
+        },
+        {
+          "text": "Blau",
+          "correct": false
+        },
+        {
+          "text": "Grün",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Gelb steht für Wohlstand; rote Wäsche wählt, wer sich Liebe wünscht.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_052",
+      "question": "Was macht man in Mexiko zu Neujahr mit einem leeren Koffer?",
+      "answers": [
+        {
+          "text": "Man läuft damit um den Block",
+          "correct": true
+        },
+        {
+          "text": "Man stellt ihn vor die Tür",
+          "correct": false
+        },
+        {
+          "text": "Man verbrennt ihn",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Der Spaziergang soll Reisen im neuen Jahr sichern — manche laufen dafür bis zur nächsten Straßenecke und zurück.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_053",
+      "question": "Welcher Salat gehört in Russland fest auf den Silvestertisch?",
+      "answers": [
+        {
+          "text": "Der Olivier-Salat",
+          "correct": true
+        },
+        {
+          "text": "Ein Rote-Bete-Salat mit Hering",
+          "correct": false
+        },
+        {
+          "text": "Ein Krautsalat mit Kümmel",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Er ist nach einem Koch benannt, der ihn im 19. Jahrhundert in Moskau erfand; das Originalrezept gilt als verschollen.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_054",
+      "question": "Welche Fernsehsendung schauen fast alle Isländer am Silvesterabend?",
+      "answers": [
+        {
+          "text": "Die Satiresendung 'Áramótaskaupið'",
+          "correct": true
+        },
+        {
+          "text": "Ein Konzert aus der Harpa",
+          "correct": false
+        },
+        {
+          "text": "Eine Übertragung vom Geysir",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Die Straßen leeren sich für eine halbe Stunde; erst danach beginnen Feuerwerk und Freudenfeuer.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_055",
+      "question": "Was findet in Madrid am Nachmittag des 31. Dezember statt?",
+      "answers": [
+        {
+          "text": "Ein großer Straßenlauf",
+          "correct": true
+        },
+        {
+          "text": "Ein Stierlauf",
+          "correct": false
+        },
+        {
+          "text": "Ein Autokorso",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Die 'San Silvestre Vallecana' zieht Zehntausende an; viele laufen verkleidet.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_056",
+      "question": "Welche Band veröffentlichte 1980 das Lied 'Happy New Year'?",
+      "answers": [
+        {
+          "text": "ABBA",
+          "correct": true
+        },
+        {
+          "text": "Queen",
+          "correct": false
+        },
+        {
+          "text": "Die Bee Gees",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Der Text ist deutlich melancholischer als der Titel; in mehreren Ländern wurde er erst Jahre später ein Hit.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_057",
+      "question": "Woher stammt der Monatsname Januar?",
+      "answers": [
+        {
+          "text": "Vom römischen Gott Janus",
+          "correct": true
+        },
+        {
+          "text": "Vom lateinischen Wort für Eis",
+          "correct": false
+        },
+        {
+          "text": "Von einem etruskischen Herrscher",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Janus hat zwei Gesichter und blickt zugleich zurück und nach vorn — passender geht es für einen Jahresbeginn kaum.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_058",
+      "question": "Was bedeutet der Trinkspruch 'Prosit Neujahr' wörtlich?",
+      "answers": [
+        {
+          "text": "'Es möge nützen'",
+          "correct": true
+        },
+        {
+          "text": "'Auf die Gesundheit'",
+          "correct": false
+        },
+        {
+          "text": "'Bis zum Grund'",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "'Prosit' ist lateinisch und stammt aus der Studentensprache des 18. Jahrhunderts.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_059",
+      "question": "Welches Sportereignis findet in Deutschland traditionell am 1. Januar statt?",
+      "answers": [
+        {
+          "text": "Das Neujahrsskispringen in Garmisch-Partenkirchen",
+          "correct": true
+        },
+        {
+          "text": "Ein Formel-1-Rennen",
+          "correct": false
+        },
+        {
+          "text": "Das Pokalfinale im Fußball",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Es ist die zweite Station der Vierschanzentournee und beginnt schon am Vormittag mit der Qualifikation.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_060",
+      "question": "Welche Blumenparade findet in Kalifornien am Neujahrstag statt?",
+      "answers": [
+        {
+          "text": "Die Rose Parade in Pasadena",
+          "correct": true
+        },
+        {
+          "text": "Die Poppy Parade in San Diego",
+          "correct": false
+        },
+        {
+          "text": "Die Lily Parade in Sacramento",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Die Wagen müssen vollständig mit pflanzlichem Material verkleidet sein — jedes Blatt zählt.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_061",
+      "question": "Wer machte 'Auld Lang Syne' in Nordamerika zum festen Bestandteil des Jahreswechsels?",
+      "answers": [
+        {
+          "text": "Der Bandleader Guy Lombardo",
+          "correct": true
+        },
+        {
+          "text": "Der Sänger Bing Crosby",
+          "correct": false
+        },
+        {
+          "text": "Der Radiomoderator Orson Welles",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Sein Orchester spielte den Titel ab 1929 jedes Jahr live um Mitternacht — erst im Radio, später im Fernsehen.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_062",
+      "question": "Was ist die walisische 'Mari Lwyd', die um den Jahreswechsel von Haus zu Haus zieht?",
+      "answers": [
+        {
+          "text": "Ein geschmückter Pferdeschädel auf einer Stange",
+          "correct": true
+        },
+        {
+          "text": "Eine Strohpuppe im Boot",
+          "correct": false
+        },
+        {
+          "text": "Eine Laterne aus Rübe",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Die Gruppe fordert in gereimten Versen Einlass; die Bewohner müssen in Reimen zurückantworten.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_063",
+      "question": "Welches Land begrüßt das neue Jahr als eines der letzten der Welt?",
+      "answers": [
+        {
+          "text": "Die USA mit den Baker- und Howlandinseln",
+          "correct": true
+        },
+        {
+          "text": "Portugal",
+          "correct": false
+        },
+        {
+          "text": "Chile",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Die unbewohnten Inseln liegen in der Zeitzone UTC−12, ganze 26 Stunden hinter Kiribati.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_064",
+      "question": "Was wirft man in Teilen Kubas und Puerto Ricos um Mitternacht aus dem Fenster?",
+      "answers": [
+        {
+          "text": "Einen Eimer Wasser",
+          "correct": true
+        },
+        {
+          "text": "Alte Kleidung",
+          "correct": false
+        },
+        {
+          "text": "Münzen",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Das Wasser soll das Unglück des alten Jahres aus dem Haus spülen.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_065",
+      "question": "Was tragen die Männer beim Feuerballwerfen im schottischen Stonehaven durch die Straßen?",
+      "answers": [
+        {
+          "text": "Brennende Drahtkörbe an langen Ketten",
+          "correct": true
+        },
+        {
+          "text": "Fackeln aus Torf",
+          "correct": false
+        },
+        {
+          "text": "Laternen aus Kürbissen",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Am Ende landen die Feuerbälle im Hafenbecken; der Brauch soll böse Geister vertreiben.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_066",
+      "question": "Wie heißt das Neujahrsbad, bei dem Schotten in den eiskalten Firth of Forth steigen?",
+      "answers": [
+        {
+          "text": "Loony Dook",
+          "correct": true
+        },
+        {
+          "text": "Cold Ceilidh",
+          "correct": false
+        },
+        {
+          "text": "Firth Plunge",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Viele springen verkleidet; die Veranstaltung sammelt Geld für wohltätige Zwecke.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_067",
+      "question": "Welches Bauwerk markiert in Sydney den Jahreswechsel mit einem der ersten großen Feuerwerke der Welt?",
+      "answers": [
+        {
+          "text": "Die Hafenbrücke",
+          "correct": true
+        },
+        {
+          "text": "Der Fernsehturm",
+          "correct": false
+        },
+        {
+          "text": "Das Parlamentsgebäude",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Wegen der Zeitzone laufen die Bilder aus Sydney in Europa oft schon am Nachmittag des 31. Dezember.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_068",
+      "question": "An welchem Bauwerk feiert Berlin traditionell die größte Silvesterparty der Stadt?",
+      "answers": [
+        {
+          "text": "Am Brandenburger Tor",
+          "correct": true
+        },
+        {
+          "text": "Am Berliner Dom",
+          "correct": false
+        },
+        {
+          "text": "Am Olympiastadion",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Die Bühnenshow auf der 'Partymeile' wird live im Fernsehen übertragen.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_069",
+      "question": "Welches Gebäude ist Mittelpunkt des Silvesterfeuerwerks in Dubai?",
+      "answers": [
+        {
+          "text": "Der Burj Khalifa",
+          "correct": true
+        },
+        {
+          "text": "Der Flughafenturm",
+          "correct": false
+        },
+        {
+          "text": "Die Sheikh-Zayid-Moschee",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Die Fassade des höchsten Gebäudes der Welt dient dabei zugleich als Projektionsfläche.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_070",
+      "question": "An welchem Strand findet eine der größten Silvesterfeiern der Welt statt?",
+      "answers": [
+        {
+          "text": "An der Copacabana in Rio de Janeiro",
+          "correct": true
+        },
+        {
+          "text": "An der Waikiki Beach auf Hawaii",
+          "correct": false
+        },
+        {
+          "text": "An der Bondi Beach in Sydney",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Millionen Menschen kommen in Weiß; nach dem Feuerwerk werden Blumen für die Meeresgöttin Iemanjá ins Wasser gelegt.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_071",
+      "question": "Was passiert am Times Square mit den Zetteln, auf die Besucher ihre Wünsche schreiben?",
+      "answers": [
+        {
+          "text": "Sie werden um Mitternacht als Konfetti abgeworfen",
+          "correct": true
+        },
+        {
+          "text": "Sie werden verbrannt",
+          "correct": false
+        },
+        {
+          "text": "Sie werden im Rathaus archiviert",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Die Wunschzettel werden vorher gesammelt und mit dem übrigen Konfetti von den Dächern geschüttet.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_072",
+      "question": "Wie lange braucht die Kugel am Times Square für ihren Weg nach unten?",
+      "answers": [
+        {
+          "text": "Genau 60 Sekunden",
+          "correct": true
+        },
+        {
+          "text": "Etwa fünf Minuten",
+          "correct": false
+        },
+        {
+          "text": "Etwa zehn Sekunden",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Sie kommt exakt um Mitternacht unten an; die Zahlen des neuen Jahres leuchten erst danach auf.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_073",
+      "question": "Woher stammt der deutsche Gruß 'Guten Rutsch' vermutlich?",
+      "answers": [
+        {
+          "text": "Von einem alten Wort für eine gute Reise",
+          "correct": true
+        },
+        {
+          "text": "Von vereisten Straßen",
+          "correct": false
+        },
+        {
+          "text": "Von einem Rodelbrauch",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Die verbreitete Herleitung aus dem Jiddischen gilt sprachwissenschaftlich als unsicher.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_074",
+      "question": "Welche Figur steht in vielen Ländern sinnbildlich für das neue Jahr?",
+      "answers": [
+        {
+          "text": "Ein Baby mit Jahreszahl-Schärpe",
+          "correct": true
+        },
+        {
+          "text": "Ein Adler",
+          "correct": false
+        },
+        {
+          "text": "Ein Schlüssel",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Das Motiv ist Jahrhunderte alt und wurde ab dem 19. Jahrhundert von Zeitschriften-Titelseiten popularisiert.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_075",
+      "question": "Was ist eine skandinavische 'Kransekake'?",
+      "answers": [
+        {
+          "text": "Ein Turm aus Mandelteigringen",
+          "correct": true
+        },
+        {
+          "text": "Ein Kranz aus Salzgebäck",
+          "correct": false
+        },
+        {
+          "text": "Ein Eiskuchen mit Beeren",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Die Ringe werden von unten nach oben immer kleiner; zum Jahreswechsel steckt oft eine Flagge oben drin.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_076",
+      "question": "Wie viele Mahlzeiten isst man in Estland der Tradition nach am Silvestertag?",
+      "answers": [
+        {
+          "text": "Sieben, neun oder zwölf",
+          "correct": true
+        },
+        {
+          "text": "Genau drei",
+          "correct": false
+        },
+        {
+          "text": "Genau fünf",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Die Zahlen gelten als Glückszahlen; man soll die Kraft von so vielen Männern in sich tragen.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_077",
+      "question": "Was tun viele Japaner in den ersten Tagen des Jahres beim 'Hatsumode'?",
+      "answers": [
+        {
+          "text": "Sie besuchen zum ersten Mal im Jahr einen Schrein oder Tempel",
+          "correct": true
+        },
+        {
+          "text": "Sie pflanzen einen Baum",
+          "correct": false
+        },
+        {
+          "text": "Sie schreiben ein Gedicht ins Meer",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Dabei werden alte Glücksbringer zurückgegeben und neue gekauft.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_078",
+      "question": "Was sind japanische 'Otoshidama'?",
+      "answers": [
+        {
+          "text": "Geldgeschenke für Kinder in kleinen Umschlägen",
+          "correct": true
+        },
+        {
+          "text": "Neujahrsgedichte auf Reispapier",
+          "correct": false
+        },
+        {
+          "text": "Kleine Glücksfiguren aus Ton",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Die Summe richtet sich nach dem Alter; ältere Kinder bekommen mehr.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_079",
+      "question": "Welche Suppe isst man in Korea am Neujahrstag?",
+      "answers": [
+        {
+          "text": "Eine Suppe mit Reiskuchenscheiben",
+          "correct": true
+        },
+        {
+          "text": "Eine Suppe mit Seetang und Muscheln",
+          "correct": false
+        },
+        {
+          "text": "Eine kalte Buchweizensuppe",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Der Überlieferung nach wird man erst ein Jahr älter, wenn man 'Tteokguk' gegessen hat.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_080",
+      "question": "Wie heißt das vietnamesische Neujahrsfest?",
+      "answers": [
+        {
+          "text": "Tet",
+          "correct": true
+        },
+        {
+          "text": "Diwali",
+          "correct": false
+        },
+        {
+          "text": "Obon",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Es folgt dem Mondkalender und fällt meist mit dem chinesischen Neujahr zusammen; Kumquat-Bäumchen gehören in jedes Haus.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_081",
+      "question": "Womit wird das jüdische Neujahrsfest Rosch ha-Schana eingeläutet?",
+      "answers": [
+        {
+          "text": "Mit einem Widderhorn",
+          "correct": true
+        },
+        {
+          "text": "Mit einer Bronzeglocke",
+          "correct": false
+        },
+        {
+          "text": "Mit einer Trommel",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Das Schofar wird nach einer festen Abfolge von Tonfolgen geblasen; das Fest fällt in den Herbst.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_082",
+      "question": "Warum wandert das islamische Neujahrsfest durch die Jahreszeiten?",
+      "answers": [
+        {
+          "text": "Weil der islamische Kalender rein lunar ist",
+          "correct": true
+        },
+        {
+          "text": "Weil es an Ostern gekoppelt ist",
+          "correct": false
+        },
+        {
+          "text": "Weil es alle vier Jahre verschoben wird",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Das Mondjahr ist rund elf Tage kürzer als das Sonnenjahr, also verschiebt sich der 1. Muharram jedes Jahr nach vorn.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_083",
+      "question": "Bis wann war der erste Weihnachtstag in Schottland kein allgemeiner Feiertag?",
+      "answers": [
+        {
+          "text": "Bis 1958",
+          "correct": true
+        },
+        {
+          "text": "Bis 1901",
+          "correct": false
+        },
+        {
+          "text": "Bis 1975",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Deshalb war Hogmanay dort jahrhundertelang das eigentliche große Fest des Winters.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_084",
+      "question": "Was gehört in Frankreich klassisch auf den Tisch des 'Réveillon de la Saint-Sylvestre'?",
+      "answers": [
+        {
+          "text": "Austern",
+          "correct": true
+        },
+        {
+          "text": "Gefüllte Paprika",
+          "correct": false
+        },
+        {
+          "text": "Rindergulasch",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Dazu kommen oft Foie gras und Champagner; gegessen wird spät und lange.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_085",
+      "question": "Was ist in Belgien ein Neujahrsbrauch für Kinder?",
+      "answers": [
+        {
+          "text": "Sie lesen den Paten einen selbst geschriebenen Brief vor",
+          "correct": true
+        },
+        {
+          "text": "Sie läuten Kuhglocken auf dem Feld",
+          "correct": false
+        },
+        {
+          "text": "Sie verstecken Münzen im Schnee",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Der Brief wird auf verziertem Papier geschrieben und am Neujahrstag feierlich vorgetragen.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_086",
+      "question": "Was geschieht beim Appenzeller 'Silvesterchlausen' in der Schweiz?",
+      "answers": [
+        {
+          "text": "Gruppen ziehen in aufwendigen Kostümen von Hof zu Hof und jodeln",
+          "correct": true
+        },
+        {
+          "text": "Es wird ein Feuerrad den Berg hinuntergerollt",
+          "correct": false
+        },
+        {
+          "text": "Die Dorfbewohner tauschen Kuhglocken",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Gefeiert wird zweimal: am 31. Dezember und am 13. Januar nach dem alten Kalender.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_087",
+      "question": "Was ist ein 'Cotillón' auf einer spanischen oder lateinamerikanischen Silvesterfeier?",
+      "answers": [
+        {
+          "text": "Eine Tüte mit Hütchen, Tröten und Luftschlangen",
+          "correct": true
+        },
+        {
+          "text": "Ein Tanz zu zwölf Paaren",
+          "correct": false
+        },
+        {
+          "text": "Ein Nachtisch mit Sahne",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Nach den zwölf Trauben wird die Tüte geöffnet und der Lärm beginnt.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_088",
+      "question": "Was wirft man in Argentinien am letzten Arbeitstag des Jahres aus den Bürofenstern?",
+      "answers": [
+        {
+          "text": "Zerrissenes Papier aus alten Akten",
+          "correct": true
+        },
+        {
+          "text": "Blumen",
+          "correct": false
+        },
+        {
+          "text": "Münzen",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Der Papierregen im Finanzviertel von Buenos Aires ist ein Bild, das jedes Jahr um die Welt geht.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_089",
+      "question": "Woher stammt das Wort 'Konfetti'?",
+      "answers": [
+        {
+          "text": "Von italienischen Zuckermandeln",
+          "correct": true
+        },
+        {
+          "text": "Von einem französischen Papierhersteller",
+          "correct": false
+        },
+        {
+          "text": "Von einem lateinischen Wort für Wind",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Beim Karneval in Mailand warf man einst Süßigkeiten; als das zu teuer wurde, kamen bunte Papierschnipsel an ihre Stelle.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_090",
+      "question": "Warum war das Jahr 1900 kein Schaltjahr?",
+      "answers": [
+        {
+          "text": "Weil volle Jahrhunderte nur bei Teilbarkeit durch 400 Schaltjahre sind",
+          "correct": true
+        },
+        {
+          "text": "Weil der Kalender damals umgestellt wurde",
+          "correct": false
+        },
+        {
+          "text": "Weil der Februar verkürzt wurde",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Nach derselben Regel fällt auch 2100 aus — 2000 dagegen war ein Schaltjahr.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_091",
+      "question": "Was wird im Vatikan am Abend des 31. Dezember gesungen?",
+      "answers": [
+        {
+          "text": "Das Te Deum als Dankgottesdienst",
+          "correct": true
+        },
+        {
+          "text": "Das Requiem",
+          "correct": false
+        },
+        {
+          "text": "Das Magnificat",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Der Papst dankt dabei für das zu Ende gehende Jahr; am 1. Januar folgt der Weltfriedenstag.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_092",
+      "question": "Wann hält das dänische Staatsoberhaupt seine Neujahrsansprache?",
+      "answers": [
+        {
+          "text": "Am Abend des 31. Dezember",
+          "correct": true
+        },
+        {
+          "text": "Am Vormittag des 1. Januar",
+          "correct": false
+        },
+        {
+          "text": "Am 6. Januar",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Die Rede um 18 Uhr strukturiert den Abend: Davor wird gegessen, danach gefeiert.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_093",
+      "question": "Was ist die niederländische 'oudejaarsconference'?",
+      "answers": [
+        {
+          "text": "Ein satirischer Jahresrückblick eines Kabarettisten",
+          "correct": true
+        },
+        {
+          "text": "Eine Talkshow mit Politikern",
+          "correct": false
+        },
+        {
+          "text": "Ein Chorkonzert",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Der Auftritt dauert oft mehr als zwei Stunden und wird am Abend des 31. Dezember live gesendet.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_094",
+      "question": "Welche Ballsaison beginnt in Wien traditionell um den Jahreswechsel?",
+      "answers": [
+        {
+          "text": "Die Faschingsballsaison",
+          "correct": true
+        },
+        {
+          "text": "Die Opernsaison",
+          "correct": false
+        },
+        {
+          "text": "Die Konzertsaison im Musikverein",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Der Kaiserball in der Hofburg findet in der Silvesternacht statt; der Opernball folgt erst im Februar.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_095",
+      "question": "Wie viele Tierzeichen umfasst der chinesische Tierkreis, der jedem Jahr ein Zeichen gibt?",
+      "answers": [
+        {
+          "text": "Zwölf",
+          "correct": true
+        },
+        {
+          "text": "Zehn",
+          "correct": false
+        },
+        {
+          "text": "Vierundzwanzig",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Die Ratte macht den Anfang; nach der Legende kam die Katze zu spät zum Wettlauf und fehlt deshalb.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_096",
+      "question": "Wie viele Weintrauben isst man in Spanien in der Silvesternacht zu den Glockenschlägen?",
+      "type": "estimate",
+      "answer": 12,
+      "min": 1,
+      "max": 60,
+      "unit": "Trauben",
+      "difficulty": "easy",
+      "fun_fact": "Zwölf, eine je Schlag — im Handel gibt es sie deshalb geschält und entkernt in der Dose.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_097",
+      "question": "Wie oft schlagen japanische Tempelglocken in der Nacht zum Neujahrstag?",
+      "type": "estimate",
+      "answer": 108,
+      "min": 0,
+      "max": 500,
+      "unit": "Schläge",
+      "difficulty": "medium",
+      "fun_fact": "108 Schläge stehen für die weltlichen Begierden, die man mit dem alten Jahr zurücklässt.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_098",
+      "question": "Wie viele Stunden liegen zwischen dem ersten und dem letzten Jahreswechsel auf der Erde?",
+      "type": "estimate",
+      "answer": 26,
+      "min": 0,
+      "max": 60,
+      "unit": "Stunden",
+      "difficulty": "hard",
+      "fun_fact": "26 Stunden — von UTC+14 auf den Linieninseln Kiribatis bis UTC−12 bei den Baker- und Howlandinseln.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_099",
+      "question": "In welchem Jahr führte Papst Gregor XIII. den heute weltweit genutzten Kalender ein?",
+      "type": "estimate",
+      "answer": 1582,
+      "min": 1200,
+      "max": 1900,
+      "unit": "Jahr",
+      "difficulty": "medium",
+      "fun_fact": "1582 — bei der Umstellung folgte auf den 4. Oktober direkt der 15. Oktober.",
+      "category": "Silvester"
+    },
+    {
+      "id": "silvester_de_100",
+      "question": "In welchem Jahr nahm der NDR den Sketch 'Dinner for One' auf, der seither zu Silvester läuft?",
+      "type": "estimate",
+      "answer": 1963,
+      "min": 1900,
+      "max": 2000,
+      "unit": "Jahr",
+      "difficulty": "medium",
+      "fun_fact": "1963 — aufgezeichnet vor Publikum in Hamburg, in englischer Sprache und ohne Untertitel.",
+      "category": "Silvester"
+    }
+  ]
+}

--- a/custom_components/quizify/questions/versions.json
+++ b/custom_components/quizify/questions/versions.json
@@ -34,5 +34,11 @@
   "tecnologia-es": "1.0",
   "imagenes-es": "1.0",
   "estimacion-es": "1.0",
-  "copa-mundial-es": "1.2"
+  "copa-mundial-es": "1.2",
+  "weihnachten-de": "1.0",
+  "christmas-en": "1.0",
+  "navidad-es": "1.0",
+  "silvester-de": "1.0",
+  "new-years-eve-en": "1.0",
+  "nochevieja-es": "1.0"
 }

--- a/custom_components/quizify/questions/weihnachten-de.json
+++ b/custom_components/quizify/questions/weihnachten-de.json
@@ -1,0 +1,2089 @@
+{
+  "name": "Weihnachten",
+  "language": "de",
+  "version": "1.0",
+  "theme": "trivia",
+  "season": {
+    "start": "12-01",
+    "end": "12-26",
+    "label": "🎄 Weihnachtszeit"
+  },
+  "questions": [
+    {
+      "id": "weihnachten_de_001",
+      "question": "Welches Unternehmen prägte ab 1931 mit seiner Werbung das heutige Bild des rundlichen Weihnachtsmanns?",
+      "answers": [
+        {
+          "text": "Coca-Cola",
+          "correct": true
+        },
+        {
+          "text": "Pepsi",
+          "correct": false
+        },
+        {
+          "text": "Nestlé",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Rot gekleidet war er schon vorher: Der Zeichner Haddon Sundblom vereinheitlichte das Bild nur, er erfand es nicht.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_002",
+      "question": "Für wen wurde das Rentier Rudolph 1939 erfunden?",
+      "answers": [
+        {
+          "text": "Für ein US-Kaufhaus",
+          "correct": true
+        },
+        {
+          "text": "Für einen Disney-Film",
+          "correct": false
+        },
+        {
+          "text": "Für eine Zigarettenmarke",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Robert L. May schrieb die Reimgeschichte als Werbegeschenk für die Kaufhauskette Montgomery Ward.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_003",
+      "question": "Warum verfolgt die nordamerikanische Luftraumüberwachung NORAD seit 1955 den Weihnachtsmann?",
+      "answers": [
+        {
+          "text": "Wegen einer falsch gedruckten Telefonnummer",
+          "correct": true
+        },
+        {
+          "text": "Wegen einer Wette zweier Generäle",
+          "correct": false
+        },
+        {
+          "text": "Wegen eines Kinofilms",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Eine Kaufhausanzeige druckte statt der Weihnachtsmann-Hotline die Nummer einer Kommandozentrale — der diensthabende Offizier spielte mit.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_004",
+      "question": "Für welches Fest wurde das Lied 'Jingle Bells' ursprünglich geschrieben?",
+      "answers": [
+        {
+          "text": "Für Thanksgiving",
+          "correct": true
+        },
+        {
+          "text": "Für Ostern",
+          "correct": false
+        },
+        {
+          "text": "Für den Nationalfeiertag",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "James Lord Pierpont veröffentlichte es 1857 als 'One Horse Open Sleigh' — ein Winterlied ohne jeden Weihnachtsbezug.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_005",
+      "question": "Welches Lied war das erste, das aus dem Weltall zur Erde gefunkt wurde?",
+      "answers": [
+        {
+          "text": "Jingle Bells",
+          "correct": true
+        },
+        {
+          "text": "Stille Nacht",
+          "correct": false
+        },
+        {
+          "text": "White Christmas",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Die Gemini-6-Besatzung meldete im Dezember 1965 erst ein 'unbekanntes Objekt' und spielte dann Mundharmonika und Schellen.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_006",
+      "question": "Auf welchem Instrument wurde 'Stille Nacht' bei der Uraufführung begleitet?",
+      "answers": [
+        {
+          "text": "Auf einer Gitarre",
+          "correct": true
+        },
+        {
+          "text": "Auf einer Orgel",
+          "correct": false
+        },
+        {
+          "text": "Auf einer Harfe",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Warum die Orgel schwieg, ist ungeklärt — die Geschichte von den Mäusen im Blasebalg kam erst viel später auf.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_007",
+      "question": "Welche Weihnachtsaufnahme gilt als meistverkaufte Single aller Zeiten?",
+      "answers": [
+        {
+          "text": "'White Christmas' von Bing Crosby",
+          "correct": true
+        },
+        {
+          "text": "'Last Christmas' von Wham!",
+          "correct": false
+        },
+        {
+          "text": "'Feliz Navidad' von José Feliciano",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Die Schätzungen liegen bei über 50 Millionen verkauften Exemplaren — kein anderer Titel kommt in die Nähe.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_008",
+      "question": "Wie lange brauchte 'Last Christmas' von Wham! bis zur ersten Nummer eins in den britischen Charts?",
+      "answers": [
+        {
+          "text": "Über 35 Jahre",
+          "correct": true
+        },
+        {
+          "text": "Zwei Wochen",
+          "correct": false
+        },
+        {
+          "text": "Es war sofort auf Platz eins",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "1984 blockierte der Benefiz-Song 'Do They Know It's Christmas?' den Spitzenplatz; erst Anfang 2021 reichte es dafür.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_009",
+      "question": "Wie lange brauchten Mariah Carey und Walter Afanasieff angeblich, um 'All I Want for Christmas Is You' zu schreiben?",
+      "answers": [
+        {
+          "text": "Etwa eine Viertelstunde",
+          "correct": true
+        },
+        {
+          "text": "Etwa ein halbes Jahr",
+          "correct": false
+        },
+        {
+          "text": "Etwa drei Wochen",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Beide erzählen die Geschichte bis heute unterschiedlich — einig sind sie sich nur darin, dass es sehr schnell ging.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_010",
+      "question": "Wonach ist der Weihnachtsstern (Poinsettie) benannt?",
+      "answers": [
+        {
+          "text": "Nach einem US-Botschafter in Mexiko",
+          "correct": true
+        },
+        {
+          "text": "Nach einem englischen Gärtner",
+          "correct": false
+        },
+        {
+          "text": "Nach einem Heiligen",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Joel Roberts Poinsett schickte die Pflanze in den 1820er-Jahren aus Mexiko in die USA.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_011",
+      "question": "Was stimmt über den Weihnachtsstern als Zimmerpflanze?",
+      "answers": [
+        {
+          "text": "Er ist für Menschen nicht tödlich giftig",
+          "correct": true
+        },
+        {
+          "text": "Ein Blatt kann ein Kind töten",
+          "correct": false
+        },
+        {
+          "text": "Sein Saft ist ein starkes Nervengift",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Der Milchsaft reizt Haut und Magen, mehr nicht — der Ruf als Todespflanze geht auf einen unbelegten Fall von 1919 zurück.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_012",
+      "question": "Wie ernährt sich die Mistel?",
+      "answers": [
+        {
+          "text": "Sie zapft ihren Wirtsbaum an und betreibt zusätzlich Photosynthese",
+          "correct": true
+        },
+        {
+          "text": "Sie lebt rein von Regenwasser",
+          "correct": false
+        },
+        {
+          "text": "Sie ernährt sich von Insekten",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Als Halbschmarotzer nimmt sie Wasser und Nährsalze aus dem Baum, den Zucker macht sie selbst.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_013",
+      "question": "Warum spricht viel dafür, dass die Rentiere vor dem Schlitten weiblich sind?",
+      "answers": [
+        {
+          "text": "Männchen werfen ihr Geweih vor dem Winter ab",
+          "correct": true
+        },
+        {
+          "text": "Männchen können nicht so weit laufen",
+          "correct": false
+        },
+        {
+          "text": "Männchen halten Winterruhe",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Rentierkühe behalten ihr Geweih bis ins Frühjahr — im Dezember tragen fast nur sie eines.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_014",
+      "question": "Was passiert bei Rentieren im arktischen Winter mit den Augen?",
+      "answers": [
+        {
+          "text": "Der reflektierende Augenhintergrund wechselt von Gold zu Blau",
+          "correct": true
+        },
+        {
+          "text": "Sie werden vorübergehend blind",
+          "correct": false
+        },
+        {
+          "text": "Sie bekommen ein drittes Augenlid",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Die blaue Variante streut mehr Licht im Auge und macht die Tiere in der Polarnacht empfindlicher.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_015",
+      "question": "Woher kommt der große Weihnachtsbaum auf dem Trafalgar Square in London?",
+      "answers": [
+        {
+          "text": "Er ist ein jährliches Geschenk aus Oslo",
+          "correct": true
+        },
+        {
+          "text": "Er wird auf einer Plantage in Wales gezogen",
+          "correct": false
+        },
+        {
+          "text": "Er wird jedes Jahr neu versteigert",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Norwegen bedankt sich damit seit 1947 für die britische Unterstützung im Zweiten Weltkrieg.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_016",
+      "question": "Wer ließ 1843 die erste kommerzielle Weihnachtskarte drucken?",
+      "answers": [
+        {
+          "text": "Henry Cole in London",
+          "correct": true
+        },
+        {
+          "text": "Königin Victoria",
+          "correct": false
+        },
+        {
+          "text": "Charles Dickens",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Cole hatte schlicht zu viele Briefe zu beantworten und ließ 1000 Karten drucken, die er zu einem Schilling verkaufte.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_017",
+      "question": "Wie lange brauchte Charles Dickens für 'Eine Weihnachtsgeschichte'?",
+      "answers": [
+        {
+          "text": "Etwa sechs Wochen",
+          "correct": true
+        },
+        {
+          "text": "Etwa vier Jahre",
+          "correct": false
+        },
+        {
+          "text": "Etwa acht Monate",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Er schrieb sie 1843 unter Geldnot und veröffentlichte sie auf eigene Rechnung — sie war binnen Tagen ausverkauft.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_018",
+      "question": "Was geschah in England unter Oliver Cromwell mit Weihnachten?",
+      "answers": [
+        {
+          "text": "Das Fest wurde per Parlamentsbeschluss verboten",
+          "correct": true
+        },
+        {
+          "text": "Es wurde auf den 1. Januar verlegt",
+          "correct": false
+        },
+        {
+          "text": "Es wurde zum Staatsfeiertag erhoben",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "1647 strichen die Puritaner das Fest als unbiblisch — in mehreren Städten kam es deswegen zu Aufständen.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_019",
+      "question": "Wann wurde Weihnachten in den USA gesetzlicher Feiertag auf Bundesebene?",
+      "answers": [
+        {
+          "text": "1870",
+          "correct": true
+        },
+        {
+          "text": "1776",
+          "correct": false
+        },
+        {
+          "text": "1935",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Bis dahin war der 25. Dezember in einigen Bundesstaaten ein ganz normaler Arbeitstag.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_020",
+      "question": "Wer erfand 1839 den Adventskranz?",
+      "answers": [
+        {
+          "text": "Der Hamburger Erzieher Johann Hinrich Wichern",
+          "correct": true
+        },
+        {
+          "text": "Martin Luther",
+          "correct": false
+        },
+        {
+          "text": "Ein Kölner Domherr",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Wichern hängte im 'Rauhen Haus' ein Wagenrad mit Kerzen auf, damit die Kinder das Warten zählen konnten.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_021",
+      "question": "In welchem Land entstand der gedruckte Adventskalender?",
+      "answers": [
+        {
+          "text": "In Deutschland",
+          "correct": true
+        },
+        {
+          "text": "In England",
+          "correct": false
+        },
+        {
+          "text": "In den Niederlanden",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Gerhard Lang brachte um 1904 die ersten Bogen mit Ausschneidebildern in den Handel; Türchen kamen später dazu.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_022",
+      "question": "Wofür steht das X in der englischen Schreibweise 'Xmas'?",
+      "answers": [
+        {
+          "text": "Für den griechischen Buchstaben Chi",
+          "correct": true
+        },
+        {
+          "text": "Für ein durchgestrichenes Kreuz",
+          "correct": false
+        },
+        {
+          "text": "Für das römische Zahlzeichen zehn",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Chi ist der Anfangsbuchstabe von Christós — die Abkürzung ist Jahrhunderte alt und keine moderne Bequemlichkeit.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_023",
+      "question": "Wie kam die Weihnachtsinsel im Indischen Ozean zu ihrem Namen?",
+      "answers": [
+        {
+          "text": "Ein Kapitän passierte sie am ersten Weihnachtstag 1643",
+          "correct": true
+        },
+        {
+          "text": "Dort wurde eine Weihnachtskrippe gefunden",
+          "correct": false
+        },
+        {
+          "text": "Sie hat die Form eines Sterns",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "William Mynors segelte vorbei und trug schlicht das Datum als Namen ein.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_024",
+      "question": "Welches Essen gilt in Japan als klassisches Weihnachtsessen?",
+      "answers": [
+        {
+          "text": "Frittiertes Hähnchen aus der Fast-Food-Kette",
+          "correct": true
+        },
+        {
+          "text": "Gegrillter Aal",
+          "correct": false
+        },
+        {
+          "text": "Ente in Orangensauce",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Eine Werbekampagne von 1974 mit dem Slogan 'Kentucky für Weihnachten' hat sich als Tradition festgesetzt.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_025",
+      "question": "Was ist in Japan die typische Weihnachtstorte?",
+      "answers": [
+        {
+          "text": "Ein Biskuit mit Sahne und Erdbeeren",
+          "correct": true
+        },
+        {
+          "text": "Ein dunkler Früchtekuchen",
+          "correct": false
+        },
+        {
+          "text": "Ein Baumkuchen mit Marzipan",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Rot und weiß wie die Landesfarben — die Torte wird am 24. Dezember gekauft und danach kaum noch verkauft.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_026",
+      "question": "Was schauen Millionen Schweden traditionell am 24. Dezember um 15 Uhr?",
+      "answers": [
+        {
+          "text": "Eine Donald-Duck-Sendung",
+          "correct": true
+        },
+        {
+          "text": "Die Rede des Königs",
+          "correct": false
+        },
+        {
+          "text": "Ein Eishockeyspiel",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "'Kalle Anka' läuft seit 1959 fast unverändert; Terminverschiebungen lösten schon öffentliche Empörung aus.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_027",
+      "question": "Was steht im schwedischen Gävle jedes Jahr im Advent auf dem Schlossplatz?",
+      "answers": [
+        {
+          "text": "Ein riesiger Bock aus Stroh",
+          "correct": true
+        },
+        {
+          "text": "Ein Eisbär aus Eis",
+          "correct": false
+        },
+        {
+          "text": "Ein Turm aus Lebkuchen",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Der Bock wird seit 1966 aufgestellt und ist seither dutzendfach angezündet worden.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_028",
+      "question": "Was versteckt man in Norwegen traditionell am Heiligabend?",
+      "answers": [
+        {
+          "text": "Die Besen",
+          "correct": true
+        },
+        {
+          "text": "Die Schuhe",
+          "correct": false
+        },
+        {
+          "text": "Die Schlüssel",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Dem alten Glauben nach ziehen in dieser Nacht Hexen umher und suchen ein Fluggerät.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_029",
+      "question": "Wie viele Weihnachtsgesellen ('Jólasveinar') kommen in Island in den Nächten vor Weihnachten?",
+      "answers": [
+        {
+          "text": "Dreizehn",
+          "correct": true
+        },
+        {
+          "text": "Drei",
+          "correct": false
+        },
+        {
+          "text": "Sieben",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Jeder hat eine eigene Marotte — einer stiehlt Skyr, einer schleckt Löffel ab, einer knallt mit Türen.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_030",
+      "question": "Was bezeichnet die isländische 'Jólabókaflóð'?",
+      "answers": [
+        {
+          "text": "Die Bücherflut vor Weihnachten",
+          "correct": true
+        },
+        {
+          "text": "Eine Flutwelle im Dezember",
+          "correct": false
+        },
+        {
+          "text": "Ein Feuerwerk am Heiligabend",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Bücher sind das klassische Geschenk; der Abend des 24. gehört dem Lesen mit Schokolade.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_031",
+      "question": "Was ist der katalanische 'Caga Tió'?",
+      "answers": [
+        {
+          "text": "Ein Holzscheit, das Geschenke ausspuckt",
+          "correct": true
+        },
+        {
+          "text": "Ein Krippenfigur mit Laterne",
+          "correct": false
+        },
+        {
+          "text": "Ein Weihnachtsgebäck",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Kinder füttern den bemalten Scheit wochenlang und verprügeln ihn am 24. Dezember mit Stöcken, bis Süßigkeiten herauskommen.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_032",
+      "question": "Welche Figur gehört in Katalonien traditionell in eine Ecke der Weihnachtskrippe?",
+      "answers": [
+        {
+          "text": "Ein hockendes Männchen mit heruntergelassener Hose",
+          "correct": true
+        },
+        {
+          "text": "Ein Fischer mit Netz",
+          "correct": false
+        },
+        {
+          "text": "Ein Bergsteiger",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Der 'Caganer' düngt sinnbildlich die Erde — die Figur gilt als Glücksbringer für das kommende Jahr.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_033",
+      "question": "Welche Dekoration am Weihnachtsbaum gilt in der Ukraine als Glücksbringer?",
+      "answers": [
+        {
+          "text": "Spinnennetze",
+          "correct": true
+        },
+        {
+          "text": "Salzkristalle",
+          "correct": false
+        },
+        {
+          "text": "Getrocknete Chilischoten",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Eine Legende erzählt von einer armen Witwe, deren kahlen Baum Spinnen über Nacht mit Netzen schmückten.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_034",
+      "question": "Wie kommen viele Gläubige in Caracas am Weihnachtsmorgen zur Frühmesse?",
+      "answers": [
+        {
+          "text": "Auf Rollschuhen",
+          "correct": true
+        },
+        {
+          "text": "Auf Eseln",
+          "correct": false
+        },
+        {
+          "text": "Barfuß im Gleichschritt",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Für die 'Misa de Aguinaldo' werden in einigen Vierteln sogar Straßen gesperrt.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_035",
+      "question": "Wer begleitet in den Alpenländern den Nikolaus als furchterregende Gestalt?",
+      "answers": [
+        {
+          "text": "Der Krampus",
+          "correct": true
+        },
+        {
+          "text": "Der Kobold Puck",
+          "correct": false
+        },
+        {
+          "text": "Der Schneemann Väterchen Frost",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Am 5. Dezember ziehen ganze Krampus-Läufe durch die Orte — mit Fell, Hörnern und Kuhglocken.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_036",
+      "question": "Aus welchem Land kommt der niederländische Sinterklaas der Erzählung nach jedes Jahr per Schiff an?",
+      "answers": [
+        {
+          "text": "Aus Spanien",
+          "correct": true
+        },
+        {
+          "text": "Aus Norwegen",
+          "correct": false
+        },
+        {
+          "text": "Aus Island",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Die Ankunft im November wird landesweit im Fernsehen übertragen; Sinterklaas beschenkt die Kinder am 5. Dezember.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_037",
+      "question": "Was wird in Finnland seit dem Mittelalter am Mittag des 24. Dezember in Turku verkündet?",
+      "answers": [
+        {
+          "text": "Der Weihnachtsfrieden",
+          "correct": true
+        },
+        {
+          "text": "Der Fischereischluss",
+          "correct": false
+        },
+        {
+          "text": "Der neue Königsname",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Die Verlesung wird im Radio übertragen und gilt als eine der ältesten ununterbrochenen Traditionen des Landes.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_038",
+      "question": "Wo liegt nach finnischer Darstellung die Werkstatt des Weihnachtsmanns?",
+      "answers": [
+        {
+          "text": "Auf dem Fjell Korvatunturi in Lappland",
+          "correct": true
+        },
+        {
+          "text": "Auf Spitzbergen",
+          "correct": false
+        },
+        {
+          "text": "Auf einer Insel vor Helsinki",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Der Berg hat die Form von Ohren — von dort soll der Weihnachtsmann die Wünsche aller Kinder hören.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_039",
+      "question": "Welche Postleitzahl hat die kanadische Post dem Weihnachtsmann zugeteilt?",
+      "answers": [
+        {
+          "text": "H0H 0H0",
+          "correct": true
+        },
+        {
+          "text": "X0X 0X0",
+          "correct": false
+        },
+        {
+          "text": "N0E 0L0",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Freiwillige beantworten jedes Jahr Millionen Briefe — in der Sprache, in der das Kind geschrieben hat.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_040",
+      "question": "In welcher Region wirkte der historische Bischof Nikolaus, auf den der Nikolaustag zurückgeht?",
+      "answers": [
+        {
+          "text": "In Myra in der heutigen Türkei",
+          "correct": true
+        },
+        {
+          "text": "In Nordschweden",
+          "correct": false
+        },
+        {
+          "text": "Auf Sizilien",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Seine Gebeine wurden 1087 nach Bari gebracht, wo sie bis heute liegen.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_041",
+      "question": "Wer setzte im deutschsprachigen Raum das Christkind als Gabenbringer durch?",
+      "answers": [
+        {
+          "text": "Martin Luther",
+          "correct": true
+        },
+        {
+          "text": "Kaiser Karl V.",
+          "correct": false
+        },
+        {
+          "text": "Die Brüder Grimm",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Luther wollte den Heiligenkult zurückdrängen — ausgerechnet die katholischen Regionen hielten das Christkind später am längsten hoch.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_042",
+      "question": "Wer verkörpert das Nürnberger Christkind auf dem Christkindlesmarkt?",
+      "answers": [
+        {
+          "text": "Eine junge Frau, die alle zwei Jahre gewählt wird",
+          "correct": true
+        },
+        {
+          "text": "Ein Kind aus der Domschule",
+          "correct": false
+        },
+        {
+          "text": "Eine Puppe an einem Kran",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Bewerberinnen müssen in Nürnberg wohnen, mindestens 1,60 Meter groß und schwindelfrei sein.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_043",
+      "question": "Seit wann findet der Dresdner Striezelmarkt urkundlich statt?",
+      "answers": [
+        {
+          "text": "Seit 1434",
+          "correct": true
+        },
+        {
+          "text": "Seit 1834",
+          "correct": false
+        },
+        {
+          "text": "Seit 1634",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Er begann als eintägiger Fleischmarkt vor dem Fest und ist damit einer der ältesten Weihnachtsmärkte überhaupt.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_044",
+      "question": "Aus welcher deutschen Region stammen die klassischen Nussknacker- und Räuchermännchenfiguren?",
+      "answers": [
+        {
+          "text": "Aus dem Erzgebirge",
+          "correct": true
+        },
+        {
+          "text": "Aus dem Schwarzwald",
+          "correct": false
+        },
+        {
+          "text": "Aus Ostfriesland",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Als der Bergbau zurückging, lebten ganze Dörfer vom Schnitzen — der Nussknacker trägt bis heute oft eine Uniform.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_045",
+      "question": "Wie wurde Tschaikowskys Ballett 'Der Nussknacker' bei der Uraufführung 1892 aufgenommen?",
+      "answers": [
+        {
+          "text": "Überwiegend kühl bis ablehnend",
+          "correct": true
+        },
+        {
+          "text": "Als sofortiger Triumph",
+          "correct": false
+        },
+        {
+          "text": "Es wurde nach dem ersten Akt abgebrochen",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Die Kritik fand die Handlung dünn und die Kinderrollen befremdlich; zum Weihnachtsklassiker wurde das Stück erst Jahrzehnte später.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_046",
+      "question": "Aus wie vielen Teilen besteht Johann Sebastian Bachs Weihnachtsoratorium?",
+      "answers": [
+        {
+          "text": "Aus sechs",
+          "correct": true
+        },
+        {
+          "text": "Aus drei",
+          "correct": false
+        },
+        {
+          "text": "Aus zwölf",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Die Teile waren für sechs verschiedene Gottesdienste zwischen dem 25. Dezember 1734 und dem 6. Januar 1735 gedacht.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_047",
+      "question": "Zu welcher Jahreszeit wurde Händels 'Messias' uraufgeführt?",
+      "answers": [
+        {
+          "text": "Im Frühjahr, kurz vor Ostern",
+          "correct": true
+        },
+        {
+          "text": "Am ersten Weihnachtstag",
+          "correct": false
+        },
+        {
+          "text": "Im Hochsommer",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Die Premiere war im April 1742 in Dublin; erst später wurde das Werk zum Weihnachtsstück.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_048",
+      "question": "Was geschah an Weihnachten 1914 an Teilen der Westfront?",
+      "answers": [
+        {
+          "text": "Soldaten beider Seiten verließen die Gräben und feierten gemeinsam",
+          "correct": true
+        },
+        {
+          "text": "Der Krieg wurde offiziell für zwei Tage beendet",
+          "correct": false
+        },
+        {
+          "text": "Es wurde eine Rekordschlacht geschlagen",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Es gab Gesang, Zigaretten und stellenweise Fußball — die Generalstäbe verboten Wiederholungen für die Folgejahre.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_049",
+      "question": "Wer stellte 1882 den ersten elektrisch beleuchteten Weihnachtsbaum auf?",
+      "answers": [
+        {
+          "text": "Ein Mitarbeiter Thomas Edisons",
+          "correct": true
+        },
+        {
+          "text": "Nikola Tesla",
+          "correct": false
+        },
+        {
+          "text": "Werner von Siemens",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Edward H. Johnson ließ 80 rot, weiß und blau gefasste Lämpchen von Hand verdrahten und den Baum dazu drehen.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_050",
+      "question": "Woraus bestand Lametta ursprünglich?",
+      "answers": [
+        {
+          "text": "Aus dünn geschlagenem Silber",
+          "correct": true
+        },
+        {
+          "text": "Aus gefärbtem Papier",
+          "correct": false
+        },
+        {
+          "text": "Aus Fischschuppen",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Nürnberger Handwerker schlugen es ab etwa 1610; es lief mit der Zeit an und musste ersetzt werden.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_051",
+      "question": "In welchem Ort begann die Herstellung gläserner Christbaumkugeln?",
+      "answers": [
+        {
+          "text": "In Lauscha in Thüringen",
+          "correct": true
+        },
+        {
+          "text": "In Murano bei Venedig",
+          "correct": false
+        },
+        {
+          "text": "In Karlsbad",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Der Legende nach konnte sich ein Glasbläser keine Äpfel und Nüsse für den Baum leisten und blies sich welche aus Glas.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_052",
+      "question": "Was enthielten englische 'mince pies' ursprünglich?",
+      "answers": [
+        {
+          "text": "Echtes Fleisch",
+          "correct": true
+        },
+        {
+          "text": "Nur Honig",
+          "correct": false
+        },
+        {
+          "text": "Gemahlene Muscheln",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Hackfleisch, Nierenfett und Trockenfrüchte waren zusammen ein Konservierungstrick; das Fleisch verschwand erst im 19. Jahrhundert.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_053",
+      "question": "Was ist der britische 'Stir-up Sunday'?",
+      "answers": [
+        {
+          "text": "Der Sonntag, an dem der Weihnachtspudding angerührt wird",
+          "correct": true
+        },
+        {
+          "text": "Der erste Adventssonntag",
+          "correct": false
+        },
+        {
+          "text": "Der Tag der Christbaumversteigerung",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Jedes Familienmitglied rührt einmal im Uhrzeigersinn und darf sich dabei etwas wünschen.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_054",
+      "question": "Welches Getränk verkauft sich in Schweden zur Weihnachtszeit besser als Cola?",
+      "answers": [
+        {
+          "text": "Julmust",
+          "correct": true
+        },
+        {
+          "text": "Glühwein",
+          "correct": false
+        },
+        {
+          "text": "Buttermilch",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Das dunkle Malzgetränk verschiebt die Marktanteile im Dezember so stark, dass Coca-Cola es zeitweise selbst produzierte.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_055",
+      "question": "Aus welchem Erdteil stammt der Truthahn, der heute vielerorts das Weihnachtsessen ist?",
+      "answers": [
+        {
+          "text": "Aus Amerika",
+          "correct": true
+        },
+        {
+          "text": "Aus Asien",
+          "correct": false
+        },
+        {
+          "text": "Aus Nordafrika",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Vor seiner Einfuhr im 16. Jahrhundert waren Gans, Schwein oder Pfau die Festbraten Europas.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_056",
+      "question": "Was ist in Deutschland an Heiligabend eines der häufigsten Abendessen?",
+      "answers": [
+        {
+          "text": "Würstchen mit Kartoffelsalat",
+          "correct": true
+        },
+        {
+          "text": "Hummer mit Reis",
+          "correct": false
+        },
+        {
+          "text": "Lammkeule",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Der Klassiker hat einen praktischen Grund: Er lässt sich vormittags vorbereiten und blockiert den Abend nicht.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_057",
+      "question": "Was ist der britische 'Boxing Day' am 26. Dezember ursprünglich?",
+      "answers": [
+        {
+          "text": "Der Tag, an dem Dienstboten und Arme ihre Geschenkbox bekamen",
+          "correct": true
+        },
+        {
+          "text": "Ein Tag für Faustkämpfe",
+          "correct": false
+        },
+        {
+          "text": "Der Tag, an dem Geschenke umgetauscht werden",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Der Name kommt von den Almosenbüchsen und Päckchen, nicht vom Sport und nicht vom Auspacken.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_058",
+      "question": "Wann laufen die 'Zwölf Weihnachtstage' des englischen Liedes?",
+      "answers": [
+        {
+          "text": "Vom 25. Dezember bis zum 5. Januar",
+          "correct": true
+        },
+        {
+          "text": "Vom 13. bis zum 24. Dezember",
+          "correct": false
+        },
+        {
+          "text": "Vom 1. bis zum 12. Dezember",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Sie enden am Vorabend des Dreikönigstags — das Lied zählt also nicht auf Weihnachten hin, sondern von ihm weg.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_059",
+      "question": "Worauf geht das deutsche Wort 'Weihnachten' zurück?",
+      "answers": [
+        {
+          "text": "Auf 'geweihte Nächte'",
+          "correct": true
+        },
+        {
+          "text": "Auf 'weiße Nächte'",
+          "correct": false
+        },
+        {
+          "text": "Auf 'Weizennächte'",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Die mittelhochdeutsche Wendung 'ze den wîhen nahten' meint die geheiligten Nächte um das Fest.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_060",
+      "question": "Woher stammt die Kombination Rot und Grün als Weihnachtsfarben?",
+      "answers": [
+        {
+          "text": "Von der Stechpalme mit roten Beeren und grünen Blättern",
+          "correct": true
+        },
+        {
+          "text": "Von der Flagge des Kirchenstaats",
+          "correct": false
+        },
+        {
+          "text": "Von den Uniformen der Postboten",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Immergrüne Pflanzen mit roten Früchten galten schon vor dem Christentum als Zeichen von Leben im Winter.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_061",
+      "question": "Was war der ursprüngliche 'Julklapp' beziehungsweise Yule Log?",
+      "answers": [
+        {
+          "text": "Ein großer Holzscheit, der über die Feiertage brennen sollte",
+          "correct": true
+        },
+        {
+          "text": "Ein Brief mit Rätseln",
+          "correct": false
+        },
+        {
+          "text": "Ein Kuchen in Baumstammform",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Erst als offene Kamine seltener wurden, wanderte das Motiv auf den Kuchenteller — die französische Bûche de Noël ist ein Nachbau.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_062",
+      "question": "Wie kam der Film 'Ist das Leben nicht schön?' von 1946 zu seinem heutigen Ruhm?",
+      "answers": [
+        {
+          "text": "Weil das Urheberrecht auslief und Sender ihn gratis zeigten",
+          "correct": true
+        },
+        {
+          "text": "Weil er zehn Oscars gewann",
+          "correct": false
+        },
+        {
+          "text": "Weil er in Schulen Pflichtstoff wurde",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "An den Kinokassen war er ein Verlust; erst die Dauerschleife im US-Fernsehen der 1970er machte ihn zum Klassiker.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_063",
+      "question": "In welcher Stadt spielt der Hauptteil von 'Kevin – Allein zu Haus'?",
+      "answers": [
+        {
+          "text": "In Chicago",
+          "correct": true
+        },
+        {
+          "text": "In Boston",
+          "correct": false
+        },
+        {
+          "text": "In Denver",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Die Familie fliegt nach Paris, Kevin bleibt in einem Vorort von Chicago zurück — gedreht wurde in Winnetka, Illinois.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_064",
+      "question": "Warum gilt 'Stirb langsam' vielen als Weihnachtsfilm?",
+      "answers": [
+        {
+          "text": "Er spielt auf einer Weihnachtsfeier am 24. Dezember",
+          "correct": true
+        },
+        {
+          "text": "Der Held heißt mit zweitem Namen Nikolaus",
+          "correct": false
+        },
+        {
+          "text": "Der Film startete an Heiligabend",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Die Debatte ist so alt wie hartnäckig; der Regisseur und der Hauptdarsteller haben sich öffentlich widersprochen.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_065",
+      "question": "Wer schrieb die Jazzmusik zum Fernsehklassiker 'Die Peanuts – Fröhliche Weihnachten' von 1965?",
+      "answers": [
+        {
+          "text": "Vince Guaraldi",
+          "correct": true
+        },
+        {
+          "text": "Dave Brubeck",
+          "correct": false
+        },
+        {
+          "text": "Duke Ellington",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Der Sender fand ein Jazztrio für eine Kindersendung zunächst unpassend — die Platte wurde ein Millionenseller.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_066",
+      "question": "Wer machte 'Rudolph, the Red-Nosed Reindeer' 1949 als Lied zum Welterfolg?",
+      "answers": [
+        {
+          "text": "Der Sänger Gene Autry",
+          "correct": true
+        },
+        {
+          "text": "Frank Sinatra",
+          "correct": false
+        },
+        {
+          "text": "Louis Armstrong",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Autry zögerte lange und nahm den Titel nur auf Drängen seiner Frau auf; es wurde seine meistverkaufte Platte.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_067",
+      "question": "In welchem Text tauchten die acht Rentiere des Weihnachtsmanns zuerst mit Namen auf?",
+      "answers": [
+        {
+          "text": "In einem Gedicht von 1823",
+          "correct": true
+        },
+        {
+          "text": "In einem Roman von Charles Dickens",
+          "correct": false
+        },
+        {
+          "text": "In einer Zeitungsanzeige von 1902",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "'A Visit from St. Nicholas' nannte auch Donder und Blitzen — die Namen sind niederländisch für Donner und Blitz.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_068",
+      "question": "In welchem Land wurde 1904 die Weihnachtsmarke zur Spendenfinanzierung erfunden?",
+      "answers": [
+        {
+          "text": "In Dänemark",
+          "correct": true
+        },
+        {
+          "text": "In Kanada",
+          "correct": false
+        },
+        {
+          "text": "In Italien",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Ein Postbeamter schlug die Zusatzmarke vor, um Kinderkliniken zu finanzieren; die Idee verbreitete sich weltweit.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_069",
+      "question": "Welche Legende erklärt die aufgehängten Weihnachtsstrümpfe?",
+      "answers": [
+        {
+          "text": "Nikolaus warf Goldstücke durch ein Fenster, die in Strümpfen landeten",
+          "correct": true
+        },
+        {
+          "text": "Ein Schneider verlor seinen Strumpf im Kamin",
+          "correct": false
+        },
+        {
+          "text": "Bergleute trockneten ihre Strümpfe am Kaminfeuer",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "In der Erzählung rettete das Gold drei Töchter eines verarmten Mannes vor einem Leben in Not.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_070",
+      "question": "Was stimmt über die 'deutsche Tradition' der Weihnachtsgurke am Baum?",
+      "answers": [
+        {
+          "text": "In Deutschland kennt sie kaum jemand",
+          "correct": true
+        },
+        {
+          "text": "Sie stammt aus dem Spreewald",
+          "correct": false
+        },
+        {
+          "text": "Sie wurde 1850 in Bayern erfunden",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Der Brauch ist vor allem in den USA verbreitet und wurde dort als deutsche Herkunftsgeschichte vermarktet.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_071",
+      "question": "Wo entstand der Brauch, sich unter einem Mistelzweig zu küssen?",
+      "answers": [
+        {
+          "text": "In England",
+          "correct": true
+        },
+        {
+          "text": "In Griechenland",
+          "correct": false
+        },
+        {
+          "text": "In Russland",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Im 18. Jahrhundert galt: Für jeden Kuss wird eine Beere gepflückt, und ist der Zweig leer, ist Schluss.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_072",
+      "question": "Was geschieht mit dem Holz des großen Baums am Rockefeller Center nach den Feiertagen?",
+      "answers": [
+        {
+          "text": "Es wird zu Bauholz für Wohltätigkeitsprojekte verarbeitet",
+          "correct": true
+        },
+        {
+          "text": "Es wird versteigert",
+          "correct": false
+        },
+        {
+          "text": "Es bleibt bis Ostern stehen",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Seit 2007 gehen die Bretter an Habitat for Humanity — der Baum steht dort seit 1931 fast jedes Jahr.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_073",
+      "question": "Welchen Rang hatte der 'gute König Wenzel' aus dem englischen Weihnachtslied wirklich?",
+      "answers": [
+        {
+          "text": "Er war Herzog von Böhmen",
+          "correct": true
+        },
+        {
+          "text": "Er war Kaiser von Byzanz",
+          "correct": false
+        },
+        {
+          "text": "Er war König von Polen",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Wenzel I. wurde erst nach seinem Tod postum zum König erhoben — im Lied ist er bereits einer.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_074",
+      "question": "Woher stammt die Melodie von 'O Tannenbaum'?",
+      "answers": [
+        {
+          "text": "Von einem alten Volkslied",
+          "correct": true
+        },
+        {
+          "text": "Von Beethoven",
+          "correct": false
+        },
+        {
+          "text": "Von einem englischen Kirchenlied",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Ernst Anschütz schrieb 1824 den heutigen Text auf eine längst bekannte Weise, die vorher von einer untreuen Geliebten handelte.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_075",
+      "question": "Welche Auszeichnung erhielt 'Stille Nacht' 2011 von der UNESCO?",
+      "answers": [
+        {
+          "text": "Es wurde immaterielles Kulturerbe Österreichs",
+          "correct": true
+        },
+        {
+          "text": "Es wurde Weltdokumentenerbe",
+          "correct": false
+        },
+        {
+          "text": "Es wurde zur Welthymne erklärt",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Das Lied ist in weit über 300 Sprachen und Dialekte übersetzt worden.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_076",
+      "question": "Was bedeutet das lateinische Wort 'adventus', von dem der Advent kommt?",
+      "answers": [
+        {
+          "text": "Ankunft",
+          "correct": true
+        },
+        {
+          "text": "Erwartung",
+          "correct": false
+        },
+        {
+          "text": "Dunkelheit",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Die Adventszeit war ursprünglich eine Fastenzeit — deshalb war das Essen vor dem 24. Dezember eher karg.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_077",
+      "question": "Was gehört in Polen traditionell unter das Tischtuch der 'Wigilia'?",
+      "answers": [
+        {
+          "text": "Heu",
+          "correct": true
+        },
+        {
+          "text": "Münzen",
+          "correct": false
+        },
+        {
+          "text": "Ein Stück Kohle",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Es erinnert an die Krippe; außerdem bleibt ein Gedeck für einen unerwarteten Gast frei.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_078",
+      "question": "Was sind die griechischen 'Kallikantzaroi'?",
+      "answers": [
+        {
+          "text": "Kobolde, die zwischen Weihnachten und Dreikönig Unfug treiben",
+          "correct": true
+        },
+        {
+          "text": "Weihnachtsgebäck aus Kreta",
+          "correct": false
+        },
+        {
+          "text": "Sternsinger in Athen",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Der Legende nach sägen sie das ganze Jahr am Weltenbaum und kommen nur in den zwölf Nächten an die Oberfläche.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_079",
+      "question": "An welchem Tag wird in Äthiopien Weihnachten ('Genna') gefeiert?",
+      "answers": [
+        {
+          "text": "Am 7. Januar",
+          "correct": true
+        },
+        {
+          "text": "Am 24. Dezember",
+          "correct": false
+        },
+        {
+          "text": "Am 2. Februar",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Die äthiopisch-orthodoxe Kirche folgt einem eigenen Kalender; das äthiopische Jahr liegt gegenüber dem gregorianischen zurück.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_080",
+      "question": "Wie viele Abende dauern die mexikanischen 'Posadas' vor Weihnachten?",
+      "answers": [
+        {
+          "text": "Neun",
+          "correct": true
+        },
+        {
+          "text": "Drei",
+          "correct": false
+        },
+        {
+          "text": "Zwölf",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Sie stellen die Herbergssuche nach — jeder Abend endet vor einer anderen Haustür mit Gesang und Piñata.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_081",
+      "question": "Wofür stehen die sieben Zacken der klassischen mexikanischen Weihnachtspiñata?",
+      "answers": [
+        {
+          "text": "Für die sieben Todsünden",
+          "correct": true
+        },
+        {
+          "text": "Für die sieben Wochentage",
+          "correct": false
+        },
+        {
+          "text": "Für sieben Sterne am Himmel",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Wer mit verbundenen Augen zuschlägt, schlägt sinnbildlich blind gegen die Sünde — die Süßigkeiten sind die Belohnung des Glaubens.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_082",
+      "question": "Wer zieht in Spanien die Nummern der Weihnachtslotterie 'El Gordo' und singt die Gewinne?",
+      "answers": [
+        {
+          "text": "Schulkinder",
+          "correct": true
+        },
+        {
+          "text": "Fernsehmoderatoren",
+          "correct": false
+        },
+        {
+          "text": "Notare der Bank von Spanien",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Die Kinder der Residencia San Ildefonso singen Nummer und Betrag seit dem 18. Jahrhundert im Wechselgesang.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_083",
+      "question": "Wer bringt in Spanien traditionell die Geschenke für die Kinder?",
+      "answers": [
+        {
+          "text": "Die Heiligen Drei Könige",
+          "correct": true
+        },
+        {
+          "text": "Der Weihnachtsmann am 24. Dezember",
+          "correct": false
+        },
+        {
+          "text": "Der heilige Nikolaus am 6. Dezember",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "In der Nacht zum 6. Januar stellen Kinder Schuhe und etwas Wasser für die Kamele bereit.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_084",
+      "question": "Welches Land ist für die längste Weihnachtssaison der Welt bekannt?",
+      "answers": [
+        {
+          "text": "Die Philippinen",
+          "correct": true
+        },
+        {
+          "text": "Island",
+          "correct": false
+        },
+        {
+          "text": "Portugal",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Sobald der September beginnt, laufen dort die Weihnachtslieder; die Saison zieht sich bis in den Januar.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_085",
+      "question": "Welche Form hat die philippinische Weihnachtslaterne 'Parol'?",
+      "answers": [
+        {
+          "text": "Einen fünfzackigen Stern",
+          "correct": true
+        },
+        {
+          "text": "Einen Halbmond",
+          "correct": false
+        },
+        {
+          "text": "Eine Glocke",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Sie steht für den Stern von Betlehem und wurde ursprünglich aus Bambus und Reispapier gebaut.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_086",
+      "question": "In welcher Jahreszeit feiert Australien Weihnachten?",
+      "answers": [
+        {
+          "text": "Im Hochsommer",
+          "correct": true
+        },
+        {
+          "text": "Im Spätherbst",
+          "correct": false
+        },
+        {
+          "text": "Im Vorfrühling",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Grillen am Strand und 'Carols by Candlelight' im Freien gehören dort zum Fest.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_087",
+      "question": "Warum feiern russisch-orthodoxe Gläubige Weihnachten am 7. Januar?",
+      "answers": [
+        {
+          "text": "Weil die Kirche am julianischen Kalender festhält",
+          "correct": true
+        },
+        {
+          "text": "Weil der Zar das Datum verschob",
+          "correct": false
+        },
+        {
+          "text": "Weil der 25. Dezember Arbeitstag ist",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Der Unterschied zum gregorianischen Kalender beträgt derzeit dreizehn Tage.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_088",
+      "question": "Was schreibt die Rezeptur für Nürnberger Elisenlebkuchen vor?",
+      "answers": [
+        {
+          "text": "Höchstens zehn Prozent Mehl",
+          "correct": true
+        },
+        {
+          "text": "Mindestens die Hälfte Honig",
+          "correct": false
+        },
+        {
+          "text": "Genau sieben Gewürze",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Die geschützte Bezeichnung verlangt außerdem einen hohen Nussanteil — deshalb sind sie so saftig.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_089",
+      "question": "Was soll die Form des Dresdner Christstollens darstellen?",
+      "answers": [
+        {
+          "text": "Das in Tücher gewickelte Christuskind",
+          "correct": true
+        },
+        {
+          "text": "Einen Schlitten",
+          "correct": false
+        },
+        {
+          "text": "Einen Schneeberg",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Der Puderzucker steht für die Windeln; das Rezept war lange durch das Butterverbot der Fastenzeit eingeschränkt.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_090",
+      "question": "Aus welcher Stadt stammt der Panettone?",
+      "answers": [
+        {
+          "text": "Aus Mailand",
+          "correct": true
+        },
+        {
+          "text": "Aus Neapel",
+          "correct": false
+        },
+        {
+          "text": "Aus Turin",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Der Hefeteig braucht mit Vorteig und mehreren Gehzeiten oft mehr als 30 Stunden.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_091",
+      "question": "Seit wann ist gewürzter Heißwein in Europa belegt?",
+      "answers": [
+        {
+          "text": "Seit der römischen Antike",
+          "correct": true
+        },
+        {
+          "text": "Seit dem 18. Jahrhundert",
+          "correct": false
+        },
+        {
+          "text": "Seit den 1920er-Jahren",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Ein römisches Kochbuch beschreibt 'conditum paradoxum' aus Wein, Honig und Pfeffer — die Vorlage des heutigen Glühweins.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_092",
+      "question": "In welcher Stadt ist der geschmückte Weihnachtsbaum erstmals urkundlich belegt?",
+      "answers": [
+        {
+          "text": "In Straßburg",
+          "correct": true
+        },
+        {
+          "text": "In Wien",
+          "correct": false
+        },
+        {
+          "text": "In Kopenhagen",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Eine Zunftordnung von 1539 erwähnt einen Baum im Münster; Kerzen kamen erst deutlich später dazu.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_093",
+      "question": "Seit wann gibt es die Weihnachtsansprache des britischen Königshauses?",
+      "answers": [
+        {
+          "text": "Seit 1932",
+          "correct": true
+        },
+        {
+          "text": "Seit 1901",
+          "correct": false
+        },
+        {
+          "text": "Seit 1966",
+          "correct": false
+        }
+      ],
+      "difficulty": "medium",
+      "fun_fact": "Georg V. sprach zuerst im Radio; das erste Fernsehbild folgte erst 1957.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_094",
+      "question": "Was ist an José Felicianos 'Feliz Navidad' von 1970 besonders?",
+      "answers": [
+        {
+          "text": "Der Text besteht nur aus wenigen Zeilen auf Spanisch und Englisch",
+          "correct": true
+        },
+        {
+          "text": "Es ist das längste Weihnachtslied der Charts",
+          "correct": false
+        },
+        {
+          "text": "Es wurde ohne Instrumente aufgenommen",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Feliciano brauchte für den Text wenige Minuten und spielte den cuatro dazu.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_095",
+      "question": "Welche astronomische Erklärung schlug Johannes Kepler für den Stern von Betlehem vor?",
+      "answers": [
+        {
+          "text": "Eine enge Begegnung von Jupiter und Saturn",
+          "correct": true
+        },
+        {
+          "text": "Einen Kometeneinschlag",
+          "correct": false
+        },
+        {
+          "text": "Eine Sonnenfinsternis",
+          "correct": false
+        }
+      ],
+      "difficulty": "hard",
+      "fun_fact": "Kepler beobachtete 1603 eine solche Konjunktion und rechnete zurück auf das Jahr 7 vor unserer Zeitrechnung.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_096",
+      "question": "Was sagt die Bibel über das Geburtsdatum Jesu?",
+      "answers": [
+        {
+          "text": "Sie nennt gar kein Datum",
+          "correct": true
+        },
+        {
+          "text": "Sie nennt den 25. Dezember",
+          "correct": false
+        },
+        {
+          "text": "Sie nennt den 6. Januar",
+          "correct": false
+        }
+      ],
+      "difficulty": "easy",
+      "fun_fact": "Der 25. Dezember setzte sich im 4. Jahrhundert durch und fiel mit römischen Festen um die Wintersonnenwende zusammen.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_097",
+      "question": "Wie viele Geschenke bekommt man insgesamt, wenn im Lied 'The Twelve Days of Christmas' jeden Tag alle bisherigen Gaben erneut überreicht werden?",
+      "type": "estimate",
+      "answer": 364,
+      "min": 0,
+      "max": 1000,
+      "unit": "Geschenke",
+      "difficulty": "medium",
+      "fun_fact": "364 — fast eines für jeden Tag des Jahres, davon allein zwölf Rebhühner im Birnbaum.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_098",
+      "question": "In welchem Jahr wurde 'Stille Nacht' zum ersten Mal gesungen?",
+      "type": "estimate",
+      "answer": 1818,
+      "min": 1700,
+      "max": 1950,
+      "unit": "Jahr",
+      "difficulty": "medium",
+      "fun_fact": "1818 in Oberndorf bei Salzburg, begleitet auf einer Gitarre statt auf der Orgel.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_099",
+      "question": "Wie hoch ist der Strohbock von Gävle, der jedes Jahr im schwedischen Advent aufgestellt wird?",
+      "type": "estimate",
+      "answer": 13,
+      "min": 1,
+      "max": 60,
+      "unit": "Meter",
+      "difficulty": "hard",
+      "fun_fact": "13 Meter hoch und rund 3,6 Tonnen schwer — trotzdem hat er die Adventszeit oft nicht überstanden.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_100",
+      "question": "Wie viele Rentiere werden im Gedicht 'A Visit from St. Nicholas' von 1823 mit Namen genannt?",
+      "type": "estimate",
+      "answer": 8,
+      "min": 0,
+      "max": 40,
+      "unit": "Rentiere",
+      "difficulty": "easy",
+      "fun_fact": "Acht — Rudolph kam erst 116 Jahre später als Werbefigur dazu.",
+      "category": "Weihnachten"
+    },
+    {
+      "id": "weihnachten_de_101",
+      "question": "Wie viele Türchen hat ein klassischer Adventskalender?",
+      "type": "estimate",
+      "answer": 24,
+      "min": 0,
+      "max": 100,
+      "unit": "Türchen",
+      "difficulty": "easy",
+      "fun_fact": "24 — der Kalender endet am Heiligabend und nicht am ersten Weihnachtstag.",
+      "category": "Weihnachten"
+    }
+  ]
+}

--- a/tests/test_holiday_packs_663.py
+++ b/tests/test_holiday_packs_663.py
@@ -1,0 +1,164 @@
+"""The season window stops standing empty eleven months a year (#663).
+
+``game/seasons.py`` has let a pack declare a recurring calendar window since
+#276, and for as long as it has existed the only packs using it were the three
+World Cup ones. A mechanism that surfaces something for two months of the year
+and nothing for the other ten is not a weak feature; from the host's side it is
+not a feature at all.
+
+The holiday packs fill the other end of the calendar: Christmas from 1 to 26
+December, New Year from 27 December to 6 January. What is worth guarding here
+is not the content — the duplicate, estimate and version tests already cover a
+pack as a pack — but the *wiring*, which is the part that has silently gone
+missing before:
+
+* the windows exist and are parseable at all (a typo in ``"12-01"`` degrades to
+  a non-seasonal pack with nothing but a log line to show for it);
+* they cover the December-into-January stretch without a gap, which is the
+  whole point of building two packs rather than one;
+* they do not overlap, so the picker never has to arbitrate between them;
+* every language carries the identical window, so a Spanish host does not get
+  the badge a week later than a German one;
+* and ``pick_active_season`` actually returns them on the days in question,
+  which is the only assertion here that exercises the mechanism end to end
+  rather than the JSON that feeds it.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from custom_components.quizify.game.seasons import (
+    Season,
+    is_in_season,
+    parse_season,
+    pick_active_season,
+)
+
+REPO = Path(__file__).resolve().parent.parent
+QUESTIONS = REPO / "custom_components" / "quizify" / "questions"
+
+CHRISTMAS = ("weihnachten-de", "christmas-en", "navidad-es")
+NEW_YEAR = ("silvester-de", "new-years-eve-en", "nochevieja-es")
+HOLIDAY_PACKS = CHRISTMAS + NEW_YEAR
+
+# The windows the packs are supposed to declare, as (start, end) month/day.
+EXPECTED_WINDOWS = {
+    CHRISTMAS: ((12, 1), (12, 26)),
+    NEW_YEAR: ((12, 27), (1, 6)),
+}
+
+
+def _pack(slug: str) -> dict:
+    return json.loads((QUESTIONS / f"{slug}.json").read_text(encoding="utf-8"))
+
+
+def _season(slug: str) -> Season | None:
+    return parse_season(_pack(slug).get("season"))
+
+
+@pytest.mark.parametrize("slug", HOLIDAY_PACKS)
+def test_every_holiday_pack_declares_a_window_that_parses(slug: str) -> None:
+    """A malformed window is not an error — it is a pack that quietly stops
+    being seasonal, which is exactly the failure this issue is about."""
+    season = _season(slug)
+    assert season is not None, f"{slug} has no usable season window"
+    assert season.label.strip(), f"{slug} would badge with the generic label"
+
+
+@pytest.mark.parametrize(
+    "group", list(EXPECTED_WINDOWS), ids=["christmas", "new-year"]
+)
+def test_all_three_languages_share_one_window(group: tuple[str, ...]) -> None:
+    """The badge has to appear on the same day in every language."""
+    start, end = EXPECTED_WINDOWS[group]
+    for slug in group:
+        season = _season(slug)
+        assert season is not None
+        assert (season.start, season.end) == (start, end), slug
+
+
+def test_the_two_windows_meet_without_a_gap_or_an_overlap() -> None:
+    """26 December hands over to the 27th, and neither day belongs to both.
+
+    A gap here would leave the days between Christmas and New Year with nothing
+    surfaced, which is precisely the stretch the second pack exists for.
+    """
+    christmas = _season(CHRISTMAS[0])
+    new_year = _season(NEW_YEAR[0])
+    assert christmas is not None and new_year is not None
+
+    for day in (date(2026, 12, 26), date(2026, 12, 27)):
+        active = [
+            s for s in (christmas, new_year) if is_in_season(s, day)
+        ]
+        assert len(active) == 1, f"{day} is covered by {len(active)} windows"
+
+    # Walk the whole stretch: every day from 1 December to 6 January is covered
+    # by exactly one of the two.
+    day = date(2026, 12, 1)
+    while day <= date(2027, 1, 6):
+        covered = sum(
+            1 for s in (christmas, new_year) if is_in_season(s, day)
+        )
+        assert covered == 1, f"{day} is covered by {covered} holiday windows"
+        day += timedelta(days=1)
+
+
+def test_the_new_year_window_wraps_across_the_turn_of_the_year() -> None:
+    """The wrap-around branch of ``is_in_season`` is the one a hand-written
+    ``start <= today <= end`` check gets wrong."""
+    new_year = _season(NEW_YEAR[0])
+    assert new_year is not None
+    assert is_in_season(new_year, date(2026, 12, 31))
+    assert is_in_season(new_year, date(2027, 1, 1))
+    assert is_in_season(new_year, date(2027, 1, 6))
+    assert not is_in_season(new_year, date(2027, 1, 7))
+
+
+@pytest.mark.parametrize(
+    "today,expected",
+    [
+        (date(2026, 12, 10), "weihnachten-de"),
+        (date(2026, 12, 26), "weihnachten-de"),
+        (date(2026, 12, 27), "silvester-de"),
+        (date(2027, 1, 6), "silvester-de"),
+        (date(2027, 1, 7), None),
+        (date(2026, 7, 15), "weltmeisterschaft"),
+    ],
+)
+def test_the_picker_pins_the_pack_whose_day_it_is(
+    today: date, expected: str | None
+) -> None:
+    """End to end over the German library: the same call the featured-pack view
+    makes, against the real season fields of the real packs."""
+    library = {
+        slug: _season(slug)
+        for slug in ("weihnachten-de", "silvester-de", "weltmeisterschaft", "musik-de")
+    }
+    assert pick_active_season(library, today) == expected
+
+
+@pytest.mark.parametrize("slug", HOLIDAY_PACKS)
+def test_a_holiday_pack_is_not_seasonal_the_rest_of_the_year(slug: str) -> None:
+    """Six months from the window, nothing is pinned — the packs add a badge to
+    the calendar rather than a permanent one."""
+    season = _season(slug)
+    assert season is not None
+    for day in (date(2026, 3, 15), date(2026, 6, 1), date(2026, 9, 30)):
+        assert not is_in_season(season, day), f"{slug} claims to be in season on {day}"
+
+
+@pytest.mark.parametrize("slug", HOLIDAY_PACKS)
+def test_a_holiday_pack_reuses_an_existing_theme(slug: str) -> None:
+    """A new ``theme`` value is not free: the picker's theme tabs are hand-written
+    buttons in ``admin.html`` with an i18n key each, and every shipped theme
+    needs an icon, a tint and a server-side emoji (see
+    tests/test_pack_labels_and_icons.py). The holiday packs are content inside
+    the existing mechanism, so they take the theme the other cross-cutting packs
+    already use."""
+    assert _pack(slug)["theme"] == "trivia"

--- a/tests/test_pack_estimates_566.py
+++ b/tests/test_pack_estimates_566.py
@@ -63,6 +63,18 @@ ESTIMATE_SETS: tuple[EstimateSet, ...] = (
     EstimateSet(theme="world-cup", packs=("weltmeisterschaft", "world-cup", "copa-mundial-es")),
     EstimateSet(theme="music", packs=("musik-de", "music-en", "musica-es")),
     EstimateSet(theme="pop-culture", packs=("popkultur", "pop-culture", "cultura-pop-es")),
+    # The holiday packs of #663. They carry no pictures, so they appear here
+    # and not in the #554 registry — the slider questions are the only part of
+    # the per-pack shape they took over, and they inherit the whole checklist
+    # by being listed rather than by their author remembering the rules.
+    EstimateSet(
+        theme="christmas",
+        packs=("weihnachten-de", "christmas-en", "navidad-es"),
+    ),
+    EstimateSet(
+        theme="new-year",
+        packs=("silvester-de", "new-years-eve-en", "nochevieja-es"),
+    ),
 )
 
 PACKS_WITH_ESTIMATES = [p for s in ESTIMATE_SETS for p in s.packs]


### PR DESCRIPTION
`game/seasons.py` has let a pack declare a recurring calendar window since #276, and until now the only packs using it were the three World Cup ones. The mechanism surfaced something for two months a year and nothing for the other ten — which, from the host's side, is not a weak feature but an absent one.

## What ships

Six packs, two holidays in three languages each. **Pack data only, no code.**

| Pack | Slug | Questions | Window |
|---|---|---|---|
| Weihnachten | `weihnachten-de` | 101 | 12-01 → 12-26 |
| Christmas | `christmas-en` | 101 | 12-01 → 12-26 |
| Navidad | `navidad-es` | 101 | 12-01 → 12-26 |
| Silvester | `silvester-de` | 100 | 12-27 → 01-06 |
| New Year's Eve | `new-years-eve-en` | 100 | 12-27 → 01-06 |
| Nochevieja | `nochevieja-es` | 100 | 12-27 → 01-06 |

Each pack is 95 or 96 multiple-choice questions plus five slider questions. Together the two windows cover 1 December to 6 January with no gap and no overlap, so the picker never has to arbitrate between them.

## How the season window picks them up

Nothing new. `QuestionBank._load_pack` parses the `season` field onto the pack metadata, `featured_pack_view` pins the in-season pack as the Featured Spotlight and returns its label, and `pack_versions_view` annotates `is_seasonal` / `season_label` per request so `admin.js` badges the card. The packs are discovered from the questions directory, so there is no registration code either — only the `versions.json` entry the catalogue test requires.

## Design gate

**No new i18n key and no new element id.** The packs take `theme: "trivia"`, the value the picture-round and estimation packs already use. A new theme value would not have been free: the theme tabs are hand-written buttons in `admin.html` with a `theme.<name>` i18n key each, and `tests/test_pack_labels_and_icons.py` requires every shipped theme to have an icon, a tint and a server-side emoji. The only new visible text is the pack's own name, description and season badge, in the established pattern.

## The quality bars

* **Duplicates.** Measured with the #593/#594 rule (same option trio, same correct answer, ≥40% wording overlap): **0 duplicate pairs** in each of the six packs. **0 identical answer trios** in each pack — no two questions even share the same three options. A looser sweep at 50% wording overlap alone leaves only cross-subject false positives ("Where does X come from?").
* **Facts that keep.** The slider questions are constants, not snapshots (the #566 lesson): 364 gifts in the Twelve Days of Christmas, 1818, the 13-metre Gävle goat, the 8 reindeer named in the 1823 poem, 24 Advent doors; 12 grapes, 108 temple bells, the 26 hours between the first and last turn of the year on Earth, 1582, 1963. Same `(answer, min, max)` triples in the same order across the three languages, different question text — registered in `EstimateSet` so they inherit the whole #566 checklist.
* **Fun facts** were written alongside each question rather than bolted on, and each one carries the detail that makes the answer checkable.
* **No image questions**, so #554 does not apply here. See below.
* **Difficulty grading** matches the library norm — 33/47/21 and 34/45/21, against roughly 33/45/22 across the existing packs. A first pass came out at 8/55/38 (graded by how obscure the fact is rather than by whether a guest can get there) and was re-graded question by question.

## Deliberately left out

* **Halloween and Carnival.** The issue offered two or three holidays; the December-into-January stretch is one continuous window and one coherent slice, and it is the stretch the issue argues for (the office party, New Year's Eve with guests in the room).
* **Picture questions.** Five per pack would mean sourcing worldwide-public-domain images and verifying each licence one file at a time — the work #554 and #795 describe, and the work #817 shows the cost of getting wrong (a picture that is public domain in one country only cannot ship). That is a separate piece with its own review, not a rider on a content PR.

## Tests

`tests/test_holiday_packs_663.py` (28 cases) guards the wiring rather than the content, since the duplicate, estimate, version and README tests already cover a pack as a pack:

* every pack declares a window that parses and carries a real label;
* all three languages of a holiday share one identical window;
* the two windows cover 1 December to 6 January with exactly one active per day;
* the new-year window wraps across the turn of the year (the branch a hand-written `start <= today <= end` gets wrong);
* `pick_active_season` returns `weihnachten-de` on 10 and 26 December, `silvester-de` on 27 December and 6 January, nothing on 7 January and `weltmeisterschaft` in July;
* no holiday pack claims to be in season in March, June or September;
* every holiday pack reuses an existing theme.

**Proof the tests fail without the change** (patch file, no `git stash`):

```
$ git apply -R /tmp/prove-663.patch
$ .venv/bin/python3 -m pytest tests/test_holiday_packs_663.py -q
28 failed in 0.43s
$ git apply /tmp/prove-663.patch
$ .venv/bin/python3 -m pytest tests/test_holiday_packs_663.py -q
28 passed in 0.12s
```

## Checks

* Full suite: `4074 passed in 103.64s` (was 4046 before).
* `ruff check .`: 213 findings, exactly the count on `origin/main` — nothing added. (`ruff format` not run; the repo is not format-clean.)
* `mypy custom_components/quizify`: `Success: no issues found in 61 source files`.
* No `www/js/` change, so no bundle rebuild; no `www/i18n/*.json` or CSS change, so no `.gz` siblings to regenerate.
* README pack count, question count (5,343 across 42 packs), theme list, table rows and the season paragraph updated — `tests/test_docs_pack_counts.py` enforces the first two.

Closes #663

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TaxQuikD1LKQmoJTphvkWV
