### PR TITLE
chore: cut 1.18.0-RC1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to Quizify are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [1.18.0-RC1] — 2026-09-08
+
+**One Score, and the Room Joins the Loud Parts**
+
+Six entries, decided in the afternoon and built the same evening.
+
+### The team wins, and everything says so
+
+Team mode kept a second, hidden score ledger. The podium showed the team; analytics, the leader sensors and the winner event all read the person underneath — so two Home Assistant events named different winners for the same final. The source is closed now, rather than a fifth reader bent into shape. In team games the evening standing had also been looking itself up under a player's name, and found nothing at all.
+
+### A window that stood empty eleven months a year
+
+Christmas and New Year, in German, English and Spanish: six packs, 603 questions, covering 1 December to 6 January without a gap. And the house now joins the auction, the betting window and Lightning — the three loudest moments it used to sit out.
+
 ## [1.17.0] — 2026-09-08
 
 **What the Reload Was Throwing Away**

--- a/custom_components/quizify/manifest.json
+++ b/custom_components/quizify/manifest.json
@@ -14,5 +14,5 @@
   "documentation": "https://github.com/mholzi/quizify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/quizify/issues",
-  "version": "1.17.0"
+  "version": "1.18.0-RC1"
 }


### PR DESCRIPTION
Cuts the release candidate for the v1.18.0 milestone.

- `manifest.json` → `1.18.0-RC1` (RC tag, not a patch bump)
- `CHANGELOG.md` section covering the span since the last **stable**, v1.17.0 — the reader never saw an intermediate RC

## Contents (all six milestone entries, all merged)

| Issue | PR |
|---|---|
| #922 bank label punctuation | #924 |
| #923 team shadow score ledger | #925 |
| #708 house plays along during the detours | #926 |
| #918 non-deterministic flush test | #927 |
| #919 dead class selectors | #928 |
| #663 holiday packs for the season window | #929 |

## Pack version check

Six pack files were added in #929. Each carries `"version": "1.0"` and each has its entry in `questions/versions.json` — both landed in the same commit. No existing pack file was modified, so no version bump was owed anywhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TaxQuikD1LKQmoJTphvkWV