### PR TITLE
fix(end screen): a team member's all-time line is their own record again

### DIFF
--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -3951,14 +3951,18 @@ class QuizifyWebSocketHandler:
         for player in game_state.get_players():
             if not self._conn.is_connection_open(player.connection_id):
                 continue
-            # The standing belongs to the entrant, not the person (#923): in
-            # team mode the game was recorded under the team's name, so asking
-            # for the member's own name returns nothing and the phone shows no
-            # line at all. Ask for the row the podium beside it is drawn from.
-            participant = game_state.get_ranked_participant_for(player.name)
-            standing = self._all_time_standing(
-                participant.name if participant is not None else player.name
-            )
+            # The player's OWN name, the same key the join frame used (#932).
+            # #923 moved this to the entrant, so a team member's phone showed
+            # the team's row worded as a personal one: "1 win from 1 game"
+            # replacing the "14 wins from 27 games" the same phone read in the
+            # lobby minutes earlier. The all-time table is keyed by entrant
+            # name, so a member with history is found here perfectly well —
+            # their record simply does not move for a game the team was
+            # recorded under, which is what one ledger (#923) means. A member
+            # with no history of their own gets no line, exactly as they got
+            # none in the lobby; the alternative is a team's record wearing a
+            # person's wording.
+            standing = self._all_time_standing(player.name)
             if standing is None:
                 continue
             sends.append(

--- a/tests/test_end_screen_standing_624.py
+++ b/tests/test_end_screen_standing_624.py
@@ -78,11 +78,11 @@ def test_each_player_gets_their_own_standing() -> None:
     )
 
     assert "for player in game_state.get_players()" in body
-    # The lookup key is the *entrant's* name since #923: in team mode the game
-    # is recorded under the team, so a member's own name finds nothing. Still
-    # one send per player — the rank is delivered to a phone, not to a room.
-    assert "self._all_time_standing(" in body
-    assert "get_ranked_participant_for(player.name)" in body
+    # And their OWN standing: the lookup key is the player's name, the same
+    # one the join frame uses. #923 briefly made it the entrant's name, which
+    # put the team's record on a member's phone in a personal wording (#932).
+    assert "self._all_time_standing(player.name)" in body
+    assert "get_ranked_participant_for" not in body
     assert '"type": "all_time_update"' in body
     # Asserts the absent CALL, not the absent word: the docstring above
     # explains why this is not a broadcast, and `_without_comments` strips

--- a/tests/test_team_member_all_time_932.py
+++ b/tests/test_team_member_all_time_932.py
@@ -1,0 +1,229 @@
+"""A team member's end screen shows *their* all-time line, not the team's (#932).
+
+The end screen pushes each phone the all-time standing it drew in the lobby,
+once the finished game has actually landed in the analytics file (#624). #923
+changed the lookup key from the person to the **entrant**, because in team mode
+the game is recorded under the team — and for a member who had never finished a
+game alone, their own name found nothing and the phone showed no line at all.
+
+What that traded away is what this file pins down. Observed on v1.18.0-RC1,
+team Sofa (Anna + Bert) beating Cleo, on Anna's phone:
+
+    lobby      All-time · 1 of 69 · 14 wins from 27 games
+    end screen All-time · 23 of 70 · 1 win from 1 game
+
+Same wording, same place on the same phone, two different people's records.
+Sofa is a team that has played once and won once, so `1 win from 1 game` is the
+team's row — read as a personal line it says Anna fell 22 places and lost 27
+games of history.
+
+The all-time table is a flat map keyed by **entrant name**, so a member who has
+played before *is* found under their own name; the pre-#923 blank was the
+first-timer case, not a broken lookup. Their record simply does not move for a
+game the team was recorded under — that is what one ledger (#923) means, and it
+is what the lobby line already said thirty seconds earlier.
+
+So the key goes back to the player's own name. A member with no history of
+their own gets no line, exactly as they got no line in the lobby; the wording
+belongs to a person, and nothing here may put a team's numbers inside it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from custom_components.quizify.analytics import QuizifyAnalytics  # noqa: E402
+from custom_components.quizify.game.state import QuizifyGameState  # noqa: E402
+from custom_components.quizify.server.websocket import (  # noqa: E402
+    QuizifyWebSocketHandler,
+)
+
+
+class _Runtime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+    def create_task(self, coro):  # noqa: ANN001
+        return asyncio.ensure_future(coro)
+
+
+async def _analytics(tmp_path: Path) -> QuizifyAnalytics:
+    """History before tonight, then tonight — recorded under the team.
+
+    Anna: 3 solo games, 2 wins. Cleo: 3 solo games, 1 win. Then team **Sofa**
+    plays its first game and wins it, so the map carries a "Sofa" row with
+    exactly one win from one game — the row the bug put on Anna's phone.
+    """
+    a = QuizifyAnalytics(_Runtime(tmp_path))
+    await a.load()
+    for game_id, players in (
+        ("g1", {"Anna": 100, "Cleo": 40}),
+        ("g2", {"Anna": 100, "Cleo": 50}),
+        ("g3", {"Cleo": 120, "Anna": 30}),
+    ):
+        await a.record_game(
+            game_id=game_id, category="mixed", difficulty="medium",
+            num_rounds=5, players=players, duration_seconds=100,
+            player_details={},
+        )
+    # Tonight: the team is the entrant, exactly as ``_record_analytics`` writes
+    # it since #923.
+    await a.record_game(
+        game_id="tonight", category="mixed", difficulty="medium", num_rounds=10,
+        players={"Sofa": 112, "Cleo": 96}, duration_seconds=600,
+        player_details={},
+    )
+    return a
+
+
+def _team_room(tmp_path: Path) -> QuizifyGameState:
+    """Anna + Bert as team Sofa, Cleo playing alone. Tonight's room."""
+    st = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="test")
+    for name in ("Anna", "Bert", "Cleo"):
+        st.add_player(name)
+    st.create_team("Sofa", "Anna")
+    st.join_team(st.get_team_of("Anna")["team_id"], "Bert")
+    return st
+
+
+def _handler(game: QuizifyGameState, tmp_path: Path) -> QuizifyWebSocketHandler:
+    """Every phone is on the wire; the sends are captured, not transported."""
+    h = QuizifyWebSocketHandler(
+        runtime=_Runtime(tmp_path), game_state_provider=lambda: game
+    )
+    conn = MagicMock()
+    conn.is_connection_open = MagicMock(return_value=True)
+    conn.send_to_player = AsyncMock()
+    h._conn = conn
+    return h
+
+
+def _standings_sent(handler: QuizifyWebSocketHandler) -> dict[str, dict]:
+    """name -> the ``all_time`` payload that phone received."""
+    out: dict[str, dict] = {}
+    for call in handler._conn.send_to_player.await_args_list:
+        player, message = call.args
+        if message.get("type") == "all_time_update":
+            out[player.name] = message["all_time"]
+    return out
+
+
+@pytest.mark.asyncio
+async def test_a_team_member_gets_their_own_record_not_the_teams(
+    tmp_path: Path,
+) -> None:
+    """The line under the podium keeps saying what it said in the lobby.
+
+    ``1 win from 1 game`` is team Sofa's first evening. Anna has three games
+    and two wins of her own, and reading the team's numbers in a sentence that
+    starts with "you" is the whole defect.
+    """
+    game = _team_room(tmp_path)
+    analytics = await _analytics(tmp_path)
+    game.set_stats_services(analytics, None)
+    handler = _handler(game, tmp_path)
+
+    await handler._dispatch_all_time_standings()
+
+    sent = _standings_sent(handler)
+    assert "Anna" in sent, "the member must still get a line"
+    assert sent["Anna"] == analytics.get_player_standing("Anna")
+    assert sent["Anna"]["games_played"] == 3
+    assert sent["Anna"]["wins"] == 2
+
+    team = analytics.get_player_standing("Sofa")
+    assert team is not None and team["games_played"] == 1, "harness sanity"
+    assert sent["Anna"] != team
+
+
+@pytest.mark.asyncio
+async def test_the_end_line_matches_the_one_the_lobby_showed_them(
+    tmp_path: Path,
+) -> None:
+    """Same phone, same wording, same person — that is the contract.
+
+    The lobby line rides the ``joined`` frame and is looked up by the player's
+    own name. Whatever the end screen sends must be the same lookup, or the
+    number silently changes identity between two screens of one session.
+    """
+    game = _team_room(tmp_path)
+    analytics = await _analytics(tmp_path)
+    game.set_stats_services(analytics, None)
+    handler = _handler(game, tmp_path)
+
+    await handler._dispatch_all_time_standings()
+
+    sent = _standings_sent(handler)
+    for name in ("Anna", "Bert", "Cleo"):
+        assert sent.get(name) == handler._all_time_standing(name), name
+
+
+@pytest.mark.asyncio
+async def test_a_member_with_no_history_gets_no_line_rather_than_the_teams(
+    tmp_path: Path,
+) -> None:
+    """Bert never finished a game alone.
+
+    His lobby showed nothing, so his end screen shows nothing. Handing him the
+    team's row instead would be the same lie as Anna's, just harder to notice.
+    """
+    game = _team_room(tmp_path)
+    game.set_stats_services(await _analytics(tmp_path), None)
+    handler = _handler(game, tmp_path)
+
+    await handler._dispatch_all_time_standings()
+
+    assert "Bert" not in _standings_sent(handler)
+
+
+@pytest.mark.asyncio
+async def test_the_solo_player_in_the_same_room_is_unchanged(
+    tmp_path: Path,
+) -> None:
+    """The control. Cleo is her own entrant, so tonight counts for her.
+
+    Four games, one of them tonight's — the line she reads at the end is the
+    lobby's line plus this game, which is what it looked like all along.
+    """
+    game = _team_room(tmp_path)
+    analytics = await _analytics(tmp_path)
+    game.set_stats_services(analytics, None)
+    handler = _handler(game, tmp_path)
+
+    await handler._dispatch_all_time_standings()
+
+    cleo = _standings_sent(handler)["Cleo"]
+    assert cleo["games_played"] == 4
+    assert cleo["wins"] == 1
+    assert cleo == analytics.get_player_standing("Cleo")
+
+
+@pytest.mark.asyncio
+async def test_solo_mode_keeps_sending_one_standing_per_phone(
+    tmp_path: Path,
+) -> None:
+    """No teams at all: nothing about this change may reach that room."""
+    game = QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="test")
+    for name in ("Anna", "Cleo"):
+        game.add_player(name)
+    analytics = await _analytics(tmp_path)
+    game.set_stats_services(analytics, None)
+    handler = _handler(game, tmp_path)
+
+    await handler._dispatch_all_time_standings()
+
+    sent = _standings_sent(handler)
+    assert set(sent) == {"Anna", "Cleo"}
+    assert sent["Anna"] == analytics.get_player_standing("Anna")
+    assert sent["Cleo"] == analytics.get_player_standing("Cleo")


### PR DESCRIPTION
Closes #932

## The defect

The end screen pushes each phone the all-time standing it drew in the lobby, once the finished game has actually landed in the analytics file (#624). [#925](https://github.com/mholzi/quizify/pull/925) ([#923](https://github.com/mholzi/quizify/issues/923)) changed the lookup key from the person to the **entrant**, and on a team member's phone that line became the *team's* row in a personal wording.

Observed in the live test of `v1.18.0-RC1` — team **Sofa** (Anna + Bert) beating **Cleo**, on Anna's phone, same session:

| Where | Line |
|---|---|
| Lobby | `All-time · 1 of 69 · 14 wins from 27 games` |
| End screen | `All-time · 23 of 70 · 1 win from 1 game` |

Sofa is a team that had played once and won once. Read as a personal line, it says Anna fell 22 places and lost 27 games of history. Cleo, her own entrant, stayed consistent throughout.

## What the store is actually keyed by

`all_time_players` is a flat `dict[str, PlayerAllTimeRecord]` keyed by the **entrant's display name** — the keys of the `players` map `_record_analytics` hands to `record_game`. Since #923 that map is `get_ranked_participants()`, so a team game writes one row named `Sofa` and no row for Anna or Bert.

That matters for the reason #925 gave for the change. A member who has played before **is** found under their own name — Anna's row with 27 games was there the whole time, and the lobby line rendered it from exactly that lookup minutes earlier. The blank #925 set out to fix is the *first-timer* case: a member with no personal history, who also saw no line in the lobby, because `get_player_standing` deliberately returns `None` rather than "1st of 1".

## The decision

**Option (a): the member sees their own standing again.** The lookup key goes back to `player.name`, the same key the `joined` and `reconnected` frames use.

A team member's own record does not move for a game their team was recorded under. That is not a bug to paper over — it is what one ledger (#923) means, and the lobby line already said so thirty seconds before. What must not happen is a team's numbers arriving inside a sentence that is about a person.

A member with no history of their own now gets no line, exactly as they got no line in the lobby. That is the same fail-soft the join path has had since #371, and it is the honest half of the trade: the alternative on offer was the team's record wearing a person's wording.

**Option (b) — keep the team's row and label it as the team's — is not built here.** It is a reasonable thing to show, and the issue says so. But it needs new visible text (an i18n key, a "Team Sofa" prefix on the line), which is a design decision rather than a bug fix. Worth opening separately if the team's season standing is wanted on the end screen.

## Tests

`tests/test_team_member_all_time_932.py`, five behavioural tests driving `_dispatch_all_time_standings` with a real analytics file: the member's own row, lobby/end agreement for every phone in the room, the historyless member who correctly gets nothing, the solo entrant in the same team game as the control, and a room with no teams at all.

Reverting only the production diff fails three of them, with the live test's own numbers:

```
FAILED test_a_team_member_gets_their_own_record_not_the_teams
FAILED test_the_end_line_matches_the_one_the_lobby_showed_them
FAILED test_a_member_with_no_history_gets_no_line_rather_than_the_teams

E  AssertionError: assert {'games_playe...re': 112, ...} == {'games_playe...re': 230, ...}
E    Differing items:
E    {'wins': 1} != {'wins': 2}
E    {'games_played': 1} != {'games_played': 3}
E    {'rank': 3} != {'rank': 1}
```

**One #925-era test encoded the defect.** `test_end_screen_standing_624.py::test_each_player_gets_their_own_standing` asserted `get_ranked_participant_for(player.name)` in the dispatcher body — the entrant lookup itself. Changed deliberately, the same way #925 changed `test_team_scoring_365`: it now pins `self._all_time_standing(player.name)` and the *absence* of `get_ranked_participant_for`. The rest of that file — one send per phone, never a broadcast, fail-soft on closed sockets — is untouched and still passes.

Full suite: **4124 passed**. `mypy`: clean, 61 source files. `ruff check .`: 213 findings, unchanged from the baseline; none in a touched file.

No frontend change: no new i18n key, no new element id, no `www/js` edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TaxQuikD1LKQmoJTphvkWV