### PR TITLE
fix: scope the head-to-head duel to the game's entrants (#931)

### DIFF
--- a/custom_components/quizify/server/websocket.py
+++ b/custom_components/quizify/server/websocket.py
@@ -1554,6 +1554,11 @@ class QuizifyWebSocketHandler:
 
         await self._conn.send(ws, {"type": "team_joined", "team": team})
         await self._round_out.send_teams_update(game_state)
+        # #931: forming or dissolving a team changes who the entrants
+        # are, so the duel underneath the roster is about different rows
+        # now. Teams do not move the roster, so nothing else recomputes
+        # it here and the old line would simply stay up.
+        await self._send_head_to_head(game_state)
 
     async def _handle_join_team(
         self, ws: web.WebSocketResponse, data: dict, game_state: QuizifyGameState
@@ -1575,6 +1580,11 @@ class QuizifyWebSocketHandler:
 
         await self._conn.send(ws, {"type": "team_joined", "team": team})
         await self._round_out.send_teams_update(game_state)
+        # #931: forming or dissolving a team changes who the entrants
+        # are, so the duel underneath the roster is about different rows
+        # now. Teams do not move the roster, so nothing else recomputes
+        # it here and the old line would simply stay up.
+        await self._send_head_to_head(game_state)
 
     async def _handle_leave_team(
         self, ws: web.WebSocketResponse, data: dict, game_state: QuizifyGameState
@@ -1593,6 +1603,11 @@ class QuizifyWebSocketHandler:
 
         await self._conn.send(ws, {"type": "team_left"})
         await self._round_out.send_teams_update(game_state)
+        # #931: forming or dissolving a team changes who the entrants
+        # are, so the duel underneath the roster is about different rows
+        # now. Teams do not move the roster, so nothing else recomputes
+        # it here and the old line would simply stay up.
+        await self._send_head_to_head(game_state)
 
     # ------------------------------------------------------------------
     # Submit answer
@@ -2080,15 +2095,26 @@ class QuizifyWebSocketHandler:
         analytics = game_state.stats_service
         if analytics is None:
             return
+        # #931: entrants, not people. ``get_ranked_participants`` is the list
+        # the podium, the leaderboard and the recorded game (#923) are all
+        # built from, and in solo mode it is exactly ``get_players()``. Asking
+        # the people instead put "Anna 13 - 6 Cleo" under a podium that had
+        # just declared team Sofa the winner: Anna never entered that game,
+        # she is one of two members of something that did, and the pair
+        # selection silently picked one of the two. The rule is therefore the
+        # ranking's own: the duel compares whoever the game is between.
         duel = analytics.get_head_to_head(
-            [p.name for p in game_state.get_players()]
+            [p.name for p in game_state.get_ranked_participants()]
         )
-        if duel is None:
-            # Fewer than two present, or no pair has met twice. Silence beats a
-            # "1-0" that reads like a record and is a coincidence.
-            return
+        # #931: a frame either way, never silence. Fewer than two entrants, or
+        # no pair of them has met twice -> the line has to LEAVE the screen
+        # rather than stand from before. The lobby recomputes this on every
+        # roster change and on every team change, and two entrants who were on
+        # screen a moment ago are one team now. Both renderers already read a
+        # frame without ``left``/``right`` as "hide", so this needs no new
+        # element and no new text.
         await self._conn.broadcast_to_admins_and_dashboards(
-            {"type": "head_to_head", "at": at, **duel}
+            {"type": "head_to_head", "at": at, **(duel or {})}
         )
 
     def _cancel_roster_flush(self) -> None:

--- a/tests/test_team_duel_scope_931.py
+++ b/tests/test_team_duel_scope_931.py
@@ -1,0 +1,350 @@
+"""The duel is between entrants, not between people (#931).
+
+Found in the v1.18.0-RC1 live test on the real HA: team **Sofa** (Anna + Bert)
+beat **Cleo**, who played alone. The podium, the awards, the leaderboard and
+both phones named Sofa — one participant. The head-to-head strip under it read
+
+    HEAD TO HEAD
+    Anna 13 - 6 Cleo   (last 90 days)
+
+Anna never entered that game. ``_broadcast_head_to_head`` asked
+``get_players()`` for the room, so the pair selection saw three people where
+the game had two entrants, and silently picked one of the two members of the
+winning team. A person's name and a 90-day record sat directly under a team
+victory with nothing saying they belong to a different scope.
+
+This is the second half of the screenshot #923 was filed from. #925 closed the
+score ledger and the ``Tonight`` line went with it; the duel is the #613
+feature and was never in that fix's scope, so it survived.
+
+**The rule chosen here:** the duel compares whoever the ranking is about.
+``get_ranked_participants()`` is the same list the podium, the leaderboard,
+the answer counter (#835) and the recorded game (#923) are built from, and in
+solo mode it *is* ``get_players()`` — so nothing changes for a room without
+teams. In team mode the candidates become the teams and the guests who joined
+none, which is exactly the set the analytics record has held since #925. A
+team with no shared history simply has no duel, and the line goes away.
+
+**And it has to go away on every surface.** Four draw the strip — the TV lobby
+and TV end screen (``#lobby-h2h`` / ``#end-h2h``), the admin lobby and admin
+end screen — all four fed by the one shared sender. The sender used to stay
+silent when there was no duel, which is fine for a screen that never had one
+and wrong for the lobby, where the line is recomputed as the room changes: two
+entrants on screen a second ago are one team now. So it sends a frame either
+way, and both renderers already treat a frame without ``left``/``right`` as
+"hide" — no new element, no new text. Teams also do not move the roster, so
+the three team handlers recompute it themselves; without that the lobby line
+stood untouched from before the team existed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.quizify.analytics import QuizifyAnalytics
+from custom_components.quizify.game.state import GamePhase, QuizifyGameState
+from custom_components.quizify.server.connection import ConnectionManager
+from custom_components.quizify.server.websocket import QuizifyWebSocketHandler
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_CC = _REPO_ROOT / "custom_components" / "quizify"
+
+
+class _Runtime:
+    def __init__(self, tmp_path: Path) -> None:
+        self.data_dir = tmp_path
+
+    async def run_in_executor(self, func, *args):  # noqa: ANN001, ANN002
+        return func(*args)
+
+    def create_task(self, coro):  # noqa: ANN001
+        return asyncio.ensure_future(coro)
+
+
+def _analytics(tmp_path: Path, games: list[dict[str, int]]) -> QuizifyAnalytics:
+    """Analytics whose detailed history is exactly these score maps.
+
+    Built without touching disk: the duel only ever reads ``games``.
+    """
+    impl = QuizifyAnalytics.__new__(QuizifyAnalytics)
+    impl._data = {"games": [{"player_scores": scores} for scores in games]}
+    return impl
+
+
+def _ws() -> MagicMock:
+    ws = MagicMock()
+    ws.closed = False
+    ws.send_json = AsyncMock()
+    return ws
+
+
+@pytest.fixture
+def game(tmp_path: Path) -> QuizifyGameState:
+    return QuizifyGameState(runtime=_Runtime(tmp_path), entry_id="test")
+
+
+@pytest.fixture
+def handler(game: QuizifyGameState, tmp_path: Path) -> QuizifyWebSocketHandler:
+    h = QuizifyWebSocketHandler(
+        runtime=_Runtime(tmp_path), game_state_provider=lambda: game
+    )
+    h._conn = ConnectionManager(_Runtime(tmp_path), lambda: game)
+    h._conn.broadcast = AsyncMock()
+    h._conn.send = AsyncMock()
+    h._conn.send_error = AsyncMock()
+    h._conn.broadcast_to_admins_and_dashboards = AsyncMock()
+    return h
+
+
+def _duels(handler: QuizifyWebSocketHandler) -> list[dict[str, Any]]:
+    return [
+        call.args[0]
+        for call in handler._conn.broadcast_to_admins_and_dashboards.await_args_list
+        if call.args and call.args[0].get("type") == "head_to_head"
+    ]
+
+
+def _the_room_from_the_live_test(game: QuizifyGameState) -> None:
+    """Anna + Bert open team Sofa; Cleo plays alone. Two entrants."""
+    for name in ("Anna", "Bert", "Cleo"):
+        game.add_player(name)
+    game.create_team("Sofa", "Anna")
+    game.join_team(game.get_team_of("Anna")["team_id"], "Bert")
+
+
+# The evenings Anna and Cleo played as individuals, before teams existed.
+_HISTORY = [
+    {"Anna": 90, "Cleo": 40},
+    {"Anna": 80, "Cleo": 20},
+    {"Anna": 10, "Cleo": 70},
+]
+
+
+# ---------------------------------------------------------------------------
+# The end screen — the defect as reported
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_team_victory_does_not_get_a_members_name_under_it(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """The reported screen: "Anna 13 - 6 Cleo" under a podium saying Sofa."""
+    _the_room_from_the_live_test(game)
+    game.set_stats_services(_analytics(tmp_path, _HISTORY), None)
+    game.phase = GamePhase.FINALE
+
+    await handler._dispatch_end_head_to_head()
+
+    (frame,) = _duels(handler)
+    assert frame["at"] == "finale"
+    assert "left" not in frame and "right" not in frame, (
+        "Anna is not an entrant of this game — she is one of two members of one"
+    )
+
+
+@pytest.mark.asyncio
+async def test_entrants_that_have_met_keep_their_duel(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """Suppression is not the rule — the rule is *whoever the game is between*.
+
+    Team Sofa has played Cleo before, so the strip is about this game and says
+    so with the names the podium uses.
+    """
+    _the_room_from_the_live_test(game)
+    game.set_stats_services(
+        _analytics(
+            tmp_path,
+            [
+                {"Sofa": 100, "Cleo": 60},
+                {"Sofa": 40, "Cleo": 90},
+                {"Sofa": 70, "Cleo": 10},
+            ],
+        ),
+        None,
+    )
+    game.phase = GamePhase.FINALE
+
+    await handler._dispatch_end_head_to_head()
+
+    (frame,) = _duels(handler)
+    assert (frame["left"], frame["right"]) == ("Sofa", "Cleo")
+    assert (frame["left_wins"], frame["right_wins"], frame["games"]) == (2, 1, 3)
+
+
+@pytest.mark.asyncio
+async def test_the_guest_who_joined_no_team_is_still_an_entrant(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """A team of one is not an error state (#365) — Cleo keeps her own row, so
+    her own history is still eligible."""
+    _the_room_from_the_live_test(game)
+    game.add_player("Dora")
+    game.set_stats_services(
+        _analytics(tmp_path, [{"Cleo": 90, "Dora": 40}, {"Cleo": 20, "Dora": 70}]),
+        None,
+    )
+    game.phase = GamePhase.FINALE
+
+    await handler._dispatch_end_head_to_head()
+
+    (frame,) = _duels(handler)
+    assert {frame["left"], frame["right"]} == {"Cleo", "Dora"}
+
+
+# ---------------------------------------------------------------------------
+# The lobby — the same rule, and the line has to leave
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_lobby_shows_the_duel_while_both_play_alone(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """Unchanged: before a team exists they are both individual entrants."""
+    for name in ("Anna", "Bert", "Cleo"):
+        game.add_player(name)
+    game.set_stats_services(_analytics(tmp_path, _HISTORY), None)
+
+    await handler._send_head_to_head(game)
+
+    (frame,) = _duels(handler)
+    assert frame["at"] == "lobby"
+    assert (frame["left"], frame["right"]) == ("Anna", "Cleo")
+    assert (frame["left_wins"], frame["right_wins"]) == (2, 1)
+
+
+@pytest.mark.asyncio
+async def test_opening_a_team_takes_the_lobby_line_off_the_screen(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """The moment Anna is in a team she stops being an entrant, and the line
+    that names her has to go — a team change does not move the roster, so
+    nothing else was recomputing it."""
+    for name in ("Anna", "Bert", "Cleo"):
+        game.add_player(name)
+    game.set_stats_services(_analytics(tmp_path, _HISTORY), None)
+    ws = _ws()
+    handler._player_for_ws = lambda gs, w: gs.get_player("Anna")  # type: ignore[assignment]
+
+    await handler._handle_create_team(ws, {"name": "Sofa"}, game)
+
+    (frame,) = _duels(handler)
+    assert frame == {"type": "head_to_head", "at": "lobby"}, (
+        "silence would have left 'Anna 13 - 6 Cleo' standing on the TV"
+    )
+
+
+@pytest.mark.asyncio
+async def test_leaving_the_team_brings_the_duel_back(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """The rule holds in both directions: the last one out dissolves the team
+    and the room is individuals again."""
+    for name in ("Anna", "Bert", "Cleo"):
+        game.add_player(name)
+    game.create_team("Sofa", "Anna")
+    game.set_stats_services(_analytics(tmp_path, _HISTORY), None)
+    ws = _ws()
+    handler._player_for_ws = lambda gs, w: gs.get_player("Anna")  # type: ignore[assignment]
+
+    await handler._handle_leave_team(ws, {}, game)
+
+    (frame,) = _duels(handler)
+    assert (frame["left"], frame["right"]) == ("Anna", "Cleo")
+
+
+@pytest.mark.asyncio
+async def test_joining_a_team_recomputes_it_too(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState, tmp_path: Path
+) -> None:
+    """All three team handlers, not just the one that was easy to reach."""
+    for name in ("Anna", "Bert", "Cleo"):
+        game.add_player(name)
+    game.create_team("Sofa", "Bert")
+    game.set_stats_services(_analytics(tmp_path, _HISTORY), None)
+    ws = _ws()
+    handler._player_for_ws = lambda gs, w: gs.get_player("Anna")  # type: ignore[assignment]
+
+    await handler._handle_join_team(
+        ws, {"team_id": game.get_team_of("Bert")["team_id"]}, game
+    )
+
+    (frame,) = _duels(handler)
+    assert frame == {"type": "head_to_head", "at": "lobby"}
+
+
+# ---------------------------------------------------------------------------
+# Solo mode is the control
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_room_without_teams_is_untouched(
+    handler: QuizifyWebSocketHandler, game: QuizifyGameState, tmp_path: Path
+) -> None:
+    for name in ("Anna", "Bert", "Cleo"):
+        game.add_player(name)
+    game.set_stats_services(_analytics(tmp_path, _HISTORY), None)
+    game.phase = GamePhase.FINALE
+
+    await handler._dispatch_end_head_to_head()
+
+    (frame,) = _duels(handler)
+    assert frame == {
+        "type": "head_to_head",
+        "at": "finale",
+        "left": "Anna",
+        "right": "Cleo",
+        "left_wins": 2,
+        "right_wins": 1,
+        "games": 3,
+    }
+
+
+def test_participants_are_what_the_sender_asks_for() -> None:
+    """A guard, because this is the sixth reader of the same defect class.
+
+    #668 wager, #800 reaction bonus, #804 hot seat, #835 answer progress and
+    #923 the score ledger were each a call site that asked the room for people
+    when the game was about entrants. Naming ``get_players()`` here again is
+    how that comes back.
+    """
+    source = (_CC / "server" / "websocket.py").read_text("utf-8")
+    body = source.split("async def _broadcast_head_to_head", 1)[1].split(
+        "\n    def ", 1
+    )[0]
+    body = re.sub(r"#.*$", "", body, flags=re.M)
+
+    assert "get_ranked_participants()" in body
+    assert "get_players()" not in body
+    # Still the one shared sender for all four surfaces (#613).
+    assert "broadcast_to_admins_and_dashboards" in body
+
+
+def test_every_team_handler_recomputes_the_lobby_duel() -> None:
+    """Create, join and leave all change who the entrants are."""
+    source = (_CC / "server" / "websocket.py").read_text("utf-8")
+    for name in ("_handle_create_team", "_handle_join_team", "_handle_leave_team"):
+        body = source.split(f"async def {name}", 1)[1].split("\n    async def ", 1)[0]
+        assert "_send_head_to_head" in body, name
+
+
+def test_both_renderers_read_an_empty_frame_as_hide() -> None:
+    """The suppression uses markup that already exists — no new element, no new
+    text. Break this and the server would be clearing a line nobody hides."""
+    for path, hide in (
+        (_CC / "www" / "js" / "dashboard.js", "classList.add('hidden')"),
+        (_CC / "www" / "js" / "admin.js", "display = 'none'"),
+    ):
+        script = path.read_text("utf-8")
+        body = script.split("function handleHeadToHead(", 1)[1].split("\n    }", 1)[0]
+        guard = body.split("if (!msg || !msg.left || !msg.right)", 1)[1][:200]
+        assert hide in guard, path.name


### PR DESCRIPTION
## The defect

Found in the `v1.18.0-RC1` live test on the real HA: team **Sofa** (Anna + Bert) beat **Cleo**, who played alone. The podium, the awards, the leaderboard and both phones all named Sofa — one participant. The head-to-head strip on the TV/dashboard end screen and on the admin end screen read:

> HEAD TO HEAD
> **Anna 13 – 6 Cleo** (last 90 days)

Anna never entered that game. `_broadcast_head_to_head` asked `get_players()` for the room, so the pair selection saw three people where the game had two entrants and silently picked one of the two members of the winning team. A person's name and a 90-day record sat directly under a team victory with nothing saying they belong to a different scope.

This is the second half of the screenshot [#923](https://github.com/mholzi/quizify/issues/923) was filed from. [#925](https://github.com/mholzi/quizify/pull/925) closed the score ledger and the `Tonight` line went with it; the duel is the [#613](https://github.com/mholzi/quizify/issues/613) feature and was never in that fix's scope, so it survived.

## The rule

**The duel compares whoever the ranking is about.** `get_ranked_participants()` is the same list the podium, the leaderboard, the answer counter ([#835](https://github.com/mholzi/quizify/issues/835)) and the recorded game ([#923](https://github.com/mholzi/quizify/issues/923)) are built from, and in solo mode it *is* `get_players()` — so nothing changes for a room without teams. In team mode the candidates become the teams and the guests who joined none, which is exactly the set the analytics record has held since [#925](https://github.com/mholzi/quizify/pull/925). A team with no shared history simply has no duel, and the line goes away.

This is mechanical rather than a judgement call: the strip now draws from the one list every other surface on that screen already draws from, so it cannot disagree with the podium above it again. Suppression is not the rule — team Sofa vs Cleo, if those two entrants have met before, still gets a duel, under the names the podium uses.

## Following the rule to every surface

Four surfaces draw the strip: the TV lobby (`#lobby-h2h`), the TV end screen (`#end-h2h`), the admin lobby and the admin end screen. All four are fed by the one shared sender, so the scope change reaches all four at once. Two follow-through changes were needed for the rule to actually hold on them:

* **The sender emits a frame either way** instead of falling silent when there is no duel. That was fine for a screen that never had one and wrong for the lobby, where the line is recomputed as the room changes: in the live test's lobby, before any team existed, `Anna 13 – 6 Cleo` was correct — both were individual entrants. The moment Anna joins a team, silence left that line standing. Both renderers already treat a frame without `left`/`right` as "hide", so this needs **no new element and no new visible text**.
* **Creating, joining and leaving a team recompute it.** Team changes do not mark the roster dirty, so nothing else was recomputing the lobby line; the old duel simply stayed up.

## Tests

New: `tests/test_team_duel_scope_931.py` (11 tests). The end screen as reported, entrants that *have* met keeping their duel, the solo guest still being an entrant, the lobby before and after a team forms, all three team handlers, solo mode as the control, plus source guards (this is the sixth reader of the person-vs-entrant defect class after [#668](https://github.com/mholzi/quizify/issues/668), [#800](https://github.com/mholzi/quizify/issues/800), [#804](https://github.com/mholzi/quizify/issues/804), [#835](https://github.com/mholzi/quizify/issues/835), [#923](https://github.com/mholzi/quizify/issues/923)) and a guard that both renderers still hide on an empty frame.

Reverting the source change and re-running the file fails 7 of the 11, headlined by:

```
E       AssertionError: Anna is not an entrant of this game — she is one of two members of one
E       assert ('left' not in {'at': 'finale', 'games': 3, 'left': 'Anna', 'left_wins': 2, ...})
```

Full suite: `4130 passed`. `ruff check .`: 213 findings, unchanged from baseline. `mypy`: clean.

Closes #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TaxQuikD1LKQmoJTphvkWV