### PR TITLE
chore: cut 1.18.0-RC2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to Quizify are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [1.18.0-RC2] — 2026-09-08
+
+**One Score, and the Room Joins the Loud Parts**
+
+Eight entries: the six this week planned, plus two that the first release candidate turned up when it was actually played.
+
+### The team is one player, everywhere
+
+Team mode had been keeping a second, hidden score ledger — the podium showed the team while analytics, the leader sensors and the winner event read the person underneath. That is closed at the source. Playing RC1 on a television then found the two places that still leaked a name: the head-to-head strip named one member under a team victory, and a member's phone showed the team's all-time record as if it were their own. Both now follow the same ranking everything else is built from.
+
+### A window that stood empty eleven months a year
+
+Christmas and New Year, in German, English and Spanish: six packs, 603 questions, covering 1 December to 6 January without a gap. And the house now joins the auction, the betting window and Lightning.
+
 ## [1.18.0-RC1] — 2026-09-08
 
 **One Score, and the Room Joins the Loud Parts**

--- a/custom_components/quizify/manifest.json
+++ b/custom_components/quizify/manifest.json
@@ -14,5 +14,5 @@
   "documentation": "https://github.com/mholzi/quizify",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mholzi/quizify/issues",
-  "version": "1.18.0-RC1"
+  "version": "1.18.0-RC2"
 }


### PR DESCRIPTION
Second release candidate for the v1.18.0 milestone.

- `manifest.json` → `1.18.0-RC2` (incremental RC, not a patch bump)
- `CHANGELOG.md` section spanning the last **stable**, v1.17.0 — the reader never saw RC1

## Why there is an RC2

RC1 was installed on the real HA and a full game was played: team **Sofa** against a solo player, holiday pack, ten rounds plus a Lightning round, through to the end screen. The headline fix held — the team wins as one participant on every surface. Two places still leaked a member's name, and both are now fixed on `main`:

| Issue | PR | What it was |
|---|---|---|
| #931 | #934 | The head-to-head strip named a team member under a team victory |
| #932 | #933 | A member's phone showed the team's all-time record as if it were their own |

Everything merged since RC1 is Python and tests, so the tested artefact has to move but the packs do not.

## Pack version check

Unchanged since RC1: the only pack files touched since v1.17.0 are the six holiday packs added in #929, each carrying `"version": "1.0"` with its entry in `questions/versions.json` — both in the same commit. No existing pack file was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TaxQuikD1LKQmoJTphvkWV